### PR TITLE
netfilter: fix file clash during install of kmod-iptables

### DIFF
--- a/package/kernel/linux/modules/netfilter.mk
+++ b/package/kernel/linux/modules/netfilter.mk
@@ -57,6 +57,7 @@ define KernelPackage/nf-ipt
   TITLE:=Iptables core
   KCONFIG:= \
 	$(KCONFIG_NF_IPT) \
+	CONFIG_IP_NF_FILTER@lt6.18 \
 	CONFIG_IP_NF_IPTABLES_LEGACY@ge6.18 \
 	CONFIG_NETFILTER_XTABLES_LEGACY@ge6.18=y
   FILES:=$(foreach mod,$(NF_IPT-m),$(LINUX_DIR)/net/$(mod).ko)

--- a/package/kernel/linux/modules/netfilter.mk
+++ b/package/kernel/linux/modules/netfilter.mk
@@ -52,31 +52,13 @@ endef
 $(eval $(call KernelPackage,nf-conncount))
 
 
-define KernelPackage/iptables
-  SUBMENU:=$(NF_MENU)
-  TITLE:=Iptables legacy
-  KCONFIG:= \
-	CONFIG_IP_NF_IPTABLES_LEGACY \
-	CONFIG_NETFILTER_XTABLES \
-	CONFIG_NETFILTER_XTABLES_LEGACY=y \
-	CONFIG_IP6_NF_IPTABLES_LEGACY \
-	CONFIG_BRIDGE_NF_EBTABLES_LEGACY
-  HIDDEN:=1
-  DEPENDS:=@!LINUX_6_12
-  FILES:= \
-	$(LINUX_DIR)/net/ipv4/netfilter/ip_tables.ko \
-	$(LINUX_DIR)/net/netfilter/x_tables.ko
-  AUTOLOAD:=$(call AutoProbe,$(notdir ip_tables x_tables))
-endef
-
-$(eval $(call KernelPackage,iptables))
-
-
 define KernelPackage/nf-ipt
   SUBMENU:=$(NF_MENU)
   TITLE:=Iptables core
