### PR TITLE
ath11k-firmware: move Download eval to top level

### DIFF
--- a/package/firmware/ath11k-firmware/Makefile
+++ b/package/firmware/ath11k-firmware/Makefile
@@ -39,6 +39,7 @@ define Download/$(ATH11K_LEGACY_FW_NAME)
 	MIRROR_HASH:=b55bf7204543c7ba87876e84788239b0e47ad62434c5b0d1169526cde36a9daa
 	SUBDIR:=$(ATH11K_LEGACY_FW_SUBDIR)
 endef
+$(eval $(call Download,$(ATH11K_LEGACY_FW_NAME)))
 
 define Package/ath11k-firmware-default
   SECTION:=firmware
@@ -65,8 +66,6 @@ define Build/Clean
 endef
 
 define Build/Prepare
-	$(eval $(call Download,ath11k-legacy-firmware))
-	
 	$(call Build/Prepare/Default,)
 
 	$(TAR) -C $(BUILD_DIR) -xf $(DL_DIR)/$(ATH11K_LEGACY_FW_SOURCE)


### PR DESCRIPTION
Move the $(eval $(call Download,ath11k-legacy-firmware)) from inside
Build/Prepare to the top level, right after the Download definition.

When the eval is inside Build/Prepare, it only runs at recipe execution
time (during compilation). This makes the legacy firmware source
invisible to `make download`, which only evaluates Download definitions
at Makefile parse time. As a result, offline builds fail because the
source was never fetched during the download phase.

This is consistent with how ath10k-ct-firmware handles multiple
Download definitions (all at top level).