### PR TITLE
generic: mxl862xx: allow CPU/SerDes ports to probe on firmware < 1.0.84

### DIFF
--- a/target/linux/generic/pending-6.12/760-04-net-dsa-mxl862xx-add-support-for-SerDes-ports.patch
+++ b/target/linux/generic/pending-6.12/760-04-net-dsa-mxl862xx-add-support-for-SerDes-ports.patch
@@ -372,7 +372,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  #endif /* __MXL862XX_CMD_H */
 --- a/drivers/net/dsa/mxl862xx/mxl862xx-phylink.c
 +++ b/drivers/net/dsa/mxl862xx/mxl862xx-phylink.c
-@@ -7,20 +7,371 @@
+@@ -7,20 +7,369 @@
   * Copyright (C) 2025 Daniel Golle <daniel@makrotopia.org>
   */
  
@@ -403,8 +403,6 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +		break;
 +	case 9:
 +	case 13:
-+		if (!MXL862XX_FW_VER_MIN(priv, 1, 0, 84))
-+			break;
 +		__set_bit(PHY_INTERFACE_MODE_SGMII, config->supported_interfaces);
 +		__set_bit(PHY_INTERFACE_MODE_1000BASEX, config->supported_interfaces);
 +		__set_bit(PHY_INTERFACE_MODE_2500BASEX, config->supported_interfaces);
@@ -746,7 +744,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  }
  
  static void mxl862xx_phylink_mac_config(struct phylink_config *config,
-@@ -48,4 +399,5 @@ const struct phylink_mac_ops mxl862xx_ph
+@@ -48,4 +397,5 @@ const struct phylink_mac_ops mxl862xx_ph
  	.mac_config = mxl862xx_phylink_mac_config,
  	.mac_link_down = mxl862xx_phylink_mac_link_down,
  	.mac_link_up = mxl862xx_phylink_mac_link_up,

--- a/target/linux/generic/pending-6.12/760-05-net-dsa-mxl862xx-add-SerDes-ethtool-statistics.patch
+++ b/target/linux/generic/pending-6.12/760-05-net-dsa-mxl862xx-add-SerDes-ethtool-statistics.patch
@@ -130,7 +130,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  
 --- a/drivers/net/dsa/mxl862xx/mxl862xx-phylink.c
 +++ b/drivers/net/dsa/mxl862xx/mxl862xx-phylink.c
-@@ -401,3 +401,100 @@ const struct phylink_mac_ops mxl862xx_ph
+@@ -399,3 +399,100 @@ const struct phylink_mac_ops mxl862xx_ph
  	.mac_link_up = mxl862xx_phylink_mac_link_up,
  	.mac_select_pcs = mxl862xx_phylink_mac_select_pcs,
  };

--- a/target/linux/generic/pending-6.12/760-18-DO-NOT-SUBMIT-net-dsa-mxl862xx-legacy-SFP-API-fallba.patch
+++ b/target/linux/generic/pending-6.12/760-18-DO-NOT-SUBMIT-net-dsa-mxl862xx-legacy-SFP-API-fallba.patch
@@ -301,7 +301,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  #define MXL862XX_XPCS_PCS_GET_STATE	(MXL862XX_XPCS_MAGIC + 0x2)
 --- a/drivers/net/dsa/mxl862xx/mxl862xx-phylink.c
 +++ b/drivers/net/dsa/mxl862xx/mxl862xx-phylink.c
-@@ -62,6 +62,152 @@ static struct mxl862xx_pcs *pcs_to_mxl86
+@@ -60,6 +60,152 @@ static struct mxl862xx_pcs *pcs_to_mxl86
  	return container_of(pcs, struct mxl862xx_pcs, pcs);
  }
  
