### PR TITLE
airoha: add Device Tree Overlay (dtso) support for AN7581 and fix PCS patch for AN7583

### DIFF
--- a/package/boot/uboot-airoha/patches/910-airoha-enable-OF_LIBFDT_OVERLAY-support-for-7581-7583.patch
+++ b/package/boot/uboot-airoha/patches/910-airoha-enable-OF_LIBFDT_OVERLAY-support-for-7581-7583.patch
@@ -1,0 +1,36 @@
+From 5bcd75ef87382aa13e4044b30f160291e8fa947e Mon Sep 17 00:00:00 2001
+From: YaleiZang <yalei.zang@airoha.com>
+Date: Mon, 8 Jun 2026 20:12:49 +0800
+Subject: [PATCH] airoha: enable OF_LIBFDT_OVERLAY support for 7581/7583
+
+Enable CONFIG_OF_LIBFDT_OVERLAY to allow loading and applying device tree overlays
+at boot time. This is necessary for systems requiring flexible hardware description
+via DT overlay, such as dynamic board variants or runtime configurable peripherals.
+
+Signed-off-by: YaleiZang <yalei.zang@airoha.com>
+---
+ configs/an7581_evb_defconfig | 1 +
+ configs/an7583_evb_defconfig | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/configs/an7581_evb_defconfig b/configs/an7581_evb_defconfig
+index be076ec7..d0058d31 100644
+--- a/configs/an7581_evb_defconfig
++++ b/configs/an7581_evb_defconfig
+@@ -103,3 +103,4 @@ CONFIG_UBI_BLOCK=y
+ CONFIG_ENV_USE_DEFAULT_ENV_TEXT_FILE=y
+ CONFIG_ENV_DEFAULT_ENV_TEXT_FILE="defenvs/an7581_rfb_env"
+ CONFIG_SHA512=y
++CONFIG_OF_LIBFDT_OVERLAY=y
+diff --git a/configs/an7583_evb_defconfig b/configs/an7583_evb_defconfig
+index 7ef2d6fe..a97c0cc5 100644
+--- a/configs/an7583_evb_defconfig
++++ b/configs/an7583_evb_defconfig
+@@ -102,3 +102,4 @@ CONFIG_UBI_BLOCK=y
+ CONFIG_ENV_USE_DEFAULT_ENV_TEXT_FILE=y
+ CONFIG_ENV_DEFAULT_ENV_TEXT_FILE="defenvs/an7583_rfb_env"
+ CONFIG_SHA512=y
++CONFIG_OF_LIBFDT_OVERLAY=y
+-- 
+2.43.0
+

--- a/target/linux/airoha/Makefile
+++ b/target/linux/airoha/Makefile
@@ -4,7 +4,7 @@ ARCH:=arm
 BOARD:=airoha
 BOARDNAME:=Airoha ARM
 SUBTARGETS:=en7523 an7581 an7583
-FEATURES:=dt squashfs nand ramdisk gpio
+FEATURES:=dt dt-overlay squashfs nand ramdisk gpio
 
 KERNEL_PATCHVER:=6.18
 

--- a/target/linux/airoha/an7581/base-files/etc/board.d/02_network
+++ b/target/linux/airoha/an7581/base-files/etc/board.d/02_network
@@ -14,6 +14,12 @@ an7581_setup_interfaces()
 	airoha,an7581-evb)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "eth1"
 		;;
+	airoha,an7581-evb-267-emmc-eagle-an8831)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 eth2" "eth1"
+		;;
+	airoha,an7581-evb-146-nand-kite-an8811)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 eth1"
+		;;
 	gemtek,w1700k-ubi)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4" "wan"
 		;;

