### PR TITLE
realtek: rtl930x: add support for Horaco ZX-SWTGW2C8F

### DIFF
--- a/target/linux/realtek/dts/rtl9303_horaco_zx-swtgw2c8f.dts
+++ b/target/linux/realtek/dts/rtl9303_horaco_zx-swtgw2c8f.dts
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl930x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "horaco,zx-swtgw2c8f", "realtek,rtl9303-soc";
+	model = "Horaco ZX-SWTGW2C8F";
+
+	aliases {
+		label-mac-device = &ethernet0;
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200 earlyprintk";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	led_set {
+		compatible = "realtek,rtl9300-leds";
+		realtek,led-mode = <RTL93XX_LED_MODE_SINGLE_COLOR_SCAN>;
+
+		led_set0 = <RTL93XX_LED_SET_NONE
+		            (RTL93XX_LED_SET_1G | RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+		            (RTL93XX_LED_SET_10G | RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinmux_disable_sys_led>;
+
+		led_sys: sys {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "heartbeat";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		mode {
+			label = "reset";
+			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	sfp0: sfp-p1 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c_hw0>;
+		mod-def0-gpio = <&gpio1 1 GPIO_ACTIVE_LOW>;
+		los-gpio = <&gpio1 2 GPIO_ACTIVE_HIGH>;
+		tx-disable-gpio = <&gpio1 0 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp1: sfp-p2 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c_hw1>;
+		mod-def0-gpio = <&gpio1 4 GPIO_ACTIVE_LOW>;
+		los-gpio = <&gpio1 5 GPIO_ACTIVE_HIGH>;
+		tx-disable-gpio = <&gpio1 3 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp2: sfp-p3 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c_hw2>;
+		mod-def0-gpio = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		los-gpio = <&gpio1 8 GPIO_ACTIVE_HIGH>;
+		tx-disable-gpio = <&gpio1 6 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp3: sfp-p4 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c_hw3>;
+		mod-def0-gpio = <&gpio1 10 GPIO_ACTIVE_LOW>;
+		los-gpio = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+		tx-disable-gpio = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp4: sfp-p5 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c_hw4>;
+		mod-def0-gpio = <&gpio1 13 GPIO_ACTIVE_LOW>;
+		los-gpio = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+		tx-disable-gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp5: sfp-p6 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c_hw5>;
+		mod-def0-gpio = <&gpio1 22 GPIO_ACTIVE_LOW>;
+		los-gpio = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+		tx-disable-gpio = <&gpio1 21 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp6: sfp-p7 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c_hw6>;
+		mod-def0-gpio = <&gpio1 25 GPIO_ACTIVE_LOW>;
+		los-gpio = <&gpio1 26 GPIO_ACTIVE_HIGH>;
+		tx-disable-gpio = <&gpio1 24 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp7: sfp-p8 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c_hw7>;
+		mod-def0-gpio = <&gpio1 28 GPIO_ACTIVE_LOW>;
+		los-gpio = <&gpio1 29 GPIO_ACTIVE_HIGH>;
+		tx-disable-gpio = <&gpio1 27 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&mdio_aux {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinmux_gpio_mdio_en>;
+	status = "okay";
+
+	gpio1: gpio@0 {
+		compatible = "realtek,rtl8231";
+		reg = <0>;
+
+		gpio-controller;
+		#gpio-cells = <2>;
+		gpio-ranges = <&gpio1 0 0 37>;
+	};
+
+};
+
+&i2c_mst1 {
+	status = "okay";
+
+	i2c_hw0: i2c@0 { reg = <0>; };
+	i2c_hw1: i2c@1 { reg = <1>; };
+	i2c_hw2: i2c@2 { reg = <2>; };
+	i2c_hw3: i2c@3 { reg = <3>; };
+	i2c_hw4: i2c@4 { reg = <4>; };
+	i2c_hw5: i2c@5 { reg = <5>; };
+	i2c_hw6: i2c@6 { reg = <6>; };
+	i2c_hw7: i2c@7 { reg = <7>; };
+};
+
+&switch0 {
+	ethernet-ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT_SFP(0, 1, 2, 0, 0)
+		SWITCH_PORT_SFP(8, 2, 3, 0, 1)
+		SWITCH_PORT_SFP(16, 3, 4, 0, 2)
+		SWITCH_PORT_SFP(20, 4, 5, 0, 3)
+		SWITCH_PORT_SFP(24, 5, 6, 0, 4)
+		SWITCH_PORT_SFP(25, 6, 7, 0, 5)
+		SWITCH_PORT_SFP(26, 7, 8, 0, 6)
+		SWITCH_PORT_SFP(27, 8, 9, 0, 7)
+
+		port@1c {
+			reg = <28>;
+			ethernet = <&ethernet0>;
+			phy-mode = "internal";
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "loader";
+				reg = <0x0 0xe0000>;
+				read-only;
+			};
+
+			partition@e0000 {
+				label = "bdinfo";
+				reg = <0xe0000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+
+					macaddr_ubootenv_ethaddr: ethaddr {
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@f0000 {
+				label = "sysinfo";
+				reg = <0xf0000 0x10000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "jffs2-cfg";
+				reg = <0x100000 0x100000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "jffs2-log";
+				reg = <0x200000 0x100000>;
+				read-only;
+			};
+
+			partition@300000 {
+				label = "runtime";
+				reg = <0x300000 0xc00000>;
+				compatible = "openwrt,uimage";
+				openwrt,ih-magic = <0x83800000>;
+			};
+
+			partition@f00000 {
+				label = "oeminfo";
+				reg = <0xf00000 0x100000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	nvmem-cells = <&macaddr_ubootenv_ethaddr 0>;
+	nvmem-cell-names = "mac-address";
+};

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -69,6 +69,23 @@ define Device/hasivo_s600wp-5gt-2sx-se
 endef
 TARGET_DEVICES += hasivo_s600wp-5gt-2sx-se
 
+define Device/horaco_zx-swtgw2c8f
+  SOC := rtl9303
+  UIMAGE_MAGIC := 0x83800000
+  DEVICE_VENDOR := Horaco
+  DEVICE_MODEL := ZX-SWTGW2C8F
+  IMAGE_SIZE := 12288k
+  $(Device/kernel-lzma)
+  IMAGES += factory.bix
+  IMAGE/factory.bix := \
+	append-kernel | \
+	pad-to 64k | \
+	append-rootfs | \
+	pad-rootfs | \
+	check-size
+endef
+TARGET_DEVICES += horaco_zx-swtgw2c8f
+
 define Device/plasmacloud-common
   SOC := rtl9302
   UIMAGE_MAGIC := 0x93000000


### PR DESCRIPTION
While support was developed and tested on the Horaco ZX-SWTGW2C8F, physically identical looking devices are also sold under the GoodTop and LIANGUO brands. It's likely these are just rebadged versions of the same OEM product.

The switch's MAC address is stored in the uboot env and works without any further hacks.

# Hardware
| | |
| ---: | :--- |
| **SoC Type** | Realtek RTL9303 |
| **RAM** | 128MB |
| **Flash** | Winbond 16MiB |
| **Ethernet** | 8x SFP+ 10G |
| **LEDs** | 1x power green hardwired <br> 1x SYS green <br> 8x2 LEDs per RJ45 port: <br>&nbsp;&nbsp;&nbsp;&nbsp; - 1x green (1G link/activity) <br>&nbsp;&nbsp;&nbsp;&nbsp; - 1x blue (10G link/activity) |
| **Button** | Reset |
| **Console** | 1x CISCO-style RJ45 RS232 port |
| **Bootloader** | Realtek U-Boot 2011.12 |

Installing OpenWrt
------------------
uboot is reachable per instructions to press Esc during boot. `rtk network on` is fully functional and tftpboot can be used for recovery. Installation is simplest via uploading the factory image through the web interface.