### PR TITLE
uart: airoha: fix out-of-bounds access in baud rate calculation

### DIFF
--- a/target/linux/airoha/patches-6.18/886-uart-add-en7523-support.patch
+++ b/target/linux/airoha/patches-6.18/886-uart-add-en7523-support.patch
@@ -1,6 +1,6 @@
 --- /dev/null
 +++ b/drivers/tty/serial/8250/8250_en7523.c
-@@ -0,0 +1,94 @@
+@@ -0,0 +1,96 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Airoha EN7523 driver.
@@ -84,6 +84,8 @@
 +		xyd_x = ((nom/denom) << 4);
 +		if (xyd_x < XYD_Y) break;
 +	}
++	if (i >= CLOCK_DIV_TAB_ELEMS)
++		i = CLOCK_DIV_TAB_ELEMS - 1;
 +
 +	serial_port_out(port, UART_XINCLKDR, clock_div_reg[i]);
 +	serial_port_out(port, UART_XYD, (xyd_x<<16) | XYD_Y);


### PR DESCRIPTION
## Bug
In `en7523_set_uart_baud_rate()`, if the for loop completes without breaking (i.e., no valid divisor is found), `i` equals `CLOCK_DIV_TAB_ELEMS` (3). The subsequent `clock_div_reg[i]` then reads `clock_div_reg[3]`, which is beyond the 3-element array (valid indices: 0, 1, 2).

## Fix
Add a bounds check after the loop: if `i >= CLOCK_DIV_TAB_ELEMS`, clamp it to `CLOCK_DIV_TAB_ELEMS - 1` to use the last (smallest) divisor as fallback.

## Impact
Out-of-bounds array read in the UART baud rate configuration path. Could read garbage from stack memory and write an incorrect value to the UART_XINCLKDR register, resulting in wrong baud rate configuration.

Fixes: 886-uart-add-en7523-support