### PR TITLE
ipq807x: Fix w_disable for Deco X80-5G

### DIFF
--- a/target/linux/qualcommax/dts/ipq8074-deco-x80-5g.dts
+++ b/target/linux/qualcommax/dts/ipq8074-deco-x80-5g.dts
@@ -33,8 +33,8 @@ to suit the TP-Link Deco X80-5G target */
 
 		w_disable {
 			gpio-export,name = "w_disable";
-			gpio-export,output = <1>;
-			gpios = <&tlmm 35 GPIO_ACTIVE_HIGH>; /* wwan disable output */
+			gpio-export,output = <0>;
+			gpios = <&tlmm 55 GPIO_ACTIVE_LOW>; /* wwan disable output */
 		};
 
 		modem-reset {


### PR DESCRIPTION
Change w_disable GPIO to 55. 

This will enable the 5G modem radio to fully work and allow use of QMI and MBIM.

Previous GPIO35 is used in the u-boot as "ONOFF_MODULE 5G", GPIO55 can be found in the stock DTS as w_disable, as can be seen in the [wiki](https://openwrt.org/toh/tp-link/deco_x80-5g_v1)
