### PR TITLE
dtc: update to 1.8.1

### DIFF
--- a/package/utils/dtc/Makefile
+++ b/package/utils/dtc/Makefile
@@ -5,11 +5,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dtc
-PKG_VERSION:=1.7.2
+PKG_VERSION:=1.8.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=f200e5ebd7afd20d4b3804a3085af0870fcf3c194f8d7f0f6985cf8bbb4ac0f4
+PKG_HASH:=454e5cce748ce957c91e7f45e66da2cff5100ddb52155d7a909c43cbeaf1bcb0
 PKG_SOURCE_URL:=@KERNEL/software/utils/dtc
 
 PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
@@ -93,7 +93,7 @@ MESON_ARGS += \
 	-Dyaml=disabled \
 	-Dvalgrind=disabled \
 	-Dpython=disabled \
-	-Dstatic-build=$(if $(CONFIG_DTC_STATIC_BUILD),true,false)
+	$(if $(CONFIG_DTC_STATIC_BUILD),--prefer-static)
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/lib


### PR DESCRIPTION
dtc: Update to 1.8.1

Changelog:
https://git.kernel.org/pub/scm/utils/dtc/dtc.git/tag/?h=v1.8.1
https://git.kernel.org/pub/scm/utils/dtc/dtc.git/tag/?h=v1.8.0

This also fixes #23671