### PR TITLE
mediatek: filogic: add support for Cudy P2 v1

### DIFF
--- a/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
+++ b/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
@@ -41,6 +41,10 @@ set_preinit_iface() {
 	zyxel,wx5600-t0-ubootmod)
 		ifname=lan1
 		;;
+	cudy,p2-v1)
+		ip link set eth0 up
+		ifname=lan
+		;;
 	*)
 		ip link set eth0 up
 		ifname=lan1

--- a/target/linux/mediatek/dts/mt7981b-cudy-p2-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-p2-v1.dts
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include "mt7981b-cudy-wr3000-nand.dtsi"
+
+/ {
+	model = "Cudy P2 v1";
+	compatible = "cudy,p2-v1", "mediatek,mt7981";
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		bootargs = "pci=noaer";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: led-power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&pio 2 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-internet-white {
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&pio 14 GPIO_ACTIVE_HIGH>;
+			function = LED_FUNCTION_WAN;
+		};
+
+		led-internet-yellow {
+			color = <LED_COLOR_ID_YELLOW>;
+			gpios = <&pio 15 GPIO_ACTIVE_HIGH>;
+			function = LED_FUNCTION_WAN;
+		};
+
+		led-internet-red {
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&pio 26 GPIO_ACTIVE_HIGH>;
+			function = LED_FUNCTION_WAN;
+		};
+
+		led-mobile-red {
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&pio 27 GPIO_ACTIVE_HIGH>;
+			function = LED_FUNCTION_MOBILE;
+		};
+
+		led-mobile-yellow {
+			color = <LED_COLOR_ID_YELLOW>;
+			gpios = <&pio 28 GPIO_ACTIVE_HIGH>;
+			function = LED_FUNCTION_MOBILE;
+		};
+
+		led-mobile-white {
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&pio 30 GPIO_ACTIVE_LOW>;
+			function = LED_FUNCTION_MOBILE;
+		};
+
+		led-wlan {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&pio 13 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "network";
+		};
+
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		voippwr {
+			gpio-export,name = "voippwr";
+			gpio-export,output = <0>;
+			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		voip_volte {
+			gpio-export,name = "voip_volte";
+			gpio-export,output = <1>;
+			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		5gpwr {
+			gpio-export,name = "5gpwr";
+			gpio-export,output = <0>;
+			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		usb5g {
+			gpio-export,name = "usb5g";
+			gpio-export,output = <0>;
+			gpios = <&pio 8 GPIO_ACTIVE_HIGH>;
+		};
+
+		ant {
+			gpio-export,name = "ant";
+			gpio-export,output = <0>;
+			gpios = <&pio 7 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+};
+
+&spi_nand {
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "wan";
+
+			nvmem-cell-names = "mac-address";
+			nvmem-cells = <&macaddr_bdinfo_de00 1>;
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan";
+		};
+
+		port@6 {
+			reg = <6>;
+			label = "cpu";
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&xhci {
+	phys = <&u2port0 PHY_TYPE_USB2>;
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&u2port0 {
+	status = "okay";
+};
+
+
+&pio {
+	pcie_pins: pcie-pins {
+		mux {
+			function = "pcie";
+			groups = "pcie_clk", "pcie_wake", "pcie_pereset";
+		};
+	};
+	i2c_pins: i2c-pins-g0 {
+		mux {
+			function = "i2c";
+			groups = "i2c0_0";
+		};
+	};
+
+	pcm_pins: pcm-pins-g0 {
+		mux {
+			function = "pcm";
+			groups = "pcm";
+		};
+	};
+
+	pwm0_pin: pwm0-pin-g0 {
+		mux {
+			function = "pwm";
+			groups = "pwm0_0";
+		};
+	};
+
+	pwm1_pin: pwm1-pin-g0 {
+		mux {
+			function = "pwm";
+			groups = "pwm1_0";
+		};
+	};
+
+	pwm2_pin: pwm2-pin {
+		mux {
+			function = "pwm";
+			groups = "pwm2";
+		};
+	};
+
+	spic_pins: spi1-pins {
+		mux {
+			function = "spi";
+			groups = "spi1_1";
+		};
+	};
+
+	uart1_pins: uart1-pins-g1 {
+		mux {
+			function = "uart";
+			groups = "uart1_1";
+		};
+	};
+
+	uart2_pins: uart2-pins-g1 {
+		mux {
+			function = "uart";
+			groups = "uart2_1";
+		};
+	};
+};
+
+&pcie {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie_pins>;
+	status = "okay";
+};
+
+&pcie_intc {
+	msi-controller;
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -105,6 +105,10 @@ cudy,wbr3000uax-v1-ubootmod)
 	ucidef_set_led_default "lan_off" "lan_off" "red:wps" "1"
 	ucidef_set_led_netdev "lan" "lan" "blue:lan" "br-lan" "link tx rx"
 	;;
+cudy,p2-v1)
+	ucidef_set_led_netdev "internet" "internet" "white:wan" "wan"
+	ucidef_set_led_netdev "5g" "5g" "white:mobile" "usb0"
+	;;
 elecom,wrc-x3000gs3)
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan"
 	;;

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -173,6 +173,7 @@ mediatek_setup_interfaces()
 	dlink,aquila-pro-ai-m60-a1)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" internet
 		;;
+	cudy,p2-v1|\
 	comfast,cf-wr632ax|\
 	comfast,cf-wr632ax-ubootmod|\
 	keenetic,kn-3911|\

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -95,6 +95,7 @@ case "$board" in
 	cudy,m3000-v1-ubootmod|\
 	cudy,m3000-v2-yt8821|\
 	cudy,m3000-v2-yt8821-ubootmod|\
+	cudy,p2-v1|\
 	cudy,re3000-v1|\
 	cudy,tr3000-256mb-v1|\
 	cudy,tr3000-v1|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1570,6 +1570,27 @@ define Device/cudy_wbr3000uax-v1-ubootmod
 endef
 TARGET_DEVICES += cudy_wbr3000uax-v1-ubootmod
 
+define Device/cudy_p2-v1
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := P2
+  DEVICE_VARIANT := v1
+  DEVICE_DTS := mt7981b-cudy-p2-v1
+  DEVICE_DTS_DIR := ../dts
+  SUPPORTED_DEVICES += R91
+  UBINIZE_OPTS := -E 5
+  DEVICE_DTS_LOADADDR := 0x44000000
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 65536k
+  KERNEL_IN_UBI := 1
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGES := sysupgrade.bin
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-ledtrig-network kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3 kmod-usb-serial-option kmod-usb-net-cdc-ether
+endef
+TARGET_DEVICES += cudy_p2-v1
+
 define Device/dlink_aquila-pro-ai-e30-a1
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := AQUILA PRO AI E30


### PR DESCRIPTION
This commit adds support for the Cudy P2 v1, a router with integrated 5G modem.

The device is similar to Cudy WR3000E v1.

SoC: MediaTek MT7981 WiSoC
RAM: 256MB DDR3
Flash: 128MB SPI-NAND
Wireless: Mediatek MT7981 2x2 DBDC 802.11ax (2.4 / 5)
5G Modem: Quectel RG500U-EB
Ethernet: 1 WAN/LAN GbE, 1 LAN GbE

MAC Addresses in OpenWrt: same handling as in WR3000s

GPIO:
- 1 Button:
  - Reset on GPIO 1
- 5 Software switches:
  - voippwr on GPIO 4 active low
  - voip_volte on GPIO 5 active low
  - 5gpwr on GPIO 6 active low
  - ant on GPIO 7 active high
  - usb5g on GPIO 8 active high
- 8 LEDs:
  - Power: white on GPIO 2 active high
  - Internet: white on GPIO 14 active high
  - Internet: yellow on GPIO 15 active high
  - Internet: red on GPIO 26 active high
  - WLAN: white on GPIO 13 active high
  - Mobile: white on GPIO 30 active low
  - Mobile: yellow on GPIO 28 active high
  - Mobile: red on GPIO 27 active high

Disassembly:
- Remove two screws hidden behind the rubber stand.
- Remove center solid plastic circle with a spudger and remove four screws.
- Slide the interior with the board up.

UART:
- UART pads are accessible on the bottom of the board and labeled
- Solder three pins: GND, RX, TX, do not connect 3V3 pin
- Settings: 115200 8N1 3.3V

5G Modem:

Quectel RG500U-EB is soldered on board and connected via USB 2.0 High Speed at 480Mb/s and PCIe v2 x1 at 5GT/s.

**The modem is usable with upstream drivers only via PPP mode using the ttyUSB2 AT port.**

The modem doesn't provide access via USB rndis_host or cdc_ncm - it should work by sending the following commands:
- AT+QCFG="ethernet",0
- AT+QCFG="usbnet",5 (for NCM or 3 for RNDIS or 1 for ECM)
- AT+QCFG="nat",0
- rebooting the modem via AT+CFUN=1,1 and rebooting the device.

It appears that the firmware is locked down and doesn't want to change the configuration and enable usb networking.

It is possible to use vendor sprd_pcie driver and use virtual PCIe network interface by sending the commands:
- AT+QCFG="ethernet",1
- AT+QCFG="nat",0
- rebooting the modem via AT+CFUN=1,1 and rebooting the device.

Connection via USB and PCIe network interface should work (but doesn't work via USB) using:
- AT+QICSGP=1,3,"apnname","username","password",3
- AT+QNETDEVCTL=1,1,1

Migration to OpenWrt using TFTP:
- Connect UART as described above
- Press the reset button while powering on the device
- U-Boot will now try to load a recovery.bin via TFTP, this must be ignored
- After detecting a timeout, the U-Boot console is available via UART
- Set up a TFTP server on IP 192.168.1.88 and connect it to one of the LAN ports
- Provide the initramfs image via TFTP as cudyp2.bin
- Run the following command in U-Boot: tftpboot 0x46000000 cudyp2.bin; bootm 0x46000000
- OpenWrt initramfs image is now booting and accessible via 192.168.1.1
- Flash the sysupgrade image

Revert back to OEM:
- Set up a TFTP server on IP 192.168.1.88 and connect it to one of the LAN ports
- Provide the Cudy firmware via TFTP as recovery.bin
- Press the reset button while powering on the device
- Recovery process will start now
- After recovery is done, the OEM firmware is available at 192.168.10.1 again

Migration to OpenWrt via OEM firmware:
- There should be a migration image available from Cudy as soon as there is official OpenWrt support
- Download the migration image via OEM web interface
- After flashing, OpenWrt is accessible via 192.168.1.1
- Flash the official OpenWrt image
