### PR TITLE
airoha: fix integer division truncation in BMT pool size calculation

### DIFF
--- a/target/linux/airoha/patches-6.18/900-airoha-bmt-support.patch
+++ b/target/linux/airoha/patches-6.18/900-airoha-bmt-support.patch
@@ -15,8 +15,8 @@
 +
 +#define MAX_BMT_SIZE        	(250) 
 +#define MAX_RAW_BAD_BLOCK_SIZE  (250)
-+#define POOL_GOOD_BLOCK_PERCENT 8/100
-+#define MAX_BMT_PERCENT         1/8
++#define POOL_GOOD_BLOCK_PERCENT 8
++#define MAX_BMT_PERCENT         1
 +
 +typedef struct {
 +    char signature[3];
@@ -228,7 +228,7 @@
 +
 +	total_blks = bmtd.total_blks;
 +	last_blk = total_blks - 1;
-+	need_valid_block_num = total_blks * POOL_GOOD_BLOCK_PERCENT;
++	need_valid_block_num = total_blks * POOL_GOOD_BLOCK_PERCENT / 100;
 +
 +	for (; last_blk > 0 ;last_blk--) { 
 +		if (is_bad_raw(last_blk)) { 
@@ -241,7 +241,7 @@
 +	}
 +	bmt_blks = total_blks - last_blk; 
 +	system_blks = total_blks - bmt_blks;
-+	bmtd.mtd->size = (total_blks -  total_blks * MAX_BMT_PERCENT) * bmtd.mtd->erasesize;
++	bmtd.mtd->size = (total_blks -  total_blks * MAX_BMT_PERCENT / 8) * bmtd.mtd->erasesize;
 +}
 +
 +


### PR DESCRIPTION
## Bug: Integer Division Truncation in BMT Macros

The macros `POOL_GOOD_BLOCK_PERCENT` and `MAX_BMT_PERCENT` in
`target/linux/airoha/patches-6.18/900-airoha-bmt-support.patch`
use C integer division which evaluates to **zero**:

```c
#define POOL_GOOD_BLOCK_PERCENT 8/100    /* evaluates to 0, not 0.08 */
#define MAX_BMT_PERCENT         1/8     /* evaluates to 0, not 0.125 */
```

### Impact

1. **`need_valid_block_num = total_blks * POOL_GOOD_BLOCK_PERCENT`**
   → `= total_blks * 0 = 0`
   → No good blocks are reserved in the pool for bad block remapping.
   The BMT has no spare blocks to remap to when bad blocks are detected.

2. **`mtd->size = (total_blks - total_blks * MAX_BMT_PERCENT) * erasesize`**
   → `= (total_blks - 0) * erasesize`
   → The BMT area is not subtracted from the visible MTD size.
   The filesystem may write over BMT metadata blocks.

### Fix

Separate the multiplier from the divisor and apply division at the usage site:

```c
#define POOL_GOOD_BLOCK_PERCENT 8
#define MAX_BMT_PERCENT         1

need_valid_block_num = total_blks * POOL_GOOD_BLOCK_PERCENT / 100;  /* 8% */
bmtd.mtd->size = (total_blks - total_blks * MAX_BMT_PERCENT / 8) * bmtd.mtd->erasesize;  /* 12.5% */
```

### Discussion

Beyond this specific fix, the overall quality of `airoha_bmt.c` raises
questions about whether BMT is actively used on production Airoha devices:

- Heavy use of global variables and `module_param` for debugging
- Debug interface with direct flash operations via sysfs
- No proper error propagation in several paths

If BMT is not used on production devices (e.g., UBI-based devices handle
bad block management separately), this code may be candidates for
removal or a more thorough rewrite. Would appreciate input from
Airoha users and maintainers on the intended status of this driver.

Cc: @hurrian @Ansuel @YaleiZang
