### PR TITLE
mediatek: fix WLAN LED indication for ipTIME AX3000SE

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-iptime-ax3000se.dts
+++ b/target/linux/mediatek/dts/mt7981b-iptime-ax3000se.dts
@@ -55,6 +55,7 @@
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_WLAN;
 			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "network";
 		};
 	};
 };

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -132,9 +132,6 @@ huasifei,wh3000r-nand)
 iptime,ax3000q)
 	ucidef_set_led_netdev "wan" "WAN" "amber:wan" "wan" "link tx rx"
 	;;
-iptime,ax3000se)
-	ucidef_set_led_netdev "wlan" "WLAN" "blue:wlan" "phy1-ap0"
-	;;
 iptime,ax3000sm)
 	ucidef_set_led_netdev "wan" "wan" "amber:wan" "eth1" "link tx rx"
 	;;

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1916,7 +1916,7 @@ define Device/iptime_ax3000se
   IMAGES := factory.bin sysupgrade.bin
   IMAGE/factory.bin := sysupgrade-tar | append-metadata | check-size | iptime-crc32 ax3kse
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-ledtrig-network
   SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
 endef
 TARGET_DEVICES += iptime_ax3000se


### PR DESCRIPTION
OpenWrt has recently added the "network" LED trigger to support routers that have a single WLAN LED for multiple phys (https://github.com/openwrt/openwrt/commit/2aa1185fb05eb7f2e4c7e4f9c66e3727010328af). This patch replaces the temporary workaround used during initial support, where the LED was triggered only by activity on a single phy. With this change, the WLAN LED on the ipTIME AX3000SE now correctly indicates activity on both `phy0` and `phy1`.

Related Links
--------------
- leds: add "network" LED trigger (lan/wan/wlan): https://github.com/openwrt/openwrt/commit/2aa1185fb05eb7f2e4c7e4f9c66e3727010328af
- https://github.com/openwrt/openwrt/pull/20771

