### PR TITLE
mediatek: wavlink wl-wn536ax6 rev a: remove old WLAN LED default

### DIFF
--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -316,7 +316,6 @@ tplink,re6000xd)
 	ucidef_set_led_netdev "eth1" "lan-3" "blue:lan-2" "eth1" "link tx rx"
 	;;
 wavlink,wl-wn536ax6-a)
-	ucidef_set_led_netdev "wifi" "wifi" "blue:wlan" "phy1-ap0" "link"
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "eth1" "link tx rx"
 	;;
 wavlink,wl-wn551x3)


### PR DESCRIPTION
Remove old UCI default for WLAN LED trigger on `phy1` which is now instead triggered by either wireless PHY by `kmod-ledtrig-network`

Fixes: adb7ff279213 ("mediatek: wavlink wl-wn536ax6 rev a: add "network" LED trigger")

Sorry I overlooked this, should have been in https://github.com/openwrt/openwrt/pull/23682 @jonasjelonek 