### PR TITLE
omnia-mcutool: Bump version to 0.3-rc4

### DIFF
--- a/package/utils/omnia-mcutool/Makefile
+++ b/package/utils/omnia-mcutool/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=omnia-mcutool
-PKG_VERSION_REAL:=0.3-rc3
+PKG_VERSION_REAL:=0.3-rc4
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=https://gitlab.nic.cz/turris/$(PKG_NAME)
-PKG_SOURCE_DATE:=2024-08-05
-PKG_SOURCE_VERSION:=3833ade1377076a5c8e394d7afe7679716af0107
-PKG_MIRROR_HASH:=63cfaa388cffc8a5a7d08c14d6428d1bb33ae7aebf62a1764fd57f8bc94f9144
+PKG_SOURCE_DATE:=2026-06-01
+PKG_SOURCE_VERSION:=195391be28d243e047ac0b1464c79c8cf0ee3125
+PKG_MIRROR_HASH:=488aacca75f0a9bc0020098f13579bcf55179e91f6a199836c079152e133678a
 
 PKG_MAINTAINER:=Marek Mojik <marek.mojik@nic.cz>
 PKG_LICENSE:=GPL-2.0-or-later
@@ -36,7 +36,6 @@ microcontroller on the Turris Omnia router. It can also show state of MCU
 settings and configure MCU options (GPIOs, LEDs, power).
 endef
 
-TARGET_CFLAGS += -std=gnu99
 TARGET_LDFLAGS += -lcrypto
 
 define Build/Compile


### PR DESCRIPTION
Bump version to 0.3-rc4, which fixes building with C23.

@neheb @robimarko 