@@ -454,7 +454,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  static int mxl862xx_xpcs_if_mode(phy_interface_t interface)
  {
  	switch (interface) {
-@@ -351,7 +497,10 @@ void mxl862xx_setup_pcs(struct mxl862xx_
+@@ -349,7 +495,10 @@ void mxl862xx_setup_pcs(struct mxl862xx_
  	pcs->slot = MXL862XX_SERDES_SLOT(port);
  	pcs->interface = PHY_INTERFACE_MODE_NA;
  
@@ -466,7 +466,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	pcs->pcs.poll = true;
  }
  
-@@ -363,9 +512,6 @@ mxl862xx_phylink_mac_select_pcs(struct p
+@@ -361,9 +510,6 @@ mxl862xx_phylink_mac_select_pcs(struct p
  	struct mxl862xx_priv *priv = dp->ds->priv;
  	int port = dp->index;
  

--- a/target/linux/generic/pending-6.18/760-04-net-dsa-mxl862xx-add-support-for-SerDes-ports.patch
+++ b/target/linux/generic/pending-6.18/760-04-net-dsa-mxl862xx-add-support-for-SerDes-ports.patch
@@ -372,7 +372,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  #endif /* __MXL862XX_CMD_H */
 --- a/drivers/net/dsa/mxl862xx/mxl862xx-phylink.c
 +++ b/drivers/net/dsa/mxl862xx/mxl862xx-phylink.c
-@@ -7,20 +7,384 @@
+@@ -7,20 +7,382 @@
   * Copyright (C) 2025 Daniel Golle <daniel@makrotopia.org>
   */
  
@@ -403,8 +403,6 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +		break;
 +	case 9:
 +	case 13:
-+		if (!MXL862XX_FW_VER_MIN(priv, 1, 0, 84))
-+			break;
 +		__set_bit(PHY_INTERFACE_MODE_SGMII, config->supported_interfaces);
 +		__set_bit(PHY_INTERFACE_MODE_1000BASEX, config->supported_interfaces);
 +		__set_bit(PHY_INTERFACE_MODE_2500BASEX, config->supported_interfaces);
@@ -759,7 +757,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  }
  
  static void mxl862xx_phylink_mac_config(struct phylink_config *config,
-@@ -48,4 +412,5 @@ const struct phylink_mac_ops mxl862xx_ph
+@@ -48,4 +410,5 @@ const struct phylink_mac_ops mxl862xx_ph
  	.mac_config = mxl862xx_phylink_mac_config,
  	.mac_link_down = mxl862xx_phylink_mac_link_down,
  	.mac_link_up = mxl862xx_phylink_mac_link_up,

--- a/target/linux/generic/pending-6.18/760-05-net-dsa-mxl862xx-add-SerDes-ethtool-statistics.patch
+++ b/target/linux/generic/pending-6.18/760-05-net-dsa-mxl862xx-add-SerDes-ethtool-statistics.patch
@@ -130,7 +130,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  
 --- a/drivers/net/dsa/mxl862xx/mxl862xx-phylink.c
 +++ b/drivers/net/dsa/mxl862xx/mxl862xx-phylink.c
-@@ -414,3 +414,100 @@ const struct phylink_mac_ops mxl862xx_ph
+@@ -412,3 +412,100 @@ const struct phylink_mac_ops mxl862xx_ph
  	.mac_link_up = mxl862xx_phylink_mac_link_up,
  	.mac_select_pcs = mxl862xx_phylink_mac_select_pcs,
  };

--- a/target/linux/generic/pending-6.18/760-18-DO-NOT-SUBMIT-net-dsa-mxl862xx-legacy-SFP-API-fallba.patch
+++ b/target/linux/generic/pending-6.18/760-18-DO-NOT-SUBMIT-net-dsa-mxl862xx-legacy-SFP-API-fallba.patch
@@ -301,7 +301,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  #define MXL862XX_XPCS_PCS_GET_STATE	(MXL862XX_XPCS_MAGIC + 0x2)
 --- a/drivers/net/dsa/mxl862xx/mxl862xx-phylink.c
 +++ b/drivers/net/dsa/mxl862xx/mxl862xx-phylink.c
-@@ -62,6 +62,153 @@ static struct mxl862xx_pcs *pcs_to_mxl86
+@@ -60,6 +60,153 @@ static struct mxl862xx_pcs *pcs_to_mxl86
  	return container_of(pcs, struct mxl862xx_pcs, pcs);
  }
  
@@ -455,7 +455,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  static int mxl862xx_xpcs_if_mode(phy_interface_t interface)
  {
  	switch (interface) {
-@@ -352,7 +499,10 @@ void mxl862xx_setup_pcs(struct mxl862xx_
+@@ -350,7 +497,10 @@ void mxl862xx_setup_pcs(struct mxl862xx_
  	pcs->slot = MXL862XX_SERDES_SLOT(port);
  	pcs->interface = PHY_INTERFACE_MODE_NA;
  
@@ -467,7 +467,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	pcs->pcs.poll = true;
  
  	__set_bit(PHY_INTERFACE_MODE_QSGMII, pcs->pcs.supported_interfaces);
-@@ -376,9 +526,6 @@ mxl862xx_phylink_mac_select_pcs(struct p
+@@ -374,9 +524,6 @@ mxl862xx_phylink_mac_select_pcs(struct p
  	struct mxl862xx_priv *priv = dp->ds->priv;
  	int port = dp->index;
  


### PR DESCRIPTION
## Summary

Commit 028dc3f57a6f ("generic: 6.18: update MxL862xx DSA switch driver", #23477) added a firmware-version gate to `mxl862xx_phylink_get_caps()` that leaves `config->supported_interfaces` empty for the CPU/SerDes ports (9, 13) when the switch runs firmware older than 1.0.84. phylink rejects an empty `supported_interfaces` bitmap, so the switch never probes and all attached LAN ports disappear on boards still shipping the older vendor firmware (e.g. the BananaPi BPi-R4 Pro 8X, which ships 1.0.70 — #21083).

This ungates **only** ports 9 and 13 so the switch probes and the user can update the firmware. Ports 10..12 and 14..16 stay gated as they are genuinely unsupported by the old firmware, per @dangowrt's guidance in #23477.

The same change is applied to both the 6.12 and 6.18 patches for parity.

## dmesg

Before (fw 1.0.70):
```
mxl862xx mdio-bus:10: switch ready after 2480ms, firmware 1.0.70 (build 70)
mxl862xx mdio-bus:10: phylink: error: empty supported_interfaces
error creating PHYLINK: -22
mxl862xx mdio-bus:10: probe with driver mxl862xx failed with error -22
```

After:
```
mxl862xx mdio-bus:10: switch ready after 2440ms, firmware 1.0.70 (build 70)
mxl862xx mdio-bus:10: configuring for fixed/10gbase-r link mode
mxl862xx mdio-bus:10: Link is Up - 10Gbps/Full - flow control off
mxl862xx mdio-bus:10 lan1: Link is Up - 1Gbps/Full
```

## Test plan
- [x] Built and flashed on BPi-R4 Pro 8X (kernel 6.18, switch fw 1.0.70): switch probes and lan1–4 come up.
- [ ] 6.12 patch carries the identical change for parity (not separately bench-tested).

Refs #23477

Made with [Cursor](https://cursor.com)