### PR TITLE
realtek: add support for Hasivo S1300WP-8XGT-4S+

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -102,6 +102,7 @@ realtek_setup_macs()
 	hasivo,f1100w-4sx-4xgt|\
 	hasivo,f1100w-4sx-4xgt-512mb|\
 	hasivo,f5800w-12s-plus|\
+	hasivo,s1300wp-8xgt-4s-plus|\
 	tplink,tl-st1008f-v2|\
 	zyxel,xgs1010-12-a1|\
 	zyxel,xgs1010-12-b1)

--- a/target/linux/realtek/base-files/etc/uci-defaults/99_fwenv-store-ethaddr
+++ b/target/linux/realtek/base-files/etc/uci-defaults/99_fwenv-store-ethaddr
@@ -44,6 +44,7 @@ case "$(board_name)" in
 hasivo,f1100w-4sx-4xgt|\
 hasivo,f1100w-4sx-4xgt-512mb|\
 hasivo,f5800w-12s-plus|\
+hasivo,s1300wp-8xgt-4s-plus|\
 tplink,tl-st1008f-v2)
 	env_ethaddr=$(macaddr_canonicalize "$(fw_printenv -n ethaddr 2>/dev/null)")
 	ethaddr_prefix=$(echo "$env_ethaddr" | cut -d: -f1-5)

