### PR TITLE
net: airoha: fix uninitialized dev in airoha_remove and airhoa typo

### DIFF
--- a/target/linux/airoha/patches-6.18/310-10-net-airoha-add-phylink-support-for-GDM2-3-4.patch
+++ b/target/linux/airoha/patches-6.18/310-10-net-airoha-add-phylink-support-for-GDM2-3-4.patch
@@ -41,7 +41,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	airoha_qdma_set_irqmask(irq_bank, index, mask, 0);
  }
  
-+static bool airhoa_is_phy_external(struct airoha_gdm_port *port)
++static bool airoha_is_phy_external(struct airoha_gdm_port *port)
 +{
 +	return port->id != 1;
 +}
@@ -53,7 +53,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	struct airoha_qdma *qdma = port->qdma;
  	u32 pse_port = FE_PSE_PORT_PPE1;
  
-+	if (airhoa_is_phy_external(port)) {
++	if (airoha_is_phy_external(port)) {
 +		err = phylink_of_phy_connect(port->phylink, dev->dev.of_node, 0);
 +		if (err) {
 +			netdev_err(dev, "%s: could not attach PHY: %d\n", __func__,
@@ -71,7 +71,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  		}
  	}
  
-+	if (airhoa_is_phy_external(port)) {
++	if (airoha_is_phy_external(port)) {
 +		phylink_stop(port->phylink);
 +		phylink_disconnect_phy(port->phylink);
 +	}
@@ -215,7 +215,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	port->nbq = id == AIROHA_GDM3_IDX && airoha_is_7581(eth) ? 4 : 0;
  	eth->ports[p] = port;
  
-+	if (airhoa_is_phy_external(port)) {
++	if (airoha_is_phy_external(port)) {
 +		err = airoha_setup_phylink(dev);
 +		if (err)
 +			return err;
@@ -230,7 +230,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
 -		if (port->dev->reg_state == NETREG_REGISTERED)
 +		if (port->dev->reg_state == NETREG_REGISTERED) {
-+			if (airhoa_is_phy_external(port))
++			if (airoha_is_phy_external(port))
 +				phylink_destroy(port->phylink);
  			unregister_netdev(port->dev);
 +		}
@@ -241,7 +241,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  		if (!port)
  			continue;
  
-+		if (airhoa_is_phy_external(port))
++		if (airoha_is_phy_external(port))
 +			phylink_destroy(port->phylink);
  		unregister_netdev(port->dev);
  		airoha_metadata_dst_free(port);

--- a/target/linux/airoha/patches-6.18/920-01-net-airoha-Introduce-airoha_gdm_dev-struct.patch
+++ b/target/linux/airoha/patches-6.18/920-01-net-airoha-Introduce-airoha_gdm_dev-struct.patch
@@ -109,7 +109,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	u32 pse_port = FE_PSE_PORT_PPE1;
  
  #if defined(CONFIG_PCS_AIROHA)
- 	if (airhoa_is_phy_external(port)) {
+ 	if (airoha_is_phy_external(port)) {
 -		err = phylink_of_phy_connect(port->phylink, dev->dev.of_node, 0);
 +		err = phylink_of_phy_connect(dev->phylink, netdev->dev.of_node, 0);
  		if (err) {
@@ -162,7 +162,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 @@ -1932,24 +1941,25 @@ static int airoha_dev_stop(struct net_de
  
  #if defined(CONFIG_PCS_AIROHA)
- 	if (airhoa_is_phy_external(port)) {
+ 	if (airoha_is_phy_external(port)) {
 -		phylink_stop(port->phylink);
 -		phylink_disconnect_phy(port->phylink);
 +		phylink_stop(dev->phylink);
@@ -781,7 +781,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 +	dev->eth = eth;
 +
 +#if defined(CONFIG_PCS_AIROHA)
-+	if (airhoa_is_phy_external(port)) {
++	if (airoha_is_phy_external(port)) {
 +		err = airoha_setup_phylink(netdev);
 +		if (err)
 +			return err;
@@ -850,7 +850,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	eth->ports[p] = port;
  
 -#if defined(CONFIG_PCS_AIROHA)
--	if (airhoa_is_phy_external(port)) {
+-	if (airoha_is_phy_external(port)) {
 -		err = airoha_setup_phylink(dev);
 -		if (err)
 -			return err;
@@ -887,7 +887,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 +		dev = port->dev;
 +		if (dev && dev->dev->reg_state == NETREG_REGISTERED) {
  #if defined(CONFIG_PCS_AIROHA)
- 			if (airhoa_is_phy_external(port))
+ 			if (airoha_is_phy_external(port))
 -				phylink_destroy(port->phylink);
 +				phylink_destroy(dev->phylink);
  #endif
@@ -905,14 +905,15 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		if (!port)
  			continue;
  
++		dev = port->dev;
++
  #if defined(CONFIG_PCS_AIROHA)
- 		if (airhoa_is_phy_external(port))
+ 		if (airoha_is_phy_external(port))
 -			phylink_destroy(port->phylink);
-+			phylink_destroy(dev->phylink);
++			if (dev)
++				phylink_destroy(dev->phylink);
  #endif
 -		unregister_netdev(port->dev);
-+
-+		dev = port->dev;
 +		if (dev)
 +			unregister_netdev(dev->dev);
  		airoha_metadata_dst_free(port);


### PR DESCRIPTION
## Bug 1: Uninitialized dev in airoha_remove()
In `airoha_remove()`, `struct airoha_gdm_dev *dev` is declared but used before initialization when `phylink_destroy(dev->phylink)` is called. The `dev = port->dev` assignment comes after the phylink_destroy call.

## Fix
Move `dev = port->dev` before the PCS_AIROHA check and add null guards for both `phylink_destroy` and `unregister_netdev`.

## Bug 2: airhoa typo
The function `airhoa_is_phy_external()` is a typo for `airoha_is_phy_external()`. This typo appears in both the phylink patch (310-10) and the multi-netdev patch (920-01).

## Impact
Bug 1: Using an uninitialized pointer is undefined behavior in C and can cause a crash during device removal. Bug 2: The typo is functionally harmless since the function name is consistent across call sites, but should be corrected for readability.

Fixes: 920-01-net-airoha-Introduce-airoha_gdm_dev-struct
Fixes: 310-10-net-airoha-add-phylink-support-for-GDM2-3-4