### PR TITLE
airoha: add dtso support for an7581

### DIFF
--- a/package/boot/uboot-airoha/patches/910-airoha-enable-OF_LIBFDT_OVERLAY-support-for-7581-758.patch
+++ b/package/boot/uboot-airoha/patches/910-airoha-enable-OF_LIBFDT_OVERLAY-support-for-7581-758.patch
@@ -1,0 +1,36 @@
+From 5bcd75ef87382aa13e4044b30f160291e8fa947e Mon Sep 17 00:00:00 2001
+From: YaleiZang <yalei.zang@airoha.com>
+Date: Mon, 8 Jun 2026 20:12:49 +0800
+Subject: [PATCH] airoha: enable OF_LIBFDT_OVERLAY support for 7581/7583
+
+Enable CONFIG_OF_LIBFDT_OVERLAY to allow loading and applying device tree overlays
+at boot time. This is necessary for systems requiring flexible hardware description
+via DT overlay, such as dynamic board variants or runtime configurable peripherals.
+
+Signed-off-by: YaleiZang <yalei.zang@airoha.com>
+---
+ configs/an7581_evb_defconfig | 1 +
+ configs/an7583_evb_defconfig | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/configs/an7581_evb_defconfig b/configs/an7581_evb_defconfig
+index be076ec7..d0058d31 100644
+--- a/configs/an7581_evb_defconfig
++++ b/configs/an7581_evb_defconfig
+@@ -103,3 +103,4 @@ CONFIG_UBI_BLOCK=y
+ CONFIG_ENV_USE_DEFAULT_ENV_TEXT_FILE=y
+ CONFIG_ENV_DEFAULT_ENV_TEXT_FILE="defenvs/an7581_rfb_env"
+ CONFIG_SHA512=y
++CONFIG_OF_LIBFDT_OVERLAY=y
+diff --git a/configs/an7583_evb_defconfig b/configs/an7583_evb_defconfig
+index 7ef2d6fe..a97c0cc5 100644
+--- a/configs/an7583_evb_defconfig
++++ b/configs/an7583_evb_defconfig
+@@ -102,3 +102,4 @@ CONFIG_UBI_BLOCK=y
+ CONFIG_ENV_USE_DEFAULT_ENV_TEXT_FILE=y
+ CONFIG_ENV_DEFAULT_ENV_TEXT_FILE="defenvs/an7583_rfb_env"
+ CONFIG_SHA512=y
++CONFIG_OF_LIBFDT_OVERLAY=y
+-- 
+2.43.0
+

--- a/target/linux/airoha/Makefile
+++ b/target/linux/airoha/Makefile
@@ -4,7 +4,7 @@ ARCH:=arm
 BOARD:=airoha
 BOARDNAME:=Airoha ARM
 SUBTARGETS:=en7523 an7581 an7583
-FEATURES:=dt squashfs nand ramdisk gpio
+FEATURES:=dt dt-overlay squashfs nand ramdisk gpio
 
 KERNEL_PATCHVER:=6.18
 

--- a/target/linux/airoha/dts/an7581-evb-nand-kite.dtso
+++ b/target/linux/airoha/dts/an7581-evb-nand-kite.dtso
@@ -1,0 +1,15 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include "an7581-npu-mt7992.dtsi"
+
+&{/} {
+	compatible = "airoha,an7581-evb", "airoha,an7581", "airoha,en7581";
+};
+
+&snfi {
+	status = "okay";
+};

