### PR TITLE
uqmi: add hotplug script to fix IPv6 default route and odhcpd on QMI ifup

### DIFF
--- a/package/network/utils/uqmi/files/etc/hotplug.d/iface/90-qmi-ipv6
+++ b/package/network/utils/uqmi/files/etc/hotplug.d/iface/90-qmi-ipv6
@@ -1,0 +1,46 @@
+#!/bin/sh
+[ "$ACTION" = "ifup" ] || exit 0
+[ "$(uci -q get network."$INTERFACE".proto)" = "qmi" ] || exit 0
+
+LOCKFILE="/tmp/qmi-ipv6-hotplug-${INTERFACE}.lock"
+
+if [ -f "$LOCKFILE" ]; then
+	PID=$(cat "$LOCKFILE")
+	[ -d "/proc/$PID" ] && exit 0
+fi
+
+ipv6_restart() {
+	TRIES=0
+	while [ $TRIES -lt 24 ]; do
+		GATEWAY=$(ifstatus "$INTERFACE" 2>/dev/null | jsonfilter -e '@.route[1].nexthop' 2>/dev/null)
+		[ -n "$GATEWAY" ] && [ "$GATEWAY" != "::" ] && break
+		sleep 5
+		TRIES=$((TRIES + 1))
+	done
+
+	rm -f "$LOCKFILE"
+
+	[ -n "$GATEWAY" ] && [ "$GATEWAY" != "::" ] || exit 1
+
+	DEVICE=$(ifstatus "$INTERFACE" 2>/dev/null | jsonfilter -e '@.l3_device' 2>/dev/null)
+	[ -n "$DEVICE" ] || exit 1
+
+	# Wait for the modem's global IPv6 address to appear on the wwan device.
+	# odhcpd derives the /64 prefix from this address; restarting it before
+	# the address is present causes it to come up with no prefix to advertise,
+	# and it will not recover until manually restarted.
+	TRIES=0
+	while [ $TRIES -lt 12 ]; do
+		ip -6 addr show dev "$DEVICE" scope global 2>/dev/null | grep -q 'inet6' && break
+		sleep 5
+		TRIES=$((TRIES + 1))
+	done
+
+	ip -6 addr show dev "$DEVICE" scope global 2>/dev/null | grep -q 'inet6' || exit 1
+
+	ip -6 route replace ::/0 via "$GATEWAY" dev "$DEVICE" metric 512
+	service odhcpd restart
+}
+
+ipv6_restart &
+echo $! > "$LOCKFILE"


### PR DESCRIPTION
## Problem

On QMI cellular connections, two related timing issues prevent IPv6 from
working for LAN clients after the modem connects:

1. **Missing IPv6 default route**: the `::/0` default route is sometimes
   not installed in the routing table after `ifup`.

2. **odhcpd prefix starvation**: `odhcpd` starts (or is restarted by
   netifd) before the modem has assigned a global IPv6 address to the
   wwan device.  `odhcpd` derives the delegated `/64` prefix from that
   address; if it starts before the address is present it comes up with
   nothing to advertise and will not recover on its own.

Both issues are consistently reproducible with carriers that issue a new
prefix delegation on every connect (observed on Verizon and T-Mobile LTE).
Each reconnect leaves LAN clients without IPv6 until `odhcpd` is restarted
manually.

## Fix

Add `package/network/utils/uqmi/files/etc/hotplug.d/iface/90-qmi-ipv6`,
a hotplug script that fires on `ifup` of any interface configured with
`proto qmi`.  It runs a background worker that:

1. Polls `ifstatus` up to 120 s for a valid (non-`::`) IPv6 gateway.
2. Polls `ip -6 addr` up to 60 s for a global-scope address on the wwan
   device.
3. Installs/replaces the `::/0` default route via the gateway.
4. Restarts `odhcpd` so it picks up the now-available prefix and begins
   advertising it to LAN clients.

A per-interface lockfile (`/tmp/qmi-ipv6-hotplug-${INTERFACE}.lock`)
prevents duplicate background workers from concurrent `ifup` events.

The uqmi `Makefile` already copies all `files/*` into the target image
(`$(CP) ./files/* $(1)/`), so no Makefile change is needed.

## Testing

Tested on:
- Quectel EC25 modem on Verizon LTE (MT7620 SoC, WE826 router)
- Multiple reconnect cycles; LAN IPv6 restored automatically each time
- No regressions observed on IPv4

Signed-off-by: S. Hoot <spoot_hoot@protonmail.com>