--- a/target/linux/realtek/dts/rtl9313_hasivo_s1300wp-8xgt-4s-plus.dts
+++ b/target/linux/realtek/dts/rtl9313_hasivo_s1300wp-8xgt-4s-plus.dts
@@ -1,0 +1,320 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl931x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/phy/phy.h>
+
+/ {
+	compatible = "hasivo,s1300wp-8xgt-4s-plus", "realtek,rtl9313-soc";
+	model = "Hasivo S1300WP-8XGT-4S+";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>,
+		      <0x90000000 0x10000000>;
+	};
+
+	aliases {
+		label-mac-device = &ethernet0;
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+	};
+
+	chosen {
+		stdout-path = "serial0:38400n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	sfp9: sfp-p9 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sda8>;
+		los-gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp10: sfp-p10 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sda6>;
+		los-gpios = <&gpio0 10 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp11: sfp-p11 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sda0>;
+		los-gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp12: sfp-p12 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sda1>;
+		los-gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	i2c_sys: i2c-system {
+		compatible = "i2c-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinmux_disable_jtag>;
+
+		scl-gpios = <&gpio0 4 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		sda-gpios = <&gpio0 3 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <28>;
+
+		rtc@51 {
+			compatible = "nxp,pcf8563";
+			reg = <0x51>;
+		};
+
+		mcu_mgmt: mcu@6f {
+			compatible = "hasivo,stc8-mfd", "syscon";
+			reg = <0x6f>;
+
+			mcu_wdt: watchdog {
+				compatible = "hasivo,mcu-wdt";
+			};
+
+			sensor {
+				compatible = "hasivo,mcu-sensor";
+			};
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_sys: led-0 {
+			gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+
+	led_set {
+		compatible = "realtek,rtl9300-leds";
+		active-low;
+
+		led_set0 = <(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_LINK |
+			     RTL93XX_LED_SET_ACT)
+			    (RTL93XX_LED_SET_5G | RTL93XX_LED_SET_2P5G |
+			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+			    (RTL93XX_LED_SET_1G | RTL93XX_LED_SET_100M |
+			     RTL93XX_LED_SET_10M | RTL93XX_LED_SET_LINK |
+			     RTL93XX_LED_SET_ACT)>;
+	};
+};
+
+&i2c_mst1 {
+	status = "okay";
+
+	i2c1_sda0: i2c@0 { reg = <0>; };
+	i2c1_sda1: i2c@1 { reg = <1>; };
+	i2c1_sda6: i2c@6 { reg = <6>; };
+	i2c1_sda8: i2c@8 { reg = <8>; };
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x0e0000>;
+				read-only;
+			};
+
+			/* stock layout calls this BDINFO; it holds the U-Boot environment */
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0x0e0000 0x010000>;
+				read-only;
+			};
+
+			/* stock layout calls this SYSINFO */
+			partition@f0000 {
+				label = "u-boot-env2";
+				reg = <0x0f0000 0x010000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "cfg";
+				reg = <0x100000 0x100000>;
+			};
+
+			partition@200000 {
+				label = "log";
+				reg = <0x200000 0x100000>;
+			};
+
+			partition@300000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				reg = <0x300000 0x1d00000>;
+			};
+		};
+	};
+};
+
+&mdio_ctrl {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinmux_enable_mdc_mdio_0>,
+		    <&pinmux_enable_mdc_mdio_1>;
+};
+
+&mdio_bus0 {
+	/* RTL8264 quad-PHY package */
+	ethernet-phy-package@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0>;
+
+		PHY_C45(0,  0)
+		PHY_C45(8,  1)
+		PHY_C45(16, 2)
+		PHY_C45(24, 3)
+	};
+};
+
+&mdio_bus1 {
+	/* RTL8264 quad-PHY package */
+	ethernet-phy-package@4 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <4>;
+
+		PHY_C45(32, 4)
+		PHY_C45(40, 5)
+		PHY_C45(48, 6)
+		PHY_C45(50, 7)
+	};
+};
+
+&phy0 {
+	tx-polarity = <PHY_POL_INVERT>;
+	realtek,enable-pma-low-power;
+};
+
+&phy8 {
+	tx-polarity = <PHY_POL_INVERT>;
+	rx-polarity = <PHY_POL_INVERT>;
+	realtek,enable-pma-low-power;
+};
+
+&phy16 {
+	tx-polarity = <PHY_POL_INVERT>;
+	realtek,enable-pma-low-power;
+};
+
+&phy24 {
+	tx-polarity = <PHY_POL_INVERT>;
+	rx-polarity = <PHY_POL_INVERT>;
+	realtek,enable-pma-low-power;
+};
+
+&phy32 {
+	tx-polarity = <PHY_POL_INVERT>;
+	realtek,enable-pma-low-power;
+};
+
+&phy40 {
+	tx-polarity = <PHY_POL_INVERT>;
+	rx-polarity = <PHY_POL_INVERT>;
+	realtek,enable-pma-low-power;
+};
+
+&phy48 {
+	tx-polarity = <PHY_POL_INVERT>;
+	realtek,enable-pma-low-power;
+};
+
+&phy50 {
+	tx-polarity = <PHY_POL_INVERT>;
+	rx-polarity = <PHY_POL_INVERT>;
+	realtek,enable-pma-low-power;
+};
+
+&switch0 {
+	ethernet-ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT_LED(0,  1, 2, 0, 0, usxgmii)
+		SWITCH_PORT_LED(8,  2, 3, 0, 0, usxgmii)
+		SWITCH_PORT_LED(16, 3, 4, 0, 0, usxgmii)
+		SWITCH_PORT_LED(24, 4, 5, 0, 0, usxgmii)
+		SWITCH_PORT_LED(32, 5, 6, 0, 0, usxgmii)
+		SWITCH_PORT_LED(40, 6, 7, 0, 0, usxgmii)
+		SWITCH_PORT_LED(48, 7, 8, 0, 0, usxgmii)
+		SWITCH_PORT_LED(50, 8, 9, 0, 0, usxgmii)
+
+		SWITCH_PORT_SFP(52, 9,  10, 0, 9)
+		SWITCH_PORT_SFP(53, 10, 11, 0, 10)
+		SWITCH_PORT_SFP(54, 11, 12, 0, 11)
+		SWITCH_PORT_SFP(55, 12, 13, 0, 12)
+
+		port@56 {
+			ethernet = <&ethernet0>;
+			reg = <56>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&serdes2 { rx-polarity = <PHY_POL_INVERT>; };
+&serdes3 {
+	tx-polarity = <PHY_POL_INVERT>;
+	rx-polarity = <PHY_POL_INVERT>;
+};
+&serdes4 { rx-polarity = <PHY_POL_INVERT>; };
+&serdes5 {
+	tx-polarity = <PHY_POL_INVERT>;
+	rx-polarity = <PHY_POL_INVERT>;
+};
+&serdes6 { rx-polarity = <PHY_POL_INVERT>; };
+&serdes7 {
+	tx-polarity = <PHY_POL_INVERT>;
+	rx-polarity = <PHY_POL_INVERT>;
+};
+&serdes8 { rx-polarity = <PHY_POL_INVERT>; };
+&serdes9 {
+	tx-polarity = <PHY_POL_INVERT>;
+	rx-polarity = <PHY_POL_INVERT>;
+};
+
+&serdes10 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes11 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes12 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes13 { tx-polarity = <PHY_POL_INVERT>; };

--- a/target/linux/realtek/image/rtl931x.mk
+++ b/target/linux/realtek/image/rtl931x.mk
@@ -12,6 +12,17 @@ define Device/hasivo_f5800w-12s-plus
 endef
 TARGET_DEVICES += hasivo_f5800w-12s-plus
 
+define Device/hasivo_s1300wp-8xgt-4s-plus
+  SOC := rtl9313
+  DEVICE_VENDOR := Hasivo
+  DEVICE_MODEL := S1300WP-8XGT-4S+
+  IMAGE_SIZE := 29696k
+  DEVICE_PACKAGES := kmod-phy-realtek kmod-rtc-pcf8563 rtl826x-firmware \
+		     kmod-hasivo-mcu-wdt kmod-hasivo-mcu-sensor
+  $(Device/kernel-lzma)
+endef
+TARGET_DEVICES += hasivo_s1300wp-8xgt-4s-plus
+
 define Device/plasmacloud-common
   SOC := rtl9312
   UIMAGE_MAGIC := 0x93100000


### PR DESCRIPTION
Adds support for the Hasivo S1300WP-8XGT-4S+, a 12-port managed switch based on the Realtek RTL9313.

**Hardware**  
* RTL9313 SoC, 512 MB RAM, 32 MB SPI-NOR
* 8× 10GBASE-T copper (two RTL8264 quad PHYs)
* 4× SFP+ (10G)
* reset button, system LED, per-port LEDs
* PCF8563 RTC
* a small management MCU on i2c that handles the watchdog and the temperature/fan readings
* POE hs104 ... 
  
**What works:** 
* Switching on all copper and SFP+ ports, per-port and system LEDs, reset button, RTC, watchdog, and temperature/fan monitoring.

**Not supported yet:** 
* PoE (the PSE chips are on the board but I haven't touched them here) and the front-panel USB port, but we will have it soon both up running... 
 
**A few things worth flagging:**
This is based on the two PRs, that have to be completed first... 
* #23762 - the MCU MFD / watchdog / hwmon drivers
* #23726 -  the rtl826x phy patch-table fix (the copper ports need it)
Once those land I'll rebase and the extra commits drop off, leaving just the board commit.

The MFD/watchdog/sensor drivers are built in (=y) instead of modules, on purpose. The MCU runs a watchdog that resets the board, and a module loads too late; the board reboots before it comes up. Built-in is the only way it survives boot. It does get compiled for the whole rtl931x subtarget, but the drivers only probe when the device tree has the matching nodes, so the other boards shouldn't be affected.

The SFP cages are a little unusual: there's no real module-presence pin on a GPIO,  presence seems to be detected over i2c, the same way the stock firmware does it. The GPIO each cage does have is actually RX_LOS, but I bound it as mod-def0, because that's the only per-cage signal the sfp driver can use as a hotplug trigger. Without it, a module plugged in after boot won't come up until a reboot. So thats the reason to not switch it to los-gpios, it would quietly breaks hotplug. I would be glad to get input if that's okay.

~~The board.d entry pins a fixed lan_list. The copper PHYs finish probing 24 s into boot, after config_generate already ran, so auto-detection comes up empty and you'd get an empty LAN bridge. Pinning the list works around that. That I have mentioned in the  #23766 , maybe someone has some ideas here...~~

**Installation**

  Connect serial (38400 8N1) and interrupt U-Boot (ctrl+c z h). The MCU watchdog resets the board while beeing in U-Boot too, so a single long upload via ymodem won't make it on time; either disable the watchdog first over i2c (reg 0x09=0x4F, then 0x0A=0x3F) or write the image in smaller chunks (which I did). For me I could not get any copper up with (rtk network on). Then load the sysupgrade image and write it to the firmware partition. Full steps + a [helper script](https://gist.github.com/carlosz1986/b914112ced5450f6dfe6437d8ad0635a) I will add later to wiki. 