### PR TITLE
realtek: pcs: simplify and shape RTL838x setup

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -939,14 +939,14 @@ static int rtpcs_838x_setup_serdes(struct rtpcs_serdes *sds,
 	rtpcs_sds_write(sds, 0x0, 0x0, 0xc00);
 	rtpcs_sds_write(sds, 0x0, 0x3, 0x7146);
 
+	rtpcs_838x_sds_patch(sds, hw_mode);
+	rtpcs_838x_sds_reset(sds);
+
 	ret = rtpcs_838x_sds_set_mode(sds, hw_mode);
 	if (ret)
 		return ret;
 
 	sds->hw_mode = hw_mode;
-
-	rtpcs_838x_sds_patch(sds, hw_mode);
-	rtpcs_838x_sds_reset(sds);
 
 	/* release reset */
 	rtpcs_sds_write(sds, 0, 3, 0x7106);

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -773,17 +773,8 @@ static void rtpcs_838x_sds_patch_5_fiber_6275b(struct rtpcs_ctrl *ctrl)
 
 static void rtpcs_838x_sds_reset(struct rtpcs_serdes *sds)
 {
-	rtpcs_sds_write_bits(sds, 2, 0, 11, 11, 0x0);	/* FIB_REG0 CFG_FIB_PDOWN */
-
-	/* analog reset */
-	rtpcs_sds_write_bits(sds, 0, 0, 1, 0, 0x0);	/* REG0 EN_RX/EN_TX */
-	rtpcs_sds_write_bits(sds, 0, 0, 1, 0, 0x3);	/* REG0 EN_RX/EN_TX */
-
-	/* digital reset */
 	rtpcs_sds_write_bits(sds, 0, 3, 6, 6, 0x1);	/* REG3 SOFT_RST */
 	rtpcs_sds_write_bits(sds, 0, 3, 6, 6, 0x0);	/* REG3 SOFT_RST */
-
-	dev_info(sds->ctrl->dev, "SerDes %d reset\n", sds->id);
 }
 
 static void rtpcs_838x_sds_fill_caps(struct rtpcs_serdes *sds)
@@ -820,11 +811,35 @@ static int rtpcs_838x_sds_power(struct rtpcs_serdes *sds, bool power_on)
 
 static int rtpcs_838x_sds_deactivate(struct rtpcs_serdes *sds)
 {
-	return rtpcs_838x_sds_power(sds, false);
+	int ret;
+
+	ret = rtpcs_838x_sds_power(sds, false);
+	if (ret)
+		return ret;
+
+	/* EN_RX | EN_TX */
+	ret = rtpcs_sds_write_bits(sds, 0, 0, 1, 0, 0x0);
+	if (ret)
+		return ret;
+
+	/* CFG_FIB_PDOWN / BMCR_PDOWN */
+	return rtpcs_sds_write_bits(sds, 2, MII_BMCR, 11, 11, 0x1);
 }
 
 static int rtpcs_838x_sds_activate(struct rtpcs_serdes *sds)
 {
+	int ret;
+
+	/* CFG_FIB_PDOWN / BMCR_PDOWN */
+	ret = rtpcs_sds_write_bits(sds, 2, 0, 11, 11, 0x0);
+	if (ret)
+		return ret;
+
+	/* EN_RX | EN_TX */
+	ret = rtpcs_sds_write_bits(sds, 0, 0, 1, 0, 0x3);
+	if (ret)
+		return ret;
+
 	return rtpcs_838x_sds_power(sds, true);
 }
 

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -665,9 +665,6 @@ static const s16 rtpcs_838x_sds_hw_mode_vals[RTPCS_SDS_MODE_MAX] = {
 
 static void rtpcs_838x_sds_patch_01_qsgmii_6275b(struct rtpcs_ctrl *ctrl)
 {
-	/* CKREFBUF_S0S1 for QSGMII */
-	regmap_write_bits(ctrl->map, RTPCS_838X_PLL_CML_CTRL, 0xf, 0xf);
-
 	rtpcs_sds_write(SDS(ctrl, 0), 1, 3, 0xf46f);
 	rtpcs_sds_write(SDS(ctrl, 0), 1, 2, 0x85fa);
 	rtpcs_sds_write(SDS(ctrl, 1), 1, 2, 0x85fa);
@@ -894,6 +891,19 @@ static int rtpcs_838x_sds_patch(struct rtpcs_serdes *sds,
 		break;
 	default:
 		break;
+	}
+
+	if (sds_id < 2) {
+		/*
+		 * These settings have to match to make QSGMII working.
+		 * Testing showed that both variants work:
+		 *   - CKREFBUF_S0S1 = 0xf + REG_CML_SEL = 0x1
+		 *   - CKREFBUF_S0S1 = 0x0 + REG_CML_SEL = 0x0
+		 */
+
+		/* CKREFBUF_S0S1 */
+		regmap_write_bits(ctrl->map, RTPCS_838X_PLL_CML_CTRL, 0xf, 0xf);
+		rtpcs_sds_write_bits(sds, 0x1, 0x3, 1, 1, 0x1); /* REG_CML_SEL */
 	}
 
 	rtpcs_sds_write(sds, 0x1, 0x9, 0x8e64);

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -685,12 +685,6 @@ static void rtpcs_838x_sds_patch_01_qsgmii_6275b(struct rtpcs_ctrl *ctrl)
 	rtpcs_sds_write(SDS(ctrl, 1), 2, 25, 0x303);
 	rtpcs_sds_write(SDS(ctrl, 0), 1, 14, 0xfcc2);
 	rtpcs_sds_write(SDS(ctrl, 1), 1, 14, 0xfcc2);
-
-	rtpcs_sds_write(SDS(ctrl, 0), 1, 9, 0x8e64);
-	rtpcs_sds_write(SDS(ctrl, 0), 1, 9, 0x8c64);
-
-	rtpcs_sds_write(SDS(ctrl, 1), 1, 9, 0x8e64);
-	rtpcs_sds_write(SDS(ctrl, 1), 1, 9, 0x8c64);
 }
 
 static void rtpcs_838x_sds_patch_23_qsgmii_6275b(struct rtpcs_ctrl *ctrl)
@@ -711,12 +705,6 @@ static void rtpcs_838x_sds_patch_23_qsgmii_6275b(struct rtpcs_ctrl *ctrl)
 	rtpcs_sds_write(SDS(ctrl, 3), 2, 25, 0x303);
 	rtpcs_sds_write(SDS(ctrl, 2), 1, 14, 0xfcc2);
 	rtpcs_sds_write(SDS(ctrl, 3), 1, 14, 0xfcc2);
-
-	rtpcs_sds_write(SDS(ctrl, 2), 1, 9, 0x8e64);
-	rtpcs_sds_write(SDS(ctrl, 2), 1, 9, 0x8c64);
-
-	rtpcs_sds_write(SDS(ctrl, 3), 1, 9, 0x8e64);
-	rtpcs_sds_write(SDS(ctrl, 3), 1, 9, 0x8c64);
 }
 
 static void rtpcs_838x_sds_patch_4_fiber_6275b(struct rtpcs_ctrl *ctrl)
@@ -729,9 +717,6 @@ static void rtpcs_838x_sds_patch_4_fiber_6275b(struct rtpcs_ctrl *ctrl)
 	rtpcs_sds_write(SDS(ctrl, 4), 1, 18, 0xab8e);
 	rtpcs_sds_write(SDS(ctrl, 4), 2, 25, 0x303);
 	rtpcs_sds_write(SDS(ctrl, 4), 1, 14, 0xfcc2);
-
-	rtpcs_sds_write(SDS(ctrl, 4), 1, 9, 0x8e64);
-	rtpcs_sds_write(SDS(ctrl, 4), 1, 9, 0x8c64);
 }
 
 static void rtpcs_838x_sds_patch_4_qsgmii_6275b(struct rtpcs_ctrl *ctrl)
