### PR TITLE
mtd: check malloc() return value in mtd_check()

### DIFF
--- a/package/system/mtd/src/mtd.c
+++ b/package/system/mtd/src/mtd.c
@@ -269,6 +269,11 @@ static int mtd_check(const char *mtd)
 
 		if (!buf)
 			buf = malloc(erasesize);
+		if (!buf) {
+			close(fd);
+			free(str);
+			return 0;
+		}
 
 		close(fd);
 		mtd = next;


### PR DESCRIPTION
## Problem

In `mtd_check()`, after `malloc(erasesize)`, the result is never checked for NULL. On allocation failure, the `buf` pointer remains NULL and is later used in `image_check()` via `read(imagefd, buf + buflen, ...)`, causing a NULL pointer dereference.

The function also walks a colon-separated device list created by `strdup()` (`str`) and opens an `fd` for each entry, so a naive early return on the malloc failure path would additionally leak both `fd` and `str`.

## Fix

Add a NULL check after `malloc()` and return early. The early return path also closes the just-opened `fd` and frees the `strdup()`'d device-list copy to avoid leaks.
