### PR TITLE
[24.10] Security update for busybox

### DIFF
--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -28,6 +28,9 @@ config BUSYBOX_DEFAULT_FEATURE_COMPRESS_USAGE
 config BUSYBOX_DEFAULT_LFS
 	bool
 	default y
+config BUSYBOX_DEFAULT_TIME64
+	bool
+	default n
 config BUSYBOX_DEFAULT_PAM
 	bool
 	default n
@@ -1181,6 +1184,9 @@ config BUSYBOX_DEFAULT_FEATURE_FIND_EXEC
 config BUSYBOX_DEFAULT_FEATURE_FIND_EXEC_PLUS
 	bool
 	default n
+config BUSYBOX_DEFAULT_FEATURE_FIND_EXEC_OK
+	bool
+	default n
 config BUSYBOX_DEFAULT_FEATURE_FIND_USER
 	bool
 	default y
@@ -2051,6 +2057,9 @@ config BUSYBOX_DEFAULT_FLASH_UNLOCK
 config BUSYBOX_DEFAULT_FLASHCP
 	bool
 	default n
+config BUSYBOX_DEFAULT_GETFATTR
+	bool
+	default n
 config BUSYBOX_DEFAULT_HDPARM
 	bool
 	default n
@@ -2457,6 +2466,9 @@ config BUSYBOX_DEFAULT_FEATURE_IP_ADDRESS
 config BUSYBOX_DEFAULT_FEATURE_IP_LINK
 	bool
 	default y
+config BUSYBOX_DEFAULT_FEATURE_IP_LINK_CAN
+	bool
+	default n
 config BUSYBOX_DEFAULT_FEATURE_IP_ROUTE
 	bool
 	default y
@@ -2680,6 +2692,9 @@ config BUSYBOX_DEFAULT_ZCIP
 	bool
 	default n
 config BUSYBOX_DEFAULT_UDHCPD
+	bool
+	default n
+config BUSYBOX_DEFAULT_FEATURE_UDHCPD_BOOTP
 	bool
 	default n
 config BUSYBOX_DEFAULT_FEATURE_UDHCPD_BASE_IP_ON_MAC
@@ -3042,9 +3057,6 @@ config BUSYBOX_DEFAULT_ASH_PRINTF
 config BUSYBOX_DEFAULT_ASH_TEST
 	bool
 	default y
-config BUSYBOX_DEFAULT_ASH_SLEEP
-	bool
-	default n
 config BUSYBOX_DEFAULT_ASH_HELP
 	bool
 	default n

--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -5,14 +5,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=busybox
-PKG_VERSION:=1.36.1
-PKG_RELEASE:=2
+PKG_VERSION:=1.37.0
+PKG_RELEASE:=1
 PKG_FLAGS:=essential
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.busybox.net/downloads \
 		https://sources.buildroot.net/$(PKG_NAME)
-PKG_HASH:=b8cc24c9574d809e7279c3be349795c5d5ceb6fdf19ca709f80cde50e47de314
+PKG_HASH:=3311dff32e746499f4df0d5df04d7eb396382d7e108bb9250e7b519b837043a4
 
 PKG_BUILD_DEPENDS:=BUSYBOX_CONFIG_PAM:libpam
 PKG_BUILD_PARALLEL:=1

--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=busybox
 PKG_VERSION:=1.37.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_FLAGS:=essential
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2

--- a/package/utils/busybox/config/Config.in
+++ b/package/utils/busybox/config/Config.in
@@ -107,6 +107,17 @@ config BUSYBOX_CONFIG_LFS
 	programs that can benefit from large file support include dd, gzip,
 	cp, mount, tar.
 
+config BUSYBOX_CONFIG_TIME64
+	bool "Support 64bit wide time types"
+	default BUSYBOX_DEFAULT_TIME64
+	depends on BUSYBOX_CONFIG_LFS
+	help
+	Make times later than 2038 representable for several libc syscalls
+	(stat, clk_gettime etc.). Note this switch is specific to glibc
+	and has no effect on platforms that already use 64bit wide time types
+	(i.e. all 64bit archs and some selected 32bit archs (currently riscv
+	and x32)).
+
 config BUSYBOX_CONFIG_PAM
 	bool "Support PAM (Pluggable Authentication Modules)"
 	default BUSYBOX_DEFAULT_PAM

--- a/package/utils/busybox/config/archival/Config.in
+++ b/package/utils/busybox/config/archival/Config.in
@@ -80,7 +80,7 @@ config BUSYBOX_CONFIG_FEATURE_GUNZIP_LONG_OPTIONS
 	default BUSYBOX_DEFAULT_FEATURE_GUNZIP_LONG_OPTIONS
 	depends on (BUSYBOX_CONFIG_GUNZIP || BUSYBOX_CONFIG_ZCAT) && BUSYBOX_CONFIG_LONG_OPTS
 config BUSYBOX_CONFIG_BUNZIP2
-	bool "bunzip2 (8.7 kb)"
+	bool "bunzip2 (9.1 kb)"
 	default BUSYBOX_DEFAULT_BUNZIP2
 	select BUSYBOX_CONFIG_FEATURE_BZIP2_DECOMPRESS
 	help
@@ -94,13 +94,13 @@ config BUSYBOX_CONFIG_BUNZIP2
 	should probably say N here.
 
 config BUSYBOX_CONFIG_BZCAT
-	bool "bzcat (8.7 kb)"
+	bool "bzcat (9 kb)"
 	default BUSYBOX_DEFAULT_BZCAT
 	select BUSYBOX_CONFIG_FEATURE_BZIP2_DECOMPRESS
 	help
 	Alias to "bunzip2 -c".
 config BUSYBOX_CONFIG_UNLZMA
-	bool "unlzma (7.5 kb)"
+	bool "unlzma (7.8 kb)"
 	default BUSYBOX_DEFAULT_UNLZMA
 	help
 	unlzma is a compression utility using the Lempel-Ziv-Markov chain
@@ -109,7 +109,7 @@ config BUSYBOX_CONFIG_UNLZMA
 	compressors.
 
 config BUSYBOX_CONFIG_LZCAT
-	bool "lzcat (7.5 kb)"
+	bool "lzcat (7.8 kb)"
 	default BUSYBOX_DEFAULT_LZCAT
 	help
 	Alias to "unlzma -c".
@@ -229,7 +229,7 @@ config BUSYBOX_CONFIG_DPKG
 	This implementation of dpkg has a number of limitations,
 	you should use the official dpkg if possible.
 config BUSYBOX_CONFIG_DPKG_DEB
-	bool "dpkg-deb (30 kb)"
+	bool "dpkg-deb (29 kb)"
 	default BUSYBOX_DEFAULT_DPKG_DEB
 	select BUSYBOX_CONFIG_FEATURE_SEAMLESS_GZ
 	help
@@ -282,7 +282,7 @@ config BUSYBOX_CONFIG_FEATURE_GZIP_DECOMPRESS
 	This will be automatically selected if gunzip or zcat is
 	enabled.
 config BUSYBOX_CONFIG_LZOP
-	bool "lzop (12 kb)"
+	bool "lzop (13 kb)"
 	default BUSYBOX_DEFAULT_LZOP
 	help
 	Lzop compression/decompresion.

--- a/package/utils/busybox/config/console-tools/Config.in
+++ b/package/utils/busybox/config/console-tools/Config.in
@@ -7,39 +7,39 @@
 menu "Console Utilities"
 
 config BUSYBOX_CONFIG_CHVT
-	bool "chvt (2 kb)"
+	bool "chvt (2.2 kb)"
 	default BUSYBOX_DEFAULT_CHVT
 	help
 	This program is used to change to another terminal.
 	Example: chvt 4 (change to terminal /dev/tty4)
 config BUSYBOX_CONFIG_CLEAR
-	bool "clear (tiny)"
+	bool "clear (371 bytes)"
 	default BUSYBOX_DEFAULT_CLEAR
 	help
 	This program clears the terminal screen.
 config BUSYBOX_CONFIG_DEALLOCVT
-	bool "deallocvt (1.9 kb)"
+	bool "deallocvt (2.2 kb)"
 	default BUSYBOX_DEFAULT_DEALLOCVT
 	help
 	This program deallocates unused virtual consoles.
 config BUSYBOX_CONFIG_DUMPKMAP
-	bool "dumpkmap (1.6 kb)"
+	bool "dumpkmap (1.9 kb)"
 	default BUSYBOX_DEFAULT_DUMPKMAP
 	help
 	This program dumps the kernel's keyboard translation table to
 	stdout, in binary format. You can then use loadkmap to load it.
 config BUSYBOX_CONFIG_FGCONSOLE
-	bool "fgconsole (1.5 kb)"
+	bool "fgconsole (1.8 kb)"
 	default BUSYBOX_DEFAULT_FGCONSOLE
 	help
 	This program prints active (foreground) console number.
 config BUSYBOX_CONFIG_KBD_MODE
-	bool "kbd_mode (4.1 kb)"
+	bool "kbd_mode (4.3 kb)"
 	default BUSYBOX_DEFAULT_KBD_MODE
 	help
 	This program reports and sets keyboard mode.
 config BUSYBOX_CONFIG_LOADFONT
-	bool "loadfont (5.2 kb)"
+	bool "loadfont (5.4 kb)"
 	default BUSYBOX_DEFAULT_LOADFONT
 	help
 	This program loads a console font from standard input.
@@ -78,25 +78,25 @@ config BUSYBOX_CONFIG_FEATURE_LOADFONT_RAW
 	default BUSYBOX_DEFAULT_FEATURE_LOADFONT_RAW
 	depends on BUSYBOX_CONFIG_LOADFONT || BUSYBOX_CONFIG_SETFONT
 config BUSYBOX_CONFIG_LOADKMAP
-	bool "loadkmap (1.8 kb)"
+	bool "loadkmap (2.1 kb)"
 	default BUSYBOX_DEFAULT_LOADKMAP
 	help
 	This program loads a keyboard translation table from
 	standard input.
 config BUSYBOX_CONFIG_OPENVT
-	bool "openvt (7.2 kb)"
+	bool "openvt (7.4 kb)"
 	default BUSYBOX_DEFAULT_OPENVT
 	help
 	This program is used to start a command on an unused
 	virtual terminal.
 config BUSYBOX_CONFIG_RESET
-	bool "reset (345 bytes)"
+	bool "reset (676 bytes)"
 	default BUSYBOX_DEFAULT_RESET
 	help
 	This program is used to reset the terminal screen, if it
 	gets messed up.
 config BUSYBOX_CONFIG_RESIZE
-	bool "resize (903 bytes)"
+	bool "resize (1.2 kb)"
 	default BUSYBOX_DEFAULT_RESIZE
 	help
 	This program is used to (re)set the width and height of your current
@@ -112,7 +112,7 @@ config BUSYBOX_CONFIG_FEATURE_RESIZE_PRINT
 	E.g.:
 	COLUMNS=80;LINES=44;export COLUMNS LINES;
 config BUSYBOX_CONFIG_SETCONSOLE
-	bool "setconsole (3.6 kb)"
+	bool "setconsole (3.8 kb)"
 	default BUSYBOX_DEFAULT_SETCONSOLE
 	help
 	Redirect writes to /dev/console to another device,
@@ -125,18 +125,18 @@ config BUSYBOX_CONFIG_FEATURE_SETCONSOLE_LONG_OPTIONS
 	default BUSYBOX_DEFAULT_FEATURE_SETCONSOLE_LONG_OPTIONS
 	depends on BUSYBOX_CONFIG_SETCONSOLE && BUSYBOX_CONFIG_LONG_OPTS
 config BUSYBOX_CONFIG_SETKEYCODES
-	bool "setkeycodes (2.1 kb)"
+	bool "setkeycodes (2.4 kb)"
 	default BUSYBOX_DEFAULT_SETKEYCODES
 	help
 	This program loads entries into the kernel's scancode-to-keycode
 	map, allowing unusual keyboards to generate usable keycodes.
 config BUSYBOX_CONFIG_SETLOGCONS
-	bool "setlogcons (1.8 kb)"
+	bool "setlogcons (2 kb)"
 	default BUSYBOX_DEFAULT_SETLOGCONS
 	help
 	This program redirects the output console of kernel messages.
 config BUSYBOX_CONFIG_SHOWKEY
-	bool "showkey (4.7 kb)"
+	bool "showkey (4.9 kb)"
 	default BUSYBOX_DEFAULT_SHOWKEY
 	help
 	Shows keys pressed.

--- a/package/utils/busybox/config/coreutils/Config.in
+++ b/package/utils/busybox/config/coreutils/Config.in
@@ -48,14 +48,14 @@ config BUSYBOX_CONFIG_FEATURE_HUMAN_READABLE
 	Allow df, du, and ls to have human readable output.
 
 config BUSYBOX_CONFIG_BASENAME
-	bool "basename (438 bytes)"
+	bool "basename (3.7 kb)"
 	default BUSYBOX_DEFAULT_BASENAME
 	help
 	basename is used to strip the directory and suffix from filenames,
 	leaving just the filename itself. Enable this option if you wish
 	to enable the 'basename' utility.
 config BUSYBOX_CONFIG_CAT
-	bool "cat (5.6 kb)"
+	bool "cat (5.8 kb)"
 	default BUSYBOX_DEFAULT_CAT
 	help
 	cat is used to concatenate files and print them to the standard
@@ -96,20 +96,20 @@ config BUSYBOX_CONFIG_FEATURE_CHOWN_LONG_OPTIONS
 	default BUSYBOX_DEFAULT_FEATURE_CHOWN_LONG_OPTIONS
 	depends on BUSYBOX_CONFIG_CHOWN && BUSYBOX_CONFIG_LONG_OPTS
 config BUSYBOX_CONFIG_CHROOT
-	bool "chroot (3.7 kb)"
+	bool "chroot (4 kb)"
 	default BUSYBOX_DEFAULT_CHROOT
 	help
 	chroot is used to change the root directory and run a command.
 	The default command is '/bin/sh'.
 config BUSYBOX_CONFIG_CKSUM
-	bool "cksum (4.1 kb)"
+	bool "cksum (4.3 kb)"
 	default BUSYBOX_DEFAULT_CKSUM
 
 config BUSYBOX_CONFIG_CRC32
-	bool "crc32 (4.1 kb)"
+	bool "crc32 (4.2 kb)"
 	default BUSYBOX_DEFAULT_CRC32
 config BUSYBOX_CONFIG_COMM
-	bool "comm (4.2 kb)"
+	bool "comm (4.4 kb)"
 	default BUSYBOX_DEFAULT_COMM
 	help
 	comm is used to compare two files line by line and return
@@ -133,7 +133,7 @@ config BUSYBOX_CONFIG_FEATURE_CP_REFLINK
 	default BUSYBOX_DEFAULT_FEATURE_CP_REFLINK
 	depends on BUSYBOX_CONFIG_FEATURE_CP_LONG_OPTIONS
 config BUSYBOX_CONFIG_CUT
-	bool "cut (5.8 kb)"
+	bool "cut (6.7 kb)"
 	default BUSYBOX_DEFAULT_CUT
 	help
 	cut is used to print selected parts of lines from
@@ -146,7 +146,7 @@ config BUSYBOX_CONFIG_FEATURE_CUT_REGEX
 	help
 	Allow regex based delimiters.
 config BUSYBOX_CONFIG_DATE
-	bool "date (7 kb)"
+	bool "date (7.2 kb)"
 	default BUSYBOX_DEFAULT_DATE
 	help
 	date is used to set the system date or display the
@@ -183,7 +183,7 @@ config BUSYBOX_CONFIG_FEATURE_DATE_COMPAT
 	the same format. With it on, 'date DATE' additionally supports
 	MMDDhhmm[[YY]YY][.ss] format.
 config BUSYBOX_CONFIG_DD
