### PR TITLE
ipq806x: fix ethernet, wifi, usb for Nokia AC400i

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -53,7 +53,8 @@ ipq806x_setup_interfaces()
 		;;
 	fortinet,fap-421e|\
 	ignitenet,ss-w2-ac2600|\
-	ubnt,unifi-ac-hd)
+	ubnt,unifi-ac-hd|\
+	nokia,ac400i)
 		ucidef_set_interface_lan "eth0 eth1"
 		;;
 	meraki,mr42)

--- a/target/linux/ipq806x/dts/qcom-ipq8065-ac400i.dts
+++ b/target/linux/ipq806x/dts/qcom-ipq8065-ac400i.dts
@@ -170,6 +170,16 @@
 			input;
 		};
 	};
+
+	usb_pwr_en_pins: usb_pwr_en_pins {
+		mux {
+			pins = "gpio58";
+			function = "gpio";
+			drive-strength = <12>;
+			bias-pull-down;
+			output-high;
+		};
+	};
 };
 
 &gsbi2 {
@@ -247,12 +257,19 @@
 	};
 };
 
-&usb3_0 {
+&hs_phy_1 {
+	status = "okay";
+};
+
+&ss_phy_1 {
 	status = "okay";
 };
 
 &usb3_1 {
 	status = "okay";
+
+	pinctrl-0 = <&usb_pwr_en_pins>;
+	pinctrl-names = "default";
 };
 
 &pcie0 {

--- a/target/linux/ipq806x/dts/qcom-ipq8065-ac400i.dts
+++ b/target/linux/ipq806x/dts/qcom-ipq8065-ac400i.dts
@@ -230,10 +230,6 @@
 
 &pcie0 {
 	status = "okay";
-
-	/delete-property/ pinctrl-0;
-	/delete-property/ pinctrl-names;
-	/delete-property/ perst-gpios;
 };
 
 &pcie_bridge0 {
@@ -248,10 +244,6 @@
 
 &pcie1 {
 	status = "okay";
-
-	/delete-property/ pinctrl-0;
-	/delete-property/ pinctrl-names;
-	/delete-property/ perst-gpios;
 };
 
 &pcie_bridge1 {

--- a/target/linux/ipq806x/dts/qcom-ipq8065-ac400i.dts
+++ b/target/linux/ipq806x/dts/qcom-ipq8065-ac400i.dts
@@ -153,6 +153,13 @@
 		};
 	};
 
+	rgmii0_pins: rgmii0_pins {
+		mux {
+			pins = "gpio66";
+			drive-strength = <8>;
+			bias-disable;
+		};
+	};
 };
 
 &gsbi5 {
@@ -259,17 +266,20 @@
 
 &mdio0 {
 	status = "okay";
+
 	pinctrl-0 = <&mdio0_pins>;
 	pinctrl-names = "default";
 
 	phy0: ethernet-phy@0 {
 		reg = <0>;
+		reset-gpios = <&qcom_pinmux 51 GPIO_ACTIVE_LOW>;
+		qca,disable-hibernation-mode;
 	};
 
 	phy1: ethernet-phy@1 {
 		reg = <1>;
+		qca,disable-hibernation-mode;
 	};
-
 };
 
 //POE
@@ -281,28 +291,21 @@
 	pinctrl-names = "default";
 
 	mdiobus = <&mdio0>;
-	phy-handle = <&phy0>;
-	phy-mode = "rgmii";
-
-	fixed-link {
-		speed = <1000>;
-		full-duplex;
-	};
+	phy-handle = <&phy1>;
+	phy-mode = "rgmii-id";
 };
 
-//LAN1
+//LAN2
 &gmac1 {
 	status = "okay";
 	qcom,id = <1>;
 
-	mdiobus = <&mdio0>;
-	phy-handle = <&phy1>;
-	phy-mode = "rgmii";
+	pinctrl-0 = <&rgmii0_pins>;
+	pinctrl-names = "default";
 
-	fixed-link {
-		speed = <1000>;
-		full-duplex;
-	};
+	mdiobus = <&mdio0>;
+	phy-handle = <&phy0>;
+	phy-mode = "rgmii-id";
 };
 
 &nand {

--- a/target/linux/ipq806x/dts/qcom-ipq8065-ac400i.dts
+++ b/target/linux/ipq806x/dts/qcom-ipq8065-ac400i.dts
@@ -160,6 +160,33 @@
 			bias-disable;
 		};
 	};
+
+	i2c0_pins: i2c0_pins {
+		mux {
+			pins = "gpio24", "gpio25";
+			function = "gsbi2";
+			drive-strength = <2>;
+			bias-pull-up;
+			input;
+		};
+	};
+};
+
+&gsbi2 {
+	qcom,mode = <GSBI_PROT_I2C>;
+	status = "okay";
+};
+
+&gsbi2_i2c {
+	status = "okay";
+
+	pinctrl-0 = <&i2c0_pins>;
+	pinctrl-names = "default";
+
+	temp-sensor@48 {
+		compatible = "ti,tmp75";
+		reg = <0x48>;
+	};
 };
 
 &gsbi5 {

--- a/target/linux/ipq806x/image/generic.mk
+++ b/target/linux/ipq806x/image/generic.mk
@@ -458,7 +458,7 @@ define Device/nokia_ac400i
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
 	BOARD_NAME := ac400i
-	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct
+	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct kmod-hwmon-lm75
 endef
 TARGET_DEVICES += nokia_ac400i
 


### PR DESCRIPTION
In previous versions of OpenWrt, ethernet was partially working,
sometimes depending on initialization state left by bootloader.
Since the switch to NSS drivers, it is completely broken.

- swap GMAC to PHY address mapping
- use rgmii internal delay
- drop `fixed-link` rates
- add pinctrl settings for `rgmii0`
- declare reset GPIO 51 (used for both PHYs)
- disable hibernation

-------------------------

In recent versions of OpenWrt, only 2.4G wifi is working.
- drop upstream overrides for pcie nodes to declare `perst-gpios` 3 and 48.

-------------------------

The board contains a TI TMP75 temperature sensor located near the ethernet
PHYs, attached to the thermal mass of the back case, close to main SoC.

- configure `gsbi2` for i2c mode
- include `kmod-hwmon-lm75` package.

-------------------------

Fix USB port:
- drop usb3_0 node
- enable usb3_1 PHYs
- set `gpio58` for power enable

-------------------------

Forum Thread: https://forum.openwrt.org/t/adding-openwrt-support-for-nokia-airscale-ac400i/78356/
