### PR TITLE
ramips: mt7620: add ZBT WE826-T2 (32M) support

### DIFF
--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we826-t-32m.dts
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we826-t-32m.dts
@@ -1,0 +1,15 @@
+#include "mt7620a_zbtlink_zbt-we826-t.dtsi"
+
+/ {
+	compatible = "zbtlink,zbt-we826-t-32m", "zbtlink,zbt-we826-t", "ralink,mt7620a-soc";
+	model = "Zbtlink ZBT-WE826-T2 (32M)";
+};
+
+&flash0 {
+	broken-flash-reset;
+};
+
+&firmware {
+	reg = <0x50000 0x1fb0000>;
+};
+

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we826-t.dtsi
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we826-t.dtsi
@@ -1,0 +1,144 @@
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "zbtlink,zbt-we826-t", "ralink,mt7620a-soc";
+
+	aliases {
+		led-boot = &led_wlan;
+		led-failsafe = &led_wlan;
+		led-running = &led_wlan;
+		led-upgrade = &led_wlan;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		4g {
+			function = "4g";
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_wlan: wlan {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash0: flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x200>;
+					};
+
+					macaddr_factory_28: macaddr@28 {
+						reg = <0x28 0x6>;
+					};
+				};
+			};
+
+			firmware: partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				/* reg property is set based on flash size in DTS files */
+			};
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+
+	mediatek,portmap = "llllw";
+};
+
+&wmac {
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};
+
+&state_default {
+	default {
+		groups = "i2c", "uartf", "wled", "spi refclk", "pa";
+		function = "gpio";
+	};
+};
+
+&pcie {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -1585,6 +1585,17 @@ define Device/zbtlink_zbt-we826-e
 endef
 TARGET_DEVICES += zbtlink_zbt-we826-e
 
+define Device/zbtlink_zbt-we826-t-32m
+  SOC := mt7620a
+  IMAGE_SIZE := 32448k
+  DEVICE_VENDOR := Zbtlink
+  DEVICE_MODEL := ZBT-WE826-T2
+  DEVICE_VARIANT := 32M
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci kmod-mmc-mtk
+  SUPPORTED_DEVICES += zbt-we826-t
+endef
+TARGET_DEVICES += zbtlink_zbt-we826-t-32m
+
 define Device/zbtlink_zbt-wr8305rt
   SOC := mt7620n
   IMAGE_SIZE := 7872k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -290,6 +290,9 @@ zbtlink,zbt-we1026-h-32m)
 zbtlink,zbt-we2026)
 	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan" "wlan0"
 	;;
+zbtlink,zbt-we826-t-32m)
+	ucidef_set_led_wlan "wlan" "Wi-Fi" "blue:wlan" "phy0tpt"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -28,6 +28,7 @@ ramips_setup_interfaces()
 	zbtlink,zbt-we826-16m|\
 	zbtlink,zbt-we826-32m|\
 	zbtlink,zbt-we826-e|\
+	zbtlink,zbt-we826-t-32m|\
 	zbtlink,zbt-wr8305rt|\
 	zyxel,keenetic-lite-iii-a|\
 	zyxel,keenetic-omni)
@@ -328,7 +329,8 @@ ramips_setup_macs()
 		;;
 	alfa-network,ac1200rm|\
 	dlink,dir-810l|\
-	trendnet,tew-810dr)
+	trendnet,tew-810dr|\
+	zbtlink,zbt-we826-t-32m)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x28)" 1)
 		;;
 	alfa-network,r36m-e4g|\


### PR DESCRIPTION
I got some WE826-T2 4G routers from Zhibotong Electronics, that came with 256 MB ram and 32 MB flash.

```
Specification
-------------
SOC         : MT7620A 580 MHz
RAM         : 256 MB
FLASH       : 32 MB SPI-NOR
WIFI        : 2.4 GHz
ETHERNET    : 4x LAN (100 Mbit), 1x WAN (100 Mbit)
BUTTONS     : 1x Reset
LEDS        : 1x Power, 1x USB, 1x WIFI, 1x WAN, 4x LAN
POWER       : 12V VDC 1A

```
While the variants already supported use zbtlink,zbt-we826 as the board, the -T2 variant uses zbtlink,zbt-we826-t in the vendor DTS, and seems to use different LED GPIOs and MAC locations (0x28 instead of 0x04).

Only the power LED is red, all others are blue.

MAC addresses as verified by OEM firmware:

```
vendor   OpenWrt   address
wmac     pyh0      factory + 0
ethernet eth0      factory + 0x28
```

Everything is working, as in the non-T2 variants.

Installation
------------
Vendor UI
---------
1. Browse to http://192.168.1.1 and login.
2. Navigate to "System" -> "Backup / Flash Firmware".
3. Press the "Select File" button and upload the sysupgrade.bin
4. Confirm the security questions, wait for a reboot and enjoy OpenWrt.

Recovery UI
-----------
1. Set your IP address to 192.168.1.2, subnet 255.255.255.0.
2. Power on the device while holding reset.
3. Release reset once the wireless led starts to blink rapidly
4. Open a chrome- or firefox based browser and browse to http://192.168.1.1
5. Upload the sysupgrade.bin, wait for a reboot and enjoy OpenWrt.
