### PR TITLE
ath79: add support for COMFAST CF-E356A

### DIFF
--- a/target/linux/ath79/dts/ar9344_comfast_cf-e356a.dts
+++ b/target/linux/ath79/dts/ar9344_comfast_cf-e356a.dts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "comfast,cf-e356a", "qca,ar9344";
+	model = "COMFAST CF-E356A";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+		label-mac-device = &eth0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: status-red {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: status-green {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		lan {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x010000>;
+				read-only;
+			};
+
+			partition@10000 {
+				label = "art";
+				reg = <0x010000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						compatible = "mac-base";
+						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+
+					cal_art_5000: calibration@5000 {
+						reg = <0x5000 0x440>;
+					};
+				};
+			};
+
+			partition@20000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x020000 0xfc0000>;
+			};
+
+			partition@fe0000 {
+				label = "configs";
+				reg = <0xfe0000 0x010000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "nvram";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x06000000 0x00000101 0x00001313>;
+
+	nvmem-cells = <&macaddr_art_0 0>;
+	nvmem-cell-names = "mac-address";
+
+	phy-mode = "rgmii-rxid";
+	phy-handle = <&phy4>;
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-gmac0 = <1>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0 2>, <&cal_art_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,0030";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&macaddr_art_0 10>, <&cal_art_5000>;
+		nvmem-cell-names = "mac-address", "calibration";
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -183,6 +183,9 @@ comfast,cf-e314n-v2)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "green:rssimediumhigh" "wlan0" "51" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:rssihigh" "wlan0" "76" "100"
 	;;
+comfast,cf-e356a)
+	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
+	;;
 comfast,cf-e375ac)
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x04"
 	ucidef_set_led_switch "wan" "WAN" "red:wan" "switch0" "0x02"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -28,6 +28,7 @@ ath79_setup_interfaces()
 	avm,fritzdvbc|\
 	comfast,cf-wr752ac-v1|\
 	comfast,cf-e130n-v2|\
+	comfast,cf-e356a|\
 	comfast,cf-e380ac-v2|\
 	devolo,dvl1200i|\
 	devolo,dvl1750c|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -804,6 +804,15 @@ define Device/comfast_cf-e355ac-v2
 endef
 TARGET_DEVICES += comfast_cf-e355ac-v2
 
+define Device/comfast_cf-e356a
+  SOC := ar9344
+  DEVICE_VENDOR := COMFAST
+  DEVICE_MODEL := CF-E356A
+  DEVICE_PACKAGES := -uboot-envtools
+  IMAGE_SIZE := 16128k
+endef
+TARGET_DEVICES += comfast_cf-e356a
+
 define Device/comfast_cf-e375ac
   SOC := qca9563
   DEVICE_VENDOR := COMFAST


### PR DESCRIPTION
Adds support for the COMFAST CF-E356A, an Atheros AR9344 dual-band
ceiling-mount access point (48 V passive PoE). Full specs are in the commit
message.

Tested on the physical device:
- Gigabit Ethernet via AR8035 PHY, bidirectional — requires `phy-mode = "rgmii-rxid"`
  (the usual `rgmii-id` mis-clocks TX and the switch drops all frames).
- Both radios up as APs: 2.4 GHz (AR9300 / PCIe) and 5 GHz (AR9340 / SoC WMAC).
- Calibration data + MACs read from the ART partition via nvmem
  (eth0/label = base, WMAC = base+2, PCIe = base+10).
- LEDs (status red/green, LAN, WLAN) and reset button incl. failsafe.
- U-Boot TFTP recovery + initramfs → sysupgrade to squashfs; running from
  squashfs + JFFS2 overlay. Boots to 192.168.1.1.

Developed with assistance from an AI coding assistant; all changes were
reviewed and tested on real hardware by the submitter.
