### PR TITLE
mediatek: wavlink wl-wn536ax6 rev a: enable nmbm bad block management and miscellaneous fixes

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -118,7 +118,8 @@ mercusys,mr90x-v1|\
 routerich,ax3000|\
 routerich,ax3000-v1|\
 tenbay,wr3000k|\
-tplink,re6000xd)
+tplink,re6000xd|\
+wavlink,wl-wn536ax6-a)
 	ubootenv_add_mtd "u-boot-env" "0x0" "0x20000" "0x20000" "1"
 	;;
 comfast,cf-e393ax|\

--- a/target/linux/mediatek/dts/mt7986a-wavlink-wl-wn536ax6-a.dts
+++ b/target/linux/mediatek/dts/mt7986a-wavlink-wl-wn536ax6-a.dts
@@ -219,13 +219,13 @@
 		conf-pd {
 			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
 			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
-			drive-strength = <MTK_DRIVE_8mA>;
+			drive-strength = <MTK_DRIVE_4mA>;
 		};
 
 		conf-pu {
 			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
 			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
-			drive-strength = <MTK_DRIVE_8mA>;
+			drive-strength = <MTK_DRIVE_4mA>;
 		};
 	};
 

--- a/target/linux/mediatek/dts/mt7986a-wavlink-wl-wn536ax6-a.dts
+++ b/target/linux/mediatek/dts/mt7986a-wavlink-wl-wn536ax6-a.dts
@@ -287,6 +287,10 @@
 		spi-cal-addrlen = <5>;
 		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
 
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;

--- a/target/linux/mediatek/dts/mt7986a-wavlink-wl-wn536ax6-a.dts
+++ b/target/linux/mediatek/dts/mt7986a-wavlink-wl-wn536ax6-a.dts
@@ -123,7 +123,7 @@
 		phy-mode = "2500base-x";
 
 		nvmem-cell-names = "mac-address";
