### PR TITLE
thermal: airoha: fix wrong variable in AN7583 error check

### DIFF
--- a/target/linux/airoha/patches-6.18/402-05-thermal-drivers-airoha-Add-support-for-AN7583.patch
+++ b/target/linux/airoha/patches-6.18/402-05-thermal-drivers-airoha-Add-support-for-AN7583.patch
@@ -231,8 +231,8 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 +	int i;
 +
 +	priv->chip_scu = device_node_to_regmap(dev->parent->of_node);
-+	if (IS_ERR(priv->map))
-+		return PTR_ERR(priv->map);
++	if (IS_ERR(priv->chip_scu))
++		return PTR_ERR(priv->chip_scu);
 +
 +	for (i = 0; i < AIROHA_THERMAL_FIELD_MAX; i++) {
 +		struct regmap_field *field;


### PR DESCRIPTION
## Bug
In `an7583_init()`, the code assigns `priv->chip_scu = device_node_to_regmap(...)` but then checks `IS_ERR(priv->map)` and returns `PTR_ERR(priv->map)`. The variable `priv->map` is not assigned in this function.

## Fix
Change `IS_ERR(priv->map)` to `IS_ERR(priv->chip_scu)` and `PTR_ERR(priv->map)` to `PTR_ERR(priv->chip_scu)` to check the variable that was just assigned.

## Impact
If `device_node_to_regmap()` fails, the error could be missed because `priv->map` might not reflect the failure, leading to a NULL pointer dereference when `priv->chip_scu` fields are accessed.

Fixes: 402-05-thermal-drivers-airoha-Add-support-for-AN7583