### PR TITLE
build: fixup version.date creation for source archives

### DIFF
--- a/include/package-defaults.mk
+++ b/include/package-defaults.mk
@@ -63,8 +63,9 @@ Build/Patch:=$(Build/Patch/Default)
 ifneq ($(strip $(PKG_UNPACK)),)
   define Build/Prepare/Default
 	$(PKG_UNPACK)
+	-find $(PKG_BUILD_DIR) -mindepth 1 -type f -not -name '.*' -not -name 'version.date' -printf '%T@\n' 2>/dev/null |\
+		cut -d. -f1 | sort -n | tail -n1 > $(PKG_BUILD_DIR)/version.date
 	[ ! -d ./src/ ] || $(CP) ./src/. $(PKG_BUILD_DIR)
-	-find $(PKG_BUILD_DIR) -mindepth 1 -type f -printf '%T@\n' 2>/dev/null | head -n1 | cut -d. -f1 > $(PKG_BUILD_DIR)/version.date
 	$(Build/Patch)
   endef
 endif


### PR DESCRIPTION
Published sources archives may contain a mixture of MTIMEs, so taking the time
of the first file found varies based on filesystem order. To fix this, sort all
MTIMEs and take the latest.

Since piping into a file directly creates that file, we also need to
specifically tell `find` to ignore `version.date`.

Furthermore, move this prior to the ./src copy step, since for some packages,
the OpenWrt build system ships extra ./src files, which would introduce the
wrong timestamps again.

Fix: e36c2946b7b574504335ff517b19b7c1eedf1bd8 build: derive PKG_SOURCE_DATE_EPOCH from the unpacked source tree
Signed-off-by: Paul Spooren <mail@aparcar.org>