### PR TITLE
dnsmasq: allow DNS only ifaces without DHCP warns

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=dnsmasq
 PKG_UPSTREAM_VERSION:=2.93
 PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=https://thekelleys.org.uk/dnsmasq/

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -193,6 +193,11 @@ append_notinterface() {
 	xappend "--except-interface=$ifname"
 }
 
+append_no_dhcp_interface() {
+	network_get_device ifname "$1" || ifname="$1"
+	xappend "--no-dhcp-interface=$ifname"
+}
+
 ismounted() {
 	local filename="$1"
 	local dirname
@@ -1053,6 +1058,7 @@ dnsmasq_start()
 	[ -n "$BOOT" ] || {
 		config_list_foreach "$cfg" "interface" append_interface
 		config_list_foreach "$cfg" "notinterface" append_notinterface
+		config_list_foreach "$cfg" "no_dhcp_interface" append_no_dhcp_interface
 	}
 	config_get_bool ignore_hosts_dir "$cfg" ignore_hosts_dir 0
 	if [ "$ignore_hosts_dir" = "1" ]; then


### PR DESCRIPTION
Allow to configure via UCI to serve DNS only on an interface without warnings about DHCP client packets when no DHCP pool exists.

Following is a warning log line example, after a while, logd's ring buffer gets polluted with instances like this:
```
Mon Jun  8 19:32:43 2026 daemon.warn dnsmasq-dhcp[1]: no address range available for DHCP request via eth4.1000
```