### PR TITLE
wifi-scripts: supplicant: generate eap and phase2 for EAP stations

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
@@ -156,16 +156,33 @@ function setup_sta(data, config) {
 			config.ca_cert = '/etc/ssl/certs/ca-certificates.crt';
 
 		switch(config.eap_type) {
+		case 'tls':
+			config.eap = 'TLS';
+			break;
 		case 'fast':
 		case 'peap':
 		case 'ttls':
 			set_default(config, 'auth', 'MSCHAPV2');
+			config.eap = uc(config.eap_type);
+
 			if (config.auth == 'EAP-TLS') {
 				if (config.ca_cert2_usesystem && fs.stat('/etc/ssl/certs/ca-certificates.crt'))
 					config.ca_cert2 = '/etc/ssl/certs/ca-certificates.crt';
 			}
+
+			let phase2proto = 'auth=';
+			let phase2auth = config.auth;
+			if (match(config.auth, /^auth/))
+				phase2proto = '';
+			else if (match(config.auth, /^EAP-/)) {
+				phase2auth = substr(config.auth, 4);
+				if (config.eap_type == 'ttls')
+					phase2proto = 'autheap=';
+			}
+			config.phase2 = phase2proto + phase2auth;
 			break;
 		}
+		config.auth = null;
 
 	}
 
@@ -194,7 +211,7 @@ function setup_sta(data, config) {
 	config.mcast_rate = ratestr(config.mcast_rate);
 
 	network_append_string_vars(config, [ 'ssid',
-		'identity', 'anonymous_identity', 'password',
+		'identity', 'anonymous_identity', 'password', 'phase2',
 		'ca_cert', 'ca_cert2', 'client_cert', 'client_cert2', 'subject_match',
 		'private_key', 'private_key_passwd', 'private_key2', 'private_key2_passwd',
 		 ]);
@@ -205,7 +222,7 @@ function setup_sta(data, config) {
 		'disable_ht', 'disable_ht40', 'disable_vht', 'vht', 'max_oper_chwidth',
 		'ht40', 'beacon_int', 'ieee80211w', 'rates', 'mesh_basic_rates', 'mcast_rate',
 		'altsubject_match', 'domain_match', 'domain_suffix_match',
-		'bssid_blacklist', 'bssid_whitelist', 'erp',
+		'bssid_blacklist', 'bssid_whitelist', 'erp', 'eap',
 		'dpp_connector', 'dpp_csign', 'dpp_netaccesskey',
 	]);
 }


### PR DESCRIPTION
The ucode rewrite of the wifi scripts omitted generation of the `eap=`
and `phase2=` directives in the wpa_supplicant network block for
WPA-Enterprise stations. While the UCI options `eap_type` and `auth` were
read and defaults applied, they were never translated into actual
wpa_supplicant config output.

This caused WPA2/WPA3-Enterprise (EAP-PEAP/TTLS/FAST/TLS) station
connections to fail — wpa_supplicant had `key_mgmt=WPA-EAP` but no EAP
method or inner authentication configured.

**Fix:**
- Generate `eap=<TYPE>` (uppercased `eap_type`)
- Generate `phase2="auth=<METHOD>"` for peap/ttls/fast (with `autheap=` prefix for TTLS with EAP-* inner method)
- Handle the `tls` case

The phase2 construction mirrors the logic from the old shell-based `hostapd.sh` supplicant setup.

**Tested** with EAP-PEAP/MSCHAPV2 against FreeRADIUS on ath11k (QCN9074) hardware.