### PR TITLE
realtek: pcs: unify some setup steps

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -4106,50 +4106,47 @@ static int rtpcs_pcs_config(struct phylink_pcs *pcs, unsigned int neg_mode,
 	if (ret < 0) {
 		dev_err(ctrl->dev, "SerDes %u doesn't support %s mode\n", sds->id,
 			phy_modes(interface));
-		return -ENOTSUPP;
+		return -EOPNOTSUPP;
 	}
 
-	mutex_lock(&ctrl->lock);
+	scoped_guard(mutex, &ctrl->lock) {
+		if (sds->hw_mode != hw_mode) {
+			dev_info(ctrl->dev, "configure SerDes %u for mode %s\n", sds->id,
+				 phy_modes(interface));
 
-	if (sds->hw_mode != hw_mode) {
-		dev_info(ctrl->dev, "configure SerDes %u for mode %s\n", sds->id,
-			 phy_modes(interface));
+			ret = rtpcs_sds_config_polarity(sds, interface);
+			if (ret < 0) {
+				dev_err(ctrl->dev, "failed to configure polarity of SerDes %u\n",
+					sds->id);
+				return ret;
+			}
 
-		ret = rtpcs_sds_config_polarity(sds, interface);
-		if (ret < 0) {
-			dev_err(ctrl->dev, "failed to configure polarity of SerDes %u\n",
-				sds->id);
-			goto out;
-		}
-
-		ret = sds->ops->deactivate(sds);
-		if (ret < 0)
-			goto out;
-
-		ret = ctrl->cfg->setup_serdes(sds, hw_mode);
-		if (ret < 0)
-			goto out;
-
-		ret = sds->ops->activate(sds);
-		if (ret < 0)
-			goto out;
-
-		if (sds->ops->post_config) {
-			ret = sds->ops->post_config(sds, hw_mode);
+			ret = sds->ops->deactivate(sds);
 			if (ret < 0)
-				goto out;
-		}
+				return ret;
 
-		sds->first_start = false;
-	} else {
-		dev_dbg(ctrl->dev, "SerDes %u already in mode %s, no change\n",
-			 sds->id, phy_modes(interface));
+			ret = ctrl->cfg->setup_serdes(sds, hw_mode);
+			if (ret < 0)
+				return ret;
+
+			ret = sds->ops->activate(sds);
+			if (ret < 0)
+				return ret;
+
+			if (sds->ops->post_config) {
+				ret = sds->ops->post_config(sds, hw_mode);
+				if (ret < 0)
+					return ret;
+			}
+
+			sds->first_start = false;
+		} else
+			dev_dbg(ctrl->dev, "SerDes %u already in mode %s, no change\n",
+				 sds->id, phy_modes(interface));
+
+		ret = sds->ops->set_autoneg(sds, neg_mode, advertising);
 	}
 
-	ret = sds->ops->set_autoneg(sds, neg_mode, advertising);
-
-out:
-	mutex_unlock(&ctrl->lock);
 	return ret;
 }
 

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -195,6 +195,10 @@ struct rtpcs_sds_ops {
 	int (*config_polarity)(struct rtpcs_serdes *sds, unsigned int tx_pol,
 			       unsigned int rx_pol);
 
+	/* required: power down before reconfiguration */
+	int (*deactivate)(struct rtpcs_serdes *sds);
+	/* required: power back up */
+	int (*activate)(struct rtpcs_serdes *sds);
 	/* optional: finalization that must follow power-up, e.g. RX calibration */
 	int (*post_config)(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode);
 };
@@ -891,8 +895,6 @@ static int rtpcs_838x_setup_serdes(struct rtpcs_serdes *sds,
 {
 	int ret;
 
-	rtpcs_838x_sds_deactivate(sds);
-
 	rtpcs_838x_sds_patch(sds, hw_mode);
 
 	ret = rtpcs_838x_sds_set_mode(sds, hw_mode);
@@ -902,9 +904,6 @@ static int rtpcs_838x_setup_serdes(struct rtpcs_serdes *sds,
 	sds->hw_mode = hw_mode;
 
 	rtpcs_838x_sds_reset(sds);
-
-	rtpcs_838x_sds_activate(sds);
-
 	return 0;
 }
 
@@ -1139,6 +1138,20 @@ static int rtpcs_839x_init(struct rtpcs_ctrl *ctrl)
 	for (int sds_id = 0; sds_id < ctrl->cfg->serdes_count; sds_id++)
 		rtpcs_839x_sds_reset(&ctrl->serdes[sds_id]);
 
+	return 0;
+}
+
+/*
+ * These no-op stubs satisfy the mandatory activate/deactivate contract until
+ * real power sequencing is implemented.
+ */
+static int rtpcs_839x_sds_deactivate(struct rtpcs_serdes *sds)
+{
+	return 0;
+}
+
+static int rtpcs_839x_sds_activate(struct rtpcs_serdes *sds)
+{
 	return 0;
 }
 
@@ -3060,10 +3073,6 @@ static int rtpcs_930x_setup_serdes(struct rtpcs_serdes *sds,
 {
 	int ret;
 
-	ret = rtpcs_930x_sds_deactivate(sds);
-	if (ret < 0)
-		return ret;
-
 	/* Apply configuration for a hardware mode to SerDes */
 	ret = rtpcs_930x_sds_config_hw_mode(sds, hw_mode);
 	if (ret < 0)
@@ -3086,8 +3095,6 @@ static int rtpcs_930x_setup_serdes(struct rtpcs_serdes *sds,
 		return ret;
 
 	sds->hw_mode = hw_mode;
-
-	rtpcs_930x_sds_activate(sds);
 
 	return 0;
 }
@@ -3856,8 +3863,6 @@ static int rtpcs_931x_setup_serdes(struct rtpcs_serdes *sds,
 	enum rtpcs_sds_media sds_media;
 	int ret;
 
-	rtpcs_931x_sds_deactivate(sds);
-
 	ret = rtpcs_931x_sds_config_hw_mode(sds, hw_mode);
 	if (ret < 0)
 		return ret;
@@ -3892,7 +3897,6 @@ static int rtpcs_931x_setup_serdes(struct rtpcs_serdes *sds,
 
 	sds->hw_mode = hw_mode;
 
-	rtpcs_931x_sds_activate(sds);
 	return 0;
 }
 
@@ -4118,7 +4122,15 @@ static int rtpcs_pcs_config(struct phylink_pcs *pcs, unsigned int neg_mode,
 			goto out;
 		}
 
+		ret = sds->ops->deactivate(sds);
+		if (ret < 0)
+			goto out;
+
 		ret = ctrl->cfg->setup_serdes(sds, hw_mode);
+		if (ret < 0)
+			goto out;
+
+		ret = sds->ops->activate(sds);
 		if (ret < 0)
 			goto out;
 
@@ -4407,6 +4419,8 @@ static const struct rtpcs_sds_ops rtpcs_838x_sds_ops = {
 	.write			= rtpcs_generic_sds_op_write,
 	.set_autoneg		= rtpcs_generic_sds_set_autoneg,
 	.restart_autoneg	= rtpcs_generic_sds_restart_autoneg,
+	.deactivate		= rtpcs_838x_sds_deactivate,
+	.activate		= rtpcs_838x_sds_activate,
 	.post_config		= rtpcs_838x_sds_post_config,
 };
 
@@ -4445,6 +4459,8 @@ static const struct rtpcs_sds_ops rtpcs_839x_sds_ops = {
 	.write			= rtpcs_generic_sds_op_write,
 	.set_autoneg		= rtpcs_generic_sds_set_autoneg,
 	.restart_autoneg	= rtpcs_generic_sds_restart_autoneg,
+	.deactivate		= rtpcs_839x_sds_deactivate,
+	.activate		= rtpcs_839x_sds_activate,
 };
 
 static const struct rtpcs_sds_regs rtpcs_839x_sds_regs = {
@@ -4488,6 +4504,8 @@ static const struct rtpcs_sds_ops rtpcs_930x_sds_ops = {
 	.reset_cmu		= rtpcs_930x_sds_reset_cmu,
 	.reconfigure_to_pll	= rtpcs_930x_sds_reconfigure_to_pll,
 	.config_polarity	= rtpcs_930x_sds_config_polarity,
+	.deactivate		= rtpcs_930x_sds_deactivate,
+	.activate		= rtpcs_930x_sds_activate,
 	.post_config		= rtpcs_930x_sds_post_config,
 };
 
@@ -4531,6 +4549,8 @@ static const struct rtpcs_sds_ops rtpcs_931x_sds_ops = {
 	.set_pll_select		= rtpcs_931x_sds_set_pll_select,
 	.reconfigure_to_pll	= rtpcs_931x_sds_reconfigure_to_pll,
 	.config_polarity	= rtpcs_931x_sds_config_polarity,
+	.deactivate		= rtpcs_931x_sds_deactivate,
+	.activate		= rtpcs_931x_sds_activate,
 };
 
 static const struct rtpcs_sds_regs rtpcs_931x_sds_regs = {

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3070,6 +3070,8 @@ static int rtpcs_930x_setup_serdes(struct rtpcs_serdes *sds,
 	 */
 	rtpcs_sds_write_bits(sds, 0x1f, 11, 1, 1, 1);
 
+	rtpcs_930x_sds_tx_config(sds, hw_mode);
+
 	/* Enable SDS in desired mode */
 	ret = rtpcs_930x_sds_set_mode(sds, hw_mode);
 	if (ret < 0)
@@ -3080,7 +3082,7 @@ static int rtpcs_930x_setup_serdes(struct rtpcs_serdes *sds,
 	rtpcs_930x_sds_activate(sds);
 
 	if (hw_mode == RTPCS_SDS_MODE_QSGMII)
-		goto skip_cali;
+		return 0;
 
 	/* Calibrate SerDes receiver in loopback mode */
 	rtpcs_930x_sds_10g_idle(sds);
@@ -3091,10 +3093,6 @@ static int rtpcs_930x_setup_serdes(struct rtpcs_serdes *sds,
 	} while (rtpcs_930x_sds_check_calibration(sds, hw_mode) && calib_tries < 3);
 	if (calib_tries >= 3)
 		pr_warn("%s: SerDes RX calibration failed\n", __func__);
-
-skip_cali:
-	/* Leave loopback mode */
-	rtpcs_930x_sds_tx_config(sds, hw_mode);
 
 	return 0;
 }

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -194,6 +194,9 @@ struct rtpcs_sds_ops {
 
 	int (*config_polarity)(struct rtpcs_serdes *sds, unsigned int tx_pol,
 			       unsigned int rx_pol);
+
+	/* optional: finalization that must follow power-up, e.g. RX calibration */
+	int (*post_config)(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode);
 };
 
 struct rtpcs_sds_reg_field {
@@ -902,6 +905,11 @@ static int rtpcs_838x_setup_serdes(struct rtpcs_serdes *sds,
 
 	rtpcs_838x_sds_activate(sds);
 
+	return 0;
+}
+
+static int rtpcs_838x_sds_post_config(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode)
+{
 	/*
 	 * Run a switch queue reset after the first start of a SerDes. This recovers ports that
 	 * were already connected during boot and will not pass traffic. Sometimes the bug can
@@ -3050,7 +3058,7 @@ static int rtpcs_930x_sds_cmu_band_get(struct rtpcs_serdes *sds)
 static int rtpcs_930x_setup_serdes(struct rtpcs_serdes *sds,
 				   enum rtpcs_sds_mode hw_mode)
 {
-	int calib_tries = 0, ret;
+	int ret;
 
 	ret = rtpcs_930x_sds_deactivate(sds);
 	if (ret < 0)
@@ -3080,6 +3088,13 @@ static int rtpcs_930x_setup_serdes(struct rtpcs_serdes *sds,
 	sds->hw_mode = hw_mode;
 
 	rtpcs_930x_sds_activate(sds);
+
+	return 0;
+}
+
+static int rtpcs_930x_sds_post_config(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode)
+{
+	int calib_tries = 0;
 
 	if (hw_mode == RTPCS_SDS_MODE_QSGMII)
 		return 0;
@@ -4107,6 +4122,12 @@ static int rtpcs_pcs_config(struct phylink_pcs *pcs, unsigned int neg_mode,
 		if (ret < 0)
 			goto out;
 
+		if (sds->ops->post_config) {
+			ret = sds->ops->post_config(sds, hw_mode);
+			if (ret < 0)
+				goto out;
+		}
+
 		sds->first_start = false;
 	} else {
 		dev_dbg(ctrl->dev, "SerDes %u already in mode %s, no change\n",
@@ -4386,6 +4407,7 @@ static const struct rtpcs_sds_ops rtpcs_838x_sds_ops = {
 	.write			= rtpcs_generic_sds_op_write,
 	.set_autoneg		= rtpcs_generic_sds_set_autoneg,
 	.restart_autoneg	= rtpcs_generic_sds_restart_autoneg,
+	.post_config		= rtpcs_838x_sds_post_config,
 };
 
 static const struct rtpcs_sds_regs rtpcs_838x_sds_regs = {
@@ -4466,6 +4488,7 @@ static const struct rtpcs_sds_ops rtpcs_930x_sds_ops = {
 	.reset_cmu		= rtpcs_930x_sds_reset_cmu,
 	.reconfigure_to_pll	= rtpcs_930x_sds_reconfigure_to_pll,
 	.config_polarity	= rtpcs_930x_sds_config_polarity,
+	.post_config		= rtpcs_930x_sds_post_config,
 };
 
 static const struct rtpcs_sds_regs rtpcs_930x_sds_regs = {


### PR DESCRIPTION
This series carves out post-config steps for specific SerDes and moves some setup steps into pcs_config, establishing a unified setup sequence. setup_serdes is kept in the middle for now to retain behavior but will be slimmed down further.