-	bool "dd (7.5 kb)"
+	bool "dd (8.3 kb)"
 	default BUSYBOX_DEFAULT_DD
 	help
 	dd copies a file (from standard input to standard output,
@@ -227,7 +227,7 @@ config BUSYBOX_CONFIG_FEATURE_DD_STATUS
 	help
 	Enable support for status=noxfer/none option.
 config BUSYBOX_CONFIG_DF
-	bool "df (6.8 kb)"
+	bool "df (7.1 kb)"
 	default BUSYBOX_DEFAULT_DF
 	help
 	df reports the amount of disk space used and available
@@ -262,26 +262,26 @@ config BUSYBOX_CONFIG_FEATURE_SKIP_ROOTFS
 
 	Otherwise, choose Y.
 config BUSYBOX_CONFIG_DIRNAME
-	bool "dirname (329 bytes)"
+	bool "dirname (611 bytes)"
 	default BUSYBOX_DEFAULT_DIRNAME
 	help
 	dirname is used to strip a non-directory suffix from
 	a file name.
 config BUSYBOX_CONFIG_DOS2UNIX
-	bool "dos2unix (5.2 kb)"
+	bool "dos2unix (5.5 kb)"
 	default BUSYBOX_DEFAULT_DOS2UNIX
 	help
 	dos2unix is used to convert a text file from DOS format to
 	UNIX format, and vice versa.
 
 config BUSYBOX_CONFIG_UNIX2DOS
-	bool "unix2dos (5.2 kb)"
+	bool "unix2dos (5.5 kb)"
 	default BUSYBOX_DEFAULT_UNIX2DOS
 	help
 	unix2dos is used to convert a text file from UNIX format to
 	DOS format, and vice versa.
 config BUSYBOX_CONFIG_DU
-	bool "du (6.3 kb)"
+	bool "du (6.5 kb)"
 	default BUSYBOX_DEFAULT_DU
 	help
 	du is used to report the amount of disk space used
@@ -292,7 +292,7 @@ config BUSYBOX_CONFIG_FEATURE_DU_DEFAULT_BLOCKSIZE_1K
 	default BUSYBOX_DEFAULT_FEATURE_DU_DEFAULT_BLOCKSIZE_1K
 	depends on BUSYBOX_CONFIG_DU
 config BUSYBOX_CONFIG_ECHO
-	bool "echo (1.8 kb)"
+	bool "echo (2 kb)"
 	default BUSYBOX_DEFAULT_ECHO
 	help
 	echo prints a specified string to stdout.
@@ -303,25 +303,25 @@ config BUSYBOX_CONFIG_FEATURE_FANCY_ECHO
 	default BUSYBOX_DEFAULT_FEATURE_FANCY_ECHO
 	depends on BUSYBOX_CONFIG_ECHO || BUSYBOX_CONFIG_ASH_ECHO || BUSYBOX_CONFIG_HUSH_ECHO
 config BUSYBOX_CONFIG_ENV
-	bool "env (4 kb)"
+	bool "env (4.3 kb)"
 	default BUSYBOX_DEFAULT_ENV
 	help
 	env is used to set an environment variable and run
 	a command; without options it displays the current
 	environment.
 config BUSYBOX_CONFIG_EXPAND
-	bool "expand (5.1 kb)"
+	bool "expand (5.3 kb)"
 	default BUSYBOX_DEFAULT_EXPAND
 	help
 	By default, convert all tabs to spaces.
 
 config BUSYBOX_CONFIG_UNEXPAND
-	bool "unexpand (5.3 kb)"
+	bool "unexpand (5.5 kb)"
 	default BUSYBOX_DEFAULT_UNEXPAND
 	help
 	By default, convert only leading sequences of blanks to tabs.
 config BUSYBOX_CONFIG_EXPR
-	bool "expr (6.6 kb)"
+	bool "expr (6.8 kb)"
 	default BUSYBOX_DEFAULT_EXPR
 	help
 	expr is used to calculate numbers and print the result
@@ -336,22 +336,22 @@ config BUSYBOX_CONFIG_EXPR_MATH_SUPPORT_64
 	the applet slightly larger, but will allow computation with very
 	large numbers.
 config BUSYBOX_CONFIG_FACTOR
-	bool "factor (2.7 kb)"
+	bool "factor (3.2 kb)"
 	default BUSYBOX_DEFAULT_FACTOR
 	help
 	factor factorizes integers
 config BUSYBOX_CONFIG_FALSE
-	bool "false (tiny)"
+	bool "false (314 bytes)"
 	default BUSYBOX_DEFAULT_FALSE
 	help
 	false returns an exit code of FALSE (1).
 config BUSYBOX_CONFIG_FOLD
-	bool "fold (4.6 kb)"
+	bool "fold (4.8 kb)"
 	default BUSYBOX_DEFAULT_FOLD
 	help
 	Wrap text to fit a specific width.
 config BUSYBOX_CONFIG_HEAD
-	bool "head (3.8 kb)"
+	bool "head (4 kb)"
 	default BUSYBOX_DEFAULT_HEAD
 	help
 	head is used to print the first specified number of lines
@@ -362,19 +362,19 @@ config BUSYBOX_CONFIG_FEATURE_FANCY_HEAD
 	default BUSYBOX_DEFAULT_FEATURE_FANCY_HEAD
 	depends on BUSYBOX_CONFIG_HEAD
 config BUSYBOX_CONFIG_HOSTID
-	bool "hostid (286 bytes)"
+	bool "hostid (566 bytes)"
 	default BUSYBOX_DEFAULT_HOSTID
 	help
 	hostid prints the numeric identifier (in hexadecimal) for
 	the current host.
 config BUSYBOX_CONFIG_ID
-	bool "id (7 kb)"
+	bool "id (7.1 kb)"
 	default BUSYBOX_DEFAULT_ID
 	help
 	id displays the current user and group ID names.
 
 config BUSYBOX_CONFIG_GROUPS
-	bool "groups (6.7 kb)"
+	bool "groups (6.8 kb)"
 	default BUSYBOX_DEFAULT_GROUPS
 	help
 	Print the group names associated with current user id.
@@ -389,17 +389,17 @@ config BUSYBOX_CONFIG_FEATURE_INSTALL_LONG_OPTIONS
 	default BUSYBOX_DEFAULT_FEATURE_INSTALL_LONG_OPTIONS
 	depends on BUSYBOX_CONFIG_INSTALL && BUSYBOX_CONFIG_LONG_OPTS
 config BUSYBOX_CONFIG_LINK
-	bool "link (3.2 kb)"
+	bool "link (3.5 kb)"
 	default BUSYBOX_DEFAULT_LINK
 	help
 	link creates hard links between files.
 config BUSYBOX_CONFIG_LN
-	bool "ln (4.9 kb)"
+	bool "ln (5.1 kb)"
 	default BUSYBOX_DEFAULT_LN
 	help
 	ln is used to create hard or soft links between files.
 config BUSYBOX_CONFIG_LOGNAME
-	bool "logname (1.1 kb)"
+	bool "logname (1.4 kb)"
 	default BUSYBOX_DEFAULT_LOGNAME
 	help
 	logname is used to print the current user's login name.
@@ -468,31 +468,31 @@ config BUSYBOX_CONFIG_FEATURE_LS_COLOR_IS_DEFAULT
 	configurable, and the output may not be legible on
 	many output screens.
 config BUSYBOX_CONFIG_MD5SUM
-	bool "md5sum (6.5 kb)"
+	bool "md5sum (6.7 kb)"
 	default BUSYBOX_DEFAULT_MD5SUM
 	help
 	Compute and check MD5 message digest
 
 config BUSYBOX_CONFIG_SHA1SUM
-	bool "sha1sum (5.9 kb)"
+	bool "sha1sum (6.7 kb)"
 	default BUSYBOX_DEFAULT_SHA1SUM
 	help
 	Compute and check SHA1 message digest
 
 config BUSYBOX_CONFIG_SHA256SUM
-	bool "sha256sum (7 kb)"
+	bool "sha256sum (8.2 kb)"
 	default BUSYBOX_DEFAULT_SHA256SUM
 	help
 	Compute and check SHA256 message digest
 
 config BUSYBOX_CONFIG_SHA512SUM
-	bool "sha512sum (7.4 kb)"
+	bool "sha512sum (7.3 kb)"
 	default BUSYBOX_DEFAULT_SHA512SUM
 	help
 	Compute and check SHA512 message digest
 
 config BUSYBOX_CONFIG_SHA3SUM
-	bool "sha3sum (6.1 kb)"
+	bool "sha3sum (6.3 kb)"
 	default BUSYBOX_DEFAULT_SHA3SUM
 	help
 	Compute and check SHA3 message digest
@@ -509,24 +509,24 @@ config BUSYBOX_CONFIG_FEATURE_MD5_SHA1_SUM_CHECK
 	against pre-calculated hash values.
 	-s and -w are useful options when verifying checksums.
 config BUSYBOX_CONFIG_MKDIR
-	bool "mkdir (4.5 kb)"
+	bool "mkdir (4.7 kb)"
 	default BUSYBOX_DEFAULT_MKDIR
 	help
 	mkdir is used to create directories with the specified names.
 config BUSYBOX_CONFIG_MKFIFO
-	bool "mkfifo (3.8 kb)"
+	bool "mkfifo (4 kb)"
 	default BUSYBOX_DEFAULT_MKFIFO
 	help
 	mkfifo is used to create FIFOs (named pipes).
 	The 'mknod' program can also create FIFOs.
 config BUSYBOX_CONFIG_MKNOD
-	bool "mknod (4.5 kb)"
+	bool "mknod (4.6 kb)"
 	default BUSYBOX_DEFAULT_MKNOD
 	help
 	mknod is used to create FIFOs or block/character special
 	files with the specified names.
 config BUSYBOX_CONFIG_MKTEMP
-	bool "mktemp (4.2 kb)"
+	bool "mktemp (4.5 kb)"
 	default BUSYBOX_DEFAULT_MKTEMP
 	help
 	mktemp is used to create unique temporary files
@@ -536,22 +536,22 @@ config BUSYBOX_CONFIG_MV
 	help
 	mv is used to move or rename files or directories.
 config BUSYBOX_CONFIG_NICE
-	bool "nice (2.1 kb)"
+	bool "nice (2.3 kb)"
 	default BUSYBOX_DEFAULT_NICE
 	help
 	nice runs a program with modified scheduling priority.
 config BUSYBOX_CONFIG_NL
-	bool "nl (4.6 kb)"
+	bool "nl (4.9 kb)"
 	default BUSYBOX_DEFAULT_NL
 	help
 	nl is used to number lines of files.
 config BUSYBOX_CONFIG_NOHUP
-	bool "nohup (2 kb)"
+	bool "nohup (2.2 kb)"
 	default BUSYBOX_DEFAULT_NOHUP
 	help
 	run a command immune to hangups, with output to a non-tty.
 config BUSYBOX_CONFIG_NPROC
-	bool "nproc (3.7 kb)"
+	bool "nproc (3.9 kb)"
 	default BUSYBOX_DEFAULT_NPROC
 	help
 	Print number of CPUs
@@ -561,29 +561,29 @@ config BUSYBOX_CONFIG_OD
 	help
 	od is used to dump binary files in octal and other formats.
 config BUSYBOX_CONFIG_PASTE
-	bool "paste (4.9 kb)"
+	bool "paste (5.1 kb)"
 	default BUSYBOX_DEFAULT_PASTE
 	help
 	paste is used to paste lines of different files together
 	and write the result to stdout
 config BUSYBOX_CONFIG_PRINTENV
-	bool "printenv (1.3 kb)"
+	bool "printenv (1.6 kb)"
 	default BUSYBOX_DEFAULT_PRINTENV
 	help
 	printenv is used to print all or part of environment.
 config BUSYBOX_CONFIG_PRINTF
-	bool "printf (3.8 kb)"
+	bool "printf (4.1 kb)"
 	default BUSYBOX_DEFAULT_PRINTF
 	help
 	printf is used to format and print specified strings.
 	It's similar to 'echo' except it has more options.
 config BUSYBOX_CONFIG_PWD
-	bool "pwd (3.7 kb)"
+	bool "pwd (4 kb)"
 	default BUSYBOX_DEFAULT_PWD
 	help
 	pwd is used to print the current directory.
 config BUSYBOX_CONFIG_READLINK
-	bool "readlink (4 kb)"
+	bool "readlink (4.8 kb)"
 	default BUSYBOX_DEFAULT_READLINK
 	help
 	This program reads a symbolic link and returns the name
@@ -596,49 +596,50 @@ config BUSYBOX_CONFIG_FEATURE_READLINK_FOLLOW
 	help
 	Enable the readlink option (-f).
 config BUSYBOX_CONFIG_REALPATH
-	bool "realpath (1.6 kb)"
+	bool "realpath (2.5 kb)"
 	default BUSYBOX_DEFAULT_REALPATH
 	help
 	Return the canonicalized absolute pathname.
 	This isn't provided by GNU shellutils, but where else does it belong.
 config BUSYBOX_CONFIG_RM
-	bool "rm (5.4 kb)"
+	bool "rm (5.5 kb)"
 	default BUSYBOX_DEFAULT_RM
 	help
 	rm is used to remove files or directories.
 config BUSYBOX_CONFIG_RMDIR
-	bool "rmdir (3.5 kb)"
+	bool "rmdir (3.8 kb)"
 	default BUSYBOX_DEFAULT_RMDIR
 	help
 	rmdir is used to remove empty directories.
 config BUSYBOX_CONFIG_SEQ
-	bool "seq (3.8 kb)"
+	bool "seq (4 kb)"
 	default BUSYBOX_DEFAULT_SEQ
 	help
 	print a sequence of numbers
 config BUSYBOX_CONFIG_SHRED
-	bool "shred (4.9 kb)"
+	bool "shred (5.5 kb)"
 	default BUSYBOX_DEFAULT_SHRED
 	help
 	Overwrite a file to hide its contents, and optionally delete it
 config BUSYBOX_CONFIG_SHUF
-	bool "shuf (5.4 kb)"
+	bool "shuf (6 kb)"
 	default BUSYBOX_DEFAULT_SHUF
 	help
 	Generate random permutations
 config BUSYBOX_CONFIG_SLEEP
-	bool "sleep (2 kb)"
+	bool "sleep (2.4 kb)"
 	default BUSYBOX_DEFAULT_SLEEP
 	help
 	sleep is used to pause for a specified number of seconds.
-	It comes in 3 versions:
+	It comes in 2 versions:
 	- small: takes one integer parameter
-	- fancy: takes multiple integer arguments with suffixes:
-		sleep 1d 2h 3m 15s
-	- fancy with fractional numbers:
-		sleep 2.3s 4.5h sleeps for 16202.3 seconds
-	Last one is "the most compatible" with coreutils sleep,
-	but it adds around 1k of code.
+	- fancy:
+		* takes multiple integer arguments with suffixes:
+			sleep 1d 2h 3m 15s
+		* allows fractional numbers:
+			sleep 2.3s 4.5h sleeps for 16202.3 seconds
+	fancy is more compatible with coreutils sleep, but it adds around
+	1k of code.
 
 config BUSYBOX_CONFIG_FEATURE_FANCY_SLEEP
 	bool "Enable multiple arguments and s/m/h/d suffixes"
@@ -647,7 +648,7 @@ config BUSYBOX_CONFIG_FEATURE_FANCY_SLEEP
 	help
 	Allow sleep to pause for specified minutes, hours, and days.
 config BUSYBOX_CONFIG_SORT
-	bool "sort (7.7 kb)"
+	bool "sort (8.1 kb)"
 	default BUSYBOX_DEFAULT_SORT
 	help
 	sort is used to sort lines of text in specified files.
@@ -672,7 +673,7 @@ config BUSYBOX_CONFIG_FEATURE_SORT_OPTIMIZE_MEMORY
 	Attempt to use less memory (by storing only one copy
 	of duplicated lines, and such). Useful if you work on huge files.
 config BUSYBOX_CONFIG_SPLIT
-	bool "split (5 kb)"
+	bool "split (5.2 kb)"
 	default BUSYBOX_DEFAULT_SPLIT
 	help
 	Split a file into pieces.
@@ -708,17 +709,17 @@ config BUSYBOX_CONFIG_FEATURE_STAT_FILESYSTEM
 	Without this, stat will not support the '-f' option to display
 	information about filesystem status.
 config BUSYBOX_CONFIG_STTY
-	bool "stty (8.9 kb)"
+	bool "stty (9.2 kb)"
 	default BUSYBOX_DEFAULT_STTY
 	help
 	stty is used to change and print terminal line settings.
 config BUSYBOX_CONFIG_SUM
-	bool "sum (4 kb)"
+	bool "sum (4.2 kb)"
 	default BUSYBOX_DEFAULT_SUM
 	help
 	checksum and count the blocks in a file
 config BUSYBOX_CONFIG_SYNC
-	bool "sync (3.8 kb)"
+	bool "sync (4 kb)"
 	default BUSYBOX_DEFAULT_SYNC
 	help
 	sync is used to flush filesystem buffers.
@@ -730,17 +731,17 @@ config BUSYBOX_CONFIG_FEATURE_SYNC_FANCY
 	sync -d FILE... executes fdatasync() on each FILE.
 	sync -f FILE... executes syncfs() on each FILE.
 config BUSYBOX_CONFIG_FSYNC
-	bool "fsync (3.6 kb)"
+	bool "fsync (3.8 kb)"
 	default BUSYBOX_DEFAULT_FSYNC
 	help
 	fsync is used to flush file-related cached blocks to disk.
 config BUSYBOX_CONFIG_TAC
-	bool "tac (3.9 kb)"
+	bool "tac (4.1 kb)"
 	default BUSYBOX_DEFAULT_TAC
 	help
 	tac is used to concatenate and print files in reverse.
 config BUSYBOX_CONFIG_TAIL
-	bool "tail (6.8 kb)"
+	bool "tail (7.2 kb)"
 	default BUSYBOX_DEFAULT_TAIL
 	help
 	tail is used to print the last specified number of lines
@@ -758,7 +759,7 @@ config BUSYBOX_CONFIG_FEATURE_FANCY_TAIL
 		-v      Always output headers giving file names
 		-F      Same as -f, but keep retrying
 config BUSYBOX_CONFIG_TEE
-	bool "tee (4.2 kb)"
+	bool "tee (4.4 kb)"
 	default BUSYBOX_DEFAULT_TEE
 	help
 	tee is used to read from standard input and write
@@ -771,7 +772,7 @@ config BUSYBOX_CONFIG_FEATURE_TEE_USE_BLOCK_IO
 	help
 	Enable this option for a faster tee, at expense of size.
 config BUSYBOX_CONFIG_TEST
-	bool "test (4.1 kb)"
+	bool "test (4.4 kb)"
 	default BUSYBOX_DEFAULT_TEST
 	help
 	test is used to check file types and compare values,
@@ -797,13 +798,13 @@ config BUSYBOX_CONFIG_FEATURE_TEST_64
 	help
 	Enable 64-bit support in test.
 config BUSYBOX_CONFIG_TIMEOUT
-	bool "timeout (6 kb)"
+	bool "timeout (6.5 kb)"
 	default BUSYBOX_DEFAULT_TIMEOUT
 	help
 	Runs a program and watches it. If it does not terminate in
 	specified number of seconds, it is sent a signal.
 config BUSYBOX_CONFIG_TOUCH
-	bool "touch (5.9 kb)"
+	bool "touch (6.1 kb)"
 	default BUSYBOX_DEFAULT_TOUCH
 	help
 	touch is used to create or change the access and/or
@@ -816,7 +817,7 @@ config BUSYBOX_CONFIG_FEATURE_TOUCH_SUSV3
 	help
 	Enable touch to use a reference file or a given date/time argument.
 config BUSYBOX_CONFIG_TR
-	bool "tr (5.1 kb)"
+	bool "tr (5.3 kb)"
 	default BUSYBOX_DEFAULT_TR
 	help
 	tr is used to squeeze, and/or delete characters from standard
@@ -841,29 +842,29 @@ config BUSYBOX_CONFIG_FEATURE_TR_EQUIV
 	useful for cases when no other way of expressing a character
 	is possible.
 config BUSYBOX_CONFIG_TRUE
-	bool "true (tiny)"
+	bool "true (311 bytes)"
 	default BUSYBOX_DEFAULT_TRUE
 	help
 	true returns an exit code of TRUE (0).
 config BUSYBOX_CONFIG_TRUNCATE
-	bool "truncate (4.2 kb)"
+	bool "truncate (4.4 kb)"
 	default BUSYBOX_DEFAULT_TRUNCATE
 	help
 	truncate truncates files to a given size. If a file does
 	not exist, it is created unless told otherwise.
 config BUSYBOX_CONFIG_TSORT
-	bool "tsort (0.7 kb)"
+	bool "tsort (2.6 kb)"
 	default BUSYBOX_DEFAULT_TSORT
 	help
 	tsort performs a topological sort.
 config BUSYBOX_CONFIG_TTY
-	bool "tty (3.6 kb)"
+	bool "tty (3.9 kb)"
 	default BUSYBOX_DEFAULT_TTY
 	help
 	tty is used to print the name of the current terminal to
 	standard output.
 config BUSYBOX_CONFIG_UNAME
-	bool "uname (3.9 kb)"
+	bool "uname (4.2 kb)"
 	default BUSYBOX_DEFAULT_UNAME
 	help
 	uname is used to print system information.
@@ -877,47 +878,47 @@ config BUSYBOX_CONFIG_UNAME_OSNAME
 	default BUSYBOX_DEFAULT_UNAME_OSNAME "GNU/Linux".
 
 config BUSYBOX_CONFIG_BB_ARCH
-	bool "arch (1.1 kb)"
+	bool "arch (1.4 kb)"
 	default BUSYBOX_DEFAULT_BB_ARCH
 	help
 	Same as uname -m.
 config BUSYBOX_CONFIG_UNIQ
-	bool "uniq (4.9 kb)"
+	bool "uniq (5.1 kb)"
 	default BUSYBOX_DEFAULT_UNIQ
 	help
 	uniq is used to remove duplicate lines from a sorted file.
 config BUSYBOX_CONFIG_UNLINK
-	bool "unlink (3.2 kb)"
+	bool "unlink (3.5 kb)"
 	default BUSYBOX_DEFAULT_UNLINK
 	help
 	unlink deletes a file by calling unlink()
 config BUSYBOX_CONFIG_USLEEP
-	bool "usleep (1.3 kb)"
+	bool "usleep (1.6 kb)"
 	default BUSYBOX_DEFAULT_USLEEP
 	help
 	usleep is used to pause for a specified number of microseconds.
 config BUSYBOX_CONFIG_UUDECODE
-	bool "uudecode (5.8 kb)"
+	bool "uudecode (5.9 kb)"
 	default BUSYBOX_DEFAULT_UUDECODE
 	help
 	uudecode is used to decode a uuencoded file.
 config BUSYBOX_CONFIG_BASE32
-	bool "base32 (4.9 kb)"
+	bool "base32 (5.5 kb)"
 	default BUSYBOX_DEFAULT_BASE32
 	help
 	Base32 encode and decode
 config BUSYBOX_CONFIG_BASE64
-	bool "base64 (4.9 kb)"
+	bool "base64 (5.3 kb)"
 	default BUSYBOX_DEFAULT_BASE64
 	help
 	Base64 encode and decode
 config BUSYBOX_CONFIG_UUENCODE
-	bool "uuencode (4.4 kb)"
+	bool "uuencode (4.7 kb)"
 	default BUSYBOX_DEFAULT_UUENCODE
 	help
 	uuencode is used to uuencode a file.
 config BUSYBOX_CONFIG_WC
-	bool "wc (4.5 kb)"
+	bool "wc (4.7 kb)"
 	default BUSYBOX_DEFAULT_WC
 	help
 	wc is used to print the number of bytes, words, and lines,
@@ -930,33 +931,33 @@ config BUSYBOX_CONFIG_FEATURE_WC_LARGE
 	help
 	Use "unsigned long long" for counter variables.
 config BUSYBOX_CONFIG_WHO
-	bool "who (3.9 kb)"
+	bool "who (5.6 kb)"
 	default BUSYBOX_DEFAULT_WHO
 	depends on BUSYBOX_CONFIG_FEATURE_UTMP
 	help
 	Print users currently logged on.
 
 config BUSYBOX_CONFIG_W
-	bool "w (3.8 kb)"
+	bool "w (5.5 kb)"
 	default BUSYBOX_DEFAULT_W
 	depends on BUSYBOX_CONFIG_FEATURE_UTMP
 	help
 	Print users currently logged on.
 
 config BUSYBOX_CONFIG_USERS
-	bool "users (3.4 kb)"
+	bool "users (3.6 kb)"
 	default BUSYBOX_DEFAULT_USERS
 	depends on BUSYBOX_CONFIG_FEATURE_UTMP
 	help
 	Print users currently logged on.
 config BUSYBOX_CONFIG_WHOAMI
-	bool "whoami (3.2 kb)"
+	bool "whoami (3.5 kb)"
 	default BUSYBOX_DEFAULT_WHOAMI
 	help
 	whoami is used to print the username of the current
 	user id (same as id -un).
 config BUSYBOX_CONFIG_YES
-	bool "yes (1.2 kb)"
+	bool "yes (1.5 kb)"
 	default BUSYBOX_DEFAULT_YES
 	help
 	yes is used to repeatedly output a specific string, or

--- a/package/utils/busybox/config/debianutils/Config.in
+++ b/package/utils/busybox/config/debianutils/Config.in
@@ -7,12 +7,12 @@
 menu "Debian Utilities"
 
 config BUSYBOX_CONFIG_PIPE_PROGRESS
-	bool "pipe_progress (275 bytes)"
+	bool "pipe_progress (576 bytes)"
 	default BUSYBOX_DEFAULT_PIPE_PROGRESS
 	help
 	Display a dot to indicate pipe activity.
 config BUSYBOX_CONFIG_RUN_PARTS
-	bool "run-parts (6.1 kb)"
+	bool "run-parts (6.2 kb)"
 	default BUSYBOX_DEFAULT_RUN_PARTS
 	help
 	run-parts is a utility designed to run all the scripts in a directory.
@@ -61,7 +61,7 @@ config BUSYBOX_CONFIG_FEATURE_START_STOP_DAEMON_FANCY
 	-v|--verbose
 	-N|--nicelevel N
 config BUSYBOX_CONFIG_WHICH
-	bool "which (3.8 kb)"
+	bool "which (4 kb)"
 	default BUSYBOX_DEFAULT_WHICH
 	help
 	which is used to find programs in your PATH and

--- a/package/utils/busybox/config/e2fsprogs/Config.in
+++ b/package/utils/busybox/config/e2fsprogs/Config.in
@@ -7,19 +7,19 @@
 menu "Linux Ext2 FS Progs"
 
 config BUSYBOX_CONFIG_CHATTR
-	bool "chattr (3.8 kb)"
+	bool "chattr (4.1 kb)"
 	default BUSYBOX_DEFAULT_CHATTR
 	help
 	chattr changes the file attributes on a second extended file system.
 config BUSYBOX_CONFIG_FSCK
-	bool "fsck (7.4 kb)"
+	bool "fsck (7.6 kb)"
 	default BUSYBOX_DEFAULT_FSCK
 	help
 	fsck is used to check and optionally repair one or more filesystems.
 	In actuality, fsck is simply a front-end for the various file system
 	checkers (fsck.fstype) available under Linux.
 config BUSYBOX_CONFIG_LSATTR
-	bool "lsattr (5.5 kb)"
+	bool "lsattr (5.7 kb)"
 	default BUSYBOX_DEFAULT_LSATTR
 	help
 	lsattr lists the file attributes on a second extended file system.

--- a/package/utils/busybox/config/editors/Config.in
+++ b/package/utils/busybox/config/editors/Config.in
@@ -7,7 +7,7 @@
 menu "Editors"
 
 config BUSYBOX_CONFIG_AWK
-	bool "awk (23 kb)"
+	bool "awk (24 kb)"
 	default BUSYBOX_DEFAULT_AWK
 	help
 	Awk is used as a pattern scanning and processing language.
@@ -31,7 +31,7 @@ config BUSYBOX_CONFIG_FEATURE_AWK_GNU_EXTENSIONS
 	This enables the use of awk library files.
 	Example: awk -f mylib.awk -e '{print myfunction($1);}' ...
 config BUSYBOX_CONFIG_CMP
-	bool "cmp (4.9 kb)"
+	bool "cmp (5.3 kb)"
 	default BUSYBOX_DEFAULT_CMP
 	help
 	cmp is used to compare two files and returns the result
@@ -57,14 +57,14 @@ config BUSYBOX_CONFIG_FEATURE_DIFF_DIR
 	This option enables support for directory and subdirectory
 	comparison.
 config BUSYBOX_CONFIG_ED
-	bool "ed (21 kb)"
+	bool "ed (16 kb)"
 	default BUSYBOX_DEFAULT_ED
 	help
 	The original 1970's Unix text editor, from the days of teletypes.
 	Small, simple, evil. Part of SUSv3. If you're not already using
 	this, you don't need it.
 config BUSYBOX_CONFIG_PATCH
-	bool "patch (9.4 kb)"
+	bool "patch (9.6 kb)"
 	default BUSYBOX_DEFAULT_PATCH
 	help
 	Apply a unified diff formatted patch.
@@ -75,7 +75,7 @@ config BUSYBOX_CONFIG_SED
 	sed is used to perform text transformations on a file
 	or input from a pipeline.
 config BUSYBOX_CONFIG_VI
-	bool "vi (23 kb)"
+	bool "vi (26 kb)"
 	default BUSYBOX_DEFAULT_VI
 	help
 	'vi' is a text editor. More specifically, it is the One True
@@ -134,7 +134,7 @@ config BUSYBOX_CONFIG_FEATURE_VI_SEARCH
 
 config BUSYBOX_CONFIG_FEATURE_VI_REGEX_SEARCH
 	bool "Enable regex in search and replace"
-	default BUSYBOX_DEFAULT_FEATURE_VI_REGEX_SEARCH   # Uses GNU regex, which may be unavailable. FIXME
+	default BUSYBOX_DEFAULT_FEATURE_VI_REGEX_SEARCH
 	depends on BUSYBOX_CONFIG_FEATURE_VI_SEARCH
 	depends on USE_GLIBC
 	help

--- a/package/utils/busybox/config/findutils/Config.in
+++ b/package/utils/busybox/config/findutils/Config.in
@@ -7,7 +7,7 @@
 menu "Finding Utilities"
 
 config BUSYBOX_CONFIG_FIND
-	bool "find (14 kb)"
+	bool "find (16 kb)"
 	default BUSYBOX_DEFAULT_FIND
 	help
 	find is used to search your system to find specified files.
@@ -136,6 +136,13 @@ config BUSYBOX_CONFIG_FEATURE_FIND_EXEC_PLUS
 	Without this option, -exec + is a synonym for -exec ;
 	(IOW: it works correctly, but without expected speedup)
 
+config BUSYBOX_CONFIG_FEATURE_FIND_EXEC_OK
+	bool "Enable -ok: execute confirmed commands"
+	default BUSYBOX_DEFAULT_FEATURE_FIND_EXEC_OK
+	depends on BUSYBOX_CONFIG_FEATURE_FIND_EXEC
+	help
+	Support the 'find -ok' option which prompts before executing.
+
 config BUSYBOX_CONFIG_FEATURE_FIND_USER
 	bool "Enable -user: username/uid matching"
 	default BUSYBOX_DEFAULT_FEATURE_FIND_USER
@@ -234,19 +241,19 @@ config BUSYBOX_CONFIG_FEATURE_FIND_LINKS
 	help
 	Support the 'find -links' option for matching number of links.
 config BUSYBOX_CONFIG_GREP
-	bool "grep (8.6 kb)"
+	bool "grep (8.9 kb)"
 	default BUSYBOX_DEFAULT_GREP
 	help
 	grep is used to search files for a specified pattern.
 
 config BUSYBOX_CONFIG_EGREP
-	bool "egrep (7.8 kb)"
+	bool "egrep (8 kb)"
 	default BUSYBOX_DEFAULT_EGREP
 	help
 	Alias to "grep -E".
 
 config BUSYBOX_CONFIG_FGREP
-	bool "fgrep (7.8 kb)"
+	bool "fgrep (8 kb)"
 	default BUSYBOX_DEFAULT_FGREP
 	help
 	Alias to "grep -F".
@@ -260,7 +267,7 @@ config BUSYBOX_CONFIG_FEATURE_GREP_CONTEXT
 	context surrounding our matching lines.
 	Print the specified number of context lines (-C).
 config BUSYBOX_CONFIG_XARGS
-	bool "xargs (7.2 kb)"
+	bool "xargs (7.6 kb)"
 	default BUSYBOX_DEFAULT_XARGS
 	help
 	xargs is used to execute a specified command for

--- a/package/utils/busybox/config/init/Config.in
+++ b/package/utils/busybox/config/init/Config.in
@@ -45,19 +45,19 @@ config BUSYBOX_CONFIG_FEATURE_BOOTCHARTD_CONFIG_FILE
 	Enable reading and parsing of $PWD/bootchartd.conf
 	and /etc/bootchartd.conf files.
 config BUSYBOX_CONFIG_HALT
-	bool "halt (4 kb)"
+	bool "halt (4.3 kb)"
 	default BUSYBOX_DEFAULT_HALT
 	help
 	Stop all processes and halt the system.
 
 config BUSYBOX_CONFIG_POWEROFF
-	bool "poweroff (4 kb)"
+	bool "poweroff (4.3 kb)"
 	default BUSYBOX_DEFAULT_POWEROFF
 	help
 	Stop all processes and power off the system.
 
 config BUSYBOX_CONFIG_REBOOT
-	bool "reboot (4 kb)"
+	bool "reboot (4.3 kb)"
 	default BUSYBOX_DEFAULT_REBOOT
 	help
 	Stop all processes and reboot the system.

--- a/package/utils/busybox/config/klibc-utils/Config.in
+++ b/package/utils/busybox/config/klibc-utils/Config.in
@@ -17,12 +17,12 @@ config BUSYBOX_CONFIG_NUKE
 	help
 	Alias to "rm -rf".
 config BUSYBOX_CONFIG_RESUME
-	bool "resume (3.2 kb)"
+	bool "resume (3.6 kb)"
 	default BUSYBOX_DEFAULT_RESUME
 	help
 	Resume from saved "suspend-to-disk" image
 config BUSYBOX_CONFIG_RUN_INIT
-	bool "run-init (7.7 kb)"
+	bool "run-init (8 kb)"
 	default BUSYBOX_DEFAULT_RUN_INIT
 	help
 	The run-init utility is used from initramfs to select a new

--- a/package/utils/busybox/config/loginutils/Config.in
+++ b/package/utils/busybox/config/loginutils/Config.in
@@ -93,18 +93,18 @@ config BUSYBOX_CONFIG_USE_BB_CRYPT_SHA
 	user which has password encrypted with these algorithms.
 
 config BUSYBOX_CONFIG_ADD_SHELL
-	bool "add-shell (3.1 kb)"
+	bool "add-shell (3.3 kb)"
 	default BUSYBOX_DEFAULT_ADD_SHELL if BUSYBOX_CONFIG_DESKTOP
 	help
 	Add shells to /etc/shells.
 
 config BUSYBOX_CONFIG_REMOVE_SHELL
-	bool "remove-shell (3 kb)"
+	bool "remove-shell (3.3 kb)"
 	default BUSYBOX_DEFAULT_REMOVE_SHELL if BUSYBOX_CONFIG_DESKTOP
 	help
 	Remove shells from /etc/shells.
 config BUSYBOX_CONFIG_ADDGROUP
-	bool "addgroup (8.6 kb)"
+	bool "addgroup (8.8 kb)"
 	default BUSYBOX_DEFAULT_ADDGROUP
 	select BUSYBOX_CONFIG_LONG_OPTS
 	help
@@ -160,7 +160,7 @@ config BUSYBOX_CONFIG_LAST_SYSTEM_ID
 	help
 	Last valid system uid or gid for adduser and addgroup
 config BUSYBOX_CONFIG_CHPASSWD
-	bool "chpasswd (18 kb)"
+	bool "chpasswd (19 kb)"
 	default BUSYBOX_DEFAULT_CHPASSWD
 	help
 	Reads a file of user name and password pairs from standard input
@@ -173,27 +173,27 @@ config BUSYBOX_CONFIG_FEATURE_DEFAULT_PASSWD_ALGO
 	help
 	Possible choices are "d[es]", "m[d5]", "s[ha256]" or "sha512".
 config BUSYBOX_CONFIG_CRYPTPW
-	bool "cryptpw (14 kb)"
+	bool "cryptpw (15 kb)"
 	default BUSYBOX_DEFAULT_CRYPTPW
 	help
 	Encrypts the given password with the crypt(3) libc function
 	using the given salt.
 
 config BUSYBOX_CONFIG_MKPASSWD
-	bool "mkpasswd (15 kb)"
+	bool "mkpasswd (16 kb)"
 	default BUSYBOX_DEFAULT_MKPASSWD
 	help
 	Encrypts the given password with the crypt(3) libc function
 	using the given salt. Debian has this utility under mkpasswd
 	name. Busybox provides mkpasswd as an alias for cryptpw.
 config BUSYBOX_CONFIG_DELUSER
-	bool "deluser (9.1 kb)"
+	bool "deluser (9.3 kb)"
 	default BUSYBOX_DEFAULT_DELUSER
 	help
 	Utility for deleting a user account.
 
 config BUSYBOX_CONFIG_DELGROUP
-	bool "delgroup (6.4 kb)"
+	bool "delgroup (6.6 kb)"
 	default BUSYBOX_DEFAULT_DELGROUP
 	help
 	Utility for deleting a group account.
@@ -206,7 +206,7 @@ config BUSYBOX_CONFIG_FEATURE_DEL_USER_FROM_GROUP
 	If called with two non-option arguments, deluser
 	or delgroup will remove an user from a specified group.
 config BUSYBOX_CONFIG_GETTY
-	bool "getty (10 kb)"
+	bool "getty (11 kb)"
 	default BUSYBOX_DEFAULT_GETTY
 	select BUSYBOX_CONFIG_FEATURE_SYSLOG
 	help
@@ -224,7 +224,7 @@ config BUSYBOX_CONFIG_GETTY
 	read -r login
 	exec /bin/login "$login"
 config BUSYBOX_CONFIG_LOGIN
-	bool "login (24 kb)"
+	bool "login (25 kb)"
 	default BUSYBOX_DEFAULT_LOGIN
 	select BUSYBOX_CONFIG_FEATURE_SYSLOG
 	help
@@ -269,7 +269,7 @@ config BUSYBOX_CONFIG_FEATURE_SECURETTY
 	The file contains the device names of tty lines (one per line,
 	without leading /dev/) on which root is allowed to login.
 config BUSYBOX_CONFIG_PASSWD
-	bool "passwd (21 kb)"
+	bool "passwd (22 kb)"
 	default BUSYBOX_DEFAULT_PASSWD
 	select BUSYBOX_CONFIG_FEATURE_SYSLOG
 	help
@@ -312,14 +312,14 @@ config BUSYBOX_CONFIG_FEATURE_SU_BLANK_PW_NEEDS_SECURE_TTY
 	default BUSYBOX_DEFAULT_FEATURE_SU_BLANK_PW_NEEDS_SECURE_TTY
 	depends on BUSYBOX_CONFIG_SU
 config BUSYBOX_CONFIG_SULOGIN
-	bool "sulogin (17 kb)"
+	bool "sulogin (18 kb)"
 	default BUSYBOX_DEFAULT_SULOGIN
 	select BUSYBOX_CONFIG_FEATURE_SYSLOG
 	help
 	sulogin is invoked when the system goes into single user
 	mode (this is done through an entry in inittab).
 config BUSYBOX_CONFIG_VLOCK
-	bool "vlock (17 kb)"
+	bool "vlock (18 kb)"
 	default BUSYBOX_DEFAULT_VLOCK
 	help
 	Build the "vlock" applet which allows you to lock (virtual) terminals.

--- a/package/utils/busybox/config/mailutils/Config.in
+++ b/package/utils/busybox/config/mailutils/Config.in
@@ -9,12 +9,12 @@ config BUSYBOX_CONFIG_FEATURE_MIME_CHARSET
 	Default charset of the message.
 
 config BUSYBOX_CONFIG_MAKEMIME
-	bool "makemime (5.4 kb)"
+	bool "makemime (5.6 kb)"
 	default BUSYBOX_DEFAULT_MAKEMIME
 	help
 	Create MIME-formatted messages.
 config BUSYBOX_CONFIG_POPMAILDIR
-	bool "popmaildir (10 kb)"
+	bool "popmaildir (11 kb)"
 	default BUSYBOX_DEFAULT_POPMAILDIR
 	help
 	Simple yet powerful POP3 mail popper. Delivers content
@@ -30,7 +30,7 @@ config BUSYBOX_CONFIG_FEATURE_POPMAILDIR_DELIVERY
 	Allow to use a custom program for message actual delivery
 	(-M "prog [args...]").
 config BUSYBOX_CONFIG_REFORMIME
-	bool "reformime (7.5 kb)"
+	bool "reformime (7.6 kb)"
 	default BUSYBOX_DEFAULT_REFORMIME
 	help
 	Parse MIME-formatted messages.

--- a/package/utils/busybox/config/miscutils/Config.in
+++ b/package/utils/busybox/config/miscutils/Config.in
@@ -7,13 +7,13 @@
 menu "Miscellaneous Utilities"
 
 config BUSYBOX_CONFIG_ADJTIMEX
-	bool "adjtimex (4.7 kb)"
+	bool "adjtimex (4.9 kb)"
 	default BUSYBOX_DEFAULT_ADJTIMEX
 	help
 	Adjtimex reads and optionally sets adjustment parameters for
 	the Linux clock adjustment algorithm.
 config BUSYBOX_CONFIG_ASCII
-	bool "ascii"
+	bool "ascii (784 bytes)"
 	default BUSYBOX_DEFAULT_ASCII
 	help
 	Print ascii table.
@@ -39,7 +39,7 @@ config BUSYBOX_CONFIG_FEATURE_COMPRESS_BBCONFIG
 	and have very little memory, this might not be a win. Otherwise,
 	you probably want this.
 config BUSYBOX_CONFIG_BC
-	bool "bc (45 kb)"
+	bool "bc (38 kb)"
 	default BUSYBOX_DEFAULT_BC
 	select BUSYBOX_CONFIG_FEATURE_DC_BIG
 	help
@@ -63,7 +63,7 @@ config BUSYBOX_CONFIG_BC
 	  5) "read()" accepts expressions, not only numeric literals.
 
 config BUSYBOX_CONFIG_DC
