### PR TITLE
tools/util-linux: include macOS system uuid header

### DIFF
--- a/tools/util-linux/patches/102-macos-uuid-next.patch
+++ b/tools/util-linux/patches/102-macos-uuid-next.patch
@@ -1,0 +1,13 @@
+--- a/libuuid/src/uuid.h
++++ b/libuuid/src/uuid.h
+@@ -35,6 +35,10 @@
+ #ifndef _UL_LIBUUID_UUID_H
+ #define _UL_LIBUUID_UUID_H
+ 
++#if defined(__clang__) && defined(__APPLE__)
++#include_next <uuid/uuid.h>
++#endif
++
+ #include <sys/types.h>
+ #ifndef _WIN32
+ #include <sys/time.h>


### PR DESCRIPTION
⚠️ This commit was cherry-picked, most likely it needs to be refreshed. Wait until CI/CD success. 

The type definition of uuid_string_t and possibly other details used by macOS SDKs like XCode is missing from util-linux.

Headers on macOS have a different inclusion guard
compared to the unique util-linux "_UL" prefix.

This uuid.h header is guaranteed to be present since macOS 10.8 and iOS 6 even without the presence of XCode or other SDKs on the system, so adding an include_next directive is safe after checking for clang.

Link: https://developer.apple.com/documentation/foundation/uuid
Link: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/uuid.3.html

Link: https://github.com/openwrt/openwrt/pull/16522

(cherry picked from commit 89056bd7b109ff4264f07cf721e6d9f4b7ad983e)

Reported in: https://github.com/openwrt/packages/pull/29673
Fixes: https://github.com/openwrt/packages/pull/29673