@@ -745,9 +730,6 @@ static void rtpcs_838x_sds_patch_4_qsgmii_6275b(struct rtpcs_ctrl *ctrl)
 	rtpcs_sds_write(SDS(ctrl, 4), 1, 18, 0xab8e);
 	rtpcs_sds_write(SDS(ctrl, 4), 2, 25, 0x303);
 	rtpcs_sds_write(SDS(ctrl, 4), 1, 14, 0xfcc2);
-
-	rtpcs_sds_write(SDS(ctrl, 4), 1, 9, 0x8e64);
-	rtpcs_sds_write(SDS(ctrl, 4), 1, 9, 0x8c64);
 }
 
 static void rtpcs_838x_sds_patch_5_fiber_6275b(struct rtpcs_ctrl *ctrl)
@@ -766,9 +748,6 @@ static void rtpcs_838x_sds_patch_5_fiber_6275b(struct rtpcs_ctrl *ctrl)
 	rtpcs_sds_write(SDS(ctrl, 5), 2, 25, 0x303);
 	rtpcs_sds_write(SDS(ctrl, 5), 1, 14, 0xf002);
 	rtpcs_sds_write(SDS(ctrl, 5), 2, 27, 0x4bf);
-
-	rtpcs_sds_write(SDS(ctrl, 5), 1, 9, 0x8e64);
-	rtpcs_sds_write(SDS(ctrl, 5), 1, 9, 0x8c64);
 }
 
 static void rtpcs_838x_sds_reset(struct rtpcs_serdes *sds)
