### PR TITLE
mvebu: enable coherent crypto on armada 37x0

### DIFF
--- a/target/linux/mvebu/patches-6.12/340-v7.2-arm64-dts-marvell-armada-37xx-mark-EIP97-as-dma-cohe.patch
+++ b/target/linux/mvebu/patches-6.12/340-v7.2-arm64-dts-marvell-armada-37xx-mark-EIP97-as-dma-cohe.patch
@@ -1,0 +1,46 @@
+From 5dd98e0389545b302b0c46cef2264b5b09c01677 Mon Sep 17 00:00:00 2001
+From: Aleksander Jan Bajkowski <olek2@wp.pl>
+Date: Sun, 24 May 2026 14:44:53 +0200
+Subject: [PATCH] arm64: dts: marvell: armada-37xx: mark EIP97 as dma-coherent
+
+Armada 37xx has coherent bus, similar to Armada 7k/8k. Cache
+synchronization consumes a lot of CPU cycles. Enabling coherent DMA
+increases IOPS performance up to 4 times. Some numbers:
+					Data length
+Algo		MB	   16	  64	 128	 256	1024	1424	4096
+DES-ECB		1	+21 %	+5 %	+5 %	+7 %	+7 %	+3 %	+20 %
+AES-ECB-128	1	+21 %	+6 %	+6 %	+6 %	+9 %	+8 %	+22 %
+AES-CBC-128	1	+21 %	+5 %	+5 %	+5 %	+6 %	+7 %	+23 %
+AES-CBC-256	1	+23 %	+7 %	+8 %	+6 %	+11 %	+13 %	+20 %
+
+					Data length
+Algo		MB	    16	    64	   256	  512	  1024	 1420	 4096	 8192
+AES-GCM-128	1	 +44 %	 +42 %	 +31 %	 +32 %	 +27 %	+30 %	+32 %	+30 %
+AES-GCM-128	8	+319 %	+326 %	+163 %	+148 %	 +75 %	+72 %	+74 %	+41 %
+AES-GCM-128	4096	+123 %	+128 %	 +90 %	 +83 %	+116 %	+59 %	+38 %	+28 %
+
+					Data length
+Algo		MB	   16	   64	  256	 1024	 2048	 4096	 8192
+MD5		1	+21 %	+15 %	+29 %	+25 %	+50 %	+16 %	+20 %
+SHA1		1	+24 %	+22 %	+27 %	+22 %	+18 %	+20 %	+20 %
+SHA256		1	+30 %	+24 %	+25 %	+26 %	+21 %	+41 %	+19 %
+SHA512		1	 +4 %	 +3 %	 +8 %	+10 %	+24 %	+10 %	+11 %
+
+Tested on Armada 3720. Platform passes testmgr selftests.
+
+Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Signed-off-by: Gregory CLEMENT <gregory.clement@bootlin.com>
+---
+ arch/arm64/boot/dts/marvell/armada-37xx.dtsi | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/arch/arm64/boot/dts/marvell/armada-37xx.dtsi
++++ b/arch/arm64/boot/dts/marvell/armada-37xx.dtsi
+@@ -440,6 +440,7 @@
+ 				interrupt-names = "ring0", "ring1", "ring2",
+ 						  "ring3", "eip", "mem";
+ 				clocks = <&nb_periph_clk 15>;
++				dma-coherent;
+ 			};
+ 
+ 			rwtm: mailbox@b0000 {

--- a/target/linux/mvebu/patches-6.18/340-v7.2-arm64-dts-marvell-armada-37xx-mark-EIP97-as-dma-cohe.patch
+++ b/target/linux/mvebu/patches-6.18/340-v7.2-arm64-dts-marvell-armada-37xx-mark-EIP97-as-dma-cohe.patch
@@ -1,0 +1,46 @@
+From 5dd98e0389545b302b0c46cef2264b5b09c01677 Mon Sep 17 00:00:00 2001
+From: Aleksander Jan Bajkowski <olek2@wp.pl>
+Date: Sun, 24 May 2026 14:44:53 +0200
+Subject: [PATCH] arm64: dts: marvell: armada-37xx: mark EIP97 as dma-coherent
+
+Armada 37xx has coherent bus, similar to Armada 7k/8k. Cache
+synchronization consumes a lot of CPU cycles. Enabling coherent DMA
+increases IOPS performance up to 4 times. Some numbers:
+					Data length
+Algo		MB	   16	  64	 128	 256	1024	1424	4096
+DES-ECB		1	+21 %	+5 %	+5 %	+7 %	+7 %	+3 %	+20 %
+AES-ECB-128	1	+21 %	+6 %	+6 %	+6 %	+9 %	+8 %	+22 %
+AES-CBC-128	1	+21 %	+5 %	+5 %	+5 %	+6 %	+7 %	+23 %
+AES-CBC-256	1	+23 %	+7 %	+8 %	+6 %	+11 %	+13 %	+20 %
+
+					Data length
+Algo		MB	    16	    64	   256	  512	  1024	 1420	 4096	 8192
+AES-GCM-128	1	 +44 %	 +42 %	 +31 %	 +32 %	 +27 %	+30 %	+32 %	+30 %
+AES-GCM-128	8	+319 %	+326 %	+163 %	+148 %	 +75 %	+72 %	+74 %	+41 %
+AES-GCM-128	4096	+123 %	+128 %	 +90 %	 +83 %	+116 %	+59 %	+38 %	+28 %
+
+					Data length
+Algo		MB	   16	   64	  256	 1024	 2048	 4096	 8192
+MD5		1	+21 %	+15 %	+29 %	+25 %	+50 %	+16 %	+20 %
+SHA1		1	+24 %	+22 %	+27 %	+22 %	+18 %	+20 %	+20 %
+SHA256		1	+30 %	+24 %	+25 %	+26 %	+21 %	+41 %	+19 %
+SHA512		1	 +4 %	 +3 %	 +8 %	+10 %	+24 %	+10 %	+11 %
+
+Tested on Armada 3720. Platform passes testmgr selftests.
+
+Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Signed-off-by: Gregory CLEMENT <gregory.clement@bootlin.com>
+---
+ arch/arm64/boot/dts/marvell/armada-37xx.dtsi | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/arch/arm64/boot/dts/marvell/armada-37xx.dtsi
++++ b/arch/arm64/boot/dts/marvell/armada-37xx.dtsi
+@@ -438,6 +438,7 @@
+ 				interrupt-names = "ring0", "ring1", "ring2",
+ 						  "ring3", "eip", "mem";
+ 				clocks = <&nb_periph_clk 15>;
++				dma-coherent;
+ 			};
+ 
+ 			rwtm: mailbox@b0000 {


### PR DESCRIPTION
Armada 37xx has coherent bus, similar to Armada 7k/8k. Cache synchronization consumes a lot of CPU cycles. Enabling coherent DMA increases IOPS performance up to 4 times. Some numbers:
~~~
					Data length
Algo		MB	   16	  64	 128	 256	1024	1424	4096
DES-ECB		1	+21 %	+5 %	+5 %	+7 %	+7 %	+3 %	+20 %
AES-ECB-128	1	+21 %	+6 %	+6 %	+6 %	+9 %	+8 %	+22 %
AES-CBC-128	1	+21 %	+5 %	+5 %	+5 %	+6 %	+7 %	+23 %
AES-CBC-256	1	+23 %	+7 %	+8 %	+6 %	+11 %	+13 %	+20 %

					Data length
Algo		MB	    16	    64	   256	  512	  1024	 1420	 4096	 8192
AES-GCM-128	1	 +44 %	 +42 %	 +31 %	 +32 %	 +27 %	+30 %	+32 %	+30 %
AES-GCM-128	8	+319 %	+326 %	+163 %	+148 %	 +75 %	+72 %	+74 %	+41 %
AES-GCM-128	4k	+123 %	+128 %	 +90 %	 +83 %	+116 %	+59 %	+38 %	+28 %

					Data length
Algo		MB	   16	   64	  256	 1024	 2048	 4096	 8192
MD5			1	+21 %	+15 %	+29 %	+25 %	+50 %	+16 %	+20 %
SHA1		1	+24 %	+22 %	+27 %	+22 %	+18 %	+20 %	+20 %
SHA256		1	+30 %	+24 %	+25 %	+26 %	+21 %	+41 %	+19 %
SHA512		1	 +4 %	 +3 %	 +8 %	+10 %	+24 %	+10 %	+11 %
~~~

Tested on Armada 3720. Platform passes testmgr selftests.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>