### PR TITLE
generic: net: phy: realtek: add rtl8261ce support

### DIFF
--- a/target/linux/generic/hack-6.18/744-net-phy-realtek-speedup-rtl8261x-fw-load.patch
+++ b/target/linux/generic/hack-6.18/744-net-phy-realtek-speedup-rtl8261x-fw-load.patch
@@ -1,0 +1,43 @@
+From: Kenneth Kasilag <kenneth@kasilag.me>
+Subject: generic: net: phy: realtek: speedup rtl8261x fw load
+
+The RTL8261x firmware patch engine applies every OP_WRITE entry with
+phy_modify_mmd(), which reads the register before writing it to preserve
+the bits outside the [msb:lsb] field. The patch data is almost entirely
+full-register (15:0) writes, for which the readback is masked away and
+serves no purpose.
+
+Use the plain phy_write_mmd() for a full-width field and keep
+phy_modify_mmd() only for the few partial-field entries. This roughly
+halves the number of MDIO transactions during the firmware download.
+
+On a native MDIO bus the readback is cheap, but when the PHY is
+reached over a slow transport such as an I2C-to-MDIO (rollball) bridge
+it can take a very long time.
+
+Signed-off-by: Kenneth Kasilag <kenneth@kasilag.me>
+---
+
+--- a/drivers/net/phy/realtek/realtek_main.c
++++ b/drivers/net/phy/realtek/realtek_main.c
+@@ -511,8 +511,18 @@ static int rtl8261x_fw_execute_entry(str
+ 
+ 	switch (entry->type) {
+ 	case OP_WRITE:
+-		ret = phy_modify_mmd(phydev, dev, addr,
+-				     GENMASK(msb, lsb), (value << lsb) & GENMASK(msb, lsb));
++		/* The firmware patch data is almost entirely full-register
++		 * writes. Issue those as a plain write: the read/modify of
++		 * phy_modify_mmd() would only be masked away, and skipping the
++		 * readback roughly halves the MDIO traffic, which dominates the
++		 * download time over a slow transport such as an I2C-to-MDIO
++		 * (rollball) bridge.
++		 */
++		if (msb == 15 && lsb == 0)
++			ret = phy_write_mmd(phydev, dev, addr, value);
++		else
++			ret = phy_modify_mmd(phydev, dev, addr, GENMASK(msb, lsb),
++					     (value << lsb) & GENMASK(msb, lsb));
+ 		if (ret) {
+ 			phydev_err(phydev, "WRITE failed: dev=%d addr=0x%04x\n", dev, addr);
+ 			return ret;

--- a/target/linux/generic/hack-6.18/745-net-phy-realtek-add-support-for-rtl8261d-ce-cg.patch
+++ b/target/linux/generic/hack-6.18/745-net-phy-realtek-add-support-for-rtl8261d-ce-cg.patch
@@ -1,0 +1,500 @@
+From: Kenneth Kasilag <kenneth@kasilag.me>
+Subject: generic: net: phy: realtek: add rtl8261(d-cg/ce) support
+
+Extend the RTL8261C-CG support to the other members of the same PHY
+family:
+
+RTL8261D-CG shares the C45 PHY ID 0x001cc898 and the firmware with
+RTL8261C-CG; vendor drivers handle both with a single driver entry and
+do not tell the two apart. Accept sub PHY IDs other than 0x00 instead
+of failing the probe, so the D variant (and future siblings) bind to
+the same driver entry and firmware.
+
+RTL8261CE is the same silicon family with the revision nibble of the
+PHY ID encoding rev A (0x001cc890) and rev C (0x001cc899); rev B is
+identical to the RTL8261C_CG ID and is already handled.
+
+On testing, all three chips accept similar patch tables, so entries
+reuse the RTL8261C-CG entry from upstream.
+
+In addition, based on a dump of the vendor driver from a Lumen W1700K2,
+the RTL8261CE init flow:
+1) waits for the internal loader
+2) triggers execution of a freshly downloaded patch
+3) programs the SerDes option slots in VEND1, the SerDes lane polarity
+settings, EEE defaults and the over-temperature downspeed bit.
+
+Since the user may want to configure those options, we configure them
+in the driver rather than statically configuring it in the patch flow.
+
+Signed-off-by: Kenneth Kasilag <kenneth@kasilag.me>
+---
+
+--- a/drivers/net/phy/realtek/realtek_main.c
++++ b/drivers/net/phy/realtek/realtek_main.c
+@@ -7,6 +7,7 @@
+  *
+  * Copyright (c) 2004 Freescale Semiconductor, Inc.
+  */
++#include <linux/bitfield.h>
+ #include <linux/bitops.h>
+ #include <linux/crc32.h>
+ #include <linux/ethtool_netlink.h>
+@@ -127,6 +128,7 @@
+ #define RTL8261X_EXT_ADDR_REG			0xa436
+ #define RTL8261X_EXT_DATA_REG			0xa438
+ #define RTL_8261X_SUB_PHY_ID_ADDR		0x801d
++#define RTL_8261X_PATCH_VER_ADDR		0x801e
+ 
+ #define RTL822X_VND1_SERDES_OPTION			0x697a
+ #define RTL822X_VND1_SERDES_OPTION_MODE_MASK		GENMASK(5, 0)
+@@ -214,6 +216,7 @@
+ #define RTL_8251B				0x001cc862
+ #define RTL_8261C				0x001cc890
+ #define RTL_8261C_CG				0x001cc898
++#define RTL_8261CE_REV_C			0x001cc899
+ 
+ #define RTL8261C_CE_MODEL		0x00
+ #define RTL8261X_IMR			0xa4d2
+@@ -249,6 +252,60 @@
+ #define RTL8261C_CE_FW_NAME	"rtl_nic/rtl8261c.bin"
+ MODULE_FIRMWARE(RTL8261C_CE_FW_NAME);
+ 
++/* PMA/PMD device ID 2 revision field: 0x0 = rev A, 0x8 = rev B, 0x9 = rev C */
++#define RTL8261X_PHYID2_REV_MASK		GENMASK(3, 0)
++#define RTL8261CE_PHYID2_REV_C			0x9
++
++/* Each VND1 SerDes option register holds two per-lane option slots with the
++ * mode in the low nibble and PHY/MAC selector bits above it; the second slot
++ * uses the same layout shifted up by 8 bits.
++ */
++#define RTL8261CE_VND1_SDS_OPT0			0x6977
++#define RTL8261CE_VND1_SDS_OPT1_3		0x6976
++#define RTL8261CE_VND1_SDS_OPT2			0x6975
++#define RTL8261CE_VND1_SDS_OPT4_9		0x6972
++#define RTL8261CE_VND1_SDS_OPT5_7		0x6974
++#define RTL8261CE_VND1_SDS_OPT6_8		0x6973
++#define RTL8261CE_SDS_OPT_MODE_MASK		GENMASK(3, 0)
++#define RTL8261CE_SDS_OPT_PHY_SEL		BIT(4)
++#define RTL8261CE_SDS_OPT_MAC_SEL		BIT(6)
++#define RTL8261CE_SDS_OPT_FIELD_MASK		(RTL8261CE_SDS_OPT_MODE_MASK | \
++						 RTL8261CE_SDS_OPT_PHY_SEL | \
++						 RTL8261CE_SDS_OPT_MAC_SEL)
++#define RTL8261CE_SDS_OPT_FIELD_VAL		(RTL8261CE_SDS_OPT_PHY_SEL | \
++						 RTL8261CE_SDS_OPT_MAC_SEL)
++
++/* Command window into the SerDes side register space */
++#define RTL8261CE_VND1_SDS_OCP_CMD		0x7587
++#define RTL8261CE_SDS_OCP_BUSY			BIT(0)
++#define RTL8261CE_SDS_OCP_CMD_READ		0x0001
++#define RTL8261CE_SDS_OCP_CMD_WRITE		0x0003
++#define RTL8261CE_VND1_SDS_OCP_ADDR		0x7588
++#define RTL8261CE_VND1_SDS_OCP_DATA		0x7589
++#define RTL8261CE_VND1_SDS_OCP_READ_DATA	0x758a
++
++/* SerDes side registers holding the two bit lane inversion code */
++#define RTL8261CE_SDS_POL_REG0			0x0000
++#define RTL8261CE_SDS_POL_REG0_MASK		GENMASK(9, 8)
++#define RTL8261CE_SDS_POL_REGC2			0x00c2
++#define RTL8261CE_SDS_POL_REGC2_MASK		GENMASK(14, 13)
++
++/* The RTL8261CE vendor init flow waits for the internal loader before the
++ * download and triggers execution of a freshly downloaded patch explicitly.
++ */
++#define RTL8261CE_VND2_PHY_STATE		0xa420
++#define RTL8261CE_VND2_PHY_STATE_READY		GENMASK(1, 0)
++#define RTL8261CE_VND2_PATCH_TRIGGER		0xa4a0
++#define RTL8261CE_PATCH_TRIGGER			BIT(10)
++#define RTL8261CE_VND2_PATCH_DONE		0xa600
++#define RTL8261CE_PATCH_DONE_MASK		GENMASK(7, 0)
++#define RTL8261CE_PATCH_DONE_LIVE		0x1
++
++#define RTL8261CE_VND2_EEE_CTRL0		0xd036
++#define RTL8261CE_VND2_EEE_CTRL1		0xd038
++#define RTL8261CE_VND2_THERMAL_SENSOR_CTRL	0xb54c
++#define RTL8261CE_THERMAL_OVERTEMP_DWNSPD_EN	BIT(3)
++
+ enum rtl8261x_fw_op {
+ 	OP_WRITE = 0x00,	/* Write */
+ 	OP_POLL  = 0x02,	/* Polling */
+@@ -356,6 +413,18 @@ static int rtl821x_modify_ext_page(struc
+ 	return phy_restore_page(phydev, oldpage, ret);
+ }
+ 
++static int rtl8261x_read_ext(struct phy_device *phydev, u16 addr)
++{
++	int ret;
++
++	ret = phy_write_mmd(phydev, MDIO_MMD_VEND2, RTL8261X_EXT_ADDR_REG,
++			    addr);
++	if (ret < 0)
++		return ret;
++
++	return phy_read_mmd(phydev, MDIO_MMD_VEND2, RTL8261X_EXT_DATA_REG);
++}
++
+ static int rtl8261x_probe(struct phy_device *phydev)
+ {
+ 	struct device *dev = &phydev->mdio.dev;
+@@ -368,12 +437,7 @@ static int rtl8261x_probe(struct phy_dev
+ 
+ 	phydev->priv = priv;
+ 
+-	ret = phy_write_mmd(phydev, MDIO_MMD_VEND2, RTL8261X_EXT_ADDR_REG,
+-			    RTL_8261X_SUB_PHY_ID_ADDR);
+-	if (ret < 0)
+-		return ret;
+-
+-	ret = phy_read_mmd(phydev, MDIO_MMD_VEND2, RTL8261X_EXT_DATA_REG);
++	ret = rtl8261x_read_ext(phydev, RTL_8261X_SUB_PHY_ID_ADDR);
+ 	if (ret < 0)
+ 		return ret;
+ 
+@@ -386,8 +450,13 @@ static int rtl8261x_probe(struct phy_dev
+ 		break;
+ 
+ 	default:
+-		phydev_err(phydev, "Unknown sub_id 0x%02x\n", sub_phy_id);
+-		return -ENODEV;
++		/* RTL8261D_CG shares the PHY ID and the firmware with
++		 * RTL8261C_CG and vendor drivers do not tell the two apart,
++		 * so accept other sub IDs instead of failing the probe.
++		 */
++		priv->fw_name = RTL8261C_CE_FW_NAME;
++		phydev_info(phydev, "RTL8261C/D detected (sub_id 0x%02x)\n", sub_phy_id);
++		break;
+ 	}
+ 
+ 	return 0;
+@@ -409,6 +478,14 @@ static int rtl8261x_get_features(struct
+ 	linkmode_set_bit(ETHTOOL_LINK_MODE_5000baseT_Full_BIT,
+ 			 phydev->supported);
+ 
++	/* 1000BASE-T and autoneg abilities are not reported reliably in the
++	 * standard C45 ability registers, both are handled through vendor
++	 * registers. Force them here.
++	 */
++	linkmode_set_bit(ETHTOOL_LINK_MODE_1000baseT_Full_BIT,
++			 phydev->supported);
++	linkmode_set_bit(ETHTOOL_LINK_MODE_Autoneg_BIT, phydev->supported);
++
+ 	return 0;
+ }
+ 
+@@ -677,6 +754,23 @@ static int rtl8261x_config_init(struct p
+ 	 * cycle or hard reset.
+ 	 */
+ 	if (priv->fw_name && !priv->fw_loaded) {
++		/* The patch loader leaves the firmware version in a scratch
++		 * register. Downloading the patch again on an already patched
++		 * PHY crashes it, so skip the download when a bootloader or
++		 * a previous boot already patched this PHY.
++		 */
++		ret = rtl8261x_read_ext(phydev, RTL_8261X_PATCH_VER_ADDR);
++		if (ret < 0)
++			return ret;
++
++		if (ret) {
++			phydev_dbg(phydev,
++				   "Firmware already patched (version 0x%04x)\n",
++				   ret);
++			priv->fw_loaded = true;
++			return 0;
++		}
++
+ 		ret = rtl8261x_fw_load(phydev);
+ 		if (ret) {
+ 			phydev_err(phydev, "Firmware loading failed: %d\n", ret);
+@@ -687,6 +781,265 @@ static int rtl8261x_config_init(struct p
+ 	return ret;
+ }
+ 
++/* The ten system-side SerDes option slots of the RTL8261CE in the order the
++ * vendor init flow programs them, every slot to MAC and PHY selector 1,
++ * mode 0.
++ */
++static const struct { u16 reg; bool high; } rtl8261ce_sds_opt[] = {
++	{ RTL8261CE_VND1_SDS_OPT0, false },
++	{ RTL8261CE_VND1_SDS_OPT1_3, false },
++	{ RTL8261CE_VND1_SDS_OPT2, false },
++	{ RTL8261CE_VND1_SDS_OPT1_3, true },
++	{ RTL8261CE_VND1_SDS_OPT4_9, false },
++	{ RTL8261CE_VND1_SDS_OPT5_7, false },
++	{ RTL8261CE_VND1_SDS_OPT6_8, false },
++	{ RTL8261CE_VND1_SDS_OPT5_7, true },
++	{ RTL8261CE_VND1_SDS_OPT6_8, true },
++	{ RTL8261CE_VND1_SDS_OPT4_9, true },
++};
++
++static int rtl8261ce_sds_ocp_wait(struct phy_device *phydev)
++{
++	int val;
++
++	return phy_read_mmd_poll_timeout(phydev, MDIO_MMD_VEND1,
++					 RTL8261CE_VND1_SDS_OCP_CMD, val,
++					 !(val & RTL8261CE_SDS_OCP_BUSY),
++					 1000, 400000, false);
++}
++
++static int rtl8261ce_sds_ocp_read(struct phy_device *phydev, u16 reg)
++{
++	int ret;
++
++	ret = phy_write_mmd(phydev, MDIO_MMD_VEND1,
++			    RTL8261CE_VND1_SDS_OCP_ADDR, reg);
++	if (ret < 0)
++		return ret;
++
++	ret = phy_write_mmd(phydev, MDIO_MMD_VEND1,
++			    RTL8261CE_VND1_SDS_OCP_CMD,
++			    RTL8261CE_SDS_OCP_CMD_READ);
++	if (ret < 0)
++		return ret;
++
++	ret = rtl8261ce_sds_ocp_wait(phydev);
++	if (ret < 0)
++		return ret;
++
++	return phy_read_mmd(phydev, MDIO_MMD_VEND1,
++			    RTL8261CE_VND1_SDS_OCP_READ_DATA);
++}
++
++static int rtl8261ce_sds_ocp_modify(struct phy_device *phydev, u16 reg,
++				    u16 mask, u16 set)
++{
++	int val, ret;
++
++	val = rtl8261ce_sds_ocp_read(phydev, reg);
++	if (val < 0)
++		return val;
++
++	ret = phy_write_mmd(phydev, MDIO_MMD_VEND1,
++			    RTL8261CE_VND1_SDS_OCP_ADDR, reg);
++	if (ret < 0)
++		return ret;
++
++	ret = phy_write_mmd(phydev, MDIO_MMD_VEND1,
++			    RTL8261CE_VND1_SDS_OCP_DATA, (val & ~mask) | set);
++	if (ret < 0)
++		return ret;
++
++	ret = phy_write_mmd(phydev, MDIO_MMD_VEND1,
++			    RTL8261CE_VND1_SDS_OCP_CMD,
++			    RTL8261CE_SDS_OCP_CMD_WRITE);
++	if (ret < 0)
++		return ret;
++
++	return rtl8261ce_sds_ocp_wait(phydev);
++}
++
++/* Apply the board level lane polarity from the firmware node. The two bit
++ * inversion code recovered from the vendor driver holds RX inversion in the
++ * upper and TX inversion in the lower bit, with the TX encoding inverted on
++ * revisions A and B. REG0 takes the code directly, REGC2 takes it with the
++ * two bits swapped.
++ */
++static int rtl8261ce_config_serdes_polarity(struct phy_device *phydev)
++{
++	struct device *dev = &phydev->mdio.dev;
++	unsigned int tx_pol, rx_pol;
++	u16 code;
++	int ret;
++
++	ret = phy_get_tx_polarity(dev_fwnode(dev), phy_modes(phydev->interface),
++				  BIT(PHY_POL_NORMAL) | BIT(PHY_POL_INVERT),
++				  PHY_POL_NORMAL, &tx_pol);
++	if (ret < 0)
++		return ret;
++
++	ret = phy_get_rx_polarity(dev_fwnode(dev), phy_modes(phydev->interface),
++				  BIT(PHY_POL_NORMAL) | BIT(PHY_POL_INVERT),
++				  PHY_POL_NORMAL, &rx_pol);
++	if (ret < 0)
++		return ret;
++
++	if (tx_pol == PHY_POL_NORMAL && rx_pol == PHY_POL_NORMAL)
++		return 0;
++
++	code = (rx_pol == PHY_POL_INVERT ? 2 : 0) |
++	       (tx_pol == PHY_POL_INVERT ? 1 : 0);
++
++	ret = phy_read_mmd(phydev, MDIO_MMD_PMAPMD, MDIO_DEVID2);
++	if (ret < 0)
++		return ret;
++
++	if (FIELD_GET(RTL8261X_PHYID2_REV_MASK, ret) != RTL8261CE_PHYID2_REV_C)
++		code ^= 1;
++
++	ret = rtl8261ce_sds_ocp_modify(phydev, RTL8261CE_SDS_POL_REG0,
++				       RTL8261CE_SDS_POL_REG0_MASK,
++				       FIELD_PREP(RTL8261CE_SDS_POL_REG0_MASK,
++						  code));
++	if (ret < 0)
++		return ret;
++
++	/* swap the two code bits for REGC2 */
++	code = ((code & 1) << 1) | (code >> 1);
++
++	return rtl8261ce_sds_ocp_modify(phydev, RTL8261CE_SDS_POL_REGC2,
++					RTL8261CE_SDS_POL_REGC2_MASK,
++					FIELD_PREP(RTL8261CE_SDS_POL_REGC2_MASK,
++						   code));
++}
++
++static int rtl8261ce_config_init(struct phy_device *phydev)
++{
++	struct rtl8261x_priv *priv = phydev->priv;
++	bool was_loaded = priv->fw_loaded;
++	unsigned int i;
++	int val, ret;
++
++	/* Wait for the internal loader before downloading the firmware. */
++	ret = phy_read_mmd_poll_timeout(phydev, MDIO_MMD_VEND2,
++					RTL8261CE_VND2_PHY_STATE, val,
++					(val & RTL8261CE_VND2_PHY_STATE_READY) ==
++					RTL8261CE_VND2_PHY_STATE_READY,
++					10000, 1000000, false);
++	if (ret)
++		return ret;
++
++	ret = rtl8261x_config_init(phydev);
++	if (ret)
++		return ret;
++
++	if (!was_loaded && priv->fw_loaded) {
++		/* The RTL8261C_CG firmware does not carry the explicit patch
++		 * execution trigger of the vendor CE init flow, issue it here
++		 * and restart the PHY again with the patch live.
++		 */
++		ret = phy_set_bits_mmd(phydev, MDIO_MMD_VEND2,
++				       RTL8261CE_VND2_PATCH_TRIGGER,
++				       RTL8261CE_PATCH_TRIGGER);
++		if (ret < 0)
++			return ret;
++
++		ret = phy_read_mmd_poll_timeout(phydev, MDIO_MMD_VEND2,
++						RTL8261CE_VND2_PATCH_DONE, val,
++						(val & RTL8261CE_PATCH_DONE_MASK) ==
++						RTL8261CE_PATCH_DONE_LIVE,
++						1000, 100000, false);
++		if (ret)
++			return ret;
++
++		ret = phy_clear_bits_mmd(phydev, MDIO_MMD_VEND2,
++					 RTL8261CE_VND2_PATCH_TRIGGER,
++					 RTL8261CE_PATCH_TRIGGER);
++		if (ret < 0)
++			return ret;
++
++		ret = phy_write_mmd(phydev, MDIO_MMD_VEND2,
++				    RTL822X_VND2_C22_REG(MII_BMCR),
++				    BMCR_RESET | BMCR_ANENABLE |
++				    BMCR_ANRESTART);
++		if (ret < 0)
++			return ret;
++	}
++
++	/* The vendor driver re-applies the SerDes option selection on every
++	 * init, also when the firmware patch is already loaded.
++	 */
++	for (i = 0; i < ARRAY_SIZE(rtl8261ce_sds_opt); i++) {
++		u16 mask = RTL8261CE_SDS_OPT_FIELD_MASK;
++		u16 set = RTL8261CE_SDS_OPT_FIELD_VAL;
++
++		if (rtl8261ce_sds_opt[i].high) {
++			mask <<= 8;
++			set <<= 8;
++		}
++
++		ret = phy_modify_mmd(phydev, MDIO_MMD_VEND1,
++				     rtl8261ce_sds_opt[i].reg, mask, set);
++		if (ret < 0)
++			return ret;
++	}
++
++	ret = rtl8261ce_config_serdes_polarity(phydev);
++	if (ret < 0)
++		return ret;
++
++	/* EEE defaults and over-temperature downspeed from the vendor driver */
++	ret = phy_write_mmd(phydev, MDIO_MMD_VEND2, RTL8261CE_VND2_EEE_CTRL0,
++			    0x0067);
++	if (ret < 0)
++		return ret;
++
++	ret = phy_write_mmd(phydev, MDIO_MMD_VEND2, RTL8261CE_VND2_EEE_CTRL1,
++			    0x0010);
++	if (ret < 0)
++		return ret;
++
++	return phy_set_bits_mmd(phydev, MDIO_MMD_VEND2,
++				RTL8261CE_VND2_THERMAL_SENSOR_CTRL,
++				RTL8261CE_THERMAL_OVERTEMP_DWNSPD_EN);
++}
++
++static int rtl8261ce_probe(struct phy_device *phydev)
++{
++	struct device *dev = &phydev->mdio.dev;
++	struct rtl8261x_priv *priv;
++	int ret;
++
++	priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	phydev->priv = priv;
++
++	/* The RTL8261C_CG firmware is a newer revision of the same patch
++	 * the vendor CE driver downloads, and the CE accepts it as well.
++	 */
++	priv->fw_name = RTL8261C_CE_FW_NAME;
++
++	ret = phy_read_mmd(phydev, MDIO_MMD_PMAPMD, MDIO_DEVID2);
++	if (ret < 0)
++		return ret;
++
++	phydev_info(phydev, "RTL8261CE rev 0x%lx detected\n",
++		    FIELD_GET(RTL8261X_PHYID2_REV_MASK, ret));
++
++	return 0;
++}
++
++static int rtl8261ce_match_phy_device(struct phy_device *phydev,
++				      const struct phy_driver *phydrv)
++{
++	u32 id = phydev->is_c45 ? phydev->c45_ids.device_ids[MDIO_MMD_PMAPMD] :
++				  phydev->phy_id;
++
++	return id == RTL_8261C || id == RTL_8261CE_REV_C;
++}
++
+ static int rtl821x_probe(struct phy_device *phydev)
+ {
+ 	struct device *dev = &phydev->mdio.dev;
+@@ -3601,12 +3954,25 @@ static struct phy_driver realtek_drvs[]
+ 		.set_tunable    = rtl826x_set_tunable,
+ 	}, {
+ 		PHY_ID_MATCH_EXACT(RTL_8261C_CG),
+-		.name           = "RTL8261C 10Gbps PHY",
++		.name           = "RTL8261C/D 10Gbps PHY",
+ 		.probe          = rtl8261x_probe,
+ 		.config_init    = rtl8261x_config_init,
+ 		.get_features   = rtl8261x_get_features,
+ 		.config_aneg    = rtl8261x_config_aneg,
+ 		.read_status    = rtl8261x_read_status,
++		.config_intr    = rtl8261x_config_intr,
++		.handle_interrupt = rtl8261x_handle_interrupt,
++		.soft_reset     = genphy_c45_soft_reset,
++		.suspend        = genphy_c45_pma_suspend,
++		.resume         = genphy_c45_pma_resume,
++	}, {
++		.match_phy_device = rtl8261ce_match_phy_device,
++		.name           = "RTL8261CE 10Gbps PHY",
++		.probe          = rtl8261ce_probe,
++		.config_init    = rtl8261ce_config_init,
++		.get_features   = rtl8261x_get_features,
++		.config_aneg    = rtl8261x_config_aneg,
++		.read_status    = rtl8261x_read_status,
+ 		.config_intr    = rtl8261x_config_intr,
+ 		.handle_interrupt = rtl8261x_handle_interrupt,
+ 		.soft_reset     = genphy_c45_soft_reset,

--- a/target/linux/generic/pending-6.18/743-01-v5-net-phy-c45-add-genphy_c45_soft_reset.patch
+++ b/target/linux/generic/pending-6.18/743-01-v5-net-phy-c45-add-genphy_c45_soft_reset.patch
@@ -1,0 +1,149 @@
+From patchwork Mon Jun 15 09:08:13 2026
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-Patchwork-Submitter: javen <javen_xu@realsil.com.cn>
+X-Patchwork-Id: 14629116
+X-Patchwork-Delegate: kuba@kernel.org
+Received: from rtits2.realtek.com.tw (rtits2.realtek.com [211.75.126.72])
+	(using TLSv1.2 with cipher ECDHE-RSA-AES128-GCM-SHA256 (128/128 bits))
+	(No client certificate requested)
+	by smtp.subspace.kernel.org (Postfix) with ESMTPS id 80E53331EBF;
+	Mon, 15 Jun 2026 09:09:47 +0000 (UTC)
+Authentication-Results: smtp.subspace.kernel.org;
+ arc=none smtp.client-ip=211.75.126.72
+ARC-Seal: i=1; a=rsa-sha256; d=subspace.kernel.org; s=arc-20240116;
+	t=1781514591; cv=none;
+ b=kyOggkk2HuIHECcH1cGl7rC9xY3GB7Nc0nMa2DZNoFXqSocLPdd915phP0dOADHFhsgTCkxbG4Rbowjt2RF51W+uHuURT3MEVrUp7uCF1K5GkuzlyLSKkTUHUSudazl5DPprHna/dXF8Q4RpPmS5RtsDRGP8KozqdPKtByP4L8I=
+ARC-Message-Signature: i=1; a=rsa-sha256; d=subspace.kernel.org;
+	s=arc-20240116; t=1781514591; c=relaxed/simple;
+	bh=Y3um3qpyHWGl0lz/BSlArkpQ3KA3tg7clz18nyjmlps=;
+	h=From:To:CC:Subject:Date:Message-ID:In-Reply-To:References:
+	 MIME-Version:Content-Type;
+ b=HHGw5ZyaRxwAmu5kZo5/Byg2Okyx8SBtF9xINIsGpXDiEzveFDDhlDLD2VAuMebDUFzt45dCMUNKvuPK6jscFM0g38jepYEIjAufQcgtnA+CqCx4MRM4l/sf3T3GkwK3tHl1oeKqA4UyxXsHl6Vj+KAquc6csXOtRRQlzhi2Fb4=
+ARC-Authentication-Results: i=1; smtp.subspace.kernel.org;
+ dmarc=pass (p=none dis=none) header.from=realsil.com.cn;
+ spf=pass smtp.mailfrom=realsil.com.cn;
+ dkim=pass (2048-bit key) header.d=realsil.com.cn header.i=@realsil.com.cn
+ header.b=ALT0Bglj; arc=none smtp.client-ip=211.75.126.72
+Authentication-Results: smtp.subspace.kernel.org;
+ dmarc=pass (p=none dis=none) header.from=realsil.com.cn
+Authentication-Results: smtp.subspace.kernel.org;
+ spf=pass smtp.mailfrom=realsil.com.cn
+Authentication-Results: smtp.subspace.kernel.org;
+	dkim=pass (2048-bit key) header.d=realsil.com.cn header.i=@realsil.com.cn
+ header.b="ALT0Bglj"
+X-SpamFilter-By: ArmorX SpamTrap 5.80 with qID 65F98KxG4611677,
+ This message is accepted by code: ctloc85258
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=realsil.com.cn;
+	s=dkim; t=1781514500;
+	bh=C5A7DXA96OZ3Yl78IqhHnJQrzYi9kruAq5KanhjRFRg=;
+	h=From:To:CC:Subject:Date:Message-ID:In-Reply-To:References:
+	 MIME-Version:Content-Transfer-Encoding:Content-Type;
+	b=ALT0BgljtCFcBCHB7xFfH77u6tJPe+s4/vrRyuH3fm8urMZrUGBNZs8sk9HEXVPBC
+	 t+gUabB6q4AIH+LVVrVqGvCjCf3NWPSoSw3BvM0RK3fJBXHSvvGR0dtwTSAGHSGDOy
+	 7AihtuC7LR78WbrbBT6i9EuvUfUJoZ5EldOsvzPevaIoXatGw20FGwgsGqVJBL1fS/
+	 cfGCpK4pjQWscIDbVYlGWKgs03FMmGfwJtx/NWOSxtFoCaelj9MekDqdq4jKQrvYLP
+	 Ok1mH7KFfT+WMg3q/6/N1mwmVHs/oHWkvsL9l27n5WkYxuT5g2Ewx0IQKqBl3yWKlT
+	 gnYA+Q+Xg332w==
+Received: from RS-EX-MBS2.realsil.com.cn ([172.29.17.102])
+	by rtits2.realtek.com.tw (8.15.2/3.29/5.94) with ESMTPS id 65F98KxG4611677
+	(version=TLSv1.2 cipher=ECDHE-RSA-AES256-GCM-SHA384 bits=256 verify=FAIL);
+	Mon, 15 Jun 2026 17:08:20 +0800
+Received: from RS-EX-MBS1.realsil.com.cn (172.29.17.101) by
+ RS-EX-MBS2.realsil.com.cn (172.29.17.102) with Microsoft SMTP Server
+ (version=TLS1_2, cipher=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384) id
+ 15.2.2562.17; Mon, 15 Jun 2026 17:08:19 +0800
+Received: from 172.29.37.154 (172.29.37.152) by RS-EX-MBS1.realsil.com.cn
+ (172.29.17.101) with Microsoft SMTP Server id 15.2.2562.17 via Frontend
+ Transport; Mon, 15 Jun 2026 17:08:19 +0800
+From: javen <javen_xu@realsil.com.cn>
+To: <andrew@lunn.ch>, <hkallweit1@gmail.com>, <linux@armlinux.org.uk>,
+	<davem@davemloft.net>, <edumazet@google.com>, <kuba@kernel.org>,
+	<pabeni@redhat.com>, <freddy_gu@realsil.com.cn>, <nb@tipi-net.de>
+CC: <netdev@vger.kernel.org>, <linux-kernel@vger.kernel.org>,
+	<daniel@makrotopia.org>, <vladimir.oltean@nxp.com>, Javen Xu
+	<javen_xu@realsil.com.cn>
+Subject: [PATCH net-next v5 1/4] net: phy: c45: add genphy_c45_soft_reset()
+Date: Mon, 15 Jun 2026 17:08:13 +0800
+Message-ID: <20260615090817.429-2-javen_xu@realsil.com.cn>
+X-Mailer: git-send-email 2.50.1.windows.1
+In-Reply-To: <20260615090817.429-1-javen_xu@realsil.com.cn>
+References: <20260615090817.429-1-javen_xu@realsil.com.cn>
+Precedence: bulk
+X-Mailing-List: netdev@vger.kernel.org
+List-Id: <netdev.vger.kernel.org>
+List-Subscribe: <mailto:netdev+subscribe@vger.kernel.org>
+List-Unsubscribe: <mailto:netdev+unsubscribe@vger.kernel.org>
+MIME-Version: 1.0
+X-Patchwork-Delegate: kuba@kernel.org
+
+From: Javen Xu <javen_xu@realsil.com.cn>
+
+Add a generic Clause 45 software reset helper. The helper sets the reset
+bit in the PMA/PMD control register and waits until the bit is cleared by
+hardware.
+
+Reviewed-by: Nicolai Buchwitz <nb@tipi-net.de>
+Signed-off-by: Javen Xu <javen_xu@realsil.com.cn>
+---
+Changes in v2:
+ - no changes, new file
+
+Changes in v3:
+ - re-order function according to the order in phy-c45.c
+
+Changes in v4:
+ - no changes
+
+Changes in v5:
+ - no changes
+
+Changes in v6:
+ - increase timeout to 600ms
+---
+ drivers/net/phy/phy-c45.c | 22 ++++++++++++++++++++++
+ include/linux/phy.h       |  1 +
+ 2 files changed, 23 insertions(+)
+
+--- a/drivers/net/phy/phy-c45.c
++++ b/drivers/net/phy/phy-c45.c
+@@ -384,6 +384,28 @@ int genphy_c45_check_and_restart_aneg(st
+ EXPORT_SYMBOL_GPL(genphy_c45_check_and_restart_aneg);
+ 
+ /**
++ * genphy_c45_soft_reset - software reset the PHY via Clause 45 PMA/PMD control register
++ * @phydev: target phy_device struct
++ *
++ * Return: 0 on success, negative errno on failure.
++ */
++int genphy_c45_soft_reset(struct phy_device *phydev)
++{
++	int ret, val;
++
++	ret = phy_set_bits_mmd(phydev, MDIO_MMD_PMAPMD, MDIO_CTRL1,
++			       MDIO_CTRL1_RESET);
++	if (ret < 0)
++		return ret;
++
++	return phy_read_mmd_poll_timeout(phydev, MDIO_MMD_PMAPMD,
++					 MDIO_CTRL1, val,
++					 !(val & MDIO_CTRL1_RESET),
++					 5000, 600000, true);
++}
++EXPORT_SYMBOL_GPL(genphy_c45_soft_reset);
++
++/**
+  * genphy_c45_aneg_done - return auto-negotiation complete status
+  * @phydev: target phy_device struct
+  *
+--- a/include/linux/phy.h
++++ b/include/linux/phy.h
+@@ -1991,6 +1991,7 @@ int genphy_c37_read_status(struct phy_de
+ /* Clause 45 PHY */
+ int genphy_c45_restart_aneg(struct phy_device *phydev);
+ int genphy_c45_check_and_restart_aneg(struct phy_device *phydev, bool restart);
++int genphy_c45_soft_reset(struct phy_device *phydev);
+ int genphy_c45_aneg_done(struct phy_device *phydev);
+ int genphy_c45_read_link(struct phy_device *phydev);
+ int genphy_c45_read_lpa(struct phy_device *phydev);

--- a/target/linux/generic/pending-6.18/743-02-v5-net-phy-c45-add-genphy_c45_config_master_slave.patch
+++ b/target/linux/generic/pending-6.18/743-02-v5-net-phy-c45-add-genphy_c45_config_master_slave.patch
@@ -1,0 +1,249 @@
+From patchwork Mon Jun 15 09:08:14 2026
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-Patchwork-Submitter: javen <javen_xu@realsil.com.cn>
+X-Patchwork-Id: 14629117
+X-Patchwork-Delegate: kuba@kernel.org
+Received: from rtits2.realtek.com.tw (rtits2.realtek.com [211.75.126.72])
+	(using TLSv1.2 with cipher ECDHE-RSA-AES128-GCM-SHA256 (128/128 bits))
+	(No client certificate requested)
+	by smtp.subspace.kernel.org (Postfix) with ESMTPS id 80D4C2F39AB;
+	Mon, 15 Jun 2026 09:09:47 +0000 (UTC)
+Authentication-Results: smtp.subspace.kernel.org;
+ arc=none smtp.client-ip=211.75.126.72
+ARC-Seal: i=1; a=rsa-sha256; d=subspace.kernel.org; s=arc-20240116;
+	t=1781514591; cv=none;
+ b=ZwlORjK1iMVBwdzOesiIt61no2Zl3DiUOXP84UEjBM/kaHNZQ3fOmEvtT2VpWMuWhhUwGbOPv8hygQTfVFSdSVuwMg/vYt830SOq8bgU9D5RA8HvoSH4NOX/VF3n3NP716SbMUUE1qan3pzsbMKd72X13U1+MP3m19MmRvUw4ic=
+ARC-Message-Signature: i=1; a=rsa-sha256; d=subspace.kernel.org;
+	s=arc-20240116; t=1781514591; c=relaxed/simple;
+	bh=XOw3wVJYzoD7vQxFAlu25Vwc4UhkBmAfnCK8B61j6fY=;
+	h=From:To:CC:Subject:Date:Message-ID:In-Reply-To:References:
+	 MIME-Version:Content-Type;
+ b=NeV39NOQ86Gara1jWrQw/0KZOGnF5ieYWAKFGsBBZfVznBoNLtaFy/eFXc1TqOJZoWmFCvWHMwGGoQQF1SgxYzJOhbfVafoeIiSoM9bmtUkIXYIa9dlcLSpxxUMiPYtEmA+sLbctmci0y1bUbskQiny2Ac51fEQlJAqB6vlpYCM=
+ARC-Authentication-Results: i=1; smtp.subspace.kernel.org;
+ dmarc=pass (p=none dis=none) header.from=realsil.com.cn;
+ spf=pass smtp.mailfrom=realsil.com.cn;
+ dkim=pass (2048-bit key) header.d=realsil.com.cn header.i=@realsil.com.cn
+ header.b=Gqin6RjW; arc=none smtp.client-ip=211.75.126.72
+Authentication-Results: smtp.subspace.kernel.org;
+ dmarc=pass (p=none dis=none) header.from=realsil.com.cn
+Authentication-Results: smtp.subspace.kernel.org;
+ spf=pass smtp.mailfrom=realsil.com.cn
+Authentication-Results: smtp.subspace.kernel.org;
+	dkim=pass (2048-bit key) header.d=realsil.com.cn header.i=@realsil.com.cn
+ header.b="Gqin6RjW"
+X-SpamFilter-By: ArmorX SpamTrap 5.80 with qID 65F98KxH4611677,
+ This message is accepted by code: ctloc85258
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=realsil.com.cn;
+	s=dkim; t=1781514500;
+	bh=h/rLb5FfioloKUAU6KfPQKgIAfw49Yh/hSCmSRuV13Y=;
+	h=From:To:CC:Subject:Date:Message-ID:In-Reply-To:References:
+	 MIME-Version:Content-Transfer-Encoding:Content-Type;
+	b=Gqin6RjWo+TRxnalk31jt0BTHai8eaT3u1Gf5Zm7cUqohuJWHlRcdMrZ+IFpwl/RA
+	 Y3Z5gWnSPlqImouEgIBJ/KgM8A6yTsH8RwAnHQLKfFYur0KeFjkILuv2b03dUQsFTd
+	 AdXnzfAWbhG9yr1moV/6c6ToXsf28nINYjCFajiStfCKRjjCs53BFzqGKs3It9bIBX
+	 7UuXETFcRalKrHfbwpEGhQ9JSjuFmIw3wDTd1T9MwGGTVAP7KxupCS0BwUDqVEKW5f
+	 El2cyHIFL6TbkwpYaarF2pofItCx2KPGAXB5sqfYHI2rWI4MYm8TlX2bbbKy7KoWzX
+	 yzg2DYVDdBI4A==
+Received: from RS-EX-MBS2.realsil.com.cn ([172.29.17.102])
+	by rtits2.realtek.com.tw (8.15.2/3.29/5.94) with ESMTPS id 65F98KxH4611677
+	(version=TLSv1.2 cipher=ECDHE-RSA-AES256-GCM-SHA384 bits=256 verify=FAIL);
+	Mon, 15 Jun 2026 17:08:20 +0800
+Received: from RS-EX-MBS1.realsil.com.cn (172.29.17.101) by
+ RS-EX-MBS2.realsil.com.cn (172.29.17.102) with Microsoft SMTP Server
+ (version=TLS1_2, cipher=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384) id
+ 15.2.2562.17; Mon, 15 Jun 2026 17:08:19 +0800
+Received: from 172.29.37.154 (172.29.37.152) by RS-EX-MBS1.realsil.com.cn
+ (172.29.17.101) with Microsoft SMTP Server id 15.2.2562.17 via Frontend
+ Transport; Mon, 15 Jun 2026 17:08:19 +0800
+From: javen <javen_xu@realsil.com.cn>
+To: <andrew@lunn.ch>, <hkallweit1@gmail.com>, <linux@armlinux.org.uk>,
+	<davem@davemloft.net>, <edumazet@google.com>, <kuba@kernel.org>,
+	<pabeni@redhat.com>, <freddy_gu@realsil.com.cn>, <nb@tipi-net.de>
+CC: <netdev@vger.kernel.org>, <linux-kernel@vger.kernel.org>,
+	<daniel@makrotopia.org>, <vladimir.oltean@nxp.com>, Javen Xu
+	<javen_xu@realsil.com.cn>
+Subject: [PATCH net-next v5 2/4] net: phy: c45: add
+ genphy_c45_config_master_slave()
+Date: Mon, 15 Jun 2026 17:08:14 +0800
+Message-ID: <20260615090817.429-3-javen_xu@realsil.com.cn>
+X-Mailer: git-send-email 2.50.1.windows.1
+In-Reply-To: <20260615090817.429-1-javen_xu@realsil.com.cn>
+References: <20260615090817.429-1-javen_xu@realsil.com.cn>
+Precedence: bulk
+X-Mailing-List: netdev@vger.kernel.org
+List-Id: <netdev.vger.kernel.org>
+List-Subscribe: <mailto:netdev+subscribe@vger.kernel.org>
+List-Unsubscribe: <mailto:netdev+unsubscribe@vger.kernel.org>
+MIME-Version: 1.0
+X-Patchwork-Delegate: kuba@kernel.org
+
+From: Javen Xu <javen_xu@realsil.com.cn>
+
+Add a generic helper to configure forced master/slave mode for Clause 45
+PHYs using the 10GBASE-T AN control register.
+
+Signed-off-by: Javen Xu <javen_xu@realsil.com.cn>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+---
+Changes in v2:
+ - no changes, new file
+
+Changes in v3:
+ - re-order function according to the order in phy-c45.c
+ - add kernel-doc about return value
+ - add MASTER_SLAVE_CFG_MASTER_PREFERRED,
+   MASTER_SLAVE_CFG_SLAVE_PREFERRED, MASTER_SLAVE_CFG_UNKNOWN,
+   MASTER_SLAVE_CFG_UNSUPPORTED, MASTER_SLAVE_CFG_SLAVE_PREFERRED cfg
+
+Changes in v4:
+ - no changes
+
+Changes in v5:
+ - move genphy_c45_an_setup_master_slave() to genphy_c45_config_aneg(),
+   as that C22 does.
+
+Changes in v6:
+ - add colon in the function description
+ - add genphy_c45_read_master_slave in read function
+---
+ drivers/net/phy/phy-c45.c | 96 +++++++++++++++++++++++++++++++++++++++
+ include/uapi/linux/mdio.h |  5 ++
+ 2 files changed, 101 insertions(+)
+
+--- a/drivers/net/phy/phy-c45.c
++++ b/drivers/net/phy/phy-c45.c
+@@ -406,6 +406,90 @@ int genphy_c45_soft_reset(struct phy_dev
+ EXPORT_SYMBOL_GPL(genphy_c45_soft_reset);
+ 
+ /**
++ * genphy_c45_an_setup_master_slave - Configure Master/Slave setting for C45 PHYs
++ * @phydev: target phy_device struct
++ *
++ * Description: Configure the forced or preferred Master/Slave role
++ * 10GBASE-T control register (MMD 7, Register 0x0020) according to
++ * IEEE 802.3 standards.
++ *
++ * Return: negative errno code on failure, 0 if Master/Slave didn't change,
++ * or 1 if Master/Slave modes changed.
++ */
++static int genphy_c45_an_setup_master_slave(struct phy_device *phydev)
++{
++	u16 ctl = 0;
++
++	switch (phydev->master_slave_set) {
++	case MASTER_SLAVE_CFG_MASTER_PREFERRED:
++		ctl = MDIO_AN_10GBT_CTRL_MS_PORT_TYPE;
++		break;
++	case MASTER_SLAVE_CFG_SLAVE_PREFERRED:
++		break;
++	case MASTER_SLAVE_CFG_MASTER_FORCE:
++		ctl = MDIO_AN_10GBT_CTRL_MS_ENABLE | MDIO_AN_10GBT_CTRL_MS_VALUE;
++		break;
++	case MASTER_SLAVE_CFG_SLAVE_FORCE:
++		ctl = MDIO_AN_10GBT_CTRL_MS_ENABLE;
++		break;
++	case MASTER_SLAVE_CFG_UNKNOWN:
++	case MASTER_SLAVE_CFG_UNSUPPORTED:
++		return 0;
++	default:
++		phydev_warn(phydev, "Unsupported Master/Slave mode\n");
++		return -EOPNOTSUPP;
++	}
++
++	return phy_modify_mmd_changed(phydev, MDIO_MMD_AN, MDIO_AN_10GBT_CTRL,
++				      MDIO_AN_10GBT_CTRL_MS_ENABLE |
++				      MDIO_AN_10GBT_CTRL_MS_VALUE |
++				      MDIO_AN_10GBT_CTRL_MS_PORT_TYPE, ctl);
++}
++
++/**
++ * genphy_c45_read_master_slave - read master/slave status
++ * @phydev: target phy_device struct
++ *
++ * Description: Read the Master/Slave configuration and status
++ * from 10GBASE-T control/status registers (MMD 7, Reg 0x0020 and 0x0021).
++ *
++ * Return: 0 on success, or a negative error code on failure.
++ */
++static int genphy_c45_read_master_slave(struct phy_device *phydev)
++{
++	int val;
++
++	val = phy_read_mmd(phydev, MDIO_MMD_AN, MDIO_AN_10GBT_CTRL);
++	if (val < 0)
++		return val;
++
++	if (val & MDIO_AN_10GBT_CTRL_MS_ENABLE) {
++		if (val & MDIO_AN_10GBT_CTRL_MS_VALUE)
++			phydev->master_slave_get = MASTER_SLAVE_CFG_MASTER_FORCE;
++		else
++			phydev->master_slave_get = MASTER_SLAVE_CFG_SLAVE_FORCE;
++	} else {
++		if (val & MDIO_AN_10GBT_CTRL_MS_PORT_TYPE)
++			phydev->master_slave_get = MASTER_SLAVE_CFG_MASTER_PREFERRED;
++		else
++			phydev->master_slave_get = MASTER_SLAVE_CFG_SLAVE_PREFERRED;
++	}
++
++	val = phy_read_mmd(phydev, MDIO_MMD_AN, MDIO_AN_10GBT_STAT);
++	if (val < 0)
++		return val;
++
++	if (val & MDIO_AN_10GBT_STAT_MS_FAULT)
++		phydev->master_slave_state = MASTER_SLAVE_STATE_ERR;
++	else if (val & MDIO_AN_10GBT_STAT_MS_RES)
++		phydev->master_slave_state = MASTER_SLAVE_STATE_MASTER;
++	else
++		phydev->master_slave_state = MASTER_SLAVE_STATE_SLAVE;
++
++	return 0;
++}
++
++/**
+  * genphy_c45_aneg_done - return auto-negotiation complete status
+  * @phydev: target phy_device struct
+  *
+@@ -1213,6 +1297,10 @@ int genphy_c45_read_status(struct phy_de
+ 			ret = genphy_c45_baset1_read_status(phydev);
+ 			if (ret < 0)
+ 				return ret;
++		} else {
++			ret = genphy_c45_read_master_slave(phydev);
++			if (ret < 0)
++				return ret;
+ 		}
+ 
+ 		phy_resolve_aneg_linkmode(phydev);
+@@ -1246,6 +1334,14 @@ int genphy_c45_config_aneg(struct phy_de
+ 	if (ret > 0)
+ 		changed = true;
+ 
++	if (!genphy_c45_baset1_able(phydev)) {
++		ret = genphy_c45_an_setup_master_slave(phydev);
++		if (ret < 0)
++			return ret;
++		if (ret > 0)
++			changed = true;
++	}
++
+ 	return genphy_c45_check_and_restart_aneg(phydev, changed);
+ }
+ EXPORT_SYMBOL_GPL(genphy_c45_config_aneg);
+--- a/include/uapi/linux/mdio.h
++++ b/include/uapi/linux/mdio.h
+@@ -303,8 +303,13 @@
+ #define MDIO_AN_10GBT_CTRL_ADV2_5G	0x0080	/* Advertise 2.5GBASE-T */
+ #define MDIO_AN_10GBT_CTRL_ADV5G	0x0100	/* Advertise 5GBASE-T */
+ #define MDIO_AN_10GBT_CTRL_ADV10G	0x1000	/* Advertise 10GBASE-T */
++#define MDIO_AN_10GBT_CTRL_MS_ENABLE	0x8000	/* Master/slave manual config enable */
++#define MDIO_AN_10GBT_CTRL_MS_VALUE	0x4000	/* Master/slave config value (1=Master) */
++#define MDIO_AN_10GBT_CTRL_MS_PORT_TYPE	0x2000	/* Master Preferred Type */
+ 
+ /* AN 10GBASE-T status register. */
++#define MDIO_AN_10GBT_STAT_MS_FAULT	0x8000	/* Master/slave fault */
++#define MDIO_AN_10GBT_STAT_MS_RES	0x4000	/* Master/slave resolution (1=Master) */
+ #define MDIO_AN_10GBT_STAT_LP2_5G	0x0020  /* LP is 2.5GBT capable */
+ #define MDIO_AN_10GBT_STAT_LP5G		0x0040  /* LP is 5GBT capable */
+ #define MDIO_AN_10GBT_STAT_LPTRR	0x0200	/* LP training reset req. */

--- a/target/linux/generic/pending-6.18/743-03-v5-net-phy-realtek-add-support-for-RTL8261C_CG.patch
+++ b/target/linux/generic/pending-6.18/743-03-v5-net-phy-realtek-add-support-for-RTL8261C_CG.patch
@@ -1,0 +1,330 @@
+From patchwork Mon Jun 15 09:08:15 2026
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-Patchwork-Submitter: javen <javen_xu@realsil.com.cn>
+X-Patchwork-Id: 14629114
+X-Patchwork-Delegate: kuba@kernel.org
+Received: from rtits2.realtek.com.tw (rtits2.realtek.com [211.75.126.72])
+	(using TLSv1.2 with cipher ECDHE-RSA-AES128-GCM-SHA256 (128/128 bits))
+	(No client certificate requested)
+	by smtp.subspace.kernel.org (Postfix) with ESMTPS id 80DC730677B;
+	Mon, 15 Jun 2026 09:09:47 +0000 (UTC)
+Authentication-Results: smtp.subspace.kernel.org;
+ arc=none smtp.client-ip=211.75.126.72
+ARC-Seal: i=1; a=rsa-sha256; d=subspace.kernel.org; s=arc-20240116;
+	t=1781514589; cv=none;
+ b=nX/QxtSU/dFSGcHRuJoYxKU4dQdE+Fb5fctQyJX5a2RcEdAgvAdVlvslc4PmolY2ReRO0tznfKneac/zy221ug2s4lmvK1ImWa8r4r7HSqexCYJ/XTiVEAB2CHT9L1EcuGAulR45AFW0F3qA5YqIWKg6jCgHHX0rSACcTClHxTQ=
+ARC-Message-Signature: i=1; a=rsa-sha256; d=subspace.kernel.org;
+	s=arc-20240116; t=1781514589; c=relaxed/simple;
+	bh=M3/DxtqCzaeXD3m0WxHA/s7uMGuqeODXRlLildZZRSQ=;
+	h=From:To:CC:Subject:Date:Message-ID:In-Reply-To:References:
+	 MIME-Version:Content-Type;
+ b=Yfxtce2sPAzA9ciFQ5rJkcTNbfUX5wL+DmSfnZvllICMRsFKcQB1M80fA2ulGI+EindtgYNMWoCmel+FQxfZDdntUB9Q15e9gAUZVbb2TM+G3HIjKYkAOdvMfsU/VIK2xpqtCPzMXB0SCqZwSOJCtXI4xlvi4yLZrTuh65QvJPI=
+ARC-Authentication-Results: i=1; smtp.subspace.kernel.org;
+ dmarc=pass (p=none dis=none) header.from=realsil.com.cn;
+ spf=pass smtp.mailfrom=realsil.com.cn;
+ dkim=pass (2048-bit key) header.d=realsil.com.cn header.i=@realsil.com.cn
+ header.b=qshthYaE; arc=none smtp.client-ip=211.75.126.72
+Authentication-Results: smtp.subspace.kernel.org;
+ dmarc=pass (p=none dis=none) header.from=realsil.com.cn
+Authentication-Results: smtp.subspace.kernel.org;
+ spf=pass smtp.mailfrom=realsil.com.cn
+Authentication-Results: smtp.subspace.kernel.org;
+	dkim=pass (2048-bit key) header.d=realsil.com.cn header.i=@realsil.com.cn
+ header.b="qshthYaE"
+X-SpamFilter-By: ArmorX SpamTrap 5.80 with qID 65F98KxI4611677,
+ This message is accepted by code: ctloc85258
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=realsil.com.cn;
+	s=dkim; t=1781514500;
+	bh=vufV7pzRgBiXm4VkgfR5HXDvZwjSYuijc8NTo8PbNgg=;
+	h=From:To:CC:Subject:Date:Message-ID:In-Reply-To:References:
+	 MIME-Version:Content-Transfer-Encoding:Content-Type;
+	b=qshthYaEb9CGkQ3hnBfhDd3tQvXrcV+I3Bpau/f+ubraY8YrEpiuKG+5qD78AK28e
+	 gNYJLq+ce0IDfH1WGAmRoBRdk0M208SuSx1Y4FIUXUT9SGn79kuUTrBhhd+Zfp0ARp
+	 DChSso8BXPX71fuBBveaPU21dWENt8EuZtn5aKoupW0gWSuIeVCwRQ8VQYiCEwUt1k
+	 fsPjRUs2uJaqLuVkmadcbF2H2AtYzbJJqVxCZWMaPvBwxSjFdOJU6zO+dkrvvWqRFs
+	 srNsOBivb2R1y9s6AVGPJqgRMjWAE+9cVdmHrsKnV5w6PzKLOIQJ0gDfTnu+NvimEm
+	 GF30qNi0H2sWA==
+Received: from RS-EX-MBS2.realsil.com.cn ([172.29.17.102])
+	by rtits2.realtek.com.tw (8.15.2/3.29/5.94) with ESMTPS id 65F98KxI4611677
+	(version=TLSv1.2 cipher=ECDHE-RSA-AES256-GCM-SHA384 bits=256 verify=FAIL);
+	Mon, 15 Jun 2026 17:08:20 +0800
+Received: from RS-EX-MBS1.realsil.com.cn (172.29.17.101) by
+ RS-EX-MBS2.realsil.com.cn (172.29.17.102) with Microsoft SMTP Server
+ (version=TLS1_2, cipher=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384) id
+ 15.2.2562.17; Mon, 15 Jun 2026 17:08:19 +0800
+Received: from 172.29.37.154 (172.29.37.152) by RS-EX-MBS1.realsil.com.cn
+ (172.29.17.101) with Microsoft SMTP Server id 15.2.2562.17 via Frontend
+ Transport; Mon, 15 Jun 2026 17:08:19 +0800
+From: javen <javen_xu@realsil.com.cn>
+To: <andrew@lunn.ch>, <hkallweit1@gmail.com>, <linux@armlinux.org.uk>,
+	<davem@davemloft.net>, <edumazet@google.com>, <kuba@kernel.org>,
+	<pabeni@redhat.com>, <freddy_gu@realsil.com.cn>, <nb@tipi-net.de>
+CC: <netdev@vger.kernel.org>, <linux-kernel@vger.kernel.org>,
+	<daniel@makrotopia.org>, <vladimir.oltean@nxp.com>, Javen Xu
+	<javen_xu@realsil.com.cn>
+Subject: [PATCH net-next v5 3/4] net: phy: realtek: add support for
+ RTL8261C_CG
+Date: Mon, 15 Jun 2026 17:08:15 +0800
+Message-ID: <20260615090817.429-4-javen_xu@realsil.com.cn>
+X-Mailer: git-send-email 2.50.1.windows.1
+In-Reply-To: <20260615090817.429-1-javen_xu@realsil.com.cn>
+References: <20260615090817.429-1-javen_xu@realsil.com.cn>
+Precedence: bulk
+X-Mailing-List: netdev@vger.kernel.org
+List-Id: <netdev.vger.kernel.org>
+List-Subscribe: <mailto:netdev+subscribe@vger.kernel.org>
+List-Unsubscribe: <mailto:netdev+unsubscribe@vger.kernel.org>
+MIME-Version: 1.0
+X-Patchwork-Delegate: kuba@kernel.org
+
+From: Javen Xu <javen_xu@realsil.com.cn>
+
+This patch adds support for Realtek phy chip RTL8261C_CG. Its PHY ID is
+0x001cc898.
+
+Signed-off-by: Javen Xu <javen_xu@realsil.com.cn>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+---
+Changes in v2:
+ - no changes, new file
+
+Changes in v3:
+ - re-order function according to the order in phy-c45.c
+ - add kernel-doc about return value
+ - add MASTER_SLAVE_CFG_MASTER_PREFERRED,
+   MASTER_SLAVE_CFG_SLAVE_PREFERRED, MASTER_SLAVE_CFG_UNKNOWN,
+   MASTER_SLAVE_CFG_UNSUPPORTED, MASTER_SLAVE_CFG_SLAVE_PREFERRED cfg
+
+Changes in v4:
+ - no changes
+
+Changes in v5:
+ - remove genphy_c45_pma_setup_forced() for this is already done when
+   calling genphy_c45_config_aneg()
+
+Changes in v6:
+ - when PHY_INTERRUPT_DISABLE, clear IMR and ISR
+ - if AUTONEG_DISABLE, nothing need to do in rtl8261x_config_aneg
+ - add rtl8261x_read_status, support 1G speed
+---
+ drivers/net/phy/realtek/realtek_main.c | 187 +++++++++++++++++++++++++
+ 1 file changed, 187 insertions(+)
+
+--- a/drivers/net/phy/realtek/realtek_main.c
++++ b/drivers/net/phy/realtek/realtek_main.c
+@@ -122,6 +122,10 @@
+ #define RTL8211F_PHYSICAL_ADDR_WORD1		17
+ #define RTL8211F_PHYSICAL_ADDR_WORD2		18
+ 
++#define RTL8261X_EXT_ADDR_REG			0xa436
++#define RTL8261X_EXT_DATA_REG			0xa438
++#define RTL_8261X_SUB_PHY_ID_ADDR		0x801d
++
+ #define RTL822X_VND1_SERDES_OPTION			0x697a
+ #define RTL822X_VND1_SERDES_OPTION_MODE_MASK		GENMASK(5, 0)
+ #define RTL822X_VND1_SERDES_OPTION_MODE_2500BASEX_SGMII		0
+@@ -207,6 +211,31 @@
+ #define RTL_8221B_VM_CG				0x001cc84a
+ #define RTL_8251B				0x001cc862
+ #define RTL_8261C				0x001cc890
++#define RTL_8261C_CG				0x001cc898
++
++#define RTL8261C_CE_MODEL		0x00
++#define RTL8261X_IMR			0xa4d2
++#define RTL8261X_ISR			0xa4d4
++#define RTL8261X_INT_AUTONEG_ERROR	BIT(0)
++#define RTL8261X_INT_PAGE_RECV		BIT(2)
++#define RTL8261X_INT_AUTONEG_DONE	BIT(3)
++#define RTL8261X_INT_LINK_CHG		BIT(4)
++#define RTL8261X_INT_PHY_REG_ACCESS	BIT(5)
++#define RTL8261X_INT_PME		BIT(7)
++#define RTL8261X_INT_ALDPS_CHG		BIT(9)
++#define RTL8261X_INT_JABBER		BIT(10)
++
++#define RTL8261X_INT_MASK_DEFAULT	(RTL8261X_INT_AUTONEG_DONE | \
++					 RTL8261X_INT_LINK_CHG)
++
++#define RTL8261X_INT_MASK_ALL		(RTL8261X_INT_AUTONEG_ERROR | \
++					 RTL8261X_INT_PAGE_RECV | \
++					 RTL8261X_INT_AUTONEG_DONE | \
++					 RTL8261X_INT_LINK_CHG | \
++					 RTL8261X_INT_PHY_REG_ACCESS | \
++					 RTL8261X_INT_PME | \
++					 RTL8261X_INT_ALDPS_CHG | \
++					 RTL8261X_INT_JABBER)
+ #define RTL_8261N				0x001ccaf3
+ #define RTL_8264				0x001ccaf2
+ #define RTL_8264B				0x001cc813
+@@ -283,6 +312,151 @@ static int rtl821x_modify_ext_page(struc
+ 	return phy_restore_page(phydev, oldpage, ret);
+ }
+ 
++static int rtl8261x_probe(struct phy_device *phydev)
++{
++	int sub_phy_id, ret;
++
++	ret = phy_write_mmd(phydev, MDIO_MMD_VEND2, RTL8261X_EXT_ADDR_REG,
++			    RTL_8261X_SUB_PHY_ID_ADDR);
++	if (ret < 0)
++		return ret;
++
++	ret = phy_read_mmd(phydev, MDIO_MMD_VEND2, RTL8261X_EXT_DATA_REG);
++	if (ret < 0)
++		return ret;
++
++	sub_phy_id = (ret >> 8) & 0xff;
++
++	switch (sub_phy_id) {
++	case RTL8261C_CE_MODEL:
++		phydev_info(phydev, "RTL8261C detected (sub_id 0x%02x)\n", sub_phy_id);
++		break;
++
++	default:
++		phydev_err(phydev, "Unknown sub_id 0x%02x\n", sub_phy_id);
++		return -ENODEV;
++	}
++
++	return 0;
++}
++
++static int rtl8261x_get_features(struct phy_device *phydev)
++{
++	int ret;
++
++	ret = genphy_c45_pma_read_abilities(phydev);
++	if (ret)
++		return ret;
++	/*
++	 * Supplement Multi-Gig speeds that may not be automatically detected
++	 * RTL8261X supports 2.5G/5G in addition to standard 10G
++	 */
++	linkmode_set_bit(ETHTOOL_LINK_MODE_2500baseT_Full_BIT,
++			 phydev->supported);
++	linkmode_set_bit(ETHTOOL_LINK_MODE_5000baseT_Full_BIT,
++			 phydev->supported);
++
++	return 0;
++}
++
++static int rtl8261x_read_status(struct phy_device *phydev)
++{
++	int ret;
++
++	ret = genphy_c45_read_status(phydev);
++	if (ret < 0)
++		return ret;
++
++	if (phydev->autoneg == AUTONEG_ENABLE && phydev->autoneg_complete) {
++		int lp_status;
++
++		lp_status = phy_read_mmd(phydev, MDIO_MMD_VEND2,
++					 RTL822X_VND2_C22_REG(MII_STAT1000));
++		if (lp_status < 0)
++			return lp_status;
++
++		if (lp_status & (LPA_1000FULL | LPA_1000HALF)) {
++			mii_stat1000_mod_linkmode_lpa_t(phydev->lp_advertising, lp_status);
++			phy_resolve_aneg_linkmode(phydev);
++		}
++	}
++
++	return 0;
++}
++
++static int rtl8261x_config_intr(struct phy_device *phydev)
++{
++	int ret;
++
++	if (phydev->interrupts == PHY_INTERRUPT_ENABLED) {
++		ret = phy_read_mmd(phydev, MDIO_MMD_VEND2, RTL8261X_ISR);
++		if (ret < 0)
++			return ret;
++
++		ret = phy_write_mmd(phydev, MDIO_MMD_VEND2, RTL8261X_IMR,
++				    RTL8261X_INT_MASK_DEFAULT);
++		if (ret < 0)
++			return ret;
++	} else {
++		ret = phy_write_mmd(phydev, MDIO_MMD_VEND2, RTL8261X_IMR, 0);
++		if (ret < 0)
++			return ret;
++
++		ret = phy_read_mmd(phydev, MDIO_MMD_VEND2, RTL8261X_ISR);
++		if (ret < 0)
++			return ret;
++	}
++
++	return 0;
++}
++
++static irqreturn_t rtl8261x_handle_interrupt(struct phy_device *phydev)
++{
++	int irq_status;
++
++	irq_status = phy_read_mmd(phydev, MDIO_MMD_VEND2, RTL8261X_ISR);
++	if (irq_status < 0) {
++		phy_error(phydev);
++		return IRQ_NONE;
++	}
++
++	if (!(irq_status & RTL8261X_INT_MASK_ALL))
++		return IRQ_NONE;
++
++	if (irq_status & (RTL8261X_INT_LINK_CHG | RTL8261X_INT_AUTONEG_DONE |
++	    RTL8261X_INT_AUTONEG_ERROR | RTL8261X_INT_JABBER))
++		phy_trigger_machine(phydev);
++
++	return IRQ_HANDLED;
++}
++
++static int rtl8261x_config_aneg(struct phy_device *phydev)
++{
++	u16 adv_1g = 0;
++	int ret;
++
++	ret = genphy_c45_config_aneg(phydev);
++	if (ret < 0)
++		return ret;
++
++	if (phydev->autoneg == AUTONEG_DISABLE)
++		return 0;
++
++	if (linkmode_test_bit(ETHTOOL_LINK_MODE_1000baseT_Full_BIT,
++			      phydev->advertising))
++		adv_1g = ADVERTISE_1000FULL;
++
++	ret = phy_modify_mmd_changed(phydev, MDIO_MMD_VEND2,
++				     RTL822X_VND2_C22_REG(MII_CTRL1000),
++				     ADVERTISE_1000FULL, adv_1g);
++	if (ret < 0)
++		return ret;
++	if (ret > 0)
++		return genphy_c45_restart_aneg(phydev);
++
++	return 0;
++}
++
+ static int rtl821x_probe(struct phy_device *phydev)
+ {
+ 	struct device *dev = &phydev->mdio.dev;
+@@ -3196,6 +3370,18 @@ static struct phy_driver realtek_drvs[]
+ 		.get_tunable    = rtl826x_get_tunable,
+ 		.set_tunable    = rtl826x_set_tunable,
+ 	}, {
++		PHY_ID_MATCH_EXACT(RTL_8261C_CG),
++		.name           = "RTL8261C 10Gbps PHY",
++		.probe          = rtl8261x_probe,
++		.get_features   = rtl8261x_get_features,
++		.config_aneg    = rtl8261x_config_aneg,
++		.read_status    = rtl8261x_read_status,
++		.config_intr    = rtl8261x_config_intr,
++		.handle_interrupt = rtl8261x_handle_interrupt,
++		.soft_reset     = genphy_c45_soft_reset,
++		.suspend        = genphy_c45_pma_suspend,
++		.resume         = genphy_c45_pma_resume,
++	}, {
+ 		.name           = "RTL8261N 10Gbps PHY",
+ 		.config_init    = rtl826x_config_init,
+ 		.probe          = rtl8261n_probe,

--- a/target/linux/generic/pending-6.18/743-04-v5-net-phy-realtek-load-firmware-for-RTL8261C_CG.patch
+++ b/target/linux/generic/pending-6.18/743-04-v5-net-phy-realtek-load-firmware-for-RTL8261C_CG.patch
@@ -1,0 +1,393 @@
+From patchwork Mon Jun 15 09:08:16 2026
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-Patchwork-Submitter: javen <javen_xu@realsil.com.cn>
+X-Patchwork-Id: 14629115
+X-Patchwork-Delegate: kuba@kernel.org
+Received: from rtits2.realtek.com.tw (rtits2.realtek.com [211.75.126.72])
+	(using TLSv1.2 with cipher ECDHE-RSA-AES128-GCM-SHA256 (128/128 bits))
+	(No client certificate requested)
+	by smtp.subspace.kernel.org (Postfix) with ESMTPS id 80EE0332EC8;
+	Mon, 15 Jun 2026 09:09:47 +0000 (UTC)
+Authentication-Results: smtp.subspace.kernel.org;
+ arc=none smtp.client-ip=211.75.126.72
+ARC-Seal: i=1; a=rsa-sha256; d=subspace.kernel.org; s=arc-20240116;
+	t=1781514590; cv=none;
+ b=IQMRkoDLbbdcz8qt37Dq0KcI6qqntznQB76Nip2sX+haeqRmL2so3XDqu6RH6Ph8WuP9rMnyK1SHkRHIZoTK1BCQUv4wo2vF4qsMzrqTkoT0ehRI514kKnOjal3C/ujODlZ6D3wiVXXvjyfB14prxG1g1wglWe31N49sLkFTcj4=
+ARC-Message-Signature: i=1; a=rsa-sha256; d=subspace.kernel.org;
+	s=arc-20240116; t=1781514590; c=relaxed/simple;
+	bh=ZHphPdc8P7pWI08v5QGUrnK6NHNNYfAbxru1oMkNBb4=;
+	h=From:To:CC:Subject:Date:Message-ID:In-Reply-To:References:
+	 MIME-Version:Content-Type;
+ b=HLqCDwOVuYmYBLsZlV1naNwjdkteM6v1SjqDfxR9VSWA0+ZHNOfFhT1dDDLm2C9OlW7dAs2HpW/yOyDqnHV850TK8gTM9q0yV7sj7TLUFmMSXmpZyJH4bwgy5YCFyT9WU1+fX1nP1f8fj/z+N/xl9vHOj2Tv0hB3K4pztmQlfe0=
+ARC-Authentication-Results: i=1; smtp.subspace.kernel.org;
+ dmarc=pass (p=none dis=none) header.from=realsil.com.cn;
+ spf=pass smtp.mailfrom=realsil.com.cn;
+ dkim=pass (2048-bit key) header.d=realsil.com.cn header.i=@realsil.com.cn
+ header.b=jRYfTzfa; arc=none smtp.client-ip=211.75.126.72
+Authentication-Results: smtp.subspace.kernel.org;
+ dmarc=pass (p=none dis=none) header.from=realsil.com.cn
+Authentication-Results: smtp.subspace.kernel.org;
+ spf=pass smtp.mailfrom=realsil.com.cn
+Authentication-Results: smtp.subspace.kernel.org;
+	dkim=pass (2048-bit key) header.d=realsil.com.cn header.i=@realsil.com.cn
+ header.b="jRYfTzfa"
+X-SpamFilter-By: ArmorX SpamTrap 5.80 with qID 65F98KxJ4611677,
+ This message is accepted by code: ctloc85258
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=realsil.com.cn;
+	s=dkim; t=1781514501;
+	bh=rspwOawn0AB706Wrhf+l0GzjJLPEY+eDqbj6JIbxyMo=;
+	h=From:To:CC:Subject:Date:Message-ID:In-Reply-To:References:
+	 MIME-Version:Content-Transfer-Encoding:Content-Type;
+	b=jRYfTzfacqLRwxQyOqEDaoL3TqrJoGAFX8wLYMxaPfqY+34f5DfWacrN6S9TPBJcv
+	 XVtqhnILxmF6ZKlcVkApPU5rObb/rCDgfSzgIjuWqAIOm363pmVceiOLgOal9f1Jjv
+	 ZAK9hXqy4/OTOVV0t/70xh22r6HBv+2Akk5Hs9b4KD3zOqfX2GZYrWw0OTfWE/KKB5
+	 19bzVzobTlm18dqc+FCF0Tf4koDKyFc/ax3+Cn9Hc9aDJHwMzvbGq3nEnw5j0ZDUmy
+	 hf+9kfo3j6Cav0ppxvn7/dChbUSgy6zFy7LEQ+WXueTxTp1KqavR1GVQDvcDwjepF6
+	 l6FBYq/7IeFww==
+Received: from RS-EX-MBS2.realsil.com.cn ([172.29.17.102])
+	by rtits2.realtek.com.tw (8.15.2/3.29/5.94) with ESMTPS id 65F98KxJ4611677
+	(version=TLSv1.2 cipher=ECDHE-RSA-AES256-GCM-SHA384 bits=256 verify=FAIL);
+	Mon, 15 Jun 2026 17:08:20 +0800
+Received: from RS-EX-MBS1.realsil.com.cn (172.29.17.101) by
+ RS-EX-MBS2.realsil.com.cn (172.29.17.102) with Microsoft SMTP Server
+ (version=TLS1_2, cipher=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384) id
+ 15.2.2562.17; Mon, 15 Jun 2026 17:08:20 +0800
+Received: from 172.29.37.154 (172.29.37.152) by RS-EX-MBS1.realsil.com.cn
+ (172.29.17.101) with Microsoft SMTP Server id 15.2.2562.17 via Frontend
+ Transport; Mon, 15 Jun 2026 17:08:20 +0800
+From: javen <javen_xu@realsil.com.cn>
+To: <andrew@lunn.ch>, <hkallweit1@gmail.com>, <linux@armlinux.org.uk>,
+	<davem@davemloft.net>, <edumazet@google.com>, <kuba@kernel.org>,
+	<pabeni@redhat.com>, <freddy_gu@realsil.com.cn>, <nb@tipi-net.de>
+CC: <netdev@vger.kernel.org>, <linux-kernel@vger.kernel.org>,
+	<daniel@makrotopia.org>, <vladimir.oltean@nxp.com>, Javen Xu
+	<javen_xu@realsil.com.cn>
+Subject: [PATCH net-next v5 4/4] net: phy: realtek: load firmware for
+ RTL8261C_CG
+Date: Mon, 15 Jun 2026 17:08:16 +0800
+Message-ID: <20260615090817.429-5-javen_xu@realsil.com.cn>
+X-Mailer: git-send-email 2.50.1.windows.1
+In-Reply-To: <20260615090817.429-1-javen_xu@realsil.com.cn>
+References: <20260615090817.429-1-javen_xu@realsil.com.cn>
+Precedence: bulk
+X-Mailing-List: netdev@vger.kernel.org
+List-Id: <netdev.vger.kernel.org>
+List-Subscribe: <mailto:netdev+subscribe@vger.kernel.org>
+List-Unsubscribe: <mailto:netdev+unsubscribe@vger.kernel.org>
+MIME-Version: 1.0
+X-Patchwork-Delegate: kuba@kernel.org
+
+From: Javen Xu <javen_xu@realsil.com.cn>
+
+This patch adds support for loading firmware. Download some parameters
+for RTL8261C_CG.
+
+Signed-off-by: Javen Xu <javen_xu@realsil.com.cn>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+---
+Changes in v2:
+ - remove __pack, struct rtl8261x_fw_header and rtl8261x_fw_entry will not pad
+ - reverse xmas tree for some definition
+ - add explanation on rtl_phy_write_mmd_bits()
+
+Changes in v3:
+ - add struct rtl8261x_priv
+
+Changes in v4:
+ - add struct device *dev
+
+Changes in v5:
+ - no changes
+
+Changes in v6:
+ - replace rtl_phy_write_mmd_bits with phy_modify_mmd, keep mdio lock
+ - check msb and lsb at the beginning of rtl8261x_fw_execute_entry()
+ - add comments on rtl8261x_config_init()
+---
+ drivers/net/phy/realtek/realtek_main.c | 220 +++++++++++++++++++++++++
+ 1 file changed, 220 insertions(+)
+
+--- a/drivers/net/phy/realtek/realtek_main.c
++++ b/drivers/net/phy/realtek/realtek_main.c
+@@ -8,7 +8,9 @@
+  * Copyright (c) 2004 Freescale Semiconductor, Inc.
+  */
+ #include <linux/bitops.h>
++#include <linux/crc32.h>
+ #include <linux/ethtool_netlink.h>
++#include <linux/firmware.h>
+ #include <linux/of.h>
+ #include <linux/phy.h>
+ #include <linux/phy/phy-common-props.h>
+@@ -240,6 +242,43 @@
+ #define RTL_8264				0x001ccaf2
+ #define RTL_8264B				0x001cc813
+ 
++#define FW_MAIN_MAGIC			0x52544C38
++#define FW_SUB_MAGIC_8261C		0x32363143
++#define RTL8261X_POLL_TIMEOUT_MS	100
++
++#define RTL8261C_CE_FW_NAME	"rtl_nic/rtl8261c.bin"
++MODULE_FIRMWARE(RTL8261C_CE_FW_NAME);
++
++enum rtl8261x_fw_op {
++	OP_WRITE = 0x00,	/* Write */
++	OP_POLL  = 0x02,	/* Polling */
++};
++
++struct rtl8261x_fw_header {
++	__le32 main_magic;	/* Main magic number 0x52544C38 ("RTL8") */
++	__le32 sub_magic;	/* Sub magic number */
++	__le16 version_major;	/* Major version */
++	__le16 version_minor;	/* Minor version */
++	__le16 num_entries;	/* Number of entries */
++	__le16 reserved;	/* Reserved */
++	__le32 crc32;		/* CRC32 checksum */
++};
++
++struct rtl8261x_fw_entry {
++	__u8  type;		/* Operation type (OP_*) */
++	__u8  dev;		/* MMD device */
++	__le16 addr;		/* Register address */
++	__u8  msb;		/* MSB bit position */
++	__u8  lsb;		/* LSB bit position */
++	__le16 value;		/* Value to write/compare */
++	__le16 timeout_ms;	/* Poll timeout in milliseconds */
++	__u8  poll_set;		/* Poll for set (1) or clear (0) */
++	__u8  reserved;		/* Reserved */
++};
++
++#define FW_HEADER_SIZE		sizeof(struct rtl8261x_fw_header)
++#define FW_ENTRY_SIZE		sizeof(struct rtl8261x_fw_entry)
++
+ /* RTL8211E and RTL8211F support up to three LEDs */
+ #define RTL8211x_LED_COUNT			3
+ 
+@@ -272,6 +311,11 @@ struct rtl822x_priv {
+ 	bool enable_aldps;
+ };
+ 
++struct rtl8261x_priv {
++	const char *fw_name;
++	bool fw_loaded;
++};
++
+ static int rtl821x_read_page(struct phy_device *phydev)
+ {
+ 	return __phy_read(phydev, RTL821x_PAGE_SELECT);
+@@ -314,8 +358,16 @@ static int rtl821x_modify_ext_page(struc
+ 
+ static int rtl8261x_probe(struct phy_device *phydev)
+ {
++	struct device *dev = &phydev->mdio.dev;
++	struct rtl8261x_priv *priv;
+ 	int sub_phy_id, ret;
+ 
++	priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	phydev->priv = priv;
++
+ 	ret = phy_write_mmd(phydev, MDIO_MMD_VEND2, RTL8261X_EXT_ADDR_REG,
+ 			    RTL_8261X_SUB_PHY_ID_ADDR);
+ 	if (ret < 0)
+@@ -329,6 +381,7 @@ static int rtl8261x_probe(struct phy_dev
+ 
+ 	switch (sub_phy_id) {
+ 	case RTL8261C_CE_MODEL:
++		priv->fw_name = RTL8261C_CE_FW_NAME;
+ 		phydev_info(phydev, "RTL8261C detected (sub_id 0x%02x)\n", sub_phy_id);
+ 		break;
+ 
+@@ -384,6 +437,153 @@ static int rtl8261x_read_status(struct p
+ 	return 0;
+ }
+ 
++static int rtl8261x_verify_firmware(struct phy_device *phydev, const struct firmware *fw)
++{
++	const struct rtl8261x_fw_header *hdr;
++	u32 main_magic, sub_magic;
++	u32 calc_crc, file_crc;
++	size_t data_len;
++	u16 num_entries;
++
++	if (fw->size < FW_HEADER_SIZE) {
++		phydev_err(phydev, "Firmware too small: %zu bytes\n", fw->size);
++		return -EINVAL;
++	}
++
++	hdr = (const struct rtl8261x_fw_header *)fw->data;
++
++	main_magic = le32_to_cpu(hdr->main_magic);
++	if (main_magic != FW_MAIN_MAGIC) {
++		phydev_err(phydev, "Invalid firmware magic: 0x%08x\n", main_magic);
++		return -EINVAL;
++	}
++
++	sub_magic = le32_to_cpu(hdr->sub_magic);
++	if (sub_magic != FW_SUB_MAGIC_8261C) {
++		phydev_err(phydev, "Invalid sub magic: 0x%08x\n", sub_magic);
++		return -EINVAL;
++	}
++
++	num_entries = le16_to_cpu(hdr->num_entries);
++	data_len = num_entries * FW_ENTRY_SIZE;
++
++	if (fw->size != sizeof(*hdr) + data_len) {
++		phydev_err(phydev, "Firmware size mismatch\n");
++		return -EINVAL;
++	}
++
++	calc_crc = crc32(~0, fw->data + FW_HEADER_SIZE, data_len) ^ ~0;
++	file_crc = le32_to_cpu(hdr->crc32);
++
++	if (calc_crc != file_crc) {
++		phydev_err(phydev, "CRC32 mismatch: calculated=0x%08x file=0x%08x\n",
++			   calc_crc, file_crc);
++		return -EINVAL;
++	}
++
++	return 0;
++}
++
++static int rtl8261x_fw_execute_entry(struct phy_device *phydev,
++				     const struct rtl8261x_fw_entry *entry)
++{
++	u16 addr, value, timeout_ms;
++	u8 dev, msb, lsb, poll_set;
++	u32 bits, expect_val;
++	int ret = 0;
++	int val;
++
++	dev = entry->dev;
++	addr = le16_to_cpu(entry->addr);
++	msb = entry->msb;
++	lsb = entry->lsb;
++	value = le16_to_cpu(entry->value);
++	timeout_ms = le16_to_cpu(entry->timeout_ms);
++	poll_set = entry->poll_set;
++
++	if (timeout_ms == 0)
++		timeout_ms = RTL8261X_POLL_TIMEOUT_MS;
++
++	if (msb > 15 || lsb > msb) {
++		phydev_err(phydev, "Invalid firmware bits: msb=%d, lsb=%d\n", msb, lsb);
++		return -EINVAL;
++	}
++
++	switch (entry->type) {
++	case OP_WRITE:
++		ret = phy_modify_mmd(phydev, dev, addr,
++				     GENMASK(msb, lsb), (value << lsb) & GENMASK(msb, lsb));
++		if (ret) {
++			phydev_err(phydev, "WRITE failed: dev=%d addr=0x%04x\n", dev, addr);
++			return ret;
++		}
++		break;
++
++	case OP_POLL: {
++		bits = GENMASK(msb, lsb);
++		expect_val = (value << lsb) & bits;
++
++		if (poll_set)
++			ret = phy_read_mmd_poll_timeout(phydev, dev, addr, val,
++							(val & bits) == expect_val,
++							1000, timeout_ms * 1000, false);
++		else
++			ret = phy_read_mmd_poll_timeout(phydev, dev, addr, val,
++							(val & bits) != expect_val,
++							1000, timeout_ms * 1000, false);
++		if (ret)
++			phydev_err(phydev, "POLL timeout: dev=%d addr=0x%04x\n",
++				   dev, addr);
++		break;
++	}
++	default:
++		phydev_err(phydev, "Unknown firmware operation: %d\n", entry->type);
++		ret = -EINVAL;
++		break;
++	}
++
++	return ret;
++}
++
++static int rtl8261x_fw_load(struct phy_device *phydev)
++{
++	struct rtl8261x_priv *priv = phydev->priv;
++	const struct rtl8261x_fw_entry *entry;
++	const struct rtl8261x_fw_header *hdr;
++	const struct firmware *fw;
++	int ret, i;
++
++	if (!priv->fw_name)
++		return 0;
++
++	ret = request_firmware(&fw, priv->fw_name, &phydev->mdio.dev);
++	if (ret) {
++		phydev_err(phydev, "Failed to load firmware %s: %d\n", priv->fw_name, ret);
++		return ret;
++	}
++
++	ret = rtl8261x_verify_firmware(phydev, fw);
++	if (ret)
++		goto release_fw;
++
++	hdr = (const struct rtl8261x_fw_header *)fw->data;
++
++	entry = (const struct rtl8261x_fw_entry *)(fw->data + FW_HEADER_SIZE);
++	for (i = 0; i < le16_to_cpu(hdr->num_entries); i++, entry++) {
++		ret = rtl8261x_fw_execute_entry(phydev, entry);
++		if (ret) {
++			phydev_err(phydev, "Entry %d failed: %d\n", i, ret);
++			goto release_fw;
++		}
++	}
++
++	priv->fw_loaded = true;
++
++release_fw:
++	release_firmware(fw);
++	return ret;
++}
++
+ static int rtl8261x_config_intr(struct phy_device *phydev)
+ {
+ 	int ret;
+@@ -457,6 +657,26 @@ static int rtl8261x_config_aneg(struct p
+ 	return 0;
+ }
+ 
++static int rtl8261x_config_init(struct phy_device *phydev)
++{
++	struct rtl8261x_priv *priv = phydev->priv;
++	int ret = 0;
++
++	/* The firmware parameters are preserved across IEEE soft resets and
++	 * suspend/resume cycles. Reloading is only necessary after a power
++	 * cycle or hard reset.
++	 */
++	if (priv->fw_name && !priv->fw_loaded) {
++		ret = rtl8261x_fw_load(phydev);
++		if (ret) {
++			phydev_err(phydev, "Firmware loading failed: %d\n", ret);
++			return ret;
++		}
++	}
++
++	return ret;
++}
++
+ static int rtl821x_probe(struct phy_device *phydev)
+ {
+ 	struct device *dev = &phydev->mdio.dev;
+@@ -3373,6 +3593,7 @@ static struct phy_driver realtek_drvs[]
+ 		PHY_ID_MATCH_EXACT(RTL_8261C_CG),
+ 		.name           = "RTL8261C 10Gbps PHY",
+ 		.probe          = rtl8261x_probe,
++		.config_init    = rtl8261x_config_init,
+ 		.get_features   = rtl8261x_get_features,
+ 		.config_aneg    = rtl8261x_config_aneg,
+ 		.read_status    = rtl8261x_read_status,


### PR DESCRIPTION
Add support for the RTL8261CE, which is a new revision of the
RTL8261 Nbase-T PHY.

Init sequence, as dumped from a binary driver of the Lumen W1700K2,
seems much different from the other RTL8261 revisions; thus add
the init sequence accordingly to kmod-phy-realtek.

Signed-off-by: Kenneth Kasilag <kenneth@kasilag.me>