### PR TITLE
realtek: rtl930x: add support for Sirivision SR-ST3408F

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -93,6 +93,7 @@ realtek_setup_macs()
 	plasmacloud,psx8|\
 	plasmacloud,psx10|\
 	plasmacloud,psx28|\
+	sirivision,sr-st3408f|\
 	zyxel,gs1920-24hp-v2)
 		lan_mac="$(get_mac_label)"
 		;;

--- a/target/linux/realtek/dts/rtl9303_sirivision_sr-st3408f.dts
+++ b/target/linux/realtek/dts/rtl9303_sirivision_sr-st3408f.dts
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "rtl930x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/phy/phy.h>
+
+/ {
+	compatible = "sirivision,sr-st3408f", "realtek,rtl9303-soc";
+	model = "Sirivision SR-ST3408F";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>, /* first 256 MiB */
+		      <0x20000000 0x10000000>; /* remaining 256 MiB */
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	aliases {
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+
+		label-mac-device = &ethernet0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_sys: led-0 {
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+
+	led_set {
+		compatible = "realtek,rtl9300-leds";
+		active-low;
+
+		led_set0 = <
+			(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_LINK)
+			(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_5G | RTL93XX_LED_SET_2P5G |
+			 RTL93XX_LED_SET_1G | RTL93XX_LED_SET_100M | RTL93XX_LED_SET_10M |
+			 RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+		>;
+
+		led_set1 = <
+			(RTL93XX_LED_SET_NONE)	/* odd outputs are not connected */
+			(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_5G | RTL93XX_LED_SET_2P5G |
+			 RTL93XX_LED_SET_1G | RTL93XX_LED_SET_100M | RTL93XX_LED_SET_10M |
+			 RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+		>;
+	};
+
+	sfp0: sfp-p5 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c4>;
+		tx-disable-gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 13 GPIO_ACTIVE_LOW>;
+		los-gpio = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp1: sfp-p6 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c5>;
+		tx-disable-gpio = <&gpio1 21 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 22 GPIO_ACTIVE_LOW>;
+		los-gpio = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp2: sfp-p7 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c6>;
+		tx-disable-gpio = <&gpio1 24 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 25 GPIO_ACTIVE_LOW>;
+		los-gpio = <&gpio1 26 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp3: sfp-p8 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c7>;
+		tx-disable-gpio = <&gpio1 27 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 28 GPIO_ACTIVE_LOW>;
+		los-gpio = <&gpio1 29 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+		#thermal-sensor-cells = <0>;
+	};
+};
+
+&i2c_mst1 {
+	status = "okay";
+
+	i2c4: i2c@4 { reg = <4>; };
+	i2c5: i2c@5 { reg = <5>; };
+	i2c6: i2c@6 { reg = <6>; };
+	i2c7: i2c@7 { reg = <7>; };
+};
+
+&mdio_aux {
+	status = "okay";
+
+	gpio1: gpio@0 {
+		compatible = "realtek,rtl8231";
+		reg = <0>;
+
+		gpio-controller;
+		#gpio-cells = <2>;
+		gpio-ranges = <&gpio1 0 0 37>;
+
+		led-controller {
+			compatible = "realtek,rtl8231-leds";
+			status = "disabled";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0xe0000>;
+				read-only;
+			};
+
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0xe0000 0x10000>;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+
+					macaddr_ubootenv_ethaddr: ethaddr {
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@f0000 {
+				label = "u-boot-env2";
+				reg = <0xf0000 0x10000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "jffs";
+				reg = <0x100000 0x100000>;
+			};
+
+			partition@200000 {
+				label = "jffs2";
+				reg = <0x200000 0x100000>;
+			};
+
+			partition@300000 {
+				label = "firmware";
+				reg = <0x300000 0xd00000>;
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <0x93000000>;
+			};
+		};
+	};
+};
+
+/* serdes for 10G PHYs have TX polarity inverted */
+&serdes2 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes3 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes4 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes5 { tx-polarity = <PHY_POL_INVERT>; };
+
+&mdio_bus0 {
+	PHY_C45(0, 0)
+	PHY_C45(8, 1)
+	PHY_C45(16, 2)
+	PHY_C45(20, 3)
+};
+
+&ethernet0 {
+	nvmem-cells = <&macaddr_ubootenv_ethaddr 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ethernet-ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/* RJ45 ports, lan1-4 */
+		SWITCH_PORT_LED(0,  1, 2, 0, 0, usxgmii)
+		SWITCH_PORT_LED(8,  2, 3, 0, 0, usxgmii)
+		SWITCH_PORT_LED(16, 3, 4, 0, 0, usxgmii)
+		SWITCH_PORT_LED(20, 4, 5, 0, 0, usxgmii)
+
+		/* SFP+ ports, lan5-8 */
+		SWITCH_PORT_SFP(24, 5, 6, 1, 0)
+		SWITCH_PORT_SFP(25, 6, 7, 1, 1)
+		SWITCH_PORT_SFP(26, 7, 8, 1, 2)
+		SWITCH_PORT_SFP(27, 8, 9, 1, 3)
+
+		/* CPU port */
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&thermal_zones {
+	sfp-thermal {
+		polling-delay-passive = <10000>;
+		polling-delay = <10000>;
+		thermal-sensors = <&sfp0>, <&sfp1>, <&sfp2>, <&sfp3>;
+		trips {
+			sfp-crit {
+				temperature = <110000>;
+				hysteresis = <1000>;
+				type = "critical";
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -12,6 +12,17 @@ define Device/d-link_dgs-1250-28x
 endef
 TARGET_DEVICES += d-link_dgs-1250-28x
 
+define Device/sirivision_sr-st3408f
+  SOC := rtl9303
+  UIMAGE_MAGIC := 0x93000000
+  DEVICE_VENDOR := Sirivision
+  DEVICE_MODEL := SR-ST3408F
+  DEVICE_PACKAGES := kmod-phy-realtek rtl8261n-firmware
+  IMAGE_SIZE := 13312k
+  $(Device/kernel-lzma)
+endef
+TARGET_DEVICES += sirivision_sr-st3408f
+
 define Device/hasivo_f1100w-4sx-4xgt-common
   SOC := rtl9303
   DEVICE_VENDOR := Hasivo


### PR DESCRIPTION
This PR adds suppport for the **Sirivision SR-ST3408F**, an 8-port 10G switch with 4x RJ45 ports and 4x SFP+ ports. It is based on the RTL9303 CPU and generally looks quite similar to the others.

Specifications:
```
SoC:      Realtek RTL9303
RAM:      512 MiB DDR3
Flash:    SPI-NOR 16 MiB (Winbond)
Ethernet: 4x RJ45 via RTL8261BE PHY (10G/5G/2.5G/1G/100M/10M)
          4x SFP+
LEDs:     1x power, 1x system green
          2x RJ45 LEDs/port (link/act, 10G)
          1x SFP+ LED/port (link/act)
Button:   Reset
Console:  Cisco-style RJ45, 115200 8n1
Fan:      4040 12V fan (hardwired)
Power:    12V 3A internal PSU
```

The RJ45 ports use the RTL8261BE 10G PHY. There's an RTL8231 GPIO expander that's used to handle the SFP port signals.

I have tested the flashing steps myself, and it works all the way through. More testers are welcome.

Let me know if you have any questions and/or changes. Thanks.