### PR TITLE
[24.10] Backport changes related to bzip2 from master branch

### DIFF
--- a/package/utils/bzip2/Makefile
+++ b/package/utils/bzip2/Makefile
@@ -62,7 +62,7 @@ CONFIGURE_ARGS += --prefix=/usr
 
 MAKE_FLAGS += \
 	-f Makefile-libbz2_so \
-	CFLAGS="$(TARGET_CFLAGS)" \
+	CFLAGS="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS)" \
 	LDFLAGS="$(TARGET_LDFLAGS)" \
 	all
 
@@ -92,7 +92,7 @@ HOST_CFLAGS += \
 	$(FPIC)
 
 HOST_MAKE_FLAGS+= \
-	CFLAGS="$(HOST_CFLAGS)" \
+	CFLAGS="$(HOST_CFLAGS) $(HOST_CPPFLAGS)" \
 	LDFLAGS="$(HOST_LDFLAGS)" \
 	all
 

--- a/package/utils/bzip2/patches/021-fix-LDFLAGS.patch
+++ b/package/utils/bzip2/patches/021-fix-LDFLAGS.patch
@@ -1,11 +1,13 @@
 --- a/Makefile-libbz2_so
 +++ b/Makefile-libbz2_so
-@@ -35,7 +35,7 @@ OBJS= blocksort.o  \
+@@ -35,8 +35,8 @@ OBJS= blocksort.o  \
        bzlib.o
  
  all: $(OBJS)
 -	$(CC) -shared -Wl,-soname -Wl,libbz2.so.1.0 -o libbz2.so.1.0.8 $(OBJS)
+-	$(CC) $(CFLAGS) -o bzip2-shared bzip2.c libbz2.so.1.0.8
 +	$(CC) -shared -Wl,-soname -Wl,libbz2.so.1.0 $(LDFLAGS) -o libbz2.so.1.0.8 $(OBJS)
- 	$(CC) $(CFLAGS) -o bzip2-shared bzip2.c libbz2.so.1.0.8
++	$(CC) $(CFLAGS) $(LDFLAGS) -o bzip2-shared bzip2.c libbz2.so.1.0.8
  	rm -f libbz2.so.1.0
  	ln -s libbz2.so.1.0.8 libbz2.so.1.0
+ 


### PR DESCRIPTION
It backports (partially! only related to bzip2) https://github.com/openwrt/openwrt/pull/20813 and https://github.com/openwrt/openwrt/pull/22056