### PR TITLE
generic: fix PATH_MAX macro redefined in exec-cmd.c on macOS 15.4

### DIFF
--- a/target/linux/generic/hack-6.6/200-tools_portability.patch
+++ b/target/linux/generic/hack-6.6/200-tools_portability.patch
@@ -61,6 +61,19 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  #define __cold
  
  typedef __u16 __bitwise __le16;
+--- a/tools/lib/subcmd/exec-cmd.c
++++ b/tools/lib/subcmd/exec-cmd.c
+@@ -12,7 +12,10 @@
+ #include "subcmd-config.h"
+ 
+ #define MAX_ARGS	32
++
++#ifndef PATH_MAX
+ #define PATH_MAX	4096
++#endif
+ 
+ static const char *argv_exec_path;
+ static const char *argv0_path;
 --- a/tools/objtool/include/objtool/objtool.h
 +++ b/tools/objtool/include/objtool/objtool.h
 @@ -12,6 +12,7 @@


### PR DESCRIPTION
cherry-pick: b77e6cd6272d55af7ea64200dd2358666d25b6db original PR: https://github.com/openwrt/openwrt/pull/18530

Fix an error while building target/linux x64 on macOS 15.4 host, due to the PATH_MAX macro being redefined:

``` C
make target/linux -j 1 V=s
…
exec-cmd.c:15:9: error: 'PATH_MAX' macro redefined [-Werror,-Wmacro-redefined]
   15 | #define PATH_MAX        4096
      |         ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/syslimits.h:103:9: note: previous definition is here
  103 | #define PATH_MAX                 1024   /* max bytes in pathname */
      |         ^
```

`exec-cmd.c` is compiled as part of `objtool` to run on the host, and therefore host headers are used, where `PATH_MAX` is already defined.

Build tested: x64 on macOS 15.7.7 Intel

@robimarko @namiltd @BKPepe