-	bool "dc (36 kb)"
+	bool "dc (29 kb)"
 	default BUSYBOX_DEFAULT_DC
 	help
 	dc is a reverse-polish notation command-line calculator which
@@ -125,7 +125,7 @@ config BUSYBOX_CONFIG_FEATURE_BC_LONG_OPTIONS
 
 endif
 config BUSYBOX_CONFIG_BEEP
-	bool "beep (2.4 kb)"
+	bool "beep (2.7 kb)"
 	default BUSYBOX_DEFAULT_BEEP
 	help
 	The beep applets beeps in a given freq/Hz.
@@ -146,7 +146,7 @@ config BUSYBOX_CONFIG_FEATURE_BEEP_LENGTH_MS
 	help
 	Length in ms for default beep.
 config BUSYBOX_CONFIG_CHAT
-	bool "chat (6.3 kb)"
+	bool "chat (6.7 kb)"
 	default BUSYBOX_DEFAULT_CHAT
 	help
 	Simple chat utility.
@@ -220,7 +220,7 @@ config BUSYBOX_CONFIG_CONSPY
 	or        conspy -nd NUM  screenshot of console num
 	or        conspy -cs NUM  poor man's GNU screen like
 config BUSYBOX_CONFIG_CROND
-	bool "crond (14 kb)"
+	bool "crond (15 kb)"
 	default BUSYBOX_DEFAULT_CROND
 	select BUSYBOX_CONFIG_FEATURE_SYSLOG
 	help
