### PR TITLE
uboot-imx: do not build efimkcapsule tool

### DIFF
--- a/package/boot/uboot-imx/Makefile
+++ b/package/boot/uboot-imx/Makefile
@@ -59,6 +59,9 @@ define U-Boot/wandboard
   BUILD_DEVICES:=wandboard_dual
 endef
 
+UBOOT_CUSTOMIZE_CONFIG := \
+	--disable TOOLS_MKEFICAPSULE
+
 UBOOT_TARGETS := \
 	apalis_imx6 \
 	kontron-osm-s-mx8mp \


### PR DESCRIPTION
This tool requires gnutls. In fact, we do not have to build it. Fix build error:

tools/mkeficapsule.c:20:10: fatal error: gnutls/gnutls.h: No such file or directory
   20 | #include <gnutls/gnutls.h>
      |          ^~~~~~~~~~~~~~~~~

Fixes: 158651a6d742 ("uboot-imx: bump to 2026.04 release")

I noticed `imx` target failed to build on the buildbot. I didn't build test this fix at all. Please check it. @sch-m