### PR TITLE
prereq-build: increase GCC requirement to 10

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -32,27 +32,25 @@ $(eval $(call TestHostCommand,proper-umask, \
 
 ifndef IB
 $(eval $(call SetupHostCommand,gcc, \
-	Please install the GNU C Compiler (gcc) 8 or later, \
-	$(CC) -dumpversion | grep -E '^([8-9]\.?|1[0-9]\.?)', \
-	gcc -dumpversion | grep -E '^([8-9]\.?|1[0-9]\.?)', \
-	gcc-8 -dumpversion | grep -E '^([8-9]\.?|1[0-9]\.?)', \
+	Please install the GNU C Compiler (gcc) 10 or later, \
+	$(CC) -dumpversion | grep -E '^(1[0-9]|[2-9][0-9])\.?', \
+	gcc -dumpversion | grep -E '^(1[0-9]|[2-9][0-9])\.?', \
 	gcc --version | grep -E 'Apple.(LLVM|clang)' ))
 
 $(eval $(call TestHostCommand,working-gcc, \
-	Please reinstall the GNU C Compiler (8 or later) - \
+	Please reinstall the GNU C Compiler (10 or later) - \
 	it appears to be broken, \
 	echo 'int main(int argc, char **argv) { return 0; }' | \
 		$(STAGING_DIR_HOST)/bin/gcc -x c -o $(TMP_DIR)/a.out -))
 
 $(eval $(call SetupHostCommand,g++, \
-	Please install the GNU C++ Compiler (g++) 8 or later, \
-	$(CXX) -dumpversion | grep -E '^([8-9]\.?|1[0-9]\.?)', \
-	g++ -dumpversion | grep -E '^([8-9]\.?|1[0-9]\.?)', \
-	g++-8 -dumpversion | grep -E '^([8-9]\.?|1[0-9]\.?)', \
+	Please install the GNU C++ Compiler (g++) 10 or later, \
+	$(CXX) -dumpversion | grep -E '^(1[0-9]|[2-9][0-9])\.?', \
+	g++ -dumpversion | grep -E '^(1[0-9]|[2-9][0-9])\.?', \
 	g++ --version | grep -E 'Apple.(LLVM|clang)' ))
 
 $(eval $(call TestHostCommand,working-g++, \
-	Please reinstall the GNU C++ Compiler (8 or later) - \
+	Please reinstall the GNU C++ Compiler (10 or later) - \
 	it appears to be broken, \
 	echo 'int main(int argc, char **argv) { return 0; }' | \
 		$(STAGING_DIR_HOST)/bin/g++ -x c++ -o $(TMP_DIR)/a.out - -lstdc++ && \


### PR DESCRIPTION
With ccache 4.13, it mandates a minimum of 10.

Fixes: 84cb042e3a8e ("tools/ccache: update to 4.13.3")

ping @PolynomialDivision 