@@ -330,7 +330,7 @@ config BUSYBOX_CONFIG_FEATURE_DEVFS
 	/dev/loop0. If your /dev directory has normal names instead of
 	devfs names, you don't want this.
 config BUSYBOX_CONFIG_DEVMEM
-	bool "devmem (2.5 kb)"
+	bool "devmem (2.7 kb)"
 	default BUSYBOX_DEFAULT_DEVMEM
 	help
 	devmem is a small program that reads and writes from physical
@@ -380,6 +380,11 @@ config BUSYBOX_CONFIG_FLASHCP
 	help
 	The flashcp binary, inspired by mtd-utils as of git head 5eceb74f7.
 	This utility is used to copy images into a MTD device.
+config BUSYBOX_CONFIG_GETFATTR
+	bool "getfattr (12.3 kb)"
+	default BUSYBOX_DEFAULT_GETFATTR
+	help
+	Get extended attributes on files
 config BUSYBOX_CONFIG_HDPARM
 	bool "hdparm (25 kb)"
 	default BUSYBOX_DEFAULT_HDPARM
@@ -437,36 +442,36 @@ config BUSYBOX_CONFIG_FEATURE_HDPARM_HDIO_GETSET_DMA
 	help
 	Enable the 'hdparm -d' option to get/set using_dma flag.
 config BUSYBOX_CONFIG_HEXEDIT
-	bool "hexedit (21 kb)"
+	bool "hexedit (15 kb)"
 	default BUSYBOX_DEFAULT_HEXEDIT
 	help
 	Edit file in hexadecimal.
 config BUSYBOX_CONFIG_I2CGET
-	bool "i2cget (5.5 kb)"
+	bool "i2cget (5.7 kb)"
 	default BUSYBOX_DEFAULT_I2CGET
 	help
 	Read from I2C/SMBus chip registers.
 
 config BUSYBOX_CONFIG_I2CSET
-	bool "i2cset (6.7 kb)"
+	bool "i2cset (6.9 kb)"
 	default BUSYBOX_DEFAULT_I2CSET
 	help
 	Set I2C registers.
 
 config BUSYBOX_CONFIG_I2CDUMP
-	bool "i2cdump (7.1 kb)"
+	bool "i2cdump (7.2 kb)"
 	default BUSYBOX_DEFAULT_I2CDUMP
 	help
 	Examine I2C registers.
 
 config BUSYBOX_CONFIG_I2CDETECT
-	bool "i2cdetect (7.1 kb)"
+	bool "i2cdetect (7.3 kb)"
 	default BUSYBOX_DEFAULT_I2CDETECT
 	help
 	Detect I2C chips.
 
 config BUSYBOX_CONFIG_I2CTRANSFER
-	bool "i2ctransfer (4.0 kb)"
+	bool "i2ctransfer (5.5 kb)"
 	default BUSYBOX_DEFAULT_I2CTRANSFER
 	help
 	Send user-defined I2C messages in one transfer.
@@ -579,7 +584,7 @@ config BUSYBOX_CONFIG_LOCK
 	help
 	  Small utility for using locks in scripts
 config BUSYBOX_CONFIG_LSSCSI
-	bool "lsscsi (2.5 kb)"
+	bool "lsscsi (2.9 kb)"
 	default BUSYBOX_DEFAULT_LSSCSI
 	help
 	lsscsi is a utility for displaying information about SCSI buses in the
@@ -587,7 +592,7 @@ config BUSYBOX_CONFIG_LSSCSI
 
 	This version uses sysfs (/sys/bus/scsi/devices) only.
 config BUSYBOX_CONFIG_MAKEDEVS
-	bool "makedevs (9.2 kb)"
+	bool "makedevs (9.4 kb)"
 	default BUSYBOX_DEFAULT_MAKEDEVS
 	help
 	'makedevs' is a utility used to create a batch of devices with
@@ -623,7 +628,7 @@ config BUSYBOX_CONFIG_MAN
 	help
 	Format and display manual pages.
 config BUSYBOX_CONFIG_MICROCOM
-	bool "microcom (5.7 kb)"
+	bool "microcom (5.9 kb)"
 	default BUSYBOX_DEFAULT_MICROCOM
 	help
 	The poor man's minicom utility for chatting with serial port devices.
@@ -635,36 +640,36 @@ config BUSYBOX_CONFIG_MIM
 	Run a script from a Makefile-like specification file.
 	Unlike 'make' dependencies aren't supported.
 config BUSYBOX_CONFIG_MT
-	bool "mt (2.5 kb)"
+	bool "mt (2.7 kb)"
 	default BUSYBOX_DEFAULT_MT
 	help
 	mt is used to control tape devices. You can use the mt utility
 	to advance or rewind a tape past a specified number of archive
 	files on the tape.
 config BUSYBOX_CONFIG_NANDWRITE
-	bool "nandwrite (4.8 kb)"
+	bool "nandwrite (5 kb)"
 	default BUSYBOX_DEFAULT_NANDWRITE
 	help
 	Write to the specified MTD device, with bad blocks awareness
 
 config BUSYBOX_CONFIG_NANDDUMP
