### PR TITLE
wifi-scripts: ap: abort BSS setup on invalid WPA PSK

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -8,6 +8,13 @@ import { append, append_raw, append_value, append_vars, append_list, append_stri
 import * as netifd from 'wifi.netifd';
 import * as iface from 'wifi.iface';
 
+function valid_wpa_psk(key) {
+	if (!key)
+		return true;
+	let len = length(key);
+	return len >= 8 && len <= 64;
+}
+
 function iface_setup(config, phy, num_global_macaddr, macaddr_base) {
 	switch(config.fixup) {
 	case 'owe':
@@ -166,6 +173,7 @@ function iface_auth_type(config, band) {
 			config.wpa_passphrase = config.key;
 		} else if (config.key) {
 			 netifd.setup_failed('INVALID_WPA_PSK');
+			 return false;
 		}
 
 		if (config.auth_type in [ 'psk', 'psk-sae', 'psk-sae-compat' ] && band != '6g') {
@@ -226,6 +234,8 @@ function iface_auth_type(config, band) {
 		append_vars(config, [
 			'dpp_connector', 'dpp_csign', 'dpp_netaccesskey',
 		]);
+
+	return true;
 }
 
 function iface_ppsk(config) {
@@ -254,10 +264,12 @@ function iface_wps(config) {
 			append_string_vars(config, [ 'multi_ap_backhaul_ssid' ]);
 			if (length(config.multi_ap_backhaul_key) == 64)
 				append('multi_ap_backhaul_wpa_psk', config.multi_ap_backhaul_key);
-			else if (length(config.multi_ap_backhaul_key) > 8)
+			else if (length(config.multi_ap_backhaul_key) >= 8)
 				append('multi_ap_backhaul_wpa_passphrase', config.multi_ap_backhaul_key);
-			else
+			else {
 				netifd.setup_failed('INVALID_WPA_PSK');
+				return false;
+			}
 		}
 
 		append_vars(config, [
@@ -265,6 +277,8 @@ function iface_wps(config) {
 			'ap_pin', 'ap_setup_locked', 'upnp_iface', 'uuid'
 		]);
 	}
+
+	return true;
 }
 
 function iface_rrm(config) {
@@ -559,7 +573,6 @@ export function generate(interface, data, config, vlans, stas, phy_features) {
 	config.ctrl_interface = '/var/run/hostapd';
 
 	config.start_disabled = data.ap_start_disabled;
-	iface_setup(config, data.phy + data.phy_suffix, data.config.num_global_macaddr, data.config.macaddr_base);
 
 	iface.parse_encryption(config, data.config, phy_features);
 	if (data.config.band == '6g') {
@@ -569,18 +582,36 @@ export function generate(interface, data, config, vlans, stas, phy_features) {
 			config.auth_type = 'eap2';
 	}
 
+	if (config.auth_type in [ 'psk', 'psk2', 'sae', 'psk-sae', 'psk-sae-compat' ] &&
+	    !config.ppsk && !valid_wpa_psk(config.key)) {
+		netifd.setup_failed('INVALID_WPA_PSK');
+		return false;
+	}
+
+	if (config.multi_ap && config.multi_ap != 1 &&
+	    config.multi_ap_backhaul_ssid &&
+	    (config.wps_pushbutton || config.wps_label) &&
+	    !valid_wpa_psk(config.multi_ap_backhaul_key)) {
+		netifd.setup_failed('INVALID_WPA_PSK');
+		return false;
+	}
+
+	iface_setup(config, data.phy + data.phy_suffix, data.config.num_global_macaddr, data.config.macaddr_base);
+
 	if (config.auth_type in [ 'psk', 'psk-sae', 'psk-sae-compat' ] && data.config.band != '6g')
 		iface_wpa_stations(config, stas);
 	if (config.auth_type in [ 'sae', 'psk-sae', 'psk-sae-compat' ])
 		iface_sae_stations(config, stas);
 
-	iface_auth_type(config, data.config.band);
+	if (!iface_auth_type(config, data.config.band))
+		return false;
 
 	iface_accounting_server(config);
 
 	iface_ppsk(config);
 
-	iface_wps(config);
+	if (!iface_wps(config))
+		return false;
 
 	iface_rrm(config);
 
@@ -643,4 +674,6 @@ export function generate(interface, data, config, vlans, stas, phy_features) {
 		append_raw('#default_macaddr');
 	else if (config.random_macaddr)
 		append_raw('#random_macaddr');
+
+	return true;
 };

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -570,7 +570,7 @@ function setup_interface(interface, data, config, vlans, stas, phy_features, fix
 	config = { ...config, fixup };
 
 	config.idx = iface_idx++;
-	ap.generate(interface, data, config, vlans, stas, phy_features);
+	return ap.generate(interface, data, config, vlans, stas, phy_features);
 }
 
 export function setup(data) {
@@ -604,10 +604,10 @@ export function setup(data) {
 
 		let owe = interface.config.encryption == 'owe' && interface.config.owe_transition;
 
-		setup_interface(k, data, interface.config, interface.vlans, interface.stas, phy_features, owe ? 'owe' : null );
+		if (setup_interface(k, data, interface.config, interface.vlans, interface.stas, phy_features, owe ? 'owe' : null ))
+			has_ap = true;
 		if (owe)
 			setup_interface(k, data, interface.config, interface.vlans, interface.stas, phy_features, 'owe-transition');
-		has_ap = true;
 	}
 
 	let config = dump_config(file_name);


### PR DESCRIPTION
When `setup_failed('INVALID_WPA_PSK')` is called due to an invalid passphrase
length, execution continues and the BSS remains running with the previous
(valid) configuration. This silently ignores the bad config change — the user
gets no indication that their new settings were rejected, and hostapd keeps
serving clients with the old key.

The old shell-based scripts called `wireless_setup_vif_failed` followed by
`return 1`, which aborted the VIF setup entirely, causing hostapd to tear
down the BSS.

**Fix:**
- Validate PSK length before `iface_setup()` writes the BSS header, so no
  partial config is emitted on failure
- Have `iface_auth_type()` return `false` on validation failure and `true`
  on success
- Propagate the return value through `ap.generate()` and `setup_interface()`
  so `hostapd.uc` only marks `has_ap` when a BSS was successfully configured

With this fix, an invalid key causes the BSS to not be included in the
hostapd config file, so hostapd tears it down — matching the old shell-script
behavior.

**Tested** with intentionally short WPA passphrase (7 chars) on ath11k hardware.
Verified BSS is torn down on bad key and recovers correctly when a valid key
is set.