@@ -916,6 +895,9 @@ static int rtpcs_838x_sds_patch(struct rtpcs_serdes *sds,
 	default:
 		break;
 	}
+
+	rtpcs_sds_write(sds, 0x1, 0x9, 0x8e64);
+	rtpcs_sds_write(sds, 0x1, 0x9, 0x8c64);
 
 	return 0;
 }

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -661,90 +661,45 @@ static const s16 rtpcs_838x_sds_hw_mode_vals[RTPCS_SDS_MODE_MAX] = {
 	[RTPCS_SDS_MODE_QSGMII]		= 0x6,
 };
 
-#define SDS(ctrl,n)	(&(ctrl)->serdes[n])
-
-static void rtpcs_838x_sds_patch_01_qsgmii_6275b(struct rtpcs_ctrl *ctrl)
+static void rtpcs_838x_sds_patch_qsgmii(struct rtpcs_serdes *sds)
 {
-	rtpcs_sds_write(SDS(ctrl, 0), 1, 3, 0xf46f);
-	rtpcs_sds_write(SDS(ctrl, 0), 1, 2, 0x85fa);
-	rtpcs_sds_write(SDS(ctrl, 1), 1, 2, 0x85fa);
-	rtpcs_sds_write(SDS(ctrl, 0), 1, 6, 0x20d8);
-	rtpcs_sds_write(SDS(ctrl, 1), 1, 6, 0x20d8);
-	rtpcs_sds_write(SDS(ctrl, 0), 1, 17, 0xb7c9);
-	rtpcs_sds_write(SDS(ctrl, 1), 1, 11, 0x482);
-	rtpcs_sds_write(SDS(ctrl, 1), 1, 10, 0x80c7);
-	rtpcs_sds_write(SDS(ctrl, 0), 1, 18, 0xab8e);
-	rtpcs_sds_write(SDS(ctrl, 0), 1, 11, 0x482);
-	rtpcs_sds_write(SDS(ctrl, 0), 1, 19, 0x24ab);
-	rtpcs_sds_write(SDS(ctrl, 1), 1, 17, 0x4208);
-	rtpcs_sds_write(SDS(ctrl, 1), 1, 18, 0xc208);
-	rtpcs_sds_write(SDS(ctrl, 0), 2, 25, 0x303);
-	rtpcs_sds_write(SDS(ctrl, 1), 2, 25, 0x303);
-	rtpcs_sds_write(SDS(ctrl, 0), 1, 14, 0xfcc2);
-	rtpcs_sds_write(SDS(ctrl, 1), 1, 14, 0xfcc2);
+	bool is_even = (rtpcs_sds_get_even(sds) == sds);
+
+	rtpcs_sds_write(sds, 0x1, 0x3, 0xf46d);
+	rtpcs_sds_write(sds, 0x1, 0x2, 0x85fa);
+	rtpcs_sds_write(sds, 0x1, 0x6, 0x20d8);
+
+	rtpcs_sds_write(sds, 0x1, 10, is_even ? 0x58c7 : 0x80c7);
+	rtpcs_sds_write(sds, 0x1, 17, is_even ? 0xb7c9 : 0x4208);
+	rtpcs_sds_write(sds, 0x1, 18, is_even ? 0xab8e : 0xc208);
+	rtpcs_sds_write(sds, 0x1, 11, 0x482);
+	if (is_even)
+		rtpcs_sds_write(sds, 0x1, 19, 0x24ab);
+
+	rtpcs_sds_write(sds, 0x2, 25, 0x303);
+	rtpcs_sds_write(sds, 0x1, 14, 0xfcc2);
 }
 
