### PR TITLE
realtek: pcs: rtl931x: touch XSGMII setup

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3897,13 +3897,6 @@ static int rtpcs_931x_setup_serdes(struct rtpcs_serdes *sds,
 	enum rtpcs_sds_media sds_media;
 	int ret;
 
-	/*
-	 * TODO: XSGMII (Realtek-proprietary 10G SGMII used by RTL8218D/E)
-	 * bring-up is not implemented yet.
-	 */
-	if (hw_mode == RTPCS_SDS_MODE_XSGMII)
-		return 0;
-
 	rtpcs_931x_sds_deactivate(sds);
 
 	ret = rtpcs_931x_sds_config_hw_mode(sds, hw_mode);

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3727,14 +3727,15 @@ static int rtpcs_931x_sds_set_media(struct rtpcs_serdes *sds, enum rtpcs_sds_med
 
 	/*
 	 * SDK identifies this as some kind of gating. It's enabled
-	 * here and later deactivated for non-10G.
+	 * here and later deactivated for non-10G and XSGMII.
 	 * (from DMS1250 SDK)
 	 */
 	rtpcs_sds_write_bits(sds, 0x5f, 0x1, 0, 0, 0x1);
 
 	/* from _phy_rtl9310_sds_init */
 	rtpcs_sds_write_bits(sds, 0x2e, 0xe, 13, 11, 0x0);
-	rtpcs_931x_sds_reset_leq_dfe(sds);
+	if (hw_mode != RTPCS_SDS_MODE_XSGMII)
+		rtpcs_931x_sds_reset_leq_dfe(sds);
 
 	/*
 	 * SDK says: media none behavior
@@ -3813,8 +3814,8 @@ static int rtpcs_931x_sds_set_media(struct rtpcs_serdes *sds, enum rtpcs_sds_med
 	regmap_write_bits(sds->ctrl->map, RTPCS_931X_ISR_SERDES_RXIDLE,
 			  BIT(sds->id - 2), BIT(sds->id - 2));
 
-	/* Gating as mentioned above, deactivated here for non-10G */
-	if (!is_10g)
+	/* Gating as mentioned above, deactivated here for non-10G and XSGMII */
+	if (!is_10g || hw_mode == RTPCS_SDS_MODE_XSGMII)
 		rtpcs_sds_write_bits(sds, 0x5f, 0x1, 0, 0, 0x0);
 
 	return 0;

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3335,7 +3335,7 @@ static int rtpcs_931x_sds_set_mode(struct rtpcs_serdes *sds,
 	int ret;
 
 	if (hw_mode == RTPCS_SDS_MODE_XSGMII)
-		return rtpcs_93xx_sds_set_mac_mode(sds, hw_mode);
+		return rtpcs_93xx_sds_set_mac_driven_mode(sds, hw_mode);
 
 	ret = rtpcs_931x_sds_apply_ip_mode(sds, hw_mode);
 	if (ret)

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -1509,6 +1509,27 @@ static int rtpcs_93xx_sds_set_mac_mode(struct rtpcs_serdes *sds, enum rtpcs_sds_
 }
 
 /*
+ * Bring up a MAC-driven mode: release the IP mode force-lock so the MAC
+ * side takes over (deactivate forces IP=OFF; this undoes that), set the
+ * MAC mode, then apply the USXGMII submode if the mode needs one.
+ */
+static int rtpcs_93xx_sds_set_mac_driven_mode(struct rtpcs_serdes *sds,
+					      enum rtpcs_sds_mode hw_mode)
+{
+	int ret;
+
+	ret = rtpcs_sds_write_bits(sds, 0x1f, 0x09, 6, 6, 0);
+	if (ret)
+		return ret;
+
+	ret = rtpcs_93xx_sds_set_mac_mode(sds, hw_mode);
+	if (ret)
+		return ret;
+
+	return rtpcs_93xx_sds_apply_usxgmii_submode(sds, hw_mode);
+}
+
+/*
  * Read/write the SerDes IP mode register: page 0x1f reg 0x09, bits 11:7
  * hold the 5-bit mode value, bit 6 is the "force mode" enable. The same
  * physical field is used on RTL930x and RTL931x.
@@ -1873,8 +1894,6 @@ static int rtpcs_930x_sds_apply_ip_mode(struct rtpcs_serdes *sds,
 
 static int rtpcs_930x_sds_set_mode(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode)
 {
-	int ret;
-
 	/*
 	 * Several modes can be configured via MAC setup, just by setting
 	 * a register to a specific value and the MAC will configure
@@ -1893,19 +1912,7 @@ static int rtpcs_930x_sds_set_mode(struct rtpcs_serdes *sds, enum rtpcs_sds_mode
 		break;
 	}
 
-	/*
-	 * MAC-driven modes: release the IP mode force-lock so the MAC side
-	 * takes over. deactivate forces IP=OFF; this undoes that.
-	 */
-	ret = rtpcs_sds_write_bits(sds, 0x1f, 0x09, 6, 6, 0);
-	if (ret)
-		return ret;
-
-	ret = rtpcs_93xx_sds_set_mac_mode(sds, hw_mode);
-	if (ret)
-		return ret;
-
-	return rtpcs_93xx_sds_apply_usxgmii_submode(sds, hw_mode);
+	return rtpcs_93xx_sds_set_mac_driven_mode(sds, hw_mode);
 }
 
 static int rtpcs_930x_sds_deactivate(struct rtpcs_serdes *sds)


### PR DESCRIPTION
This setup touches the XSGMII setup for RTL931x which was practically dead before because it was skipped in early configuration. So far, it hasn't been validated on a real device.

Tests on Linksys LGS352C, the currently only RTL931x device using this mode, show that some small adjustments need to be taken to achieve a "working" state. Working here means, it doesn't break the configuration that was previously done by U-boot. Since this runs unconditionally in U-boot anyway, it's fine to possibly rely on that for the time being.
