### PR TITLE
build: no per package signing with SIGNED_PACKAGES disabled

### DIFF
--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -620,7 +620,7 @@ else
 	  $$(APK_SCRIPTS_$(1)) \
 	  --info "depends:$$(foreach depends,$$(subst $$(comma),$$(space),$$(subst $$(space),,$$(subst $$(paren_right),,$$(subst $$(paren_left),,$$(Package/$(1)/DEPENDS))))),$$(depends))" \
 	  --files "$$(IDIR_$(1))" \
-	  $(if $(CONFIG_SIGN_EACH_PACKAGE),--sign $(BUILD_KEY_APK_SEC),) \
+	  $(if $(and $(CONFIG_SIGN_EACH_PACKAGE),$(CONFIG_SIGNED_PACKAGES)),--sign $(BUILD_KEY_APK_SEC),) \
 	  --output "$$(PACK_$(1))"
 endif
 


### PR DESCRIPTION
CONFIG_SIGN_EACH_PACKAGE controls whether each individual .apk file is signed with the build key, independently from CONFIG_SIGNED_PACKAGES, which signs the package list/index. As a result, disabling SIGNED_PACKAGES (e.g. via "make ... CONFIG_SIGNED_PACKAGES=") was not enough to stop per-package signing.

Right now, buildbot phase2 SDK signs every package with its local key, even though the resulting feed indexes are signed centrally afterwards. As a result, this breaks reproducibility.

Make per-package signing depend on SIGNED_PACKAGES  in the package-pack.mk --sign guard so a make-variable override takes effect.  

Signed-off-by: Paul Spooren <mail@aparcar.org>