-	bool "nanddump (5.2 kb)"
+	bool "nanddump (5.4 kb)"
 	default BUSYBOX_DEFAULT_NANDDUMP
 	help
 	Dump the content of raw NAND chip
 config BUSYBOX_CONFIG_PARTPROBE
-	bool "partprobe (3.5 kb)"
+	bool "partprobe (3.7 kb)"
 	default BUSYBOX_DEFAULT_PARTPROBE
 	help
 	Ask kernel to rescan partition table.
 config BUSYBOX_CONFIG_RAIDAUTORUN
-	bool "raidautorun (1.3 kb)"
+	bool "raidautorun (1.6 kb)"
 	default BUSYBOX_DEFAULT_RAIDAUTORUN
 	help
 	raidautorun tells the kernel md driver to
 	search and start RAID arrays.
 config BUSYBOX_CONFIG_READAHEAD
-	bool "readahead (1.5 kb)"
+	bool "readahead (1.7 kb)"
 	default BUSYBOX_DEFAULT_READAHEAD
 	depends on BUSYBOX_CONFIG_LFS
 	help
@@ -691,7 +696,7 @@ config BUSYBOX_CONFIG_RFKILL
 	rfkill block|unblock wlan : block/unblock all wlan(wifi) devices
 
 config BUSYBOX_CONFIG_RUNLEVEL
-	bool "runlevel (559 bytes)"
+	bool "runlevel (837 bytes)"
 	default BUSYBOX_DEFAULT_RUNLEVEL
 	depends on BUSYBOX_CONFIG_FEATURE_UTMP
 	help
@@ -700,50 +705,50 @@ config BUSYBOX_CONFIG_RUNLEVEL
 	This applet uses utmp but does not rely on busybox supporing
 	utmp on purpose. It is used by e.g. emdebian via /etc/init.d/rc.
 config BUSYBOX_CONFIG_RX
-	bool "rx (2.9 kb)"
+	bool "rx (3.2 kb)"
 	default BUSYBOX_DEFAULT_RX
 	help
 	Receive files using the Xmodem protocol.
 config BUSYBOX_CONFIG_SEEDRNG
-	bool "seedrng (1.3 kb)"
+	bool "seedrng (9.1 kb)"
 	default BUSYBOX_DEFAULT_SEEDRNG
 	help
 	Seed the kernel RNG from seed files, meant to be called
 	once during startup, once during shutdown, and optionally
 	at some periodic interval in between.
 config BUSYBOX_CONFIG_SETFATTR
-	bool "setfattr (3.7 kb)"
+	bool "setfattr (3.9 kb)"
 	default BUSYBOX_DEFAULT_SETFATTR
 	help
 	Set/delete extended attributes on files
 config BUSYBOX_CONFIG_SETSERIAL
-	bool "setserial (6.9 kb)"
+	bool "setserial (7.1 kb)"
 	default BUSYBOX_DEFAULT_SETSERIAL
 	help
 	Retrieve or set Linux serial port.
 config BUSYBOX_CONFIG_STRINGS
-	bool "strings (4.6 kb)"
+	bool "strings (4.8 kb)"
 	default BUSYBOX_DEFAULT_STRINGS
 	help
 	strings prints the printable character sequences for each file
 	specified.
 config BUSYBOX_CONFIG_TIME
-	bool "time (6.8 kb)"
+	bool "time (8.1 kb)"
 	default BUSYBOX_DEFAULT_TIME
 	help
 	The time command runs the specified program with the given arguments.
 	When the command finishes, time writes a message to standard output
 	giving timing statistics about this program run.
 config BUSYBOX_CONFIG_TREE
-	bool "tree (0.6 kb)"
+	bool "tree (2.5 kb)"
 	default BUSYBOX_DEFAULT_TREE
 	help
 	List files and directories in a tree structure.
 config BUSYBOX_CONFIG_TS
-	bool "ts (450 bytes)"
+	bool "ts (4.4 kb)"
 	default BUSYBOX_DEFAULT_TS
 config BUSYBOX_CONFIG_TTYSIZE
-	bool "ttysize (432 bytes)"
+	bool "ttysize (718 bytes)"
 	default BUSYBOX_DEFAULT_TTYSIZE
 	help
 	A replacement for "stty size". Unlike stty, can report only width,
@@ -751,52 +756,52 @@ config BUSYBOX_CONFIG_TTYSIZE
 	error, but returns default 80x24.
 	Usage in shell scripts: width=`ttysize w`.
 config BUSYBOX_CONFIG_UBIATTACH
-	bool "ubiattach (4.2 kb)"
+	bool "ubiattach (4.5 kb)"
 	default BUSYBOX_DEFAULT_UBIATTACH
 	help
 	Attach MTD device to an UBI device.
 
 config BUSYBOX_CONFIG_UBIDETACH
-	bool "ubidetach (4.1 kb)"
+	bool "ubidetach (4.3 kb)"
 	default BUSYBOX_DEFAULT_UBIDETACH
 	help
 	Detach MTD device from an UBI device.
 
 config BUSYBOX_CONFIG_UBIMKVOL
-	bool "ubimkvol (5.3 kb)"
+	bool "ubimkvol (5.5 kb)"
 	default BUSYBOX_DEFAULT_UBIMKVOL
 	help
 	Create a UBI volume.
 
 config BUSYBOX_CONFIG_UBIRMVOL
-	bool "ubirmvol (4.9 kb)"
+	bool "ubirmvol (5.1 kb)"
 	default BUSYBOX_DEFAULT_UBIRMVOL
 	help
 	Delete a UBI volume.
 
 config BUSYBOX_CONFIG_UBIRSVOL
-	bool "ubirsvol (4.2 kb)"
+	bool "ubirsvol (4.4 kb)"
 	default BUSYBOX_DEFAULT_UBIRSVOL
 	help
 	Resize a UBI volume.
 
 config BUSYBOX_CONFIG_UBIUPDATEVOL
-	bool "ubiupdatevol (5.2 kb)"
+	bool "ubiupdatevol (5.6 kb)"
 	default BUSYBOX_DEFAULT_UBIUPDATEVOL
 	help
 	Update a UBI volume.
 config BUSYBOX_CONFIG_UBIRENAME
-	bool "ubirename (2.4 kb)"
+	bool "ubirename (2.7 kb)"
 	default BUSYBOX_DEFAULT_UBIRENAME
 	help
 	Utility to rename UBI volumes
 config BUSYBOX_CONFIG_VOLNAME
-	bool "volname (1.6 kb)"
+	bool "volname (1.9 kb)"
 	default BUSYBOX_DEFAULT_VOLNAME
 	help
 	Prints a CD-ROM volume name.
 config BUSYBOX_CONFIG_WATCHDOG
-	bool "watchdog (5.3 kb)"
+	bool "watchdog (5.7 kb)"
 	default BUSYBOX_DEFAULT_WATCHDOG
 	help
 	The watchdog utility is used with hardware or software watchdog

--- a/package/utils/busybox/config/modutils/Config.in
+++ b/package/utils/busybox/config/modutils/Config.in
@@ -47,7 +47,7 @@ config BUSYBOX_CONFIG_INSMOD
 	help
 	insmod is used to load specified modules in the running kernel.
 config BUSYBOX_CONFIG_LSMOD
-	bool "lsmod (1.9 kb)"
+	bool "lsmod (2.1 kb)"
 	default BUSYBOX_DEFAULT_LSMOD
 	help
 	lsmod is used to display a list of loaded modules.
@@ -66,7 +66,7 @@ config BUSYBOX_CONFIG_MODINFO
 	help
 	Show information about a Linux Kernel module
 config BUSYBOX_CONFIG_MODPROBE
-	bool "modprobe (28 kb)"
+	bool "modprobe (27 kb)"
 	default BUSYBOX_DEFAULT_MODPROBE
 	help
 	Handle the loading of modules, and their dependencies on a high
@@ -83,7 +83,7 @@ config BUSYBOX_CONFIG_FEATURE_MODPROBE_BLACKLIST
 	hardware autodetection scripts to load modules like evdev, frame
 	buffer drivers etc.
 config BUSYBOX_CONFIG_RMMOD
-	bool "rmmod (3.3 kb)"
+	bool "rmmod (3.5 kb)"
 	default BUSYBOX_DEFAULT_RMMOD
 	help
 	rmmod is used to unload specified modules from the kernel.

--- a/package/utils/busybox/config/networking/Config.in
+++ b/package/utils/busybox/config/networking/Config.in
@@ -90,12 +90,12 @@ config BUSYBOX_CONFIG_ARP
 	help
 	Manipulate the system ARP cache.
 config BUSYBOX_CONFIG_ARPING
-	bool "arping (9 kb)"
+	bool "arping (9.1 kb)"
 	default BUSYBOX_DEFAULT_ARPING
 	help
 	Ping hosts by ARP packets.
 config BUSYBOX_CONFIG_BRCTL
-	bool "brctl (4.7 kb)"
+	bool "brctl (9.9 kb)"
 	default BUSYBOX_DEFAULT_BRCTL
 	help
 	Manage ethernet bridges.
@@ -120,12 +120,12 @@ config BUSYBOX_CONFIG_FEATURE_BRCTL_SHOW
 	Add support for option which prints the current config:
 		show
 config BUSYBOX_CONFIG_DNSD
-	bool "dnsd (9.8 kb)"
+	bool "dnsd (10 kb)"
 	default BUSYBOX_DEFAULT_DNSD
 	help
 	Small and static DNS server daemon.
 config BUSYBOX_CONFIG_ETHER_WAKE
-	bool "ether-wake (4.9 kb)"
+	bool "ether-wake (5.2 kb)"
 	default BUSYBOX_DEFAULT_ETHER_WAKE
 	help
 	Send a magic packet to wake up sleeping machines.
@@ -167,13 +167,13 @@ config BUSYBOX_CONFIG_FEATURE_FTPD_AUTHENTICATION
 	of the user it was started under, and does not require login.
 	Take care to not launch it under root.
 config BUSYBOX_CONFIG_FTPGET
-	bool "ftpget (7.8 kb)"
+	bool "ftpget (7.9 kb)"
 	default BUSYBOX_DEFAULT_FTPGET
 	help
 	Retrieve a remote file via FTP.
 
 config BUSYBOX_CONFIG_FTPPUT
-	bool "ftpput (7.5 kb)"
+	bool "ftpput (7.6 kb)"
 	default BUSYBOX_DEFAULT_FTPPUT
 	help
 	Store a remote file via FTP.
@@ -183,13 +183,13 @@ config BUSYBOX_CONFIG_FEATURE_FTPGETPUT_LONG_OPTIONS
 	default BUSYBOX_DEFAULT_FEATURE_FTPGETPUT_LONG_OPTIONS
 	depends on BUSYBOX_CONFIG_LONG_OPTS && (BUSYBOX_CONFIG_FTPGET || BUSYBOX_CONFIG_FTPPUT)
 config BUSYBOX_CONFIG_HOSTNAME
-	bool "hostname (5.5 kb)"
+	bool "hostname (5.8 kb)"
 	default BUSYBOX_DEFAULT_HOSTNAME
 	help
 	Show or set the system's host name.
 
 config BUSYBOX_CONFIG_DNSDOMAINNAME
-	bool "dnsdomainname (3.6 kb)"
+	bool "dnsdomainname (3.8 kb)"
 	default BUSYBOX_DEFAULT_DNSDOMAINNAME
 	help
 	Alias to "hostname -d".
@@ -408,7 +408,7 @@ config BUSYBOX_CONFIG_IFENSLAVE
 	Userspace application to bind several interfaces
 	to a logical interface (use with kernel bonding driver).
 config BUSYBOX_CONFIG_IFPLUGD
-	bool "ifplugd (10 kb)"
+	bool "ifplugd (11 kb)"
 	default BUSYBOX_DEFAULT_IFPLUGD
 	help
 	Network interface plug detection daemon.
@@ -569,7 +569,7 @@ config BUSYBOX_CONFIG_IP
 	trying to be portable, it's better to use "ip CMD" forms.
 
 config BUSYBOX_CONFIG_IPADDR
-	bool "ipaddr (14 kb)"
+	bool "ipaddr (15 kb)"
 	default BUSYBOX_DEFAULT_IPADDR
 	select BUSYBOX_CONFIG_FEATURE_IP_ADDRESS
 	help
@@ -590,7 +590,7 @@ config BUSYBOX_CONFIG_IPROUTE
 	Short form of "ip route"
 
 config BUSYBOX_CONFIG_IPTUNNEL
-	bool "iptunnel (9.6 kb)"
+	bool "iptunnel (9.8 kb)"
 	default BUSYBOX_DEFAULT_IPTUNNEL
 	select BUSYBOX_CONFIG_FEATURE_IP_TUNNEL
 	help
@@ -604,7 +604,7 @@ config BUSYBOX_CONFIG_IPRULE
 	Short form of "ip rule"
 
 config BUSYBOX_CONFIG_IPNEIGH
-	bool "ipneigh (8.3 kb)"
+	bool "ipneigh (8.6 kb)"
 	default BUSYBOX_DEFAULT_IPNEIGH
 	select BUSYBOX_CONFIG_FEATURE_IP_NEIGH
 	help
@@ -623,6 +623,12 @@ config BUSYBOX_CONFIG_FEATURE_IP_LINK
 	depends on BUSYBOX_CONFIG_IP || BUSYBOX_CONFIG_IPLINK
 	help
 	Configure network devices with "ip".
+
+config BUSYBOX_CONFIG_FEATURE_IP_LINK_CAN
+	bool "ip link set type can"
+	default BUSYBOX_DEFAULT_FEATURE_IP_LINK_CAN
+	help
+	Configure CAN devices with "ip".
 
 config BUSYBOX_CONFIG_FEATURE_IP_ROUTE
 	bool "ip route"
@@ -669,7 +675,7 @@ config BUSYBOX_CONFIG_FEATURE_IP_RARE_PROTOCOLS
 	Ethernet, wireless, infrared, ppp/slip, ip tunnelling
 	link types are supported without this option selected.
 config BUSYBOX_CONFIG_IPCALC
-	bool "ipcalc (4.4 kb)"
+	bool "ipcalc (4.6 kb)"
 	default BUSYBOX_DEFAULT_IPCALC
 	help
 	ipcalc takes an IP address and netmask and calculates the
@@ -688,14 +694,14 @@ config BUSYBOX_CONFIG_FEATURE_IPCALC_FANCY
 	Adds the options hostname, prefix and silent to the output of
 	"ipcalc".
 config BUSYBOX_CONFIG_FAKEIDENTD
-	bool "fakeidentd (8.7 kb)"
+	bool "fakeidentd (9 kb)"
 	default BUSYBOX_DEFAULT_FAKEIDENTD
 	select BUSYBOX_CONFIG_FEATURE_SYSLOG
 	help
 	fakeidentd listens on the ident port and returns a predefined
 	fake value on any query.
 config BUSYBOX_CONFIG_NAMEIF
-	bool "nameif (6.6 kb)"
+	bool "nameif (6.9 kb)"
 	default BUSYBOX_DEFAULT_NAMEIF
 	select BUSYBOX_CONFIG_FEATURE_SYSLOG
 	help
@@ -723,7 +729,7 @@ config BUSYBOX_CONFIG_FEATURE_NAMEIF_EXTENDED
 		new_interface_name  mac=00:80:C8:38:91:B5
 		new_interface_name  00:80:C8:38:91:B5
 config BUSYBOX_CONFIG_NBDCLIENT
-	bool "nbd-client (6 kb)"
+	bool "nbd-client (6.3 kb)"
 	default BUSYBOX_DEFAULT_NBDCLIENT
 	help
 	Network block device client
@@ -792,7 +798,7 @@ config BUSYBOX_CONFIG_FEATURE_NETSTAT_PRG
 	Add support for -p flag to print out PID and program name.
 	+700 bytes of code.
 config BUSYBOX_CONFIG_NSLOOKUP
-	bool "nslookup (9.7 kb)"
+	bool "nslookup (10 kb)"
 	default BUSYBOX_DEFAULT_NSLOOKUP
 	help
 	nslookup is a tool to query Internet name servers.
@@ -807,7 +813,7 @@ config BUSYBOX_CONFIG_FEATURE_NSLOOKUP_LONG_OPTIONS
 	default BUSYBOX_DEFAULT_FEATURE_NSLOOKUP_LONG_OPTIONS
 	depends on BUSYBOX_CONFIG_FEATURE_NSLOOKUP_BIG && BUSYBOX_CONFIG_LONG_OPTS
 config BUSYBOX_CONFIG_NTPD
