### PR TITLE
realtek: 6.18: select rtl826x phy patch table by chip version

### DIFF
--- a/target/linux/generic/pending-6.18/742-net-phy-realtek-add-5G-and-10G-PHY-support.patch
+++ b/target/linux/generic/pending-6.18/742-net-phy-realtek-add-5G-and-10G-PHY-support.patch
@@ -64,7 +64,7 @@ Signed-off-by: Balázs Triszka <info@balika011.hu>
  #include <linux/string_choices.h>
  #include <net/phy/realtek_phy.h>
  
-@@ -205,10 +207,26 @@
+@@ -205,10 +207,25 @@
  #define RTL_8221B_VM_CG				0x001cc84a
  #define RTL_8251B				0x001cc862
  #define RTL_8261C				0x001cc890
@@ -80,7 +80,6 @@ Signed-off-by: Balázs Triszka <info@balika011.hu>
 +#define   RTL826X_VEND1_SERDES_GLOBAL_CFG_HSO_INV	BIT(7)
 +
 +#define RTL826X_VEND1_PKG_MODEL			0x103
-+#define RTL826X_VEND1_VERSION_ID		0x104
 +
 +#define RTL826X_VND2_INER			0xA424
 +#define   RTL826X_VND2_INER_LINK_STATUS		BIT(4)
@@ -91,7 +90,7 @@ Signed-off-by: Balázs Triszka <info@balika011.hu>
  MODULE_DESCRIPTION("Realtek PHY driver");
  MODULE_AUTHOR("Johnson Leung");
  MODULE_LICENSE("GPL");
-@@ -1993,6 +2011,125 @@ static int rtl8251b_c45_match_phy_device
+@@ -1993,6 +2010,125 @@ static int rtl8251b_c45_match_phy_device
  	return rtlgen_is_c45_match(phydev, RTL_8251B, true);
  }
  
