### PR TITLE
mtd: fix buffer leak and fd leak in mtd_dump()

### DIFF
--- a/package/system/mtd/src/mtd.c
+++ b/package/system/mtd/src/mtd.c
@@ -367,7 +367,7 @@ mtd_dump(const char *mtd, int part_offset, int size)
 {
 	int ret = 0, offset = 0;
 	int fd;
-	char *buf;
+	char *buf = NULL;
 
 	if (quiet < 2)
 		fprintf(stderr, "Dumping %s ...\n", mtd);
@@ -385,8 +385,10 @@ mtd_dump(const char *mtd, int part_offset, int size)
 		lseek(fd, part_offset, SEEK_SET);
 
 	buf = malloc(erasesize);
-	if (!buf)
-		return -1;
+	if (!buf) {
+		ret = -1;
+		goto out;
+	}
 
 	do {
 		int len = (size > erasesize) ? (erasesize) : (size);
@@ -410,6 +412,7 @@ mtd_dump(const char *mtd, int part_offset, int size)
 	} while (size > 0);
 
 out:
+	free(buf);
 	close(fd);
 	return ret;
 }


### PR DESCRIPTION
## Problems

Two leaks in `mtd_dump()`:

1. **Buffer leak**: The buffer allocated with `malloc(erasesize)` is never freed before returning, leaking `erasesize` bytes on every call.
2. **fd leak on malloc failure**: The pre-existing malloc-NULL early return (`if (!buf) return -1;`) skips the `close(fd)` cleanup, leaking the just-opened MTD file descriptor.

## Fix

1. Initialize `buf` to NULL.
2. Route the malloc-NULL case through the existing `out:` label so `fd` is closed.
3. Add `free(buf)` to the `out:` cleanup path so both `fd` and `buf` are released consistently on every exit (including the malloc-NULL case, where `free(NULL)` is a no-op).
