### PR TITLE
mediatek: mt7981b: add support for Comfast CF-E391AX

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-comfast-cf-e391ax.dts
+++ b/target/linux/mediatek/dts/mt7981b-comfast-cf-e391ax.dts
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: EUPL-1.2
+
+/dts-v1/;
+
+#include "mt7981b.dtsi"
+
+/ {
+	model = "COMFAST CF-E391AX";
+	compatible = "comfast,cf-e391ax", "mediatek,mt7981";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_red;
+		led-failsafe = &led_red;
+		led-running = &led_blue;
+		led-upgrade = &led_green;
+	};
+
+	chosen {
+		bootargs-override = "console=ttyS0,115200n8";
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000>, <0 0x10000000>;
+		device_type = "memory";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_blue: blue {
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_red: red {
+			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_green: green {
+			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	/* LAN 1G - YT8531 */
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-handle = <&phy_yt8531>;
+		phy-mode = "sgmii";
+		nvmem-cells = <&macaddr_factory_e000 0>;
+		nvmem-cell-names = "mac-address";
+		managed = "in-band-status";
+		max-speed = <1000>;
+	};
+
+	/* WAN 2.5G - GPY211 */
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-handle = <&phy_gpy211>;
+		phy-mode = "2500base-x";
+		nvmem-cells = <&macaddr_factory_e000 1>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&mdio_bus {
+	status = "okay";
+
+	/delete-node/ ethernet-phy@0;
+
+	phy_yt8531: phy@3 {
+		reg = <3>;
+		compatible = "ethernet-phy-id4f51.e91a";
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;  /* 0x0c 0x27 */
+		reset-assert-us = <10000>;
+		reset-deassert-us = <50000>;
+	};
+
+	phy_gpy211: phy@5 {
+		reg = <5>;
+		compatible = "ethernet-phy-id67c9.de10";
+		reset-gpios = <&pio 14 GPIO_ACTIVE_LOW>;  /* 0x0c 0x0e */
+		reset-assert-us = <600>;
+		reset-deassert-us = <20000>;
+	};
+};
+
+&crypto {
+	status = "okay";
+};
+
+/* pinctrl@11d00000 */
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+
+};
+
+
+/* spi@1100a000 */
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	spi_nand: spi_nand@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4E 0x41 0x4E 0x44>; /* SPINAND */
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x00000 0x0100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x0100000 0x0080000>;
+				read-only;
+			};
+
+			factory: partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x0200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					/* WiFi MAC */
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_factory_8000: macaddr@8000 {
+						compatible = "mac-base";
+						reg = <0x8000 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					/* ethernet MAC */
+					macaddr_factory_e000: macaddr@e000 {
+						compatible = "mac-base";
+						reg = <0xe000 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x0200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x4000000>;
+				compatible = "linux,ubi";
+			};
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_4 0>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_4 1>; /* or <&macaddr_factory_8000 0> */;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&xhci {
+	status = "disabled";
+};
+
+&usb_phy {
+	status = "disabled";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -119,6 +119,9 @@ mediatek_setup_interfaces()
 	bananapi,bpi-r4-poe)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan sfp-wan"
 		;;
+	comfast,cf-e391ax)
+		ucidef_set_interfaces_lan_wan "eth0" eth1
+		;;
 	comfast,cf-e393ax)
 		ucidef_set_interfaces_lan_wan "lan1" eth1
 		;;

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -986,6 +986,30 @@ define Device/cmcc_rax3000m
 endef
 TARGET_DEVICES += cmcc_rax3000m
 
+define Device/comfast_cf-e391ax
+  DEVICE_VENDOR := COMFAST
+  DEVICE_MODEL := CF-E391AX
+  DEVICE_DTS := mt7981b-comfast-cf-e391ax
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTC_FLAGS := --pad 4096
+  DEVICE_DTS_LOADADDR := 0x43f00000
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  KERNEL_LOADADDR := 0x44000000
+  KERNEL = kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS = kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 65536k
+  KERNEL_IN_UBI := 1
+  IMAGES := sysupgrade.bin factory.bin
+  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += comfast_cf-e391ax
+
 define Device/comfast_cf-e393ax
   DEVICE_VENDOR := COMFAST
   DEVICE_MODEL := CF-E393AX


### PR DESCRIPTION
This PR adds suppport for the Comfast CF-E391AX, a Wi-Fi 6 POE powered  access point, which looks similar to the Comfast CF E393AX but with a different hardware.

# Specifications
```
SoC:      Mediatek MT7981B
RAM:      256 MiB DDR3
Flash:    SPI-NAND 256 MiB
WiFi:     Mediatek MT7976CN
          2.4 GHz: 802.11b/g/n/ax (up to 40 MHz)
          5 GHz: 802.11a/b/g/n/ac/ax (up to 160 MHz)
Ethernet: 1× Motorcomm YT8531SC‑CA (10/100/1000Base‑T) — eth0
          1× MaxLinear GPY211 (10/100/1000/2500Base‑T) — eth1
LEDs:     1x status (blue, green, red)
Buttons:  Reset
Console:  3.3v, 115200n8
Power:    POE (802.3af/802.3at) powered via either RJ45
```

# Rooting
Uploading OpenWrt / rooting the AP does not require opening the case.
Console access requires opening the case; pinholes labeled VCC GND TX RX.
Rooting procedure referenced from the  [Comfast CF-E393AX initial pull request](https://github.com/openwrt/openwrt/pull/13959)

# Tests
Device has been used daily for over two months without issues: boot, Ethernet, Wi‑Fi and basic operation verified.