--- a/target/linux/airoha/dts/an7581-evb-146-nand-kite-an8811.dtso
+++ b/target/linux/airoha/dts/an7581-evb-146-nand-kite-an8811.dtso
@@ -1,0 +1,182 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+&{/} {
+	model = "Airoha AN7581 Evaluation Board  (Kite + AN8811)";
+	compatible = "airoha,an7581-evb-146-nand-kite-an8811", "airoha,an7581", "airoha,en7581","airoha,pon-upstream";
+
+	gpio-keys-polled {
+		wifi_2g {
+			label = "wifi_2g";
+			linux,code = <BTN_2>;
+			gpios = <&en7581_pinctrl 4 GPIO_ACTIVE_LOW>;
+		};
+		
+		wifi_5g {
+			label = "wifi_5g";
+			linux,code = <BTN_3>;
+			gpios = <&en7581_pinctrl 5 GPIO_ACTIVE_LOW>;
+		};
+		
+		led_enable {
+			label = "led_enable";
+			linux,code = <BTN_1>;
+			gpios = <&en7581_pinctrl 6 GPIO_ACTIVE_LOW>;
+		};
+		
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&en7581_pinctrl 7 GPIO_ACTIVE_LOW>;
+		};
+	};
+	
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			label = "power";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&en7581_pinctrl 17 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		/*led-1 {
+			label = "xponLos";
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 25 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};*/
+
+		led-2 {
+			label = "internet";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 20 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			label = "wps";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 22 GPIO_ACTIVE_LOW>;
+		};
+
+		led-4 {
+			label = "voip_hook";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 24 GPIO_ACTIVE_LOW>;
+		};
+		
+		led-5 {
+			label = "usb0";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led-6 {
+			label = "usb1";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&snfi {
+	status = "okay";
+};
+	
+&en7581_pinctrl {
+	gswp1_led0_pins: gswp1-led0-pins {
+		mux {
+			function = "phy1_led0";
+			pins = "gpio43";
+		};
+	};
+
+	gswp2_led0_pins: gswp2-led0-pins {
+		mux {
+			function = "phy2_led0";
+			pins = "gpio44";
+		};
+	};
+
+	gswp3_led0_pins: gswp3-led0-pins {
+		mux {
+			function = "phy3_led0";
+			pins = "gpio45";
+		};
+	};
+
+	gswp4_led0_pins: gswp4-led0-pins {
+		mux {
+			function = "phy4_led0";
+			pins = "gpio46";
+		};
+	};
+};
+
+&pcie0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_rst_pins>;
+	status = "okay";
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		wifi@0,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+			airoha,npu = <&npu>;
+			airoha,eth = <&eth>;
+		};
+	};
+};
+	
+&pcie1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie1_rst_pins>;
+	status = "okay";
+
+	pcie@1,0 {
+		reg = <0x0000 0 0 0 0>;
+		wifi@1,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+			airoha,npu = <&npu>;
+			airoha,eth = <&eth>;
+		};
+	};
+};
+
+&npu {
+	firmware-name="airoha/en7581_npu_rv32.bin", "airoha/en7581_npu_data.bin";
+	status = "okay";
+};
+
+&mdio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+	an8811: ethernet-phy@f {
+		compatible = "ethernet-phy-id03a2.a411";
+		reg = <0xf>;
+		phy-mode = "2500base-x";
+		reset-deassert-us = <350000>;
+		reset-assert-us = <200000>;
+		reset-gpios = <&en7581_pinctrl 31 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&gdm4 {
+	status = "okay";
+
+	phy-handle = <&an8811>;
+	phy-mode = "2500base-x";
+};

--- a/target/linux/airoha/dts/an7581-evb-267-emmc-eagle-an8831.dtso
+++ b/target/linux/airoha/dts/an7581-evb-267-emmc-eagle-an8831.dtso
@@ -1,0 +1,234 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+&{/} {
+	model = "Airoha AN7581 Evaluation Board  (Eagle + AN8831)";
+	compatible ="airoha,an7581-evb-267-emmc-eagle-an8831", "airoha,an7581", "airoha,en7581","airoha,pon-upstream";
+
+	pwmleds-0 {
+		compatible = "pwm-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pwm_gpio27_idx11_pins>;
+
+		pwm-0 {
+			label = "power_sw";
+			pwms = <&en7581_pwm 11 4000000 0>;
+			max-brightness = <255>;
+			active-low;
+		};
+	};
+	
+	leds {
+		compatible = "gpio-leds";
+
+		/*led-0 {
+			label = "power_sw";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&en7581_pinctrl 27 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};*/
+
+		led-1 {
+			label = "usb0";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 28 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led-2 {
+			label = "internet";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 29 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led-3 {
+			label = "fxs1";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 30 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		/*led-4 {
+			label = "xponStatus";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 34 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};*/
+
+		led-5 {
+			label = "wifi";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 15 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		/*led-6 {
+			label = "xponLos";
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 35 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};*/
+	};
+};
+
+&mmc0 {
+	pinctrl-names = "default", "state_uhs";
+	pinctrl-0 = <&mmc_pins>;
+	pinctrl-1 = <&mmc_pins>;
+	status = "okay";		
+};
+	
+&en7581_pinctrl {
+	pcie2_rst_pins: pcie2-rst-pins {
+		conf {
+			pins = "pcie_reset2";
+			drive-open-drain = <1>;
+		};
+	};
+
+	pwm_gpio27_idx11_pins: pwm-gpio27-idx11-pins {
+		function = "pwm";
+		pins = "gpio27";
+		output-enable;
+	};
+};
+
+&pcie0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_rst_pins>;
+	status = "okay";
+	airoha,x2-mode;
+	airoha,sister-pcie = <&pcie1>;
+
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		wifi@0,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+
+			airoha,npu = <&npu>;
+			airoha,eth = <&eth>;
+		};
+	};
+};
+
+&pcie2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie2_rst_pins>;
+	status = "okay";
+
+	pcie@2,0 {
+		#address-cells = <3>;
+		#size-cells = <2>;
+		reg = <0x0000 0 0 0 0>;
+		mt7996@1,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+	
+			airoha,npu = <&npu>;
+			airoha,eth = <&eth>;
+		};
+	};
+};
+
+&pcie1 {
+	status = "disabled";
+};
+
+&npu {
+	firmware-name="airoha/en7581_MT7996_npu_rv32.bin", "airoha/en7581_MT7996_npu_data.bin";
+	status = "okay";
+};
+
+&mdio {
+	as21xx_0: ethernet-phy@1c {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <0x1c>;
+
+		firmware-name = "as21x1x_fw.bin";
+
+		reset-deassert-us = <1000000>;
+		reset-assert-us = <1000000>;
+		reset-gpios = <&en7581_pinctrl 30 GPIO_ACTIVE_LOW>;
+
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led@0 {
+				reg = <0>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_LAN;
+				function-enumerator = <0>;
+				default-state = "keep";
+			};
+
+			led@1 {
+				reg = <1>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_LAN;
+				function-enumerator = <1>;
+				default-state = "keep";
+			};
+		};
+	};
+
+	as21xx_1: ethernet-phy@1d {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <0x1d>;
+
+		firmware-name = "as21x1x_fw.bin";
+
+		reset-deassert-us = <1000000>;
+		reset-assert-us = <1000000>;
+		reset-gpios = <&en7581_pinctrl 31 GPIO_ACTIVE_LOW>;
+
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led@0 {
+				reg = <0>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_LAN;
+				function-enumerator = <0>;
+				default-state = "keep";
+			};
+
+			led@1 {
+				reg = <1>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_LAN;
+				function-enumerator = <1>;
+				default-state = "keep";
+			};
+		};
+	};
+};
+
+
+&gdm2 {
+	status = "okay";
+	managed = "in-band-status";
+	phy-handle = <&as21xx_0>;
+	phy-mode = "usxgmii";
+};
+
+&gdm4 {
+	status = "okay";
+	managed = "in-band-status";
+	phy-handle = <&as21xx_1>;
+	phy-mode = "usxgmii";
+};

