### PR TITLE
scripts/ext-toolchain: start with versioned bins

### DIFF
--- a/scripts/ext-toolchain.sh
+++ b/scripts/ext-toolchain.sh
@@ -461,7 +461,7 @@ probe_cc() {
 		local bin
 		for bin in "bin" "usr/bin" "usr/local/bin"; do
 			local cmd
-			for cmd in "$TOOLCHAIN/$bin/"*-*cc*; do
+			for cmd in "$TOOLCHAIN/$bin/"*-*cc*[0-9] "$TOOLCHAIN/$bin/"*-*cc*; do
 				if [ -x "$cmd" ] && [ ! -h "$cmd" ]; then
 					CC="$(cd "${cmd%/*}"; pwd)/${cmd##*/}"
 					return 0


### PR DESCRIPTION
Make sure that when searching for CC, we will start with versioned binaries and fallback to other binaries only later on. Otherwise we might end up with arm-openwrt-linux-muslgnueabi-gcc-ar being our CC.