-		nvmem-cells = <&macaddr_hw_44e 0>;
+		nvmem-cells = <&macaddr_factory_3fff4>;
 
 		fixed-link {
 			full-duplex;
@@ -140,7 +140,7 @@
 		phy-handle = <&phy6>;
 
 		nvmem-cell-names = "mac-address";
-		nvmem-cells = <&macaddr_hw_44e 1>;
+		nvmem-cells = <&macaddr_factory_3fffa>;
 	};
 
 	mdio-bus {
@@ -150,7 +150,7 @@
 		/* MaxLinear GPY211C 2.5G PHY */
 		phy6: phy@6 {
 			/*
-			 * Force the ID here as the PHY only reports it's
+			 * Force the ID here as the PHY only reports its
 			 * (C45) ID correctly after a reset (before resetting
 			 * it reports 0xfffffff, which causes only the genphy
 			 * driver to match).
@@ -320,6 +320,14 @@
 					eeprom_factory_0: eeprom@0 {
 						reg = <0x0 0x1000>;
 					};
+
+					macaddr_factory_3fff4: macaddr@3fff4 {
+						reg = <0x3fff4 0x6>;
+					};
+
+					macaddr_factory_3fffa: macaddr@3fffa {
+						reg = <0x3fffa 0x6>;
+					};
 				};
 			};
 
@@ -338,18 +346,6 @@
 				label = "HW";
 				reg = <0x4580000 0x80000>;
 				read-only;
-
-				nvmem-layout {
-					compatible = "fixed-layout";
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					macaddr_hw_44e: macaddr@44e {
-						compatible = "mac-base";
-						reg = <0x44e 0x11>;
-						#nvmem-cell-cells = <1>;
-					};
-				};
 			};
 		};
 	};

--- a/target/linux/mediatek/dts/mt7986a-wavlink-wl-wn536ax6-a.dts
+++ b/target/linux/mediatek/dts/mt7986a-wavlink-wl-wn536ax6-a.dts
@@ -72,7 +72,9 @@
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_WLAN;
 			gpios = <&pio 32 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
+			linux,default-trigger = "network";
+			family = "wlan";
+			mode = "link tx rx";
 		};
 	};
 

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -228,6 +228,13 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
 		;;
+	routerich,ax3000|\
+	routerich,ax3000-ubootmod|\
+	zbtlink,zbt-z8102ax|\
+	zbtlink,zbt-z8102ax-v2)
+		addr=$(mtd_get_mac_binary "Factory" 0x4)
+		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
+		;;
 	ruijie,rg-x60-pro)
 		addr=$(mtd_get_mac_ascii product_info ethaddr)
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
@@ -252,12 +259,9 @@ case "$board" in
 	tplink,tl-xtr8488)
 		[ "$PHYNBR" = "1" ] && get_mac_label > /sys${DEVPATH}/macaddress
 		;;
-	routerich,ax3000|\
-	routerich,ax3000-ubootmod|\
-	zbtlink,zbt-z8102ax|\
-	zbtlink,zbt-z8102ax-v2)
+	wavlink,wl-wn536ax6-a)
 		addr=$(mtd_get_mac_binary "Factory" 0x4)
-		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_setbit $addr 26) > /sys${DEVPATH}/macaddress
 		;;
 	wavlink,wl-wn573hx3)
 		addr=$(mtd_get_mac_binary factory 0x04)

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -3250,7 +3250,7 @@ define Device/wavlink_wl-wn536ax6-a
   IMAGE_SIZE := 65536k
   KERNEL_INITRAMFS_SUFFIX := .itb
   KERNEL_IN_UBI := 1
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
+  DEVICE_PACKAGES := kmod-ledtrig-network kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware kmod-usb3
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += wavlink_wl-wn536ax6-a


### PR DESCRIPTION
I have put some commits from https://github.com/openwrt/openwrt/pull/22655 here as they are not relevant to the UBI layout 'ubootmod' and don't need to be held up by that.

**In particular, nmbm is important to prevent potential data corruption**

---

#### [mediatek: wavlink wl-wn536ax6 rev a: enable nmbm bad block management](https://github.com/openwrt/openwrt/pull/23682/changes/dcce4a7f3c565df5793a86101a44979f178e3d9e)
Enable nmbm bad block management with up to 8 MiB reserved. The manufacturer's stock device tree contains the property `compatible = "generic,nmbm";` in node `nmbm_spim_nand` and manufacturer's stock bootlog contains "nmbm nmbm_spim_nand: NMBM has been successfully attached"

---

#### [mediatek: wavlink wl-wn536ax6 rev a: set SPI drive strength 4mA](https://github.com/openwrt/openwrt/pull/23682/changes/209a8fe7376e2979d0a0a80d617ee424dc0ee26d)
Change SPI drive strength to 4mA to match Mediatek SDK and prevent potential signal overshoot ([1](https://github.com/openwrt/openwrt/pull/18752#issuecomment-2865095510), [2](https://git01.mediatek.com/plugins/gitiles/openwrt/feeds/mtk-openwrt-feeds/+/003744197aa3a587828b4330ab1112ebdb9e840a))

---

#### [mediatek: wavlink wl-wn536ax6 rev a: change nvmem layout for MAC addresses](https://github.com/openwrt/openwrt/pull/23682/changes/04f5823f835b45f5a9943ef7d1c1c1a955596e9c)
- Though functionally correct previously, it was not technically correct as it was reading the first MAC address from the "HW" partition and then incrementing by 1 for the second MAC address, when it should have read the second MAC address directly. 
- LAN/WAN MAC addresses were also found in "Factory" at `0x3fff4` and `0x3fffa` like many other Mediatek devices, so I have changed to read them directly from these locations instead.

---

#### [mediatek: wavlink wl-wn536ax6 rev a: fix WLAN 5GHz MAC address](https://github.com/openwrt/openwrt/pull/23682/changes/2fe7396cabc00fe9bcab57cc8f83006495d9a6ed)
change 5G WLAN MAC address to match manufacturer's stock firmware. The last 3 octets of the second MAC address in partition "Factory" at `0x0a` are completely different to the other MAC addresses and do not appear anywhere in the manufacturer's stock firmware. 

---

#### [uboot-envtools: mediatek_filogic: wavlink wl-wn536ax6 rev a: add config](https://github.com/openwrt/openwrt/pull/23682/changes/1e3474ebbdb7de0a451ca8f9d74e266d34a5605e)
Add config for WAVLINK WL-WN536AX6 Rev a to be able to read and write U-Boot environment variables.

---

#### [mediatek: wavlink wl-wn536ax6 rev a: add "network" LED trigger](https://github.com/openwrt/openwrt/pull/23682/changes/adb7ff2792134e8488a1ae6e5f3488174a5942c1)
Currently the "WiFi" LED indicator light is triggered only by activity on the 5 GHz PHY. Change it to be triggered by WLAN activity on either Wi-Fi PHY, matching stock behaviour, by using `kmod-ledtrig-network` added in https://github.com/openwrt/openwrt/commit/2aa1185fb05eb7f2e4c7e4f9c66e3727010328af ('leds: add "network" LED trigger (lan/wan/wlan)') (https://github.com/openwrt/openwrt/pull/19903).