-	bool "ntpd (22 kb)"
+	bool "ntpd (23 kb)"
 	default BUSYBOX_DEFAULT_NTPD
 	help
 	The NTP client/server daemon.
@@ -855,22 +861,22 @@ config BUSYBOX_CONFIG_FEATURE_FANCY_PING
 	or terminate with SIGALRM in 5 seconds otherwise.
 	No command-line options will be recognized.
 config BUSYBOX_CONFIG_PSCAN
-	bool "pscan (6 kb)"
+	bool "pscan (6.2 kb)"
 	default BUSYBOX_DEFAULT_PSCAN
 	help
 	Simple network port scanner.
 config BUSYBOX_CONFIG_ROUTE
-	bool "route (8.7 kb)"
+	bool "route (9 kb)"
 	default BUSYBOX_DEFAULT_ROUTE
 	help
 	Route displays or manipulates the kernel's IP routing tables.
 config BUSYBOX_CONFIG_SLATTACH
-	bool "slattach (6.2 kb)"
+	bool "slattach (6.3 kb)"
 	default BUSYBOX_DEFAULT_SLATTACH
 	help
 	slattach configures serial line as SLIP network interface.
 config BUSYBOX_CONFIG_SSL_CLIENT
-	bool "ssl_client (25 kb)"
+	bool "ssl_client (28 kb)"
 	default BUSYBOX_DEFAULT_SSL_CLIENT
 	select BUSYBOX_CONFIG_TLS
 	help
@@ -929,7 +935,7 @@ config BUSYBOX_CONFIG_FEATURE_TELNET_WIDTH
 	default BUSYBOX_DEFAULT_FEATURE_TELNET_WIDTH
 	depends on BUSYBOX_CONFIG_TELNET
 config BUSYBOX_CONFIG_TELNETD
-	bool "telnetd (12 kb)"
+	bool "telnetd (13 kb)"
 	default BUSYBOX_DEFAULT_TELNETD
 	select BUSYBOX_CONFIG_FEATURE_SYSLOG
 	help
@@ -1076,7 +1082,7 @@ config BUSYBOX_CONFIG_TRACEROUTE
 	Utility to trace the route of IP packets.
 
 config BUSYBOX_CONFIG_TRACEROUTE6
-	bool "traceroute6 (13 kb)"
+	bool "traceroute6 (12 kb)"
 	default BUSYBOX_DEFAULT_TRACEROUTE6
 	depends on BUSYBOX_CONFIG_FEATURE_IPV6
 	help
@@ -1095,7 +1101,7 @@ config BUSYBOX_CONFIG_FEATURE_TRACEROUTE_USE_ICMP
 	default BUSYBOX_DEFAULT_FEATURE_TRACEROUTE_USE_ICMP
 	depends on BUSYBOX_CONFIG_TRACEROUTE || BUSYBOX_CONFIG_TRACEROUTE6
 config BUSYBOX_CONFIG_TUNCTL
-	bool "tunctl (6.2 kb)"
+	bool "tunctl (6.4 kb)"
 	default BUSYBOX_DEFAULT_TUNCTL
 	help
 	tunctl creates or deletes tun devices.
@@ -1108,12 +1114,12 @@ config BUSYBOX_CONFIG_FEATURE_TUNCTL_UG
 	Allow to specify owner and group of newly created interface.
 	340 bytes of pure bloat. Say no here.
 config BUSYBOX_CONFIG_VCONFIG
-	bool "vconfig (2.3 kb)"
+	bool "vconfig (2.6 kb)"
 	default BUSYBOX_DEFAULT_VCONFIG
 	help
 	Creates, removes, and configures VLAN interfaces
 config BUSYBOX_CONFIG_WGET
-	bool "wget (38 kb)"
+	bool "wget (41 kb)"
 	default BUSYBOX_DEFAULT_WGET
 	help
 	wget is a utility for non-interactive download of files from HTTP
@@ -1233,12 +1239,12 @@ config BUSYBOX_CONFIG_FEATURE_WGET_OPENSSL
 	By default TLS verification is performed, unless
 	--no-check-certificate option is passed.
 config BUSYBOX_CONFIG_WHOIS
-	bool "whois (6.3 kb)"
+	bool "whois (6.5 kb)"
 	default BUSYBOX_DEFAULT_WHOIS
 	help
 	whois is a client for the whois directory service
 config BUSYBOX_CONFIG_ZCIP
-	bool "zcip (8.4 kb)"
+	bool "zcip (8.7 kb)"
 	default BUSYBOX_DEFAULT_ZCIP
 	select BUSYBOX_CONFIG_FEATURE_SYSLOG
 	help

--- a/package/utils/busybox/config/networking/udhcp/Config.in
+++ b/package/utils/busybox/config/networking/udhcp/Config.in
@@ -11,6 +11,13 @@ config BUSYBOX_CONFIG_UDHCPD
 	udhcpd is a DHCP server geared primarily toward embedded systems,
 	while striving to be fully functional and RFC compliant.
 
+config BUSYBOX_CONFIG_FEATURE_UDHCPD_BOOTP
+	bool "Answer to BOOTP requests as well"
+	default BUSYBOX_DEFAULT_FEATURE_UDHCPD_BOOTP
+	depends on BUSYBOX_CONFIG_UDHCPD
+	help
+	Support old BOOTP protocol too.
+
 config BUSYBOX_CONFIG_FEATURE_UDHCPD_BASE_IP_ON_MAC
 	bool "Select IP address based on client MAC"
 	default BUSYBOX_DEFAULT_FEATURE_UDHCPD_BASE_IP_ON_MAC
@@ -44,7 +51,7 @@ config BUSYBOX_CONFIG_DHCPD_LEASES_FILE
 	of the file. Normally it is safe to leave it untouched.
 
 config BUSYBOX_CONFIG_DUMPLEASES
-	bool "dumpleases (5.1 kb)"
+	bool "dumpleases (5.3 kb)"
 	default BUSYBOX_DEFAULT_DUMPLEASES
 	help
 	dumpleases displays the leases written out by the udhcpd.
@@ -52,7 +59,7 @@ config BUSYBOX_CONFIG_DUMPLEASES
 	by the absolute time that it expires in seconds from epoch.
 
 config BUSYBOX_CONFIG_DHCPRELAY
-	bool "dhcprelay (5.2 kb)"
+	bool "dhcprelay (5.5 kb)"
 	default BUSYBOX_DEFAULT_DHCPRELAY
 	help
 	dhcprelay listens for DHCP requests on one or more interfaces

--- a/package/utils/busybox/config/printutils/Config.in
+++ b/package/utils/busybox/config/printutils/Config.in
@@ -7,18 +7,18 @@
 menu "Print Utilities"
 
 config BUSYBOX_CONFIG_LPD
-	bool "lpd (5.5 kb)"
+	bool "lpd (5.7 kb)"
 	default BUSYBOX_DEFAULT_LPD
 	help
 	lpd is a print spooling daemon.
 config BUSYBOX_CONFIG_LPR
-	bool "lpr (9.9 kb)"
+	bool "lpr (10 kb)"
 	default BUSYBOX_DEFAULT_LPR
 	help
 	lpr sends files (or standard input) to a print spooling daemon.
 
 config BUSYBOX_CONFIG_LPQ
-	bool "lpq (9.9 kb)"
+	bool "lpq (10 kb)"
 	default BUSYBOX_DEFAULT_LPQ
 	help
 	lpq is a print spool queue examination and manipulation program.

--- a/package/utils/busybox/config/procps/Config.in
+++ b/package/utils/busybox/config/procps/Config.in
@@ -22,26 +22,26 @@ config BUSYBOX_CONFIG_FEATURE_SHOW_THREADS
 	and 'h' command in top.
 
 config BUSYBOX_CONFIG_FREE
-	bool "free (3.1 kb)"
+	bool "free (3.8 kb)"
 	default BUSYBOX_DEFAULT_FREE
 	help
 	free displays the total amount of free and used physical and swap
 	memory in the system, as well as the buffers used by the kernel.
 	The shared memory column should be ignored; it is obsolete.
 config BUSYBOX_CONFIG_FUSER
-	bool "fuser (7 kb)"
+	bool "fuser (7.3 kb)"
 	default BUSYBOX_DEFAULT_FUSER
 	help
 	fuser lists all PIDs (Process IDs) that currently have a given
 	file open. fuser can also list all PIDs that have a given network
 	(TCP or UDP) port open.
 config BUSYBOX_CONFIG_IOSTAT
-	bool "iostat (7.6 kb)"
+	bool "iostat (8 kb)"
 	default BUSYBOX_DEFAULT_IOSTAT
 	help
 	Report CPU and I/O statistics
 config BUSYBOX_CONFIG_KILL
-	bool "kill (3.1 kb)"
+	bool "kill (3.4 kb)"
 	default BUSYBOX_DEFAULT_KILL
 	help
 	The command kill sends the specified signal to the specified
@@ -49,7 +49,7 @@ config BUSYBOX_CONFIG_KILL
 	signal is sent.
 
 config BUSYBOX_CONFIG_KILLALL
-	bool "killall (5.6 kb)"
+	bool "killall (5.9 kb)"
 	default BUSYBOX_DEFAULT_KILLALL
 	help
 	killall sends a signal to all processes running any of the
@@ -57,7 +57,7 @@ config BUSYBOX_CONFIG_KILLALL
 	sent.
 
 config BUSYBOX_CONFIG_KILLALL5
-	bool "killall5 (5.3 kb)"
+	bool "killall5 (5.6 kb)"
 	default BUSYBOX_DEFAULT_KILLALL5
 	help
 	The SystemV killall command. killall5 sends a signal
@@ -65,34 +65,34 @@ config BUSYBOX_CONFIG_KILLALL5
 	in its own session, so it won't kill the shell that is running
 	the script it was called from.
 config BUSYBOX_CONFIG_LSOF
-	bool "lsof (3.4 kb)"
+	bool "lsof (3.7 kb)"
 	default BUSYBOX_DEFAULT_LSOF
 	help
 	Show open files in the format of:
 	PID <TAB> /path/to/executable <TAB> /path/to/opened/file
 config BUSYBOX_CONFIG_MPSTAT
-	bool "mpstat (9.8 kb)"
+	bool "mpstat (10 kb)"
 	default BUSYBOX_DEFAULT_MPSTAT
 	help
 	Per-processor statistics
 config BUSYBOX_CONFIG_NMETER
-	bool "nmeter (11 kb)"
+	bool "nmeter (12 kb)"
 	default BUSYBOX_DEFAULT_NMETER
 	help
 	Prints selected system stats continuously, one line per update.
 config BUSYBOX_CONFIG_PGREP
-	bool "pgrep (6.5 kb)"
+	bool "pgrep (6.8 kb)"
 	default BUSYBOX_DEFAULT_PGREP
 	help
 	Look for processes by name.
 
 config BUSYBOX_CONFIG_PKILL
-	bool "pkill (7.5 kb)"
+	bool "pkill (7.8 kb)"
 	default BUSYBOX_DEFAULT_PKILL
 	help
 	Send signals to processes by name.
 config BUSYBOX_CONFIG_PIDOF
-	bool "pidof (6.3 kb)"
+	bool "pidof (6.5 kb)"
 	default BUSYBOX_DEFAULT_PIDOF
 	help
 	Pidof finds the process id's (pids) of the named programs. It prints
@@ -114,12 +114,12 @@ config BUSYBOX_CONFIG_FEATURE_PIDOF_OMIT
 	The special pid %PPID can be used to name the parent process
 	of the pidof, in other words the calling shell or shell script.
 config BUSYBOX_CONFIG_PMAP
-	bool "pmap (6 kb)"
+	bool "pmap (6.2 kb)"
 	default BUSYBOX_DEFAULT_PMAP
 	help
 	Display processes' memory mappings.
 config BUSYBOX_CONFIG_POWERTOP
-	bool "powertop (9.6 kb)"
+	bool "powertop (9.9 kb)"
 	default BUSYBOX_DEFAULT_POWERTOP
 	help
 	Analyze power consumption on Intel-based laptops
@@ -132,7 +132,7 @@ config BUSYBOX_CONFIG_FEATURE_POWERTOP_INTERACTIVE
 	Without this, powertop will only refresh display every 10 seconds.
 	No keyboard commands will work, only ^C to terminate.
 config BUSYBOX_CONFIG_PS
-	bool "ps (11 kb)"
+	bool "ps (12 kb)"
 	default BUSYBOX_DEFAULT_PS
 	help
 	ps gives a snapshot of the current processes.
@@ -172,23 +172,23 @@ config BUSYBOX_CONFIG_FEATURE_PS_ADDITIONAL_COLUMNS
 	default BUSYBOX_DEFAULT_FEATURE_PS_ADDITIONAL_COLUMNS
 	depends on (BUSYBOX_CONFIG_PS || BUSYBOX_CONFIG_MINIPS) && BUSYBOX_CONFIG_DESKTOP
 config BUSYBOX_CONFIG_PSTREE
-	bool "pstree (9.3 kb)"
+	bool "pstree (9.4 kb)"
 	default BUSYBOX_DEFAULT_PSTREE
 	help
 	Display a tree of processes.
 config BUSYBOX_CONFIG_PWDX
-	bool "pwdx (3.7 kb)"
+	bool "pwdx (3.9 kb)"
 	default BUSYBOX_DEFAULT_PWDX
 	help
 	Report current working directory of a process
 config BUSYBOX_CONFIG_SMEMCAP
-	bool "smemcap (2.5 kb)"
+	bool "smemcap (3 kb)"
 	default BUSYBOX_DEFAULT_SMEMCAP
 	help
 	smemcap is a tool for capturing process data for smem,
 	a memory usage statistic tool.
 config BUSYBOX_CONFIG_BB_SYSCTL
-	bool "sysctl (7.4 kb)"
+	bool "sysctl (7.9 kb)"
 	default BUSYBOX_DEFAULT_BB_SYSCTL
 	help
 	Configure kernel parameters at runtime.
@@ -254,7 +254,7 @@ config BUSYBOX_CONFIG_FEATURE_TOPMEM
 	help
 	Enable 's' in top (gives lots of memory info).
 config BUSYBOX_CONFIG_UPTIME
-	bool "uptime (3.7 kb)"
+	bool "uptime (4 kb)"
 	default BUSYBOX_DEFAULT_UPTIME
 	help
 	uptime gives a one line display of the current time, how long
@@ -268,7 +268,7 @@ config BUSYBOX_CONFIG_FEATURE_UPTIME_UTMP_SUPPORT
 	help
 	Display the number of users currently logged on.
 config BUSYBOX_CONFIG_WATCH
-	bool "watch (4.4 kb)"
+	bool "watch (5.2 kb)"
 	default BUSYBOX_DEFAULT_WATCH
 	help
 	watch is used to execute a program periodically, showing

--- a/package/utils/busybox/config/runit/Config.in
+++ b/package/utils/busybox/config/runit/Config.in
@@ -7,44 +7,44 @@
 menu "Runit Utilities"
 
 config BUSYBOX_CONFIG_CHPST
-	bool "chpst (9 kb)"
+	bool "chpst (9.2 kb)"
 	default BUSYBOX_DEFAULT_CHPST
 	help
 	chpst changes the process state according to the given options, and
 	execs specified program.
 
 config BUSYBOX_CONFIG_SETUIDGID
-	bool "setuidgid (4 kb)"
+	bool "setuidgid (4.2 kb)"
 	default BUSYBOX_DEFAULT_SETUIDGID
 	help
 	Sets soft resource limits as specified by options
 
 config BUSYBOX_CONFIG_ENVUIDGID
-	bool "envuidgid (3.9 kb)"
+	bool "envuidgid (4.1 kb)"
 	default BUSYBOX_DEFAULT_ENVUIDGID
 	help
 	Sets $UID to account's uid and $GID to account's gid
 
 config BUSYBOX_CONFIG_ENVDIR
-	bool "envdir (2.5 kb)"
+	bool "envdir (2.9 kb)"
 	default BUSYBOX_DEFAULT_ENVDIR
 	help
 	Sets various environment variables as specified by files
 	in the given directory
 
 config BUSYBOX_CONFIG_SOFTLIMIT
