### PR TITLE
ath10k: lower beacon_int_min_gcd for multi-BSS 10.4 combination

### DIFF
--- a/package/kernel/mac80211/patches/ath10k/992-ath10k-bcn-int-min-gcd-50.patch
+++ b/package/kernel/mac80211/patches/ath10k/992-ath10k-bcn-int-min-gcd-50.patch
@@ -1,0 +1,11 @@
+--- a/drivers/net/wireless/ath/ath10k/mac.c
++++ b/drivers/net/wireless/ath/ath10k/mac.c
+@@ -9879,7 +9879,7 @@ ieee80211_iface_combination ath10k_10_4_bcn_int_if_comb[] = {
+ 		.max_interfaces = 16,
+ 		.num_different_channels = 1,
+ 		.beacon_int_infra_match = true,
+-		.beacon_int_min_gcd = 100,
++		.beacon_int_min_gcd = 50,
+ #ifdef CPTCFG_ATH10K_DFS_CERTIFIED
+ 		.radar_detect_widths =  BIT(NL80211_CHAN_WIDTH_20_NOHT) |
+ 					BIT(NL80211_CHAN_WIDTH_20) |


### PR DESCRIPTION
The ath10k_10_4_bcn_int_if_comb combination is selected when the
firmware sets WMI_SERVICE_VDEV_DIFFERENT_BEACON_INTERVAL_SUPPORT,
indicating it can manage independent beacon intervals per VDEV.

The current beacon_int_min_gcd of 100 forces the GCD of all concurrent
AP beacon intervals to be at least 100 TUs, silently blocking the
widely-used 50 TU beacon interval in multi-BSS configurations.

When the primary BSS starts at beacon_int=50 TU, any subsequent BSS
opening on the same phy fails with EBUSY: cfg80211_iter_combinations()
computes GCD=50 from the running BSS, then rejects the combination
because 50 < beacon_int_min_gcd (100).

Lower the minimum GCD to 50 to permit 50 TU beacon intervals across
multiple BSSes. Tested on QCA9984/QCA9994 (three concurrent APs at
50 TU).

Signed-off-by: S. Hoot <spoot_hoot@protonmail.com>