### PR TITLE
base-files: {ucidef,config_generate}: rgb led support

### DIFF
--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -404,6 +404,25 @@ generate_led() {
 		set system.$cfg.default='$default'
 	EOF
 
+	local colors
+	json_get_keys attrs
+
+	# set color_* variables, add to `colors' array
+	for attr in $attrs; do
+		echo $attr
+		echo "$attr" | grep -q "^color_.*" || continue
+		json_get_var "${attr}_val" "$attr" 	#
+		eval local $attr="\$${attr}_val"	# ex. color_blue=$color_blue_val
+		colors="$colors $attr"
+	done
+
+
+	for color in $colors; do
+		eval local color_val=\$$color
+		echo uci set system.$cfg.$color="$color_val"
+		uci set system.$cfg.$color="$color_val"
+	done
+
 	case "$type" in
 		gpio)
 			local gpio inverted

--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -409,7 +409,6 @@ generate_led() {
 
 	# set color_* variables, add to `colors' array
 	for attr in $attrs; do
-		echo $attr
 		echo "$attr" | grep -q "^color_.*" || continue
 		json_get_var "${attr}_val" "$attr" 	#
 		eval local $attr="\$${attr}_val"	# ex. color_blue=$color_blue_val
@@ -419,7 +418,6 @@ generate_led() {
 
 	for color in $colors; do
 		eval local color_val=\$$color
-		echo uci set system.$cfg.$color="$color_val"
 		uci set system.$cfg.$color="$color_val"
 	done
 

--- a/package/base-files/files/lib/functions/uci-defaults.sh
+++ b/package/base-files/files/lib/functions/uci-defaults.sh
@@ -428,6 +428,20 @@ _ucidef_set_led_common() {
 	json_add_string sysfs "$sysfs"
 }
 
+ucidef_add_led_color() {
+	local cfg="led_$1"
+	local channel="$2"
+	local val="$3"
+
+	json_select_object led
+	json_select_object "$1"
+
+	json_add_string "color_${channel}" "$val"
+
+	json_select ..
+	json_select ..
+}
+
 ucidef_set_led_default() {
 	local default="$4"
 

--- a/package/base-files/files/lib/functions/uci-defaults.sh
+++ b/package/base-files/files/lib/functions/uci-defaults.sh
@@ -448,6 +448,9 @@ ucidef_set_led_default() {
 	_ucidef_set_led_common "$1" "$2" "$3"
 
 	json_add_string default "$default"
+	[ "$default" = 1 ] && {
+		json_add_string trigger default-on
+	}
 	json_select ..
 
 	json_select ..


### PR DESCRIPTION
This adds support for specifying led color intesnities (`color_*` in uci) in `/etc/board.d`.

Also adds setting `default-on` trigger for `ucidef_set_led_default`.