### PR TITLE
ramips: yuncore 1200f: fix label-mac-device alias and remove comments

### DIFF
--- a/target/linux/ramips/dts/mt7628an_yuncore_1200f.dts
+++ b/target/linux/ramips/dts/mt7628an_yuncore_1200f.dts
@@ -23,7 +23,7 @@
 	};
 
 	aliases {
-		label-mac = &ethernet;
+		label-mac-device = &ethernet;
 		led-boot = &led_indicator;
 		led-failsafe = &led_indicator;
 		led-running = &led_indicator;
@@ -108,18 +108,10 @@
 						reg = <0x0 0x400>;
 					};
 
-					/*
-					 * Observed at factory + 0x4:
-					 * 9c:e5:49:60:2a:64
-					 */
 					macaddr_factory_4: macaddr@4 {
 						reg = <0x4 0x6>;
 					};
 
-					/*
-					 * Observed at factory + 0x28:
-					 * 9c:e5:49:60:2a:65
-					 */
 					macaddr_factory_28: macaddr@28 {
 						reg = <0x28 0x6>;
 					};
@@ -128,13 +120,6 @@
 						reg = <0x8000 0x4da8>;
 					};
 
-					/*
-					 * Observed at factory + 0x8004:
-					 * 9c:e5:49:60:2a:66
-					 *
-					 * Do not apply mac-address-increment here.
-					 * The stored address is already the final 5 GHz MAC.
-					 */
 					macaddr_factory_8004: macaddr@8004 {
 						reg = <0x8004 0x6>;
 					};


### PR DESCRIPTION
Fix label-mac-device alias (from "label-mac") and remove MAC address comments.

Fixes: 1ba7b38cfc82 ("ramips: add support for Yuncore 1200F") (https://github.com/openwrt/openwrt/pull/23613)