### PR TITLE
mediatek: add support for NRadio C2000-MAX

### DIFF
--- a/target/linux/mediatek/dts/mt7987a-nradio-c2000-max.dts
+++ b/target/linux/mediatek/dts/mt7987a-nradio-c2000-max.dts
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "mt7987a.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "NRadio C2000-MAX";
+	compatible = "nradio,c2000-max",
+		     "mediatek,mt7987a",
+		     "mediatek,mt7987";
+
+	aliases {
+		label-mac-device = &gmac1;
+		led-boot = &led_status;
+		led-failsafe = &led_error;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n1 earlycon=uart8250,mmio32,0x11000000 pci=pcie_bus_perf root=PARTLABEL=rootfs rootwait rootfstype=squashfs,f2fs";
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		cpe-pwr {
+			gpio-export,name = "cpe-pwr";
+			gpio-export,output = <0>;
+			gpios = <&pio 49 GPIO_ACTIVE_LOW>;
+		};
+
+		cpe-sel0 {
+			gpio-export,name = "cpe-sel0";
+			gpio-export,output = <1>;
+			gpios = <&pio 48 GPIO_ACTIVE_HIGH>;
+		};
+
+		fan-hw {
+			gpio-export,name = "fan-hw";
+			gpio-export,output = <0>;
+			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <10>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+			debounce-interval = <10>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led_status: status {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		signal-1 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_INDICATOR;
+			function-enumerator = <0>;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		signal-2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_INDICATOR;
+			function-enumerator = <1>;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		signal-3 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_INDICATOR;
+			function-enumerator = <2>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led_error: error {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_FAULT;
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+};
+
+&eth {
+	status = "okay";
+};
+
+&fan {
+	pwms = <&pwm 1 50000 0>;
+	status = "okay";
+};
+
+&gmac0 {
+	phy-mode = "2500base-x";
+	phy-handle = <&phy1>;
+	status = "okay";
+};
+
+&gmac1 {
+	openwrt,netdev-name = "lan";
+	phy-mode = "internal";
+	phy-handle = <&phy15>;
+	status = "okay";
+};
+
+&mdio {
+	phy1: phy@1 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <1>;
+		reset-gpios = <&pio 42 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <100000>;
+		reset-deassert-us = <100000>;
+		interrupt-parent = <&pio>;
+		interrupts = <41 IRQ_TYPE_LEVEL_LOW>;
+		realtek,aldps-enable;
+	};
+
+	phy15: phy@15 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <15>;
+		phy-mode = "internal";
+		pinctrl-names = "i2p5gbe-led";
+		pinctrl-0 = <&i2p5gbe_led0_pins>;
+	};
+};
+
+&mmc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	pinctrl-names = "default", "state_uhs";
+	pinctrl-0 = <&sd_pins_default>;
+	pinctrl-1 = <&sd_pins_uhs>;
+	bus-width = <4>;
+	max-frequency = <48000000>;
+	cap-sd-highspeed;
+	vmmc-supply = <&reg_3p3v>;
+	vqmmc-supply = <&reg_3p3v>;
+	no-mmc;
+	no-sdio;
+	status = "okay";
+
+	card@0 {
+		compatible = "mmc-card";
+		reg = <0>;
+
+		block {
+			compatible = "block-device";
+
+			partitions {
+				block-partition-factory {
+					partname = "factory";
+
+					nvmem-layout {
+						compatible = "fixed-layout";
+						#address-cells = <1>;
+						#size-cells = <1>;
+
+						eeprom_factory_0: eeprom@0 {
+							reg = <0x0 0x1000>;
+						};
+					};
+				};
+			};
+		};
+	};
+};
+
+&pcie0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_pins>;
+	reset-gpios = <&pio 38 GPIO_ACTIVE_HIGH>;
+	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+
+		wifi@0,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+
+			nvmem-cells = <&eeprom_factory_0>;
+			nvmem-cell-names = "eeprom";
+
+			ieee80211-freq-limit = <2400000 2500000>,
+					       <5170000 5835000>;
+		};
+	};
+};
+
+&pio {
+	pwm1_pins: pwm1-pins {
+		mux {
+			function = "pwm";
+			groups = "pwm1_0";
+		};
+	};
+};
+
+&pwm {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm1_pins>;
+	status = "okay";
+};
+
+&ssusb {
+	status = "okay";
+
+	vusb33-supply = <&reg_3p3v>;
+};
+
+&tphyu3port0 {
+	status = "okay";
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_pins>;
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -118,6 +118,9 @@ mediatek_setup_interfaces()
 	cudy,ap3000wall-v1)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4 lan5"
 		;;
+	nradio,c2000-max)
+		ucidef_set_interface_lan "lan"
+		;;
 	comfast,cf-xr186|\
 	cudy,ap3000outdoor-v1|\
 	cudy,ap3000-v1|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -310,6 +310,11 @@ platform_do_upgrade() {
 		CI_ROOTPART="rootfs_2nd"
 		emmc_do_upgrade "$1"
 		;;
+	nradio,c2000-max)
+		CI_KERNPART="kernel"
+		CI_ROOTPART="rootfs"
+		emmc_do_upgrade "$1"
+		;;
 	ubnt,unifi-6-plus)
 		CI_KERNPART="kernel0"
 		EMMC_ROOT_DEV="$(cmdline_get_var root)"
