### PR TITLE
ramips: fix Phicomm K2G WAN by enabling rgmii1

### DIFF
--- a/target/linux/ramips/dts/mt7620a_phicomm_k2g.dts
+++ b/target/linux/ramips/dts/mt7620a_phicomm_k2g.dts
@@ -21,7 +21,7 @@
 
 &ethernet {
 	pinctrl-names = "default";
-	pinctrl-0 = <&rgmii2_pins &mdio_pins>;
+	pinctrl-0 = <&rgmii1_pins &mdio_pins>;
 
 	mediatek,portmap = "llllw";
 


### PR DESCRIPTION
The K2G's WAN port is an external RTL8211F gigabit PHY on switch port 5, reached over the SoC's rgmii1 pins. The device tree only requests rgmii2_pins, so nothing ever claims rgmii1 and the pins keep whatever the bootloader left them as.

When rgmii1 is muxed to GPIO the WAN port comes up but receives nothing: port 5 RxGPC stays at 0 and wan never gets a DHCP lease. rgmii1 vs GPIO is GPIOMODE (SYSC + 0x60) bit 9; requesting rgmii1_pins makes the pinmux driver clear it and the WAN RX path works again. The rgmii1 pads (GPIO 24-35) aren't used for anything else on this board.

This mostly bites people who flashed the K2's bootloader onto a K2G (the K2G has no Breed of its own), which leaves the gigabit port dead. The usual workaround is reflashing the stock U-Boot, which is easy to brick; fixing it in the device tree avoids that. Background: https://www.right.com.cn/forum/thread-333376-1-1.html

Tested on a K2G: WAN gets a DHCP lease and passes traffic.