### PR TITLE
mvebu: improve Turris Mox compatibility (allow upgrades, add bluetooth driver, remove driver SDIO boot delay)

### DIFF
--- a/target/linux/mvebu/cortexa53/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mvebu/cortexa53/base-files/lib/upgrade/platform.sh
@@ -43,6 +43,7 @@ methode_update_active_bootscript() {
 
 platform_check_image() {
 	case "$(board_name)" in
+	cznic,turris-mox|\
 	glinet,gl-mv1000|\
 	globalscale,espressobin|\
 	globalscale,espressobin-emmc|\
@@ -59,6 +60,7 @@ platform_check_image() {
 
 platform_do_upgrade() {
 	case "$(board_name)" in
+	cznic,turris-mox|\
 	glinet,gl-mv1000|\
 	globalscale,espressobin|\
 	globalscale,espressobin-emmc|\
@@ -117,6 +119,7 @@ platform_do_upgrade() {
 }
 platform_copy_config() {
 	case "$(board_name)" in
+	cznic,turris-mox|\
 	glinet,gl-mv1000|\
 	globalscale,espressobin|\
 	globalscale,espressobin-emmc|\

--- a/target/linux/mvebu/image/cortexa53.mk
+++ b/target/linux/mvebu/image/cortexa53.mk
@@ -6,7 +6,7 @@ define Device/cznic_turris-mox
     kmod-rtc-ds1307 kmod-i2c-pxa kmod-dsa kmod-dsa-mv88e6xxx kmod-sfp \
     kmod-phy-marvell kmod-phy-marvell-10g kmod-ath10k ath10k-board-qca988x \
     ath10k-firmware-qca988x kmod-mt7915e kmod-mt7915-firmware mwlwifi-firmware-88w8997 \
-    wpad-basic-mbedtls kmod-mwifiex-sdio
+    wpad-basic-mbedtls kmod-mwifiex-sdio kmod-btmrvl
   SOC := armada-3720
   BOOT_SCRIPT := turris-mox
 endef

--- a/target/linux/mvebu/image/turris-mox.bootscript
+++ b/target/linux/mvebu/image/turris-mox.bootscript
@@ -40,7 +40,7 @@ if part uuid ${devtype} ${devnum}:${distro_bootpart} bootuuid; then
 			fi
 		fi
 		if test "$filesize" != "0"; then
-			setenv bootargs "earlyprintk console=ttyMV0,115200 earlycon=ar3700_uart,0xd0012000 rootfstype=${rootfstype} root=${rootdev} rootflags=${rootflags} rootwait ${contract} rw cfg80211.freg=${regdomain} ${quirks}"
+			setenv bootargs "earlyprintk console=ttyMV0,115200 earlycon=ar3700_uart,0xd0012000 rootfstype=${rootfstype} root=${rootdev} rootflags=${rootflags} rootwait ${contract} rw cfg80211.freg=${regdomain} sysctl.kernel.firmware_config.force_sysfs_fallback=0 ${quirks}"
 			booti ${kernel_addr_r} - ${fdt_addr_r}
 			echo "Booting Image failed"
 		else


### PR DESCRIPTION
This merge request enables Turris MOX sysupgrade feature, adds driver for onboard Bluetooth and firmware fallback handling is turned off to prevent 60s boot delay.

What changed
- Routed Turris MOX through legacy SD card upgrade helper
- Added Bluetooth support module package for Turris MOX: `kmod-btmrvl`
- Updated MOX boot arguments to include: `sysctl.kernel.firmware_config.force_sysfs_fallback=0`

```
[   15.813197] mwifiex_sdio mmc1:0001:1: WLAN is not the winner! Skip FW dnld
[   16.306866] mwifiex_sdio mmc1:0001:1: WLAN FW is active
[   16.344192] mwifiex_sdio mmc1:0001:1: host_mlme: enable, key_api: 2
[   16.460201] mwifiex_sdio mmc1:0001:1: Direct firmware load for nxp/rgpower_US.bin failed with error -2
[   16.469530] mwifiex_sdio mmc1:0001:1: Falling back to sysfs fallback for: nxp/rgpower_US.bin
[   79.969960] mwifiex_sdio mmc1:0001:1: info: MWIFIEX VERSION: mwifiex 1.0 (16.68.1.p197)
[   79.978070] mwifiex_sdio mmc1:0001:1: driver_version = mwifiex 1.0 (16.68.1.p197)
```


Tested on the latest SNAPSHOT. squashfs was used. It worked including settings persistence.