### PR TITLE
scripts: dhcp/dhcpv6: handling of invalid client ID values

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -16,6 +16,13 @@ NO_EXPORT=1
 LOAD_STATE=1
 LIST_SEP=" "
 
+# check for valid hexdump and strip common separators and leading/trailing blanks
+# input can be single- or multi-line, separators can be none, dash, colon or one or more spaces/tabs
+hexdump_2hex() {
+	[ -z "$1" ] && return
+	echo -n "$1" | tr '\nA-F' ' a-f' | sed -nr '/^\s*[0-9a-f]{2}((\s+|[:-]?)[0-9a-f]{2})*\s*$/s/[[:space:]:-]*//pg'
+}
+
 # xor multiple hex values of the same length
 xor() {
 	local val

--- a/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
+++ b/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
@@ -40,9 +40,14 @@ proto_dhcp_get_default_clientid() {
 	local duid
 	local iaid
 
-	network_generate_iface_iaid iaid "$iface"
 	duid="$(uci_get network @globals[0] dhcp_default_duid)"
-	[ -n "$duid" ] && printf "ff%s%s" "$iaid" "$duid"
+	[ -n "$duid" ] && {
+		duid="$(hexdump_2hex "$duid")"
+		[ -z "$duid" ] && logger -p warn -t dhcp "$iface: ignoring invalid dhcp_default_duid value"
+	}
+	[ -z "$duid" ] && return
+	network_generate_iface_iaid iaid "$iface"
+	printf "ff%s%s" "$iaid" "$duid"
 }
 
 proto_dhcp_setup() {
@@ -65,8 +70,12 @@ proto_dhcp_setup() {
 	[ "$defaultreqopts" = 0 ] && defaultreqopts="-o" || defaultreqopts=
 	[ "$broadcast" = 1 ] && broadcast="-B" || broadcast=
 	[ "$norelease" = 1 ] && norelease="" || norelease="-R"
+	[ -n "$clientid" ] && {
+		clientid="$(hexdump_2hex "$clientid")"
+		[ -z "$clientid" ] && logger -p warn -t dhcp "$iface: ignoring invalid clientid value"
+	}
 	[ -z "$clientid" ] && clientid="$(proto_dhcp_get_default_clientid "$iface")"
-	[ -n "$clientid" ] && clientid="-x 0x3d:${clientid//:/}"
+	[ -n "$clientid" ] && clientid="-x 0x3d:$clientid"
 	[ -n "$vendorid" ] && append dhcpopts "-x 0x3c:$(echo -n "$vendorid" | hexdump -ve '1/1 "%02x"')"
 	[ -n "$iface6rd" ] && proto_export "IFACE6RD=$iface6rd"
 	[ "$iface6rd" != 0 -a -f /lib/netifd/proto/6rd.sh ] && append dhcpopts "-O 212"

--- a/package/network/ipv6/odhcp6c/files/dhcpv6.sh
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.sh
@@ -87,7 +87,15 @@ proto_dhcpv6_setup() {
 	[ -z "$reqprefix" -o "$reqprefix" = "auto" ] && reqprefix=0
 	[ "$reqprefix" != "no" ] && append opts "-P$reqprefix"
 
+	[ -n "$clientid" ] && {
+		clientid="$(hexdump_2hex "$clientid")"
+		[ -z "$clientid" ] && logger -p warn -t dhcpv6 "$iface: ignoring invalid clientid value"
+	}
 	[ -z "$clientid" ] && clientid="$(uci_get network @globals[0] dhcp_default_duid)"
+	[ -n "$clientid" ] && {
+		clientid="$(hexdump_2hex "$clientid")"
+		[ -z "$clientid" ] && logger -p warn -t dhcpv6 "$iface: ignoring invalid dhcp_default_duid value"
+	}
 	[ -n "$clientid" ] && append opts "-c$clientid"
 
 	[ "$defaultreqopts" = "0" ] && append opts "-R"


### PR DESCRIPTION
Verify and clean up client ID and global DUID config values before use, in order to prevent DHCP client malfunction and loss of IPv4 and/or IPv6 connectivity.

A DHCPv6 DUID resp. DHCPv4 client ID specification is expected to be a hex string of even-numbered length (ie. a sequence of bytes in hex notation without separators). Specifying a non-hex string will cause `odhcpc`/`udhcpc` to fail with an error message. The resulting endless reinvoke-loop by `netifd` results in 100% CPU load and loss of IPv4 and/or IPv6 connectivity. Values of odd-numbered length will be parsed incorrectly (truncated by `odhcpc` resp. improperly padded by `udhcpc`), resulting in unexpected and non-matching client IDs to be sent in DHCP requests.

Before this PR, client ID configuration values were mostly passed to `udhcpc` and `odhcpc` unverified and unsanitized. It was the user's responsibility to configure correct values. This wasn't usually an issue, as specifying a client ID was a rather uncommon corner case prior to OpenWrt 25.12.

With 25.12, however, OpenWrt heavily relies on passing predefined client IDs to `odhcpc` and `udhcpc`. Therefore, these values should be checked before use, in order to prevent broken connectivity and other errors.

With this PR, the fall back mechanism, when an invalid client ID is encountered, is as follows:

* If a (user-configured) `network.<ifname>.clientid` setting is found invalid, ignore and fall back to using `network.globals.dhcp_default_duid`
* In case `network.globals.dhcp_default_duid` is invalid (e.g. has been tampered with), don't pass a client ID to `udhcpc`/`odhcpc`
* As a last resort, `udhcpc`/`odhcpc` will use their defaults, which currently is the i/f MAC address resp. the i/f DUID-LL

After this PR (in contrast to before), also hex strings with commonly used separators are accepted, such as colons (e.g. MAC address c&ps from *nix outputs, was previously only accepted for IPv4), dashes (e.g. MAC address c&ps from Windows, or UUID strings) as well as any number of spaces, tabs and even line breaks. This should greatly reduce the chance of failure to accept a correct, but badly formatted user-defined client ID.

As processing is now stopped before `uphcpc`/`odhcpc` can throw an error, have the dhcp(v6) scripts log a warning message if an invalid client ID is encountered, so the user has a chance to see that something's wrong.

This PR only improves handling of _incorrect_ settings for better system stability. There is no behavior change if the respective settings are valid or unconfigured.

This PR should be merged into Main, as well as 25.12.