@@ -217,7 +216,7 @@ Signed-off-by: Balázs Triszka <info@balika011.hu>
  static int rtlgen_resume(struct phy_device *phydev)
  {
  	int ret = genphy_resume(phydev);
-@@ -2214,6 +2351,493 @@ static int rtlgen_sfp_config_aneg(struct
+@@ -2214,6 +2350,493 @@ static int rtlgen_sfp_config_aneg(struct
  	return 0;
  }
  
@@ -711,7 +710,7 @@ Signed-off-by: Balázs Triszka <info@balika011.hu>
  static struct phy_driver realtek_drvs[] = {
  	{
  		PHY_ID_MATCH_EXACT(0x00008201),
-@@ -2520,6 +3144,108 @@ static struct phy_driver realtek_drvs[]
+@@ -2520,6 +3143,108 @@ static struct phy_driver realtek_drvs[]
  		.resume		= genphy_resume,
  		.read_mmd	= genphy_read_mmd_unsupported,
  		.write_mmd	= genphy_write_mmd_unsupported,
@@ -1205,13 +1204,18 @@ Signed-off-by: Balázs Triszka <info@balika011.hu>
 +MODULE_FIRMWARE("rtl8264b.bin");
 --- /dev/null
 +++ b/drivers/net/phy/realtek/phy_patch_rtl826x.h
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,16 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +
 +#ifndef __PHY_PATCH_RTL826X_H__
 +#define __PHY_PATCH_RTL826X_H__
 +
++#include <linux/bits.h>
 +#include <linux/phy.h>
++
++/* VEND1 0x104: PHY version; bits [2:0] select the firmware patch-table variant */
++#define RTL826X_VEND1_VERSION_ID		0x104
++#define   RTL826X_VEND1_VERSION_ID_VARIANT	GENMASK(2, 0)
 +
 +int rtl8261n_phy_patch_db_init(struct phy_device *phydev);
 +int rtl8264b_phy_patch_db_init(struct phy_device *phydev);

--- a/target/linux/generic/pending-6.18/743-net-phy-realtek-rtl826x-select-patch-table-by-chip-version.patch
+++ b/target/linux/generic/pending-6.18/743-net-phy-realtek-rtl826x-select-patch-table-by-chip-version.patch
@@ -1,0 +1,53 @@
+From: Carlo Szelinsky <github@szelinsky.de>
+Date: Mon, 9 Jun 2026 21:00:00 +0200
+Subject: net: phy: realtek: rtl826x select patch table by chip version
+
+The 5G/10G register patch engine picks the firmware patch table from the
+PHY ID: rtl8264b_phy_patch_db_init() always loads "rtl8264b.bin" and
+rtl8261n_phy_patch_db_init() always loads "rtl8261n.bin".
+
+The Realtek vendor driver does not work that way. It selects the table at
+runtime from VEND1 register 0x104[2:0] (0 = RTL8264B table, otherwise the
+RTL8261N-C table), independent of the PHY ID. The RTL8264 marketing ID
+(0x001ccaf2) covers dies of both kinds.
+
+On a Hasivo S1300WP-8XGT-4S+ the RTL8264 PHYs report 0x104 = 0xf802
+([2:0] = 2), so the vendor driver applies the RTL8261N-C table. Forcing
+the RTL8264B table instead, the patch engine runs to ~99% and then the
+PCS never reaches state 1 (VEND2 0xA600 stuck at 0x1000); config_init
+fails with -ETIME and the copper ports never come up. Loading
+"rtl8261n.bin" for 0x104[2:0] != 0 makes the patch succeed and the ports
+link up.
+
+Restore the vendor behaviour in the RTL8264B probe path: read 0x104[2:0]
+and fall back to the RTL8261N-C table when it is non-zero. Boards using
+such a die must ship rtl8261n.bin in addition to rtl8264b.bin.
+
+Signed-off-by: Carlo Szelinsky <github@szelinsky.de>
+---
+--- a/drivers/net/phy/realtek/phy_patch_rtl826x.c
++++ b/drivers/net/phy/realtek/phy_patch_rtl826x.c
+@@ -280,6 +280,23 @@ int rtl8261n_phy_patch_db_init(struct ph
+ 
+ int rtl8264b_phy_patch_db_init(struct phy_device *phydev)
+ {
++	int ver;
++
++	/*
++	 * The RTL8264 marketing ID (0x001ccaf2) covers dies that need either
++	 * the RTL8264B or the RTL8261N-C firmware patch table. The vendor
++	 * driver selects between them from VEND1 0x104[2:0] (0 = RTL8264B,
++	 * otherwise RTL8261N-C), not from the PHY ID. Honour that: an RTL8264
++	 * die with 0x104[2:0] != 0 patched with the RTL8264B table never locks
++	 * its PCS and fails config_init with -ETIME.
++	 */
++	ver = phy_read_mmd(phydev, MDIO_MMD_VEND1, RTL826X_VEND1_VERSION_ID);
++	if (ver < 0)
++		return ver;
++
++	if (ver & RTL826X_VEND1_VERSION_ID_VARIANT)
++		return rtl826x_phy_patch_db_init(phydev, "rtl8261n.bin");
++
+ 	return rtl826x_phy_patch_db_init(phydev, "rtl8264b.bin");
+ }
+ 

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -57,7 +57,7 @@ define Device/hasivo_s1100w-8xgt-se
   DEVICE_VENDOR := Hasivo
   DEVICE_MODEL := S1100W-8XGT-SE
   IMAGE_SIZE := 12288k
-  DEVICE_PACKAGES := rtl8264b-firmware
+  DEVICE_PACKAGES := rtl8264b-firmware rtl8261n-firmware
   $(Device/kernel-lzma)
 endef
 TARGET_DEVICES += hasivo_s1100w-8xgt-se

--- a/target/linux/realtek/patches-6.18/024-02-v7.1-net-phy-realtek-add-RTL8224-pair-order-support.patch
+++ b/target/linux/realtek/patches-6.18/024-02-v7.1-net-phy-realtek-add-RTL8224-pair-order-support.patch
@@ -54,7 +54,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  #define RTL8366RB_POWER_SAVE			0x15
  #define RTL8366RB_POWER_SAVE_ON			BIT(12)
  
-@@ -1889,6 +1892,66 @@ static int rtl8224_cable_test_get_status
+@@ -1888,6 +1891,66 @@ static int rtl8224_cable_test_get_status
  	return rtl8224_cable_test_report(phydev, finished);
  }
  
@@ -121,7 +121,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  static bool rtlgen_supports_2_5gbps(struct phy_device *phydev)
  {
  	int val;
-@@ -3096,6 +3159,8 @@ static struct phy_driver realtek_drvs[]
+@@ -3095,6 +3158,8 @@ static struct phy_driver realtek_drvs[]
  		PHY_ID_MATCH_EXACT(0x001ccad0),
  		.name		= "RTL8224 2.5Gbps PHY",
  		.flags		= PHY_POLL_CABLE_TEST,

--- a/target/linux/realtek/patches-6.18/024-04-v7.1-net-phy-realtek-add-RTL8224-polarity-support.patch
+++ b/target/linux/realtek/patches-6.18/024-04-v7.1-net-phy-realtek-add-RTL8224-polarity-support.patch
@@ -32,7 +32,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  
  #define RTL8366RB_POWER_SAVE			0x15
  #define RTL8366RB_POWER_SAVE_ON			BIT(12)
-@@ -1940,9 +1941,40 @@ static int rtl8224_mdi_config_order(stru
+@@ -1939,9 +1940,40 @@ static int rtl8224_mdi_config_order(stru
  					  order ? BIT(port_offset) : 0);
  }
  

--- a/target/linux/realtek/patches-6.18/030-v7.2-net-phy-realtek-support-MDI-swapping-for-RTL8226-CG.patch
+++ b/target/linux/realtek/patches-6.18/030-v7.2-net-phy-realtek-support-MDI-swapping-for-RTL8226-CG.patch
@@ -60,7 +60,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  #define RTL8366RB_POWER_SAVE			0x15
  #define RTL8366RB_POWER_SAVE_ON			BIT(12)
  
-@@ -1391,6 +1406,144 @@ static int rtl822x_init_phycr1(struct ph
+@@ -1390,6 +1405,144 @@ static int rtl822x_init_phycr1(struct ph
  				      mask, val);
  }
  
@@ -205,7 +205,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  static int rtl822x_set_serdes_option_mode(struct phy_device *phydev, bool gen1)
  {
  	bool has_2500, has_sgmii;
-@@ -3083,6 +3236,7 @@ static struct phy_driver realtek_drvs[]
+@@ -3082,6 +3235,7 @@ static struct phy_driver realtek_drvs[]
  		.soft_reset	= rtl822x_c45_soft_reset,
  		.get_features	= rtl822x_c45_get_features,
  		.config_aneg	= rtl822x_c45_config_aneg,

--- a/target/linux/realtek/patches-6.18/743-net-realtek-serdes-configuration.patch
+++ b/target/linux/realtek/patches-6.18/743-net-realtek-serdes-configuration.patch
@@ -42,7 +42,7 @@
  #define RTL8221B_PHYCR1				0xa430
  #define RTL8221B_PHYCR1_ALDPS_EN		BIT(2)
  #define RTL8221B_PHYCR1_ALDPS_XTAL_OFF_EN	BIT(12)
-@@ -2069,6 +2104,147 @@ exit:
+@@ -2068,6 +2103,147 @@ exit:
  	return ret;
  }
  
@@ -190,7 +190,7 @@
  static int rtl8224_mdi_config_order(struct phy_device *phydev)
  {
  	struct device_node *np = phydev->mdio.dev.of_node;
-@@ -2123,6 +2299,10 @@ static int rtl8224_config_init(struct ph
+@@ -2122,6 +2298,10 @@ static int rtl8224_config_init(struct ph
  {
  	int ret;
  


### PR DESCRIPTION
The in-tree realtek 5G/10G driver picks the firmware patch table from the PHY ID (RTL8264 -> rtl8264b.bin). I assume that vendor driver instead picks it from VEND1 0x104[2:0] (0 = RTL8264B, else RTL8261N-C), independent of PHY ID.

On the S1300WP the RTL8264 dies read 0x104=0xf802 ([2:0]=2), so they need the RTL8261N-C table.
The RTL8264B table leaves the PCS unlocked (0xA600 stuck 0x1000) and config_init fails with -ETIME. Read 0x104[2:0] and load rtl8261n.bin when non-zero. Boards with that logic must ship rtl8261n.bin....
More here: #23713 and #23427
For me this fixes the issue but I would love to hear from the experts if this is the right approach... 

@andrewjlamarche   does this work for your board as well?
best
