### PR TITLE
wifi-scripts: mac80211 prints errors on wifi reconf

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
@@ -250,7 +250,7 @@ function setup() {
 				break;
 			// fallthrough
 		case 'mesh':
-			supplicant_mesh ??= !system("wpa_supplicant -vmesh");
+			supplicant_mesh ??= (fs.access('/usr/sbin/wpa_supplicant', 'x') && !system("/usr/sbin/wpa_supplicant -vmesh"));
 			if (mode == "mesh" && !supplicant_mesh)
 				break;
 			// fallthrough

--- a/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
@@ -217,7 +217,7 @@ function setup() {
 		idx[mode] ??= 0;
 		let mode_idx = idx[mode]++;
 
-		if (!v.config.ifname) 
+		if (!v.config.ifname)
 			v.config.ifname = data.ifname_prefix + mode + mode_idx;
 		push(active_ifnames, v.config.ifname);
 

--- a/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
@@ -83,7 +83,9 @@ function setup_phy(phy, config, data) {
 	if (config.rxantenna == 'all')
 		config.rxantenna = 0xffffffff;
 
-	if (config.txantenna != data?.txantenna || config.rxantenna != data?.rxantenna)
+	let antenna_changed = (config.txantenna != data?.txantenna || config.rxantenna != data?.rxantenna);
+
+	if (antenna_changed)
 		reset_config(phy, config.radio);
 
 	netifd.set_data({
@@ -98,8 +100,11 @@ function setup_phy(phy, config, data) {
 	else
 		config.txpower = 'auto';
 
-	log(`Configuring '${phy}' txantenna: ${config.txantenna}, rxantenna: ${config.rxantenna} distance: ${config.distance}`);
-	system(`iw phy ${phy} set antenna ${config.txantenna} ${config.rxantenna}`);
+	log(`Configuring '${phy}' distance: ${config.distance}`);
+	if (antenna_changed) {
+		log(`Setting antenna for '${phy}' txantenna: ${config.txantenna}, rxantenna: ${config.rxantenna}`);
+		system(`iw phy ${phy} set antenna ${config.txantenna} ${config.rxantenna}`);
+	}
 	system(`iw phy ${phy} set distance ${config.distance}`);
 	system(`iw phy ${phy} set txpower ${config.txpower}`);
 


### PR DESCRIPTION
When running `wifi reconf` on a router with openwrt-25.12 firmware, some messages are printed to the log:

```
Mon May 25 20:23:00 2026 daemon.notice hostapd: Reload all interfaces
Mon May 25 20:23:00 2026 daemon.notice hostapd: Reloaded settings for phy phy0
Mon May 25 20:23:00 2026 daemon.notice hostapd: Reloaded settings for phy phy1
Mon May 25 20:23:00 2026 daemon.notice netifd: radio0 (7822): wifi-scripts: Starting
Mon May 25 20:23:00 2026 daemon.notice netifd: radio0 (7822): command failed: Not supported (-122)
Mon May 25 20:23:00 2026 daemon.notice netifd: radio0 (7822): /bin/sh: wpa_supplicant: not found
Mon May 25 20:23:01 2026 daemon.notice hostapd: Set new config for phy phy0: /var/run/hostapd-phy0.conf
Mon May 25 20:23:01 2026 daemon.notice hostapd: Reloaded settings for phy phy0
```

This has been noticed in: https://github.com/freifunk-gluon/gluon/pull/3757#issuecomment-4536664527

Both come from the ucode `mac80211.sh` netifd handler. Neither indicates an actual failure - the radio reconfigures correctly.

This PR fixes both:

  - `wifi-scripts: mac80211: only set antenna when config changes` - `iw phy ... set antenna` was called unconditionally on every reconf.
    `mac80211`'s `ieee80211_set_antenna()` rejects this with `-EOPNOTSUPP` once the radio is started, producing the `command failed: Not supported (-122)` message. The fix skips the call unless the antenna config has actually changed (`reset_config()` tears down interfaces in the same branch, so `local->started` is false exactly when we do need it). This mirrors mainline OpenWrt's bash `mac80211.sh` behaviour. Also splits the `Configuring '${phy}'...` log line so antenna details aren't claimed when the call was skipped.
  - `wifi-scripts: mac80211: check wpa_supplicant exists before mesh probe` - mesh-capability detection ran `wpa_supplicant -vmesh` unconditionally to probe driver support.
    On builds without wpa_supplicant installed (like gluon deployments), this produces the `/bin/sh: wpa_supplicant: not found` line, even when no mesh interface is configured. Guarded behind `fs.access('/usr/sbin/wpa_supplicant', 'x')`, using the absolute path (matches existing pattern elsewhere in the file).

Validated with Aruba AP-325 and Genexis EX400