### PR TITLE
ramips: mt7621: build initramfs-factory.trx for easy flashing of ASUS RT-AX53U from vendor WebGUI 

### DIFF
--- a/target/linux/ramips/image/Makefile
+++ b/target/linux/ramips/image/Makefile
@@ -29,6 +29,14 @@ LOADER_FLASH_START := $(ldrflashstart-y)
 
 KERNEL_DTB = kernel-bin | append-dtb | lzma
 
+define Build/asus-trx
+	# don't stop the whole build if check-size removed the input file
+	[ ! -e $@ ] || { \
+		$(STAGING_DIR_HOST)/bin/asusuimage $(wordlist 1,$(words $(1)),$(1)) -i $@ -o $@.new; \
+		mv $@.new $@; \
+	}
+endef
+
 define Build/jcg-header
 	$(STAGING_DIR_HOST)/bin/jcgimage -v $(1) \
 		$(if $(JCG_MAXSIZE), -m $$(($(call exp_units,$(JCG_MAXSIZE)))),) \

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -481,6 +481,13 @@ define Device/asus_rt-ax53u
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
 	check-size
   DEVICE_PACKAGES := kmod-mt7915-firmware kmod-usb3 kmod-usb-ledtrig-usbport
+ifeq ($(IB),)
+ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
+  ARTIFACTS := initramfs-factory.trx
+  ARTIFACT/initramfs-factory.trx := append-image-stage initramfs-kernel.bin | \
+	check-size 16m | asus-trx -v 2 -n $$(DEVICE_MODEL) -b 386 -e 19999
+endif
+endif
 endef
 TARGET_DEVICES += asus_rt-ax53u
 


### PR DESCRIPTION
Build an `initramfs-factory.trx` image suitable for flashing directly via the vendor firmware WebGUI, without using TFTP or SSH.

To use:
1. Flash the `initramfs-factory.trx` file with the vendor firmware administrative interface.
2. Wait until the router restarts, login to OpenWRT via LuCI (or SSH) and upgrade firmware using the `sysupgrade-squashfs.bin` image file.

It is necessary to use TRX version 2, which has a kernel size limit of 16MB (TRX version 3 is rejected by vendor firmware). To avoid stopping the whole build when the input file turns out larger, check in the `Build/asus-trx` macro if `check-size` removed the input file and don't error out in this case.

Note: It should be possible to prepare an image to flash the router in one step, but this will be more complicated, because vendor firmware and OpenWRT use a slightly different partition layout.

Note: I'm opening https://github.com/openwrt/openwrt/pull/22552 anew, because that PR was on the tenth page of PRs in GitHub UI and I expected noone to look at it again. I have rebased and retested the changes and updated the commit description slightly.