-	bool "softlimit (4.5 kb)"
+	bool "softlimit (4.7 kb)"
 	default BUSYBOX_DEFAULT_SOFTLIMIT
 	help
 	Sets soft resource limits as specified by options
 config BUSYBOX_CONFIG_RUNSV
-	bool "runsv (7.8 kb)"
+	bool "runsv (8.2 kb)"
 	default BUSYBOX_DEFAULT_RUNSV
 	help
 	runsv starts and monitors a service and optionally an appendant log
 	service.
 config BUSYBOX_CONFIG_RUNSVDIR
-	bool "runsvdir (6.3 kb)"
+	bool "runsvdir (6.6 kb)"
 	default BUSYBOX_DEFAULT_RUNSVDIR
 	help
 	runsvdir starts a runsv process for each subdirectory, or symlink to
@@ -60,7 +60,7 @@ config BUSYBOX_CONFIG_FEATURE_RUNSVDIR_LOG
 	message (viewable via top/ps). Otherwise (feature is off
 	or no parameter), error messages go to stderr only.
 config BUSYBOX_CONFIG_SV
-	bool "sv (8.5 kb)"
+	bool "sv (8.7 kb)"
 	default BUSYBOX_DEFAULT_SV
 	help
 	sv reports the current status and controls the state of services
@@ -75,14 +75,14 @@ config BUSYBOX_CONFIG_SV_DEFAULT_SERVICE_DIR
 	Defaults to "/var/service"
 
 config BUSYBOX_CONFIG_SVC
-	bool "svc (8.4 kb)"
+	bool "svc (8.7 kb)"
 	default BUSYBOX_DEFAULT_SVC
 	help
 	svc controls the state of services monitored by the runsv supervisor.
 	It is compatible with daemontools command with the same name.
 
 config BUSYBOX_CONFIG_SVOK
-	bool "svok (1.5 kb)"
+	bool "svok (1.8 kb)"
 	default BUSYBOX_DEFAULT_SVOK
 	help
 	svok checks whether runsv supervisor is running.

--- a/package/utils/busybox/config/shell/Config.in
+++ b/package/utils/busybox/config/shell/Config.in
@@ -87,7 +87,7 @@ config BUSYBOX_CONFIG_SHELL_ASH
 	depends on !BUSYBOX_CONFIG_NOMMU
 
 config BUSYBOX_CONFIG_ASH
-	bool "ash (78 kb)"
+	bool "ash (80 kb)"
 	default BUSYBOX_DEFAULT_ASH
 	depends on !BUSYBOX_CONFIG_NOMMU
 	select BUSYBOX_CONFIG_SHELL_ASH
@@ -201,11 +201,6 @@ config BUSYBOX_CONFIG_ASH_TEST
 	default BUSYBOX_DEFAULT_ASH_TEST
 	depends on BUSYBOX_CONFIG_SHELL_ASH
 
-config BUSYBOX_CONFIG_ASH_SLEEP
-	bool "sleep builtin"
-	default BUSYBOX_DEFAULT_ASH_SLEEP
-	depends on BUSYBOX_CONFIG_SHELL_ASH
-
 config BUSYBOX_CONFIG_ASH_HELP
 	bool "help builtin"
 	default BUSYBOX_DEFAULT_ASH_HELP
@@ -227,7 +222,7 @@ config BUSYBOX_CONFIG_ASH_CMDCMD
 
 endif # ash options
 config BUSYBOX_CONFIG_CTTYHACK
-	bool "cttyhack (2.4 kb)"
+	bool "cttyhack (2.7 kb)"
 	default BUSYBOX_DEFAULT_CTTYHACK
 	help
 	One common problem reported on the mailing list is the "can't
@@ -270,7 +265,7 @@ config BUSYBOX_CONFIG_CTTYHACK
 
 	# getty 115200 $(cttyhack)
 config BUSYBOX_CONFIG_HUSH
-	bool "hush (68 kb)"
+	bool "hush (70 kb)"
 	default BUSYBOX_DEFAULT_HUSH
 	select BUSYBOX_CONFIG_SHELL_HUSH
 	help

--- a/package/utils/busybox/config/sysklogd/Config.in
+++ b/package/utils/busybox/config/sysklogd/Config.in
@@ -7,7 +7,7 @@
 menu "System Logging Utilities"
 
 config BUSYBOX_CONFIG_KLOGD
-	bool "klogd (5.7 kb)"
+	bool "klogd (6.2 kb)"
 	default BUSYBOX_DEFAULT_KLOGD
 	help
 	klogd is a utility which intercepts and logs all
@@ -35,7 +35,7 @@ config BUSYBOX_CONFIG_FEATURE_KLOGD_KLOGCTL
 
 	If in doubt, say 'Y'.
 config BUSYBOX_CONFIG_LOGGER
-	bool "logger (6.3 kb)"
+	bool "logger (6.5 kb)"
 	default BUSYBOX_DEFAULT_LOGGER
 	select BUSYBOX_CONFIG_FEATURE_SYSLOG
 	help
@@ -44,7 +44,7 @@ config BUSYBOX_CONFIG_LOGGER
 	they can be logged. This is generally used to help locate
 	problems that occur within programs and scripts.
 config BUSYBOX_CONFIG_LOGREAD
-	bool "logread (4.8 kb)"
+	bool "logread (5 kb)"
 	default BUSYBOX_DEFAULT_LOGREAD
 	help
 	If you enabled Circular Buffer support, you almost
@@ -64,7 +64,7 @@ config BUSYBOX_CONFIG_FEATURE_LOGREAD_REDUCED_LOCKING
 	contention at some minor memory expense.
 
 config BUSYBOX_CONFIG_SYSLOGD
-	bool "syslogd (13 kb)"
+	bool "syslogd (14 kb)"
 	default BUSYBOX_DEFAULT_SYSLOGD
 	help
 	The syslogd utility is used to record logs of all the

--- a/package/utils/busybox/config/util-linux/Config.in
+++ b/package/utils/busybox/config/util-linux/Config.in
@@ -7,7 +7,7 @@
 menu "Linux System Utilities"
 
 config BUSYBOX_CONFIG_ACPID
-	bool "acpid (9 kb)"
+	bool "acpid (9.3 kb)"
 	default BUSYBOX_DEFAULT_ACPID
 	help
 	acpid listens to ACPI events coming either in textual form from
@@ -28,7 +28,7 @@ config BUSYBOX_CONFIG_FEATURE_ACPID_COMPAT
 	help
 	Accept and ignore compatibility options -g -m -s -S -v.
 config BUSYBOX_CONFIG_BLKDISCARD
-	bool "blkdiscard (4.3 kb)"
+	bool "blkdiscard (4.6 kb)"
 	default BUSYBOX_DEFAULT_BLKDISCARD
 	help
 	blkdiscard discards sectors on a given device.
@@ -46,23 +46,23 @@ config BUSYBOX_CONFIG_FEATURE_BLKID_TYPE
 	help
 	Show TYPE="filesystem type"
 config BUSYBOX_CONFIG_BLOCKDEV
-	bool "blockdev (2.3 kb)"
+	bool "blockdev (2.6 kb)"
 	default BUSYBOX_DEFAULT_BLOCKDEV
 	help
 	Performs some ioctls with block devices.
 config BUSYBOX_CONFIG_CAL
-	bool "cal (5.8 kb)"
+	bool "cal (6.1 kb)"
 	default BUSYBOX_DEFAULT_CAL
 	help
 	cal is used to display a monthly calendar.
 config BUSYBOX_CONFIG_CHRT
-	bool "chrt (4.7 kb)"
+	bool "chrt (5.1 kb)"
 	default BUSYBOX_DEFAULT_CHRT
 	help
 	Manipulate real-time attributes of a process.
 	This requires sched_{g,s}etparam support in your libc.
 config BUSYBOX_CONFIG_DMESG
-	bool "dmesg (3.7 kb)"
+	bool "dmesg (3.9 kb)"
 	default BUSYBOX_DEFAULT_DMESG
 	help
 	dmesg is used to examine or control the kernel ring buffer. When the
@@ -94,7 +94,7 @@ config BUSYBOX_CONFIG_FEATURE_DMESG_PRETTY
 		<6>BIOS-provided physical RAM map:
 		<6> BIOS-e820: 0000000000000000 - 000000000009f000 (usable)
 config BUSYBOX_CONFIG_EJECT
-	bool "eject (4 kb)"
+	bool "eject (4.3 kb)"
 	default BUSYBOX_DEFAULT_EJECT
 	help
 	Used to eject cdroms. (defaults to /dev/cdrom)
@@ -107,17 +107,17 @@ config BUSYBOX_CONFIG_FEATURE_EJECT_SCSI
 	Add the -s option to eject, this allows to eject SCSI-Devices and
 	usb-storage devices.
 config BUSYBOX_CONFIG_FALLOCATE
-	bool "fallocate (4.1 kb)"
+	bool "fallocate (4.3 kb)"
 	default BUSYBOX_DEFAULT_FALLOCATE
 	help
 	Preallocate space for files.
 config BUSYBOX_CONFIG_FATATTR
-	bool "fatattr (1.9 kb)"
+	bool "fatattr (2.2 kb)"
 	default BUSYBOX_DEFAULT_FATATTR
 	help
 	fatattr lists or changes the file attributes on a fat file system.
 config BUSYBOX_CONFIG_FBSET
-	bool "fbset (5.9 kb)"
+	bool "fbset (6.2 kb)"
 	default BUSYBOX_DEFAULT_FBSET
 	help
 	fbset is used to show or change the settings of a Linux frame buffer
@@ -144,12 +144,12 @@ config BUSYBOX_CONFIG_FEATURE_FBSET_READMODE
 	default BUSYBOX_DEFAULT_FEATURE_FBSET_READMODE /etc/fb.modes, which can be used to set frame buffer
 	device to pre-defined video modes.
 config BUSYBOX_CONFIG_FDFORMAT
-	bool "fdformat (4.4 kb)"
+	bool "fdformat (4.7 kb)"
 	default BUSYBOX_DEFAULT_FDFORMAT
 	help
 	fdformat is used to low-level format a floppy disk.
 config BUSYBOX_CONFIG_FDISK
-	bool "fdisk (37 kb)"
+	bool "fdisk (31 kb)"
 	default BUSYBOX_DEFAULT_FDISK
 	help
 	The fdisk utility is used to divide hard disks into one or more
@@ -222,18 +222,18 @@ config BUSYBOX_CONFIG_FEATURE_FDISK_ADVANCED
 	partition, and similarly evil things. Unless you have a very good
 	reason you would be wise to leave this disabled.
 config BUSYBOX_CONFIG_FINDFS
-	bool "findfs (12 kb)"
+	bool "findfs (11 kb)"
 	default BUSYBOX_DEFAULT_FINDFS
 	select BUSYBOX_CONFIG_VOLUMEID
 	help
 	Prints the name of a filesystem with given label or UUID.
 config BUSYBOX_CONFIG_FLOCK
-	bool "flock (6.3 kb)"
+	bool "flock (6.5 kb)"
 	default BUSYBOX_DEFAULT_FLOCK
 	help
 	Manage locks from shell scripts
 config BUSYBOX_CONFIG_FDFLUSH
-	bool "fdflush (1.3 kb)"
+	bool "fdflush (1.6 kb)"
 	default BUSYBOX_DEFAULT_FDFLUSH
 	help
 	fdflush is only needed when changing media on slightly-broken
@@ -245,7 +245,7 @@ config BUSYBOX_CONFIG_FDFLUSH
 	leave this disabled.
 
 config BUSYBOX_CONFIG_FREERAMDISK
-	bool "freeramdisk (1.3 kb)"
+	bool "freeramdisk (1.6 kb)"
 	default BUSYBOX_DEFAULT_FREERAMDISK
 	help
 	Linux allows you to create ramdisks. This utility allows you to
@@ -265,18 +265,18 @@ config BUSYBOX_CONFIG_FSCK_MINIX
 	check for and attempt to repair any corruption that occurs to a minix
 	filesystem.
 config BUSYBOX_CONFIG_FSFREEZE
-	bool "fsfreeze (3.5 kb)"
+	bool "fsfreeze (3.7 kb)"
 	default BUSYBOX_DEFAULT_FSFREEZE
 	select BUSYBOX_CONFIG_LONG_OPTS
 	help
 	Halt new accesses and flush writes on a mounted filesystem.
 config BUSYBOX_CONFIG_FSTRIM
-	bool "fstrim (4.4 kb)"
+	bool "fstrim (4.6 kb)"
 	default BUSYBOX_DEFAULT_FSTRIM
 	help
 	Discard unused blocks on a mounted filesystem.
 config BUSYBOX_CONFIG_GETOPT
-	bool "getopt (5.8 kb)"
+	bool "getopt (6 kb)"
 	default BUSYBOX_DEFAULT_GETOPT
 	help
 	The getopt utility is used to break up (parse) options in command
@@ -293,26 +293,27 @@ config BUSYBOX_CONFIG_FEATURE_GETOPT_LONG
 	help
 	Enable support for long options (option -l).
 config BUSYBOX_CONFIG_HEXDUMP
-	bool "hexdump (8.6 kb)"
+	bool "hexdump (8.7 kb)"
 	default BUSYBOX_DEFAULT_HEXDUMP
 	help
 	The hexdump utility is used to display binary data in a readable
 	way that is comparable to the output from most hex editors.
 
 config BUSYBOX_CONFIG_HD
-	bool "hd (7.8 kb)"
+	bool "hd (8.3 kb)"
 	default BUSYBOX_DEFAULT_HD
 	help
 	hd is an alias to hexdump -C.
 config BUSYBOX_CONFIG_XXD
-	bool "xxd (8.9 kb)"
+	bool "xxd (11 kb)"
 	default BUSYBOX_DEFAULT_XXD
 	help
 	The xxd utility is used to display binary data in a readable
 	way that is comparable to the output from most hex editors.
 config BUSYBOX_CONFIG_HWCLOCK
-	bool "hwclock (5.8 kb)"
+	bool "hwclock (5.9 kb)"
 	default BUSYBOX_DEFAULT_HWCLOCK
+	select BUSYBOX_CONFIG_LONG_OPTS
 	help
 	The hwclock utility is used to read and set the hardware clock
 	on a system. This is primarily used to set the current time on
@@ -331,26 +332,26 @@ config BUSYBOX_CONFIG_FEATURE_HWCLOCK_ADJTIME_FHS
 
 	pathname.com/fhs/pub/fhs-2.3.html#VARLIBHWCLOCKSTATEDIRECTORYFORHWCLO
 config BUSYBOX_CONFIG_IONICE
-	bool "ionice (3.8 kb)"
+	bool "ionice (4 kb)"
 	default BUSYBOX_DEFAULT_IONICE
 	help
 	Set/set program io scheduling class and priority
 	Requires kernel >= 2.6.13
 config BUSYBOX_CONFIG_IPCRM
-	bool "ipcrm (3.2 kb)"
+	bool "ipcrm (3.5 kb)"
 	default BUSYBOX_DEFAULT_IPCRM
 	help
 	The ipcrm utility allows the removal of System V interprocess
 	communication (IPC) objects and the associated data structures
 	from the system.
 config BUSYBOX_CONFIG_IPCS
-	bool "ipcs (11 kb)"
+	bool "ipcs (12 kb)"
 	default BUSYBOX_DEFAULT_IPCS
 	help
 	The ipcs utility is used to provide information on the currently
 	allocated System V interprocess (IPC) objects in the system.
 config BUSYBOX_CONFIG_LAST
-	bool "last (6.1 kb)"
+	bool "last (7.4 kb)"
 	default BUSYBOX_DEFAULT_LAST
 	depends on BUSYBOX_CONFIG_FEATURE_WTMP
 	help
@@ -364,14 +365,14 @@ config BUSYBOX_CONFIG_FEATURE_LAST_FANCY
 	'last' displays detailed information about the last users that
 	logged into the system (mimics sysvinit last). +900 bytes.
 config BUSYBOX_CONFIG_LOSETUP
-	bool "losetup (5.5 kb)"
+	bool "losetup (6.2 kb)"
 	default BUSYBOX_DEFAULT_LOSETUP
 	help
 	losetup is used to associate or detach a loop device with a regular
 	file or block device, and to query the status of a loop device. This
 	version does not currently support enabling data encryption.
 config BUSYBOX_CONFIG_LSPCI
