### PR TITLE
nftables: add patch for non bash shell

### DIFF
--- a/package/network/utils/nftables/patches/0001-build-fix-.-configure-with-non-bash-shell.patch
+++ b/package/network/utils/nftables/patches/0001-build-fix-.-configure-with-non-bash-shell.patch
@@ -1,0 +1,34 @@
+From 2e3c68f26d5bd60c8ea7467fa9018c282a7d8c47 Mon Sep 17 00:00:00 2001
+From: Jan Palus <jpalus@fastmail.com>
+Date: Sat, 6 Dec 2025 00:43:58 +0100
+Subject: [PATCH] build: fix ./configure with non-bash shell
+
+ CONFIG_SHELL=/bin/dash ./configure
+
+breaks with:
+
+ ./config.status: 2044: Syntax error: Bad for loop variable
+
+Fixes: 64c07e38f049 ("table: Embed creating nft version into userdata")
+Signed-off-by: Jan Palus <jpalus@fastmail.com>
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 6825474b..dd172e88 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -157,7 +157,7 @@ AC_CONFIG_COMMANDS([nftversion.h], [
+ 	echo "	${STABLE_RELEASE}"
+ 	echo "};"
+ 	echo "static char nftbuildstamp[[]] = {"
+-	for ((i = 56; i >= 0; i-= 8)); do
++	for i in `seq 56 -8 0`; do
+ 		echo "	((uint64_t)MAKE_STAMP >> $i) & 0xff,"
+ 	done
+ 	echo "};"
+-- 
+2.54.0
+


### PR DESCRIPTION
Backport for 'syntax error: bad for loop variable' error from nftables. Will be fixed after nftables 1.1.6.

The applied patch contains the fix from https://git.netfilter.org/nftables/commit/?id=2e3c68f26d5bd60c8ea7467fa9018c282a7d8c47. Fixed right after the nftables 1.1.6 release.

Steps to reproduce: Compile OpenWrt under Alpine Linux,

I repdouced the error with  [docker-openwrt-build-env](https://github.com/mwarning/docker-openwrt-build-env):

```
git clone https://github.com/mwarning/docker-openwrt-builder.git
cd docker-openwrt-builder
docker build -t openwrt_builder_alpine .

mkdir ~/mybuild
docker run -v ~/mybuild:/home/user -it openwrt_builder /bin/bash

git clone https://git.openwrt.org/openwrt/openwrt.git
cd openwrt
./scripts/feeds update -a
./scripts/feeds install -a
make menuconfig
# selector zerotier package (probably not needed)
make
```

!! Important: This MR does not fix the problem yet. The patch does not seem to get applied correctly. I need some help here. !!
