### PR TITLE
net: airoha: fix uninitialized dev in airoha_remove

### DIFF
--- a/target/linux/airoha/patches-6.18/920-01-net-airoha-Introduce-airoha_gdm_dev-struct.patch
+++ b/target/linux/airoha/patches-6.18/920-01-net-airoha-Introduce-airoha_gdm_dev-struct.patch
@@ -905,14 +905,15 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		if (!port)
  			continue;
  
++		dev = port->dev;
++
  #if defined(CONFIG_PCS_AIROHA)
  		if (airhoa_is_phy_external(port))
 -			phylink_destroy(port->phylink);
-+			phylink_destroy(dev->phylink);
++			if (dev)
++				phylink_destroy(dev->phylink);
  #endif
 -		unregister_netdev(port->dev);
-+
-+		dev = port->dev;
 +		if (dev)
 +			unregister_netdev(dev->dev);
  		airoha_metadata_dst_free(port);


### PR DESCRIPTION
## Bug
In `airoha_remove()`, `struct airoha_gdm_dev *dev` is declared but used before initialization when `phylink_destroy(dev->phylink)` is called. The `dev = port->dev` assignment comes AFTER the `phylink_destroy` call.

## Fix
Move `dev = port->dev` before the PCS_AIROHA check and add null guards for both `phylink_destroy` and `unregister_netdev` operations.

## Note on the airhoa typo
The `airhoa_is_phy_external()` typo is **NOT** changed in this PR. The typo appears in multiple patches across the series (`310-10`, `920-01`, `606`, `920-02/03/06/07/09/12`), and renaming it would require coordinated changes across all these patches to avoid breaking patch context and causing undefined-symbol compile errors.

Since the typo is internally consistent and functionally harmless, this PR focuses solely on the critical uninitialized-`dev` bug fix.

Fixes: 920-01-net-airoha-Introduce-airoha_gdm_dev-struct