### PR TITLE
scripts: dhcpv6: harmonize IAID between IA_NA and IA_PD requests

### DIFF
--- a/package/network/ipv6/odhcp6c/files/dhcpv6.sh
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 . /lib/functions.sh
+. /lib/functions/network.sh
 . ../netifd-proto.sh
 . /lib/config/uci.sh
 init_proto "$@"
@@ -9,7 +10,7 @@ proto_dhcpv6_init_config() {
 	renew_handler=1
 
 	proto_config_add_string 'reqaddress:or("try","force","none")'
-	proto_config_add_string 'reqprefix:or("auto","no",range(0, 64))'
+	proto_config_add_string reqprefix
 	proto_config_add_string clientid
 	proto_config_add_string 'reqopts:list(uinteger)'
 	proto_config_add_string 'defaultreqopts:bool'
@@ -85,7 +86,25 @@ proto_dhcpv6_setup() {
 	[ -n "$reqaddress" ] && append opts "-N$reqaddress"
 
 	[ -z "$reqprefix" -o "$reqprefix" = "auto" ] && reqprefix=0
-	[ "$reqprefix" != "no" ] && append opts "-P$reqprefix"
+	[ "$reqprefix" != "no" ] && {
+		# append interface IAID if none specified
+		local iaid=$(echo -n $reqprefix | sed -nr 's/^.*:([0-9A-Fa-f]{1,8})$/\1/p')
+		[ -z "$iaid" ] && {
+			network_generate_iface_iaid iaid "$iface"
+			reqprefix="$reqprefix:$iaid"
+		}
+		# validate prefix/length hint
+		local hint=${reqprefix%:$iaid}
+		[ "${hint#/}" -le "128" ] 2>/dev/null && {
+			reqprefix=${reqprefix#/}
+		} || {
+			validate_data cidr6 "$hint" 2>/dev/null || {
+				reqprefix="0:$iaid"
+				logger -p warn -t dhcpv6 "$iface: ignoring invalid prefix hint"
+			}
+		}
+		append opts "-P$reqprefix"
+	}
 
 	[ -n "$clientid" ] && {
 		clientid="$(hexdump_2hex "$clientid")"


### PR DESCRIPTION
For DHCPv6 address requests (IA_NA), `odhcp6c` currently uses the first eight digits of the i/f name's MD5 hash as IAID (pre-25.12: always "1").

In case of DHCPv6-PD, however, `odhcp6c` expects the IAID to be specified explicitly for the IA_PD(s) requested, otherwise it will start counting the IAID from "1" up for each "-P" argument (it supports multiple).

As OpenWrt only requests a single IA_PD per interface, make sure to pass the identical IAID for IA_PD to `odhcpc` as is used for IA_NA, unless a custom IAID was [explicitly specified](https://openwrt.org/docs/guide-user/network/ipv6/configuration#client_identifiers) in the i/f configuration.

This prevents regressions with ISPs that expect an IA_PD request to come from the same IAID+DUID combination as the IA_NA request.

Move the setting validation for `reqprefix` (that somehow wasn't working anyway) from the `init` to the `setup` codeblock and improve it to catch most invalid `reqprefix` values. Similar to #23662, invalid settings could previously cause 100% CPU load due to endless `netifd` reinvoke loop.

It may be appropriate to merge this PR not only into Main, but also into 25.12, due to likely fixing the below issues (and maybe more) that were introduced during the 25.12-rc phase.

Fixes: #20815
Fixes: #21350 (possibly)
Fixes: #22309 (possibly)