### PR TITLE
libmd: update to 1.2.0

### DIFF
--- a/package/libs/libmd/Makefile
+++ b/package/libs/libmd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmd
-PKG_VERSION:=1.1.0
+PKG_VERSION:=1.2.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://archive.hadrons.org/software/libmd/
-PKG_HASH:=1bd6aa42275313af3141c7cf2e5b964e8b1fd488025caf2f971f43b00776b332
+PKG_HASH:=ac15ffb8430502fbaccdec66c5a82ee0eab0b0f36220df56710feadfeb13d0a0
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
this brings sha3 and black support into it.

```
90c4f43 Release libmd 1.2.0
fc4f75a build: Set TAR_OPTIONS to avoid leaking maintainer information on dist
36d829e build: Request tar-ustar format for distribution
c1b3bff Remove spurious blank lines at the beginning of functions
0ae00e2 Fix and hook SHA3 and SHAKE support
2c0d2f0 Add internal endian conversion functions support
3bb8921 Add internal explicit_bzero() support
4442c4b Add SHA3 and SHAKE support
7b740a6 doc: Move derived code attribution to a Comment field
bb5a08e doc: Remove redundant «Copyright ©» prefix from Copyright field in COPYING
9b03479 build: Add Maintainer and License fields to the .pc file
8fffa5f doc: Remove «All rights reserved» from COPYING
d5b8e85 build: Rename LIBMD_ABI to SOVERSION
ea62163 build: Add a coverage regex to the CI job
7e32142 man: Sync SHA2 changes from OpenBSD
488d585 build: Add a new vpath-tests CI test
b49ee25 build: Refactor autogen call into before_script
137dd4e build: Fix out-of-tree build
```

Signed-off-by: Seo Suchan <tjtncks@gmail.com>

not sure openwrt image actually uses it though