-static void rtpcs_838x_sds_patch_23_qsgmii_6275b(struct rtpcs_ctrl *ctrl)
+static void rtpcs_838x_sds_patch_fiber(struct rtpcs_serdes *sds)
 {
-	rtpcs_sds_write(SDS(ctrl, 2), 1, 3, 0xf46d);
-	rtpcs_sds_write(SDS(ctrl, 2), 1, 2, 0x85fa);
-	rtpcs_sds_write(SDS(ctrl, 3), 1, 2, 0x85fa);
-	rtpcs_sds_write(SDS(ctrl, 2), 1, 6, 0x20d8);
-	rtpcs_sds_write(SDS(ctrl, 3), 1, 6, 0x20d8);
-	rtpcs_sds_write(SDS(ctrl, 2), 1, 17, 0xb7c9);
-	rtpcs_sds_write(SDS(ctrl, 2), 1, 18, 0xab8e);
-	rtpcs_sds_write(SDS(ctrl, 2), 1, 11, 0x482);
-	rtpcs_sds_write(SDS(ctrl, 3), 1, 11, 0x482);
-	rtpcs_sds_write(SDS(ctrl, 2), 1, 19, 0x24ab);
-	rtpcs_sds_write(SDS(ctrl, 3), 1, 17, 0x4208);
-	rtpcs_sds_write(SDS(ctrl, 3), 1, 18, 0xc208);
-	rtpcs_sds_write(SDS(ctrl, 2), 2, 25, 0x303);
-	rtpcs_sds_write(SDS(ctrl, 3), 2, 25, 0x303);
-	rtpcs_sds_write(SDS(ctrl, 2), 1, 14, 0xfcc2);
-	rtpcs_sds_write(SDS(ctrl, 3), 1, 14, 0xfcc2);
-}
+	bool is_even = rtpcs_sds_get_even(sds) == sds;
 
