### PR TITLE
arm-trusted-firmware-tools: update to version 2.15.0

### DIFF
--- a/package/boot/arm-trusted-firmware-tools/Makefile
+++ b/package/boot/arm-trusted-firmware-tools/Makefile
@@ -8,9 +8,9 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=arm-trusted-firmware-tools
-PKG_VERSION:=2.12
+PKG_VERSION:=2.15.0
 PKG_RELEASE:=1
-PKG_HASH:=b4c047493cac1152203e1ba121ae57267e4899b7bf56eb365e22a933342d31c9
+PKG_HASH:=67b772aaa58218712c062ccd103f1d53cf74d9543e251f20ac037a6dbf821a10
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_HOST_ONLY:=1


### PR DESCRIPTION
arm-trusted-firmware-tools provides the host-side fiptool and cert_create
utilities used when building TF-A based boot firmware.

Update to TF-A v2.15.0. The release is tagged `v2.15.0` (there is no bare
`v2.15` tag). The existing patches were refreshed against the new source.

Compile-tested only on mediatek/filogic (aarch64_cortex-a53); the host
tools build cleanly. Not run-tested on hardware.

Signed-off-by in each commit; no functional change beyond the version bump.