--- a/target/linux/airoha/dts/an7581-evb-multievb.dts
+++ b/target/linux/airoha/dts/an7581-evb-multievb.dts
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/dts-v1/;
+
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include "an7581.dtsi"
+#include "an7581_flash.dtsi"
+
+/ {
+	model = "Airoha AN7581 Evaluation Board";
+	compatible = "airoha,an7581", "airoha,en7581";
+
+	aliases {
+		serial0 = &uart1;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200 earlycon";
+		stdout-path = "serial0:115200n8";
+		linux,usable-memory-range = <0x0 0x80200000 0x0 0x3FE00000>;
+	};
+
+	memory@80000000 {
+		device_type = "memory";
+		reg = <0x0 0x80000000 0x2 0x00000000>;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		btn-reset {
+			label = "reset";
+			linux,code = <BTN_0>;
+			gpios = <&en7581_pinctrl 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+	
+	sfp1: sfp1 {
+		compatible = "sff,sfp";
+	};
+
+	efuse-banks {
+		compatible = "airoha,an7581-efuses";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		bank@0 {
+			reg = <0>;
+		};
+
+		bank@1 {
+			reg = <1>;
+		};
+	};
+};
+
+&{/reserved-memory} {
+	/delete-node/ npu-txbufid@90c00000;
+	/delete-node/ npu-ba@90c06800;
+
+	npu_ba: npu-ba@90c00000 {
+		no-map;
+		reg = <0x0 0x90c00000 0x0 0x200000>;
+	};
+
+	npu_txbufid: npu-txbufid@90e00000 {
+		no-map;
+		reg = <0x0 0x90e00000 0x0 0xea60>;
+	};
+};
+
+&en7581_pinctrl {
+	gpio-ranges = <&en7581_pinctrl 0 13 47>;
+
+	mdio_pins: mdio-pins {
+		mux {
+			function = "mdio";
+			groups = "mdio";
+		};
+
+		conf {
+			pins = "gpio2";
+			output-high;
+		};
+	};
+
+	pcie0_rst_pins: pcie0-rst-pins {
+		conf {
+			pins = "pcie_reset0";
+			drive-open-drain = <1>;
+		};
+	};
+
+	pcie1_rst_pins: pcie1-rst-pins {
+		conf {
+			pins = "pcie_reset1";
+			drive-open-drain = <1>;
+		};
+	};
+
+	mmc_pins: mmc-pins {
+		mux {
+			function = "emmc";
+			groups = "emmc";
+		};
+	};
+};
+
+&i2c0 {
+	status = "okay";
+};
+
+&i2c1 {
+	status = "disabled";
+};
+
+&pciephy {
+	status = "okay";
+};
+
+&pcie0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_rst_pins>;
+	status = "okay";
+};
+
+&pcie1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie1_rst_pins>;
+	status = "okay";
+};
+
+&npu {
+	firmware-name="airoha/en7581_NOWIFI_npu_rv32.bin", "airoha/en7581_NOWIFI_npu_data.bin";
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb1 {
+	status = "okay";
+
+	mediatek,u3p-dis-msk = <0x1>;
+	phys = <&usb1_phy PHY_TYPE_USB2>;
+};
+
+&eth {
+	status = "okay";
+};
+
+&gdm1 {
+	status = "okay";
+};
+
+&switch {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+	status = "okay";
+};
+
+&gsw_port1 {
+	status = "okay";
+	label = "lan1";
+};
+
+&gsw_phy1 {
+	status = "okay";
+};
+
+&gsw_phy1_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	active-low;
+};
+
+&gsw_port2 {
+	status = "okay";
+	label = "lan2";
+};
+
+&gsw_phy2 {
+	status = "okay";
+};
+
+&gsw_phy2_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	active-low;
+};
+
+&gsw_port3 {
+	status = "okay";
+	label = "lan3";
+};
+
+&gsw_phy3 {
+	status = "okay";
+};
+
+&gsw_phy3_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	active-low;
+};
+
+&gsw_port4 {
+	status = "okay";
+	label = "lan4";
+};
+
+&gsw_phy4 {
+	status = "okay";
+};
+
+&gsw_phy4_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	active-low;
+};

--- a/target/linux/airoha/dts/an7581_flash.dtsi
+++ b/target/linux/airoha/dts/an7581_flash.dtsi
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+
+
+&spi_nand {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		bl2@0 {
+			label = "bl2";
+			reg = <0x0 0x20000>;
+		};
+
+		ubi@20000 {
+			label = "ubi";
+			reg = <0x20000 0x0>;
+		};
+	};
+};
+
+&mmc0 {
+	pinctrl-names = "default", "state_uhs";
+	pinctrl-0 = <&mmc_pins>;
+	pinctrl-1 = <&mmc_pins>;
+	status = "disabled";
+	
+	#address-cells = <1>;
+	#size-cells = <0>;
+	
+	card@0 {
+		compatible = "mmc-card";
+		reg = <0>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			bootloader@0 {
+				label = "bootloader";
+				reg = <0x00000000 0x00080000>;
+			};
+
+			tclinux@80000 {
+				label = "tclinux";
+				reg = <0x00080000 0x02800000>;
+			};
+
+			tclinux_slave@2880000 {
+				label = "tclinux_slave";
+				reg = <0x02880000 0x02800000>;
+			};
+
+			rootfs_data@5080000 {
+				label = "rootfs_data";
+				reg = <0x5080000 0x00800000>;
+			};
+		};
+	};
+};

--- a/target/linux/airoha/image/an7581.mk
+++ b/target/linux/airoha/image/an7581.mk
@@ -83,6 +83,21 @@ define Device/airoha_an7581-evb-emmc-kite
 endef
 TARGET_DEVICES += airoha_an7581-evb-emmc-kite
 
+define Device/airoha_an7581-evb-multievb
+  DEVICE_VENDOR := Airoha
+  DEVICE_MODEL := AN7581 Evaluation Board (multievb)
+  DEVICE_DTS := an7581-evb-multievb
+  DEVICE_DTS_OVERLAY := an7581-evb-146-nand-kite-an8811 an7581-evb-267-emmc-eagle-an8831
+  DEVICE_DTC_FLAGS := --pad 20480
+  DEVICE_PACKAGES := kmod-i2c-an7581 airoha-en7581-npu-firmware airoha-en7581-mt7996-npu-firmware kmod-mt7992-firmware \
+		    wpad-basic-mbedtls
+  IMAGE/sysupgrade.bin := append-kernel | pad-to 8M | append-rootfs | pad-rootfs | append-metadata
+  ARTIFACT/preloader.bin := an7581-preloader rfb
+  ARTIFACT/bl31-uboot.fip := an7581-bl31-uboot rfb
+  ARTIFACTS := preloader.bin bl31-uboot.fip
+endef
+TARGET_DEVICES += airoha_an7581-evb-multievb
+
 define Device/gemtek_w1700k-ubi
   DEVICE_VENDOR := Gemtek
   DEVICE_MODEL := W1700K


### PR DESCRIPTION
Enable dtso handling for dynamic hardware configuration and flexible device adaptation.

Example (U-Boot):
setenv bootcmd "ubi read 81800000 kernel; bootm 0x81800000#config-1#an7581-evb-146-nand-kite-an8811"
saveenv

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