-static void rtpcs_838x_sds_patch_4_fiber_6275b(struct rtpcs_ctrl *ctrl)
-{
-	rtpcs_sds_write(SDS(ctrl, 4), 1, 2, 0x85fa);
-	rtpcs_sds_write(SDS(ctrl, 4), 1, 11, 0x1482);
-	rtpcs_sds_write(SDS(ctrl, 4), 1, 6, 0x20d8);
-	rtpcs_sds_write(SDS(ctrl, 4), 1, 10, 0xc3);
-	rtpcs_sds_write(SDS(ctrl, 4), 1, 17, 0xb7c9);
-	rtpcs_sds_write(SDS(ctrl, 4), 1, 18, 0xab8e);
-	rtpcs_sds_write(SDS(ctrl, 4), 2, 25, 0x303);
-	rtpcs_sds_write(SDS(ctrl, 4), 1, 14, 0xfcc2);
-}
-
-static void rtpcs_838x_sds_patch_4_qsgmii_6275b(struct rtpcs_ctrl *ctrl)
-{
-	rtpcs_sds_write(SDS(ctrl, 4), 1, 3, 0xf46d);
-	rtpcs_sds_write(SDS(ctrl, 4), 1, 2, 0x85fa);
-	rtpcs_sds_write(SDS(ctrl, 4), 1, 11, 0x0482);
-	rtpcs_sds_write(SDS(ctrl, 4), 1, 6, 0x20d8);
-	rtpcs_sds_write(SDS(ctrl, 4), 1, 10, 0x58c7);
-	rtpcs_sds_write(SDS(ctrl, 4), 1, 17, 0xb7c9);
-	rtpcs_sds_write(SDS(ctrl, 4), 1, 18, 0xab8e);
-	rtpcs_sds_write(SDS(ctrl, 4), 2, 25, 0x303);
-	rtpcs_sds_write(SDS(ctrl, 4), 1, 14, 0xfcc2);
-}
-
-static void rtpcs_838x_sds_patch_5_fiber_6275b(struct rtpcs_ctrl *ctrl)
-{
-	rtpcs_sds_write(SDS(ctrl, 5), 1, 2, 0x85fa);
-	rtpcs_sds_write(SDS(ctrl, 5), 1, 3, 0x00);
-	rtpcs_sds_write(SDS(ctrl, 5), 1, 4, 0xdccc);
-	rtpcs_sds_write(SDS(ctrl, 5), 1, 5, 0x00);
-	rtpcs_sds_write(SDS(ctrl, 5), 1, 6, 0x3600);
-	rtpcs_sds_write(SDS(ctrl, 5), 1, 7, 0x03);
-	rtpcs_sds_write(SDS(ctrl, 5), 1, 8, 0x79aa);
-	rtpcs_sds_write(SDS(ctrl, 5), 1, 9, 0x8c64);
-	rtpcs_sds_write(SDS(ctrl, 5), 1, 10, 0xc3);
-	rtpcs_sds_write(SDS(ctrl, 5), 1, 11, 0x1482);
-	rtpcs_sds_write(SDS(ctrl, 5), 2, 24, 0x14aa);
-	rtpcs_sds_write(SDS(ctrl, 5), 2, 25, 0x303);
-	rtpcs_sds_write(SDS(ctrl, 5), 1, 14, 0xf002);
-	rtpcs_sds_write(SDS(ctrl, 5), 2, 27, 0x4bf);
+	rtpcs_sds_write(sds, 1, 2, 0x85fa);
+	rtpcs_sds_write(sds, 1, 3, 0x00);
+	rtpcs_sds_write(sds, 1, 4, 0xdccc);
+	rtpcs_sds_write(sds, 1, 5, 0x00);
+	rtpcs_sds_write(sds, 1, 6, is_even ? 0x20d8 : 0x3600);
+	rtpcs_sds_write(sds, 1, 7, 0x03);
+	rtpcs_sds_write(sds, 1, 8, 0x79aa);
+	rtpcs_sds_write(sds, 1, 9, 0x8c64);
+	rtpcs_sds_write(sds, 1, 10, 0xc3);
+	rtpcs_sds_write(sds, 1, 11, 0x1482);
+	rtpcs_sds_write(sds, 1, 17, 0xb7c9);
+	rtpcs_sds_write(sds, 1, 18, 0xab8e);
+	rtpcs_sds_write(sds, 2, 24, 0x14aa);
+	rtpcs_sds_write(sds, 2, 25, 0x303);
+	rtpcs_sds_write(sds, 1, 14, 0xf002);
+	rtpcs_sds_write(sds, 2, 27, 0x4bf);
 }
 
 static void rtpcs_838x_sds_reset(struct rtpcs_serdes *sds)
@@ -874,20 +829,10 @@ static int rtpcs_838x_sds_patch(struct rtpcs_serdes *sds,
 
 	switch (hw_mode) {
 	case RTPCS_SDS_MODE_1000BASEX:
-		if (sds_id == 4)
-			rtpcs_838x_sds_patch_4_fiber_6275b(ctrl);
-		else if (sds_id == 5)
-			rtpcs_838x_sds_patch_5_fiber_6275b(ctrl);
-
+		rtpcs_838x_sds_patch_fiber(sds);
 		break;
 	case RTPCS_SDS_MODE_QSGMII:
-		if (sds_id == 0 || sds_id == 1)
-			rtpcs_838x_sds_patch_01_qsgmii_6275b(ctrl);
-		else if (sds_id == 2 || sds_id == 3)
-			rtpcs_838x_sds_patch_23_qsgmii_6275b(ctrl);
-		else if (sds_id == 4)
-			rtpcs_838x_sds_patch_4_qsgmii_6275b(ctrl);
-
+		rtpcs_838x_sds_patch_qsgmii(sds);
 		break;
 	default:
 		break;


### PR DESCRIPTION
Do some good to the RTL838x SerDes code. Reduce to big patching stuff to what's needed.

Also do some reordering to work towards a unified setup sequence.

Tested on GS1900-10HP B1 and HPE JG924A