### PR TITLE
package: make APK embedded help gzip reproducible

### DIFF
--- a/package/system/apk/patches/0011-genhelp-reproducible-gzip.patch
+++ b/package/system/apk/patches/0011-genhelp-reproducible-gzip.patch
@@ -1,0 +1,11 @@
+--- a/src/genhelp.lua
++++ b/src/genhelp.lua
+@@ -168,7 +168,7 @@ function scapp:compress(data)
+ 		f:write(data)
+ 		f:close()
+
+-		local p = io.popen(('gzip -%d < %s'):format(level, tmp), 'r')
++		local p = io.popen(('gzip -n%d < %s'):format(level, tmp), 'r')
+ 		if p ~= nil then
+ 			ret = p:read("*all")
+ 			p:close()


### PR DESCRIPTION
APK compresses it's helptext using LUA and require `zlib`, which isn't available on the Buildbots. It thens falls back to `gzip`, which embeds the MTIME, making the binary itself unreproducible.

This commits adds a downstream patch to run `gzip` with `-n`, setting the time to 0.