-  KCONFIG:=$(KCONFIG_NF_IPT)
-  DEPENDS:=+!LINUX_6_12:kmod-iptables
+  KCONFIG:= \
+	$(KCONFIG_NF_IPT) \
+	CONFIG_IP_NF_IPTABLES_LEGACY@ge6.18 \
+	CONFIG_NETFILTER_XTABLES_LEGACY@ge6.18=y
   FILES:=$(foreach mod,$(NF_IPT-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoProbe,$(notdir $(NF_IPT-m)))
 endef
@@ -87,7 +69,9 @@ $(eval $(call KernelPackage,nf-ipt))
 define KernelPackage/nf-ipt6
   SUBMENU:=$(NF_MENU)
   TITLE:=Ip6tables core
-  KCONFIG:=$(KCONFIG_NF_IPT6)
+  KCONFIG:= \
+	$(KCONFIG_NF_IPT6) \
+	CONFIG_IP6_NF_IPTABLES_LEGACY@ge6.18
   FILES:=$(foreach mod,$(NF_IPT6-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoProbe,$(notdir $(NF_IPT6-m)))
   DEPENDS:=+kmod-nf-ipt +kmod-nf-log6
@@ -1099,7 +1083,9 @@ define KernelPackage/ebtables
   TITLE:=Bridge firewalling modules
   DEPENDS:=+kmod-ipt-core
   FILES:=$(foreach mod,$(EBTABLES-m),$(LINUX_DIR)/net/$(mod).ko)
-  KCONFIG:=$(KCONFIG_EBTABLES)
+  KCONFIG:= \
+	$(KCONFIG_EBTABLES) \
+	CONFIG_BRIDGE_NF_EBTABLES_LEGACY@ge6.18
   AUTOLOAD:=$(call AutoProbe,$(notdir $(EBTABLES-m)))
 endef
 


### PR DESCRIPTION
A regression in #21078 caused `ip_tables.ko` and `x_tables.ko` to be installed by both `kmod-nf-ipt` and `kmod-iptables`:

``` bash
Collected errors:
 * check_data_file_clashes: Package kmod-nf-ipt wants to install file /Volumes/x64/openwrt/build_dir/target-x86_64_musl/root-x86/lib/modules/6.18.33/ip_tables.ko
	But that file is already provided by package  * kmod-iptables
 * check_data_file_clashes: Package kmod-nf-ipt wants to install file /Volumes/x64/openwrt/build_dir/target-x86_64_musl/root-x86/lib/modules/6.18.33/x_tables.ko
	But that file is already provided by package  * kmod-iptables
 * opkg_install_cmd: Cannot install package kmod-ipt-chaos.
 * check_data_file_clashes: Package kmod-nf-ipt wants to install file /Volumes/x64/openwrt/build_dir/target-x86_64_musl/root-x86/lib/modules/6.18.33/ip_tables.ko
	But that file is already provided by package  * kmod-iptables
 * check_data_file_clashes: Package kmod-nf-ipt wants to install file /Volumes/x64/openwrt/build_dir/target-x86_64_musl/root-x86/lib/modules/6.18.33/x_tables.ko
	But that file is already provided by package  * kmod-iptables
 * opkg_install_cmd: Cannot install package kmod-nf-ipt.
 * check_data_file_clashes: Package kmod-nf-ipt wants to install file /Volumes/x64/openwrt/build_dir/target-x86_64_musl/root-x86/lib/modules/6.18.33/ip_tables.ko
	But that file is already provided by package  * kmod-iptables
 * check_data_file_clashes: Package kmod-nf-ipt wants to install file /Volumes/x64/openwrt/build_dir/target-x86_64_musl/root-x86/lib/modules/6.18.33/x_tables.ko
	But that file is already provided by package  * kmod-iptables
 * opkg_install_cmd: Cannot install package kmod-nf-ipt6.
 * check_data_file_clashes: Package kmod-nf-ipt wants to install file /Volumes/x64/openwrt/build_dir/target-x86_64_musl/root-x86/lib/modules/6.18.33/ip_tables.ko
	But that file is already provided by package  * kmod-iptables
 * check_data_file_clashes: Package kmod-nf-ipt wants to install file /Volumes/x64/openwrt/build_dir/target-x86_64_musl/root-x86/lib/modules/6.18.33/x_tables.ko
	But that file is already provided by package  * kmod-iptables
 * opkg_install_cmd: Cannot install package kmod-nft-compat.
```

1. Fix: drop `kmod-iptables` and move its flags:
``` Makefile
- CONFIG_IP_NF_IPTABLES_LEGACY     -> kmod-nf-ipt
- CONFIG_NETFILTER_XTABLES_LEGACY  -> kmod-nf-ipt
- CONFIG_IP6_NF_IPTABLES_LEGACY    -> kmod-nf-ipt6
- CONFIG_BRIDGE_NF_EBTABLES_LEGACY -> kmod-ebtables
```

Also drop `CONFIG_NETFILTER_XTABLES`, because it is already present in `KCONFIG_NF_IPT`. Apply the `@ge6.18` filter so that the flags are enabled on `linux-6.18` and later and disabled on `linux-6.12`, even though they do not seem to have any negative impact on `linux-6.12`.

2. Add a flag `CONFIG_IP_NF_FILTER` to `kmod-nf-ipt`, to fix an edge case where it is selected, but `kmod-ipt-core` is not. The `@lt6.18` filter selects `linux` < `6.18`, currently only `linux-6.12`.

``` bash
make package/kernel/linux/compile -j 1 V=s
net/ipv4/netfilter/ip_tables.ko is missing
```

Build and run tested: target `x64` `linux-6.18`, host macOS 15.7.7 x64.
Build and run tested: target `mvebu/cortexa9/WRT3200ACM` `linux-6.12`, host macOS 15.7.7 x64.

Internal state of make variables: https://github.com/openwrt/openwrt/pull/23631#issuecomment-4975139557
Fixes: #23630

@namiltd @robimarko @hauke @Ansuel 