@@ -395,7 +400,8 @@ platform_check_image() {
 		;;
 	creatlentem,clt-r30b1|\
 	creatlentem,clt-r30b1-112m|\
-	nradio,c8-668gl)
+	nradio,c8-668gl|\
+	nradio,c2000-max)
 		# tar magic `ustar`
 		magic="$(dd if="$1" bs=1 skip=257 count=5 2>/dev/null)"
 
@@ -445,6 +451,7 @@ platform_copy_config() {
 	huasifei,wh3000-pro-emmc|\
 	jdcloud,re-cp-03|\
 	nradio,c8-668gl|\
+	nradio,c2000-max|\
 	smartrg,sdg-8612|\
 	smartrg,sdg-8614|\
 	smartrg,sdg-8622|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2744,6 +2744,17 @@ define Device/nradio_c8-668gl
 endef
 TARGET_DEVICES += nradio_c8-668gl
 
+define Device/nradio_c2000-max
+  DEVICE_VENDOR := NRadio
+  DEVICE_MODEL := C2000-MAX
+  DEVICE_DTS := mt7987a-nradio-c2000-max
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := mt7987-2p5g-phy-firmware kmod-hwmon-pwmfan kmod-usb3
+  IMAGE_SIZE := 248320k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata | check-size
+endef
+TARGET_DEVICES += nradio_c2000-max
+
 define Device/openembed_som7981
   DEVICE_VENDOR := OpenEmbed
   DEVICE_MODEL := SOM7981


### PR DESCRIPTION
This adds initial board support for the NRadio C2000-MAX, an MT7987A-based 5G CPE.

The current implementation targets the alternative GPT-partitioned SD boot layout used by existing downstream OpenWrt/MYOS images. The stock NROS firmware uses a different layout: it boots from a 32 MiB SPI-NOR and uses a single-partition SD card for overlay and user storage.

Support currently added:
- device tree for NRadio C2000-MAX
- mediatek/filogic image profile
- default LAN setup on the integrated MT7987 2.5GbE PHY
- sysupgrade handling for GPT partitions named `kernel` and `rootfs`

## Hardware verified on vendor NROS 2.2.12.n0.c1

- SoC: MediaTek MT7987A
- RAM: 512 MiB DDR4 (`MemTotal: 493016 kB`; DT memory size `0x20000000`)
- Boot flash: Macronix MX25L25645G 32 MiB SPI-NOR
- Stock SPI-NOR layout: `BL2` 256 KiB, `u-boot-env` 64 KiB, `Factory` 1 MiB, `bdinfo` 512 KiB, `FIP` 1 MiB, and `firmware` 29.1875 MiB; the FIT firmware is split into `kernel`, `rootfs`, and `rootfs_data` MTD devices
- Stock bootloader: U-Boot `2025.01-rc4`, FIT boot configuration `config-1`
- Removable storage: SDXC, 4-bit bus; stock NROS uses one MBR/F2FS partition as `/overlay` and user storage
- Wi-Fi: MediaTek MT7993 PCIe Wi-Fi 7, PCI ID `14c3:7993`, vendor SKU `MT7993-BE3600-7976C`, 2.4 GHz 2x2 and 5 GHz 2x2
- Ethernet: one physical 2.5GbE LAN/WAN port driven by the integrated MT7987 2.5GbE PHY at MDIO address 15; there is no external Ethernet PHY
- Cellular modem: TD Tech MT5700M-CN, USB ID `3466:3301`, connected through an internal USB SuperSpeed link; exposes CDC-NCM and four `ttyUSB` ports
- USB: internal xHCI link is used by the modem; the external USB-C connector is the PD power input, not a general-purpose USB host port
- Cooling: PWM-controlled fan on PWM1 plus fan power GPIO
- LEDs: blue status, three blue signal LEDs, and red error LED
- Buttons: reset and WPS
- UART: UART0 console at 115200 8N1; physical pinout remains unverified
- Power: USB-C PD input; 5 V/3 A, 9 V/2.22 A, or 12 V/1.67 A according to the vendor manual

## MAC and calibration data

- The per-device base MAC is stored in the SPI-NOR `bdinfo` partition. On the tested unit the six raw MAC bytes start at offset `0x9`; vendor NROS exposes the same value as `bdinfo -g fac_mac` and applies it to LAN and the first Wi-Fi radio. The actual per-device value is intentionally omitted here.
- The stock Wi-Fi calibration partition is the 1 MiB SPI-NOR `Factory` partition.
- Existing downstream GPT SD images contain a separate `factory` partition and the current PR reads calibration data from that SD copy. A whole-disk upstream image must not overwrite or replace unique per-device calibration data without a defined preservation/provisioning path.

## Current limitations / follow-up required

- The current commit message and DTS still contain the obsolete external-PHY/gmac0 description and the old 256 MiB RAM value. Those do not match the verified hardware and need correction in the branch.
- The current image only supports sysupgrade of an existing GPT-SD OpenWrt installation. It does not yet provide a first-install whole-disk `sdcard.img` image.
- OpenWrt U-Boot artifacts and a FIT/ITB sysupgrade flow, as requested in review, are still missing.
- MT7993 Wi-Fi and the cellular modem remain outside this initial upstream board-support scope because the working downstream stacks use vendor/prebuilt components.
- The vendor unit has no accessible UART header/pinout, so the captures below are from the running stock system over SSH rather than a serial boot console.

Evidence:
- vendor NROS capture: https://gist.github.com/561410590/5ed060bfe7d581eb30021b94eec3eebd
- downstream OpenWrt/MYOS capture: https://gist.github.com/561410590/6aad9d35831e73e9fe97b02aedef602b
- vendor hardware manual: https://www.nradiowifi.com/article/C2000说明书.html