### PR TITLE
busybox: fix signal handling in non-interactive envirement

### DIFF
--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=busybox
 PKG_VERSION:=1.38.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_FLAGS:=essential
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2

--- a/package/utils/busybox/patches/302-ash-clear-bb_got_signal-for-non-interactive-shell.patch
+++ b/package/utils/busybox/patches/302-ash-clear-bb_got_signal-for-non-interactive-shell.patch
@@ -1,0 +1,34 @@
+From 8a7c45305f37bc7138c329d8f7debef8a4c9ddad Mon Sep 17 00:00:00 2001
+From: Seo Suchan <tjtncks@gmail.com>
+Date: Fri, 12 Jun 2026 11:37:18 +0900
+Subject: [PATCH] ash: clear bb_got_signal for non-interactive shell
+
+Patch itself origianlly submitted by Ian Cooper <iancooper@hotmail.com>
+
+preadfd doesn't run in non-interactive shells, but it can set in non_interactive shells too.
+we always need to clear bb_got_signal otherwise it wll infinite loop.
+clean this flag when ash processes trap as backup.
+
+Fixes: #23745
+Upstream-Status: Reported https://github.com/vda-linux/busybox_mirror/issues/16
+Suggested-by: Ian Cooper <iancooper@hotmail.com>
+
+Signed-off-by: Seo Suchan <tjtncks@gmail.com>
+---
+ shell/ash.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/shell/ash.c b/shell/ash.c
+index fb887f31b..3eb73eaa4 100644
+--- a/shell/ash.c
++++ b/shell/ash.c
+@@ -9608,6 +9608,9 @@ dotrap(void)
+ 		savestatus = status;
+ 	}
+ 	pending_sig = 0;
++#if ENABLE_FEATURE_EDITING
++	bb_got_signal = 0;
++#endif
+ 	barrier();
+ 
+ 	TRACE(("dotrap entered\n"));


### PR DESCRIPTION
fixes Https://github.com/openwrt/openwrt/issues/23745

upstream had bug bb_got_signal to be never cleared in noninteractive session, this fixes this while waiting for upstream merge.

the patch iself is written by  Ian Cooper <iancooper@hotmail.com>

Signed-off-by: Seo Suchan <tjtncks@gmail.com>

