### PR TITLE
thermal: airoha: fix wrong variable in TEMPOFFSETL regmap_write

### DIFF
--- a/target/linux/airoha/patches-6.18/402-01-thermal-airoha-convert-to-regmap-API.patch
+++ b/target/linux/airoha/patches-6.18/402-01-thermal-airoha-convert-to-regmap-API.patch
@@ -41,7 +41,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 -		writel(TEMP_TO_RAW(priv, low) >> 4,
 -		       priv->base + EN7581_TEMPOFFSETL);
 +		regmap_write(priv->map, EN7581_TEMPOFFSETL,
-+			     TEMP_TO_RAW(priv, high) >> 4);
++			     TEMP_TO_RAW(priv, low) >> 4);
  
  		enable_monitor = true;
  	}


### PR DESCRIPTION
## Bug
In the thermal driver regmap conversion patch, `regmap_write(priv->map, TEMPOFFSETL, TEMP_TO_RAW(priv, high))` writes the **high** trip temperature to the **TEMPOFFSETL** (low offset) register.

## Fix
Change `TEMP_TO_RAW(priv, high)` to `TEMP_TO_RAW(priv, low)` so the low trip value is written to the correct TEMPOFFSETL register.

## Impact
Without this fix, the low temperature offset register gets the high trip value, so the thermal zone low trip threshold is wrong. This could cause the thermal driver to miss low-temperature alerts or trigger them at incorrect temperatures.

Fixes: 402-01-thermal-airoha-convert-to-regmap-API