### PR TITLE
ath79: add HH41V compatibility to Alcatel HH40V device tree

### DIFF
--- a/target/linux/ath79/dts/qca9531_alcatel_hh40v.dts
+++ b/target/linux/ath79/dts/qca9531_alcatel_hh40v.dts
@@ -7,8 +7,8 @@
 #include <dt-bindings/leds/common.h>
 
 / {
-	compatible = "alcatel,hh40v", "qca,qca9531";
-	model = "Alcatel HH40V";
+	compatible = "alcatel,hh40v", "alcatel,hh41v", "qca,qca9531";
+	model = "Alcatel HH40V / HH41V";
 
 	aliases {
 		label-mac-device = &wmac;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -228,6 +228,8 @@ define Device/alcatel_hh40v
   SOC := qca9531
   DEVICE_VENDOR := Alcatel
   DEVICE_MODEL := HH40V
+  DEVICE_ALT0_VENDOR := Alcatel
+  DEVICE_ALT0_MODEL := HH41V
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-serial-option kmod-usb-net-rndis
   IMAGE_SIZE := 14976k
   IMAGES += factory.bin


### PR DESCRIPTION
The Alcatel HH41V is hardware-identical to the HH40V, sharing the same PCB, flash layout, radios, and peripherals. Add the HH41V compatible string to allow the same firmware image to boot on both device models.