### PR TITLE
ca-certificates: update to 20260601

### DIFF
--- a/package/system/ca-certificates/Makefile
+++ b/package/system/ca-certificates/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ca-certificates
-PKG_VERSION:=20260223
+PKG_VERSION:=20260601
 PKG_RELEASE:=1
 PKG_MAINTAINER:=
 
@@ -16,7 +16,7 @@ PKG_LICENSE_FILES:=debian/copyright
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@DEBIAN/pool/main/c/ca-certificates
-PKG_HASH:=2fa2b00d4360f0d14ec51640ae8aea9e563956b95ea786e3c3c01c4eead42b56
+PKG_HASH:=7ab6301f7f34eef90a4d278647c260bc0762e0e14561f4649854cf4b0d4bea21
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
changelog: https://salsa.debian.org/debian/ca-certificates/-/blob/master/debian/changelog

```
  * Remove ca-certificates-local example (closes: #988912, #1127101).
  * Update Mozilla certificate authority bundle to version 2.86 The following certificate authority was added (+):
    + e-Szigno TLS Root CA 2023 The following certificate authorities were removed (-):
    - QuoVadis Root CA 2
    - QuoVadis Root CA 3
    - DigiCert Assured ID Root CA
    - DigiCert Global Root CA
    - DigiCert High Assurance EV Root CA
    - SwissSign Gold CA - G2
    - SecureTrust CA
    - Secure Global CA
    - COMODO Certification Authority
    - Certigna
    - certSIGN ROOT CA
    - AffirmTrust Commercial
    - AffirmTrust Networking
    - AffirmTrust Premium
    - AffirmTrust Premium ECC
    - TeliaSonera Root CA v1
    - Entrust Root Certification Authority - G2
    - Entrust Root Certification Authority - EC1
    - Trustwave Global Certification Authority
    - Trustwave Global ECC P256 Certification Authority
    - Trustwave Global ECC P384 Certification Authority
    - GLOBALTRUST 2020
    - GTS Root R2
    - FIRMAPROFESIONAL CA ROOT-A WEB The following certificate authority was renamed (~): ~ "OISTE Server Root RSA G1" (removed leading space)
```