-	bool "lspci (6.3 kb)"
+	bool "lspci (6.4 kb)"
 	default BUSYBOX_DEFAULT_LSPCI
 	help
 	lspci is a utility for displaying information about PCI buses in the
@@ -379,7 +380,7 @@ config BUSYBOX_CONFIG_LSPCI
 
 	This version uses sysfs (/sys/bus/pci/devices) only.
 config BUSYBOX_CONFIG_LSUSB
-	bool "lsusb (4.2 kb)"
+	bool "lsusb (4.4 kb)"
 	default BUSYBOX_DEFAULT_LSUSB
 	help
 	lsusb is a utility for displaying information about USB buses in the
@@ -387,7 +388,7 @@ config BUSYBOX_CONFIG_LSUSB
 
 	This version uses sysfs (/sys/bus/usb/devices) only.
 config BUSYBOX_CONFIG_MDEV
-	bool "mdev (17 kb)"
+	bool "mdev (20 kb)"
 	default BUSYBOX_DEFAULT_MDEV
 	help
 	mdev is a mini-udev implementation for dynamically creating device
@@ -454,7 +455,7 @@ config BUSYBOX_CONFIG_FEATURE_MDEV_DAEMON
 	resources than registering mdev as hotplug helper or using the
 	uevent applet.
 config BUSYBOX_CONFIG_MESG
-	bool "mesg (1.4 kb)"
+	bool "mesg (1.8 kb)"
 	default BUSYBOX_DEFAULT_MESG
 	help
 	Mesg controls access to your terminal by others. It is typically
@@ -505,18 +506,18 @@ config BUSYBOX_CONFIG_MKFS_REISER
 	Utility to create ReiserFS filesystems.
 	Note: this applet needs a lot of testing and polishing.
 config BUSYBOX_CONFIG_MKDOSFS
-	bool "mkdosfs (7.2 kb)"
+	bool "mkdosfs (7.6 kb)"
 	default BUSYBOX_DEFAULT_MKDOSFS
 	help
 	Utility to create FAT32 filesystems.
 
 config BUSYBOX_CONFIG_MKFS_VFAT
-	bool "mkfs.vfat (7.2 kb)"
+	bool "mkfs.vfat (7.6 kb)"
 	default BUSYBOX_DEFAULT_MKFS_VFAT
 	help
 	Alias to "mkdosfs".
 config BUSYBOX_CONFIG_MKSWAP
-	bool "mkswap (6.3 kb)"
+	bool "mkswap (6.6 kb)"
 	default BUSYBOX_DEFAULT_MKSWAP
 	help
 	The mkswap utility is used to configure a file or disk partition as
@@ -535,7 +536,7 @@ config BUSYBOX_CONFIG_FEATURE_MKSWAP_UUID
 	help
 	Generate swap spaces with universally unique identifiers.
 config BUSYBOX_CONFIG_MORE
-	bool "more (7 kb)"
+	bool "more (7.2 kb)"
 	default BUSYBOX_DEFAULT_MORE
 	help
 	more is a simple utility which allows you to read text one screen
@@ -544,7 +545,7 @@ config BUSYBOX_CONFIG_MORE
 	you will probably find this utility very helpful. If you don't have
 	any need to reading text files, you can leave this disabled.
 config BUSYBOX_CONFIG_MOUNT
-	bool "mount (23 kb)"
+	bool "mount (24 kb)"
 	default BUSYBOX_DEFAULT_MOUNT
 	help
 	All files and filesystems in Unix are arranged into one big directory
@@ -634,7 +635,7 @@ config BUSYBOX_CONFIG_FEATURE_MOUNT_OTHERTAB
 	help
 	Support mount -T (specifying an alternate fstab)
 config BUSYBOX_CONFIG_MOUNTPOINT
-	bool "mountpoint (4.9 kb)"
+	bool "mountpoint (5.1 kb)"
 	default BUSYBOX_DEFAULT_MOUNTPOINT
 	help
 	mountpoint checks if the directory is a mountpoint.
@@ -659,12 +660,12 @@ config BUSYBOX_CONFIG_NOLOGIN_DEPENDENCIES
 	If you know these will be available externally you can
 	disable this option.
 config BUSYBOX_CONFIG_NSENTER
-	bool "nsenter (6.5 kb)"
+	bool "nsenter (6.8 kb)"
 	default BUSYBOX_DEFAULT_NSENTER
 	help
 	Run program with namespaces of other processes.
 config BUSYBOX_CONFIG_PIVOT_ROOT
-	bool "pivot_root (1.1 kb)"
+	bool "pivot_root (1.4 kb)"
 	default BUSYBOX_DEFAULT_PIVOT_ROOT
 	help
 	The pivot_root utility swaps the mount points for the root filesystem
@@ -675,7 +676,7 @@ config BUSYBOX_CONFIG_PIVOT_ROOT
 	Note: This is for initrd in linux 2.4. Under initramfs (introduced
 	in linux 2.6) use switch_root instead.
 config BUSYBOX_CONFIG_RDATE
-	bool "rdate (5.6 kb)"
+	bool "rdate (5.9 kb)"
 	default BUSYBOX_DEFAULT_RDATE
 	help
 	The rdate utility allows you to synchronize the date and time of your
@@ -683,44 +684,44 @@ config BUSYBOX_CONFIG_RDATE
 	the RFC868 protocol, which is built into the inetd daemon on most
 	systems.
 config BUSYBOX_CONFIG_RDEV
-	bool "rdev (1.8 kb)"
+	bool "rdev (2.1 kb)"
 	default BUSYBOX_DEFAULT_RDEV
 	help
 	Print the device node associated with the filesystem mounted at '/'.
 config BUSYBOX_CONFIG_READPROFILE
-	bool "readprofile (7.1 kb)"
+	bool "readprofile (7.5 kb)"
 	default BUSYBOX_DEFAULT_READPROFILE
 	help
 	This allows you to parse /proc/profile for basic profiling.
 config BUSYBOX_CONFIG_RENICE
-	bool "renice (4.2 kb)"
+	bool "renice (4.4 kb)"
 	default BUSYBOX_DEFAULT_RENICE
 	help
 	Renice alters the scheduling priority of one or more running
 	processes.
 config BUSYBOX_CONFIG_REV
-	bool "rev (4.4 kb)"
+	bool "rev (4.6 kb)"
 	default BUSYBOX_DEFAULT_REV
 	help
 	Reverse lines of a file or files.
 config BUSYBOX_CONFIG_RTCWAKE
-	bool "rtcwake (6.8 kb)"
+	bool "rtcwake (7.5 kb)"
 	default BUSYBOX_DEFAULT_RTCWAKE
 	help
 	Enter a system sleep state until specified wakeup time.
 config BUSYBOX_CONFIG_SCRIPT
-	bool "script (8.6 kb)"
+	bool "script (8.8 kb)"
 	default BUSYBOX_DEFAULT_SCRIPT
 	help
 	The script makes typescript of terminal session.
 config BUSYBOX_CONFIG_SCRIPTREPLAY
-	bool "scriptreplay (2.4 kb)"
+	bool "scriptreplay (2.6 kb)"
 	default BUSYBOX_DEFAULT_SCRIPTREPLAY
 	help
 	This program replays a typescript, using timing information
 	given by script -t.
 config BUSYBOX_CONFIG_SETARCH
-	bool "setarch (3.6 kb)"
+	bool "setarch (3.8 kb)"
 	default BUSYBOX_DEFAULT_SETARCH
 	help
 	The linux32 utility is used to create a 32bit environment for the
@@ -729,18 +730,18 @@ config BUSYBOX_CONFIG_SETARCH
 	(like amd64/x86, ppc64/ppc, sparc64/sparc, etc...).
 
 config BUSYBOX_CONFIG_LINUX32
-	bool "linux32 (3.3 kb)"
+	bool "linux32 (3.6 kb)"
 	default BUSYBOX_DEFAULT_LINUX32
 	help
 	Alias to "setarch linux32".
 
 config BUSYBOX_CONFIG_LINUX64
-	bool "linux64 (3.3 kb)"
+	bool "linux64 (3.5 kb)"
 	default BUSYBOX_DEFAULT_LINUX64
 	help
 	Alias to "setarch linux64".
 config BUSYBOX_CONFIG_SETPRIV
-	bool "setpriv (6.6 kb)"
+	bool "setpriv (6.9 kb)"
 	default BUSYBOX_DEFAULT_SETPRIV
 	select BUSYBOX_CONFIG_LONG_OPTS
 	help
@@ -775,7 +776,7 @@ config BUSYBOX_CONFIG_FEATURE_SETPRIV_CAPABILITY_NAMES
 	this option allows using the human-readable names in addition to
 	the index-based names.
 config BUSYBOX_CONFIG_SETSID
-	bool "setsid (3.6 kb)"
+	bool "setsid (3.8 kb)"
 	default BUSYBOX_DEFAULT_SETSID
 	help
 	setsid runs a program in a new session
@@ -818,7 +819,7 @@ config BUSYBOX_CONFIG_FEATURE_SWAPONOFF_LABEL
 	This allows for specifying a device by label or uuid, rather than by
 	name. This feature utilizes the same functionality as blkid/findfs.
 config BUSYBOX_CONFIG_SWITCH_ROOT
-	bool "switch_root (5.5 kb)"
+	bool "switch_root (5.7 kb)"
 	default BUSYBOX_DEFAULT_SWITCH_ROOT
 	help
 	The switch_root utility is used from initramfs to select a new
@@ -837,7 +838,7 @@ config BUSYBOX_CONFIG_SWITCH_ROOT
 	list of active mount points. That's why.
 
 config BUSYBOX_CONFIG_TASKSET
-	bool "taskset (4.2 kb)"
+	bool "taskset (5.6 kb)"
 	default BUSYBOX_DEFAULT_TASKSET
 	help
 	Retrieve or set a processes's CPU affinity.
@@ -860,7 +861,7 @@ config BUSYBOX_CONFIG_FEATURE_TASKSET_CPULIST
 	Add support for taking/printing affinity as CPU list when '-c'
 	option is used. For example, it prints '0-3,7' instead of mask '8f'.
 config BUSYBOX_CONFIG_UEVENT
-	bool "uevent (3.1 kb)"
+	bool "uevent (3.5 kb)"
 	default BUSYBOX_DEFAULT_UEVENT
 	help
 	uevent is a netlink listener for kernel uevent notifications
@@ -881,14 +882,14 @@ config BUSYBOX_CONFIG_FEATURE_UMOUNT_ALL
 	help
 	Support -a option to unmount all currently mounted filesystems.
 config BUSYBOX_CONFIG_UNSHARE
-	bool "unshare (7.2 kb)"
+	bool "unshare (7.3 kb)"
 	default BUSYBOX_DEFAULT_UNSHARE
 	depends on !BUSYBOX_CONFIG_NOMMU
 	select BUSYBOX_CONFIG_LONG_OPTS
 	help
 	Run program with some namespaces unshared from parent.
 config BUSYBOX_CONFIG_WALL
-	bool "wall (2.6 kb)"
+	bool "wall (2.9 kb)"
 	default BUSYBOX_DEFAULT_WALL
 	depends on BUSYBOX_CONFIG_FEATURE_UTMP
 	help

--- a/package/utils/busybox/files/cron
+++ b/package/utils/busybox/files/cron
@@ -28,7 +28,7 @@ start_service() {
 	ln -s /etc/crontabs /var/spool/cron/ 2>/dev/null
 
 	procd_open_instance
-	procd_set_param command "$PROG" -f -c /etc/crontabs -l "${loglevel:-5}"
+	procd_set_param command "$PROG" -f -c /etc/crontabs -l "${loglevel:-7}"
 	for crontab in /etc/crontabs/*; do
 		 procd_set_param file "$crontab"
 	done

--- a/package/utils/busybox/patches/001-fix-non-x86-build.patch
+++ b/package/utils/busybox/patches/001-fix-non-x86-build.patch
@@ -1,0 +1,14 @@
+Index: busybox-1.37.0/libbb/hash_md5_sha.c
+===================================================================
+--- busybox-1.37.0.orig/libbb/hash_md5_sha.c
++++ busybox-1.37.0/libbb/hash_md5_sha.c
+@@ -1313,7 +1313,9 @@ unsigned FAST_FUNC sha1_end(sha1_ctx_t *
+ 	hash_size = 8;
+ 	if (ctx->process_block == sha1_process_block64
+ #if ENABLE_SHA1_HWACCEL
++# if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
+ 	 || ctx->process_block == sha1_process_block64_shaNI
++# endif
+ #endif
+ 	) {
+ 		hash_size = 5;

--- a/package/utils/busybox/patches/200-udhcpc_reduce_msgs.patch
+++ b/package/utils/busybox/patches/200-udhcpc_reduce_msgs.patch
@@ -1,6 +1,6 @@
 --- a/networking/udhcp/dhcpc.c
 +++ b/networking/udhcp/dhcpc.c
-@@ -722,6 +722,7 @@ static int bcast_or_ucast(struct dhcp_pa
+@@ -711,6 +711,7 @@ static int bcast_or_ucast(struct dhcp_pa
  static NOINLINE int send_discover(uint32_t requested)
  {
  	struct dhcp_packet packet;
@@ -8,7 +8,7 @@
  
  	/* Fill in: op, htype, hlen, cookie, chaddr fields,
  	 * xid field, message type option:
-@@ -736,6 +737,7 @@ static NOINLINE int send_discover(uint32
+@@ -725,6 +726,7 @@ static NOINLINE int send_discover(uint32
  	 */
  	add_client_options(&packet);
  

--- a/package/utils/busybox/patches/201-udhcpc_changed_ifindex.patch
+++ b/package/utils/busybox/patches/201-udhcpc_changed_ifindex.patch
@@ -1,6 +1,6 @@
 --- a/networking/udhcp/dhcpc.c
 +++ b/networking/udhcp/dhcpc.c
-@@ -1384,6 +1384,12 @@ int udhcpc_main(int argc UNUSED_PARAM, c
+@@ -1374,6 +1374,12 @@ int udhcpc_main(int argc UNUSED_PARAM, c
  		struct pollfd pfds[2];
  		struct dhcp_packet packet;
  

--- a/package/utils/busybox/patches/301-ip-link-fix-netlink-msg-size.patch
+++ b/package/utils/busybox/patches/301-ip-link-fix-netlink-msg-size.patch
@@ -1,6 +1,6 @@
 --- a/networking/libiproute/iplink.c
 +++ b/networking/libiproute/iplink.c
-@@ -683,7 +683,7 @@ static int do_add_or_delete(char **argv,
+@@ -953,7 +953,7 @@ static int do_add_or_delete(char **argv,
  	}
  	xrtnl_open(&rth);
  	ll_init_map(&rth);

--- a/package/utils/busybox/patches/530-nslookup-ensure-unique-transaction-IDs-for-the-DNS-queries.patch
+++ b/package/utils/busybox/patches/530-nslookup-ensure-unique-transaction-IDs-for-the-DNS-queries.patch
@@ -29,7 +29,7 @@ Forwarded: http://lists.busybox.net/pipermail/busybox/2022-October/089911.html
 ---
 --- a/networking/nslookup.c
 +++ b/networking/nslookup.c
-@@ -978,6 +978,10 @@ int nslookup_main(int argc UNUSED_PARAM,
+@@ -1370,6 +1370,10 @@ int nslookup_main(int argc UNUSED_PARAM,
  		}
  	}
  


### PR DESCRIPTION
Solves: https://github.com/openwrt/openwrt/pull/17107#issuecomment-4395997016
Backported from the main repository: https://github.com/openwrt/openwrt/pull/17107
Changelog for busybox 1.37.0: https://lists.busybox.net/pipermail/busybox-cvs/2024-September/041903.html

Fixes CVEs:
- CVE-2023-42363
- CVE-2023-42364
- CVE-2023-42365. 
- Most likely also fixes CVE-2022-48174
Here is the announcement from SUSE: https://www.suse.com/support/update/announcement/2025/suse-su-202503271-1/

Reference: https://forum.turris.cz/t/busybox-cve-reproductions-on-turrisos-9-0-5-cve-2022-48174-cve-2023-42364-cve-2023-42365/22616

In the past, Busybox developers provided fixes for individual versions https://busybox.net/downloads/ , but they stopped doing that since version 1.25.1 even though their homepage has link for patches to 1.36.0, but it leads to not found.