### PR TITLE
vscode: update editor formatting and line endings settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
-    "git.alwaysSignOff": true
+    "git.alwaysSignOff": true,
+    "files.trimTrailingWhitespace": true,
+    "files.insertFinalNewline": true,
+    "files.trimFinalNewlines": true,
+    "files.eol": "\n"
 }


### PR DESCRIPTION
Enable trailing whitespace trimming, insert final newline, and force LF.

Based on https://github.com/openwrt/packages/pull/28306 , but without git validation.
Requested here: https://github.com/openwrt/openwrt/pull/16540#issuecomment-4684884812