--- a/target/linux/airoha/dts/an7581-multievb.dts
+++ b/target/linux/airoha/dts/an7581-multievb.dts
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/dts-v1/;
+
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include "an7581.dtsi"
+
+/ {
+	model = "Airoha AN7581 Evaluation Board";
+	compatible = "airoha,an7581-evb", "airoha,an7581", "airoha,en7581";
+
+	aliases {
+		serial0 = &uart1;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200 earlycon";
+		stdout-path = "serial0:115200n8";
+		linux,usable-memory-range = <0x0 0x80200000 0x0 0x1fe00000>;
+	};
+
+	memory@80000000 {
+		device_type = "memory";
+		reg = <0x0 0x80000000 0x2 0x00000000>;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+		btn0 {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&en7581_pinctrl 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pwm_gpio18_idx10_pins>;
+		lan4_green {
+			label = "pon:green";
+			pwms = <&en7581_pwm 10 4000000 0>;
+			max-brightness = <255>;
+			active-low;
+		};
+	};
+
+
+	leds {
+		compatible = "gpio-leds";
+
+		pwr_led: led-0 {
+			label = "pwr";
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&en7581_pinctrl 17 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		los_led: led-2 {
+			label = "los";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 19 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		internet_led: led-3 {
+			label = "internet";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 20 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+	};
+};
+
+&en7581_pinctrl {
+	gpio-ranges = <&en7581_pinctrl 0 13 47>;
+
+	mdio_pins: mdio-pins {
+		mux {
+			function = "mdio";
+			groups = "mdio";
+		};
+
+		conf {
+			pins = "gpio2";
+			output-high;
+		};
+	};
+
+	pcie0_rst_pins: pcie0-rst-pins {
+		conf {
+			pins = "pcie_reset0";
+			drive-open-drain = <1>;
+		};
+	};
+
+	pcie1_rst_pins: pcie1-rst-pins {
+		conf {
+			pins = "pcie_reset1";
+			drive-open-drain = <1>;
+		};
+	};
+
+	gswp1_led0_pins: gswp1-led0-pins {
+		mux {
+			function = "phy1_led0";
+			pins = "gpio33";
+		};
+	};
+
+	gswp2_led0_pins: gswp2-led0-pins {
+		mux {
+			function = "phy2_led0";
+			pins = "gpio34";
+		};
+	};
+
+	gswp3_led0_pins: gswp3-led0-pins {
+		mux {
+			function = "phy3_led0";
+			pins = "gpio35";
+		};
+	};
+
+	gswp4_led0_pins: gswp4-led0-pins {
+		mux {
+			function = "phy4_led0";
+			pins = "gpio42";
+		};
+	};
+
+	pwm_gpio18_idx10_pins: pwm-gpio18-idx10-pins {
+		function = "pwm";
+		pins = "gpio18";
+		output-enable;
+	};
+
+	mmc_pins: mmc-pins {
+		mux {
+			function = "emmc";
+			groups = "emmc";
+		};
+	};
+};
+
+&mmc0 {
+	pinctrl-names = "default", "state_uhs";
+	pinctrl-0 = <&mmc_pins>;
+	pinctrl-1 = <&mmc_pins>;
+	status = "disabled";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	card@0 {
+		compatible = "mmc-card";
+		reg = <0>;
+
+		block {
+			compatible = "block-device";
+			partitions {
+				block-partition-factory {
+					partname = "art";
+
+					nvmem-layout {
+						compatible = "fixed-layout";
+						#address-cells = <1>;
+						#size-cells = <1>;
+
+						eeprom_factory_0: eeprom@0 {
+							reg = <0x40000 0x1e00>;
+						};
+
+						mac_factory_2c0000: mac@2c0000 {
+							reg = <0x2c0000 0x6>;
+						};
+
+						pon_mac_factory_2c0006: pon_mac@2c0006 {
+							reg = <0x2c0006 0x6>;
+						};
+
+						onu_type_factory_2e0000: onu_type@2e0000 {
+							reg = <0x2e0000 0x10>;
+						};
+
+						board_config_factory_2e0010: board_config@2e0010 {
+							reg = <0x2e0010 0x8>;
+						};
+					};
+				};
+			};
+		};
+	};
+};
+
+&spi_nand {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		bl2@0 {
+			label = "bl2";
+			reg = <0x0 0x20000>;
+		};
+
+		ubi@20000 {
+			label = "ubi";
+			reg = <0x20000 0x0>;
+		};
+	};
+};
+
+&i2c0 {
+	status = "okay";
+};
+
+&pcie0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_rst_pins>;
+	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		wifi@0,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+			airoha,npu = <&npu>;
+			airoha,eth = <&eth>;
+		};
+	};
+};
+
+&pcie1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie1_rst_pins>;
+	status = "okay";
+
+	pcie@1,0 {
+		reg = <0x0000 0 0 0 0>;
+		wifi@0,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+			airoha,npu = <&npu>;
+			airoha,eth = <&eth>;
+		};
+	};
+};
+
+&npu {
+	status = "okay";
+};
+
+&eth {
+	status = "okay";
+};
+
+&gdm1 {
+	status = "okay";
+};
+
+&switch {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+	status = "okay";
+};
+
+&gsw_port1 {
+	status = "okay";
+	label = "lan1";
+};
+
+&gsw_phy1 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gswp1_led0_pins>;
+	status = "okay";
+};
+
+&gsw_phy1_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+};
+
+&gsw_port2 {
+	status = "okay";
+	label = "lan2";
+};
+
+&gsw_phy2 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gswp2_led0_pins>;
+	status = "okay";
+};
+
+&gsw_phy2_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+};
+
+&gsw_port3 {
+	status = "okay";
+	label = "lan3";
+};
+
+&gsw_phy3 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gswp3_led0_pins>;
+	status = "okay";
+};
+
+&gsw_phy3_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+};
+
+&gsw_port4 {
+	status = "okay";
+	label = "lan4";
+};
+
+&gsw_phy4 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gswp4_led0_pins>;
+	status = "okay";
+};
+
+&gsw_phy4_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+};

--- a/target/linux/airoha/image/an7581.mk
+++ b/target/linux/airoha/image/an7581.mk
@@ -83,6 +83,22 @@ define Device/airoha_an7581-evb-emmc-kite
 endef
 TARGET_DEVICES += airoha_an7581-evb-emmc-kite
 
+define Device/airoha_an7581-multievb
+  $(call Device/FitImageLzma)
+  DEVICE_VENDOR := Airoha
+  DEVICE_MODEL := AN7581 Evaluation Board (multievb)
+  DEVICE_PACKAGES := kmod-leds-pwm kmod-i2c-an7581 kmod-pwm-airoha kmod-input-gpio-keys-polled
+  DEVICE_DTS := an7581-multievb
+  DEVICE_DTS_OVERLAY := an7581-evb-nand-kite
+  DEVICE_DTS_CONFIG := config@1
+  IMAGE/sysupgrade.bin := append-kernel | pad-to 128k | append-rootfs | pad-rootfs | append-metadata
+  ARTIFACT/preloader.bin := an7581-preloader rfb
+  ARTIFACT/bl31-uboot.fip := an7581-bl31-uboot rfb
+  ARTIFACTS := preloader.bin bl31-uboot.fip
+  DEVICE_DTC_FLAGS := --pad 20480
+endef
+TARGET_DEVICES += airoha_an7581-multievb
+
 define Device/gemtek_w1700k-ubi
   DEVICE_VENDOR := Gemtek
   DEVICE_MODEL := W1700K


### PR DESCRIPTION
Enable dtso handling for dynamic hardware configuration and flexible device adaptation.

Example (U-Boot):
setenv bootcmd "ubi read 81800000 kernel; bootm 0x81800000#config@1#an7581-evb-nand-kite"

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
