### PR TITLE
mediatek: filogic: add support for TOTOLINK X6000R (NAND)

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-totolink-x6000r-nand.dts
+++ b/target/linux/mediatek/dts/mt7981b-totolink-x6000r-nand.dts
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+
+#include <dt-bindings/leds/common.h>
+
+#include "mt7981b.dtsi"
+
+/ {
+	model = "TOTOLINK X6000R (NAND)";
+	compatible = "totolink,x6000r-nand", "mediatek,mt7981";
+
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_status;
+		led-failsafe = &led_status_red;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		rootdisk = <&ubi_rootdisk>;
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x10000000>;
+		device_type = "memory";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: led-1 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status: led-2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 15 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cells = <&macaddr_factory_14>;
+		nvmem-cell-names = "mac-address";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+		label = "wan";
+
+		nvmem-cells = <&macaddr_factory_1a>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&mdio_bus {
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "lan4";
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "lan3";
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan2";
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan1";
+			};
+
+			port@6 {
+				reg = <6>;
+				label = "cpu";
+				ethernet = <&gmac0>;
+				phy-mode = "2500base-x";
+
+				fixed-link {
+					speed = <2500>;
+					full-duplex;
+					pause;
+				};
+			};
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand: flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			factory: partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_14: macaddr@14 {
+						reg = <0x14 0x6>;
+					};
+
+					macaddr_factory_1a: macaddr@1a {
+						reg = <0x1a 0x6>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ffw";
+				reg = <0x580000 0x1480000>;
+			};
+
+			partition@1a00000 {
+				label = "ubi";
+				reg = <0x1a00000 0x5c00000>;
+				compatible = "linux,ubi";
+
+				volumes {
+					ubi_rootdisk: ubi-volume-fit {
+						volname = "fit";
+					};
+				};
+			};
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&wifi {
+	status = "okay";
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};
+
+&watchdog {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -294,7 +294,8 @@ teltonika,rutc50)
 	ucidef_set_led_netdev "wan-green" "WAN" "mdio-bus:00:green:wan" "wan" "link_1000 tx rx"
 	ucidef_set_led_netdev "wan-amber" "WAN" "mdio-bus:00:amber:wan" "wan" "link_100 link_10 tx rx"
 	;;
-totolink,x6000r)
+totolink,x6000r|\
+totolink,x6000r-nand)
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan" "link tx rx"
 	;;
 tplink,archer-ax80-v1-eu)

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -184,7 +184,8 @@ platform_do_upgrade() {
 	xiaomi,redmi-router-ax6000-ubootmod|\
 	xiaomi,mi-router-wr30u-ubootmod|\
 	zyxel,ex5601-t0-ubootmod|\
-	zyxel,wx5600-t0-ubootmod)
+	zyxel,wx5600-t0-ubootmod|\
+	totolink,x6000r-nand)
 		fit_do_upgrade "$1"
 		;;
 	acer,predator-w6|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -3039,6 +3039,31 @@ define Device/totolink_x6000r
 endef
 TARGET_DEVICES += totolink_x6000r
 
+define Device/totolink_x6000r-nand
+  DEVICE_VENDOR := TOTOLINK
+  DEVICE_MODEL := X6000R
+  DEVICE_VARIANT := (NAND)
+  DEVICE_DTS := mt7981b-totolink-x6000r-nand
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 90000k
+  KERNEL_IN_UBI := 1
+  UBOOTENV_IN_UBI := 1
+  IMAGES := sysupgrade.itb
+  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
+  KERNEL := kernel-bin | gzip
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/sysupgrade.itb := append-kernel | \
+	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
+  ARTIFACTS := factory.ubi
+  ARTIFACT/factory.ubi := ubinize-image fit squashfs-sysupgrade.itb
+endef
+TARGET_DEVICES += totolink_x6000r-nand
+
 define Device/tplink_archer-ax80-v1
   DEVICE_VENDOR := TP-Link
   DEVICE_MODEL := Archer AX80


### PR DESCRIPTION
   This adds support for the NAND variant of TOTOLINK X6000R.
   The SPI NOR variant is already supported in-tree.

   Hardware specification
   ---------------------
   - SoC       : MediaTek MT7981B (dual-core ARM Cortex-A53 1.3 GHz)
   - RAM       : 256 MiB DDR3
   - Flash     : Winbond SPI-NAND 128 MiB
   - WLAN      : MediaTek MT7976C dual-band WiFi 6
     - 2.4 GHz : b/g/n/ax, MIMO 2x2
     - 5 GHz   : a/n/ac/ax, MIMO 2x2
   - Ethernet  : 5x 10/100/1000 Mbps (MediaTek MT7531AE switch)
   - Buttons   : Reset, WPS/Mesh
   - LEDs      : WAN (green), Status (red), Status (blue)
   - Power     : 12 VDC, 1 A

   Flash instructions
   ------------------
   The device ships with OpenWrt 24.10 firmware and uboot.
   Upload the sysupgrade.itb image via LuCI web interface
   (System > Backup/Flash).

   MAC address layout
   ------------------
   - LAN (gmac0)    : Factory partition offset 0x14 (xx:xx:xx:xx:xx:xx)
   - WAN (gmac1)    : Factory partition offset 0x1a (xx:xx:xx:xx:xx:xx)
   - WLAN 2.4 GHz   : Factory partition offset 0x04
   - WLAN 5 GHz     : Factory partition offset 0x0a


  Device info collection:
   ------------------
root@OpenWrt:~# cat /proc/cpuinfo
processor       : 0
BogoMIPS        : 26.00
Features        : fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x0
CPU part        : 0xd03
CPU revision    : 4

processor       : 1
BogoMIPS        : 26.00
Features        : fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x0
CPU part        : 0xd03
CPU revision    : 4

root@OpenWrt:~# free -h
              total        used        free      shared  buff/cache   available
Mem:         238360       68692      142692         228       26976      131492
Swap:             0           0           0
root@OpenWrt:~# cat /proc/mtd
dev:    size   erasesize  name
mtd0: 00100000 00020000 "BL2"
mtd1: 00080000 00020000 "u-boot-env"
mtd2: 00200000 00020000 "Factory"
mtd3: 00200000 00020000 "FIP"
mtd4: 01480000 00020000 "ffw"
mtd5: 05c00000 00020000 "ubi"
root@OpenWrt:~# ethtool -i eth0
driver: mtk_soc_eth
version: 6.18.34
firmware-version:
expansion-rom-version:
bus-info: 15100000.ethernet
supports-statistics: yes
supports-test: no
supports-eeprom-access: no
supports-register-dump: yes
supports-priv-flags: no
root@OpenWrt:~# dmesg | grep -iE "(cpu|memory|nand|wifi|eth|usb)"
[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Machine model: TOTOLINK X6000R (NAND)
[    0.000000] OF: reserved mem: 0x0000000047c80000..0x0000000047d7ffff (1024 KiB) nomap non-reusable wmcpu-reserved@47c80000
[    0.000000] Early memory node ranges
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] percpu: Embedded 20 pages/cpu s43416 r8192 d30312 u81920
[    0.000000] pcpu-alloc: s43416 r8192 d30312 u81920 alloc=20*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: GICv3 CPU interface
[    0.000000] CPU features: kernel page table isolation disabled by kernel configuration
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=2, Nodes=1
[    0.000000] rcu:     RCU restricting CPUs from NR_CPUS=4 to nr_cpu_ids=2.
[    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=2
[    0.000000] RCU Tasks Trace: Setting shift to 1 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=2.
[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x000000000c080000
[    0.007595] cacheinfo: Unable to detect cache hierarchy for CPU 0
[    0.008800] smp: Bringing up secondary CPUs ...
[    0.009195] Detected VIPT I-cache on CPU1
[    0.009240] GICv3: CPU1: found redistributor 1 region 0:0x000000000c0a0000
[    0.009270] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
[    0.009350] smp: Brought up 1 node, 2 CPUs
[    0.009358] CPU: All CPU(s) started at EL2
[    0.009361] CPU features: detected: 32-bit EL0 Support
[    0.009364] CPU features: detected: CRC32 instructions
[    0.009525] CPU features: emulated: Privileged Access Never (PAN) using TTBR0_EL1 switching
[    0.009658] Memory: 235692K/262144K available (9664K kernel code, 946K rwdata, 2976K rodata, 960K init, 295K bss, 24744K reserved, 0K cma-reserved)
[    0.049795] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.053063] cryptd: max_cpu_qlen set to 1000
[    0.932233] spi-nand spi0.0: Winbond SPI NAND was found.
[    0.937549] spi-nand spi0.0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
[    1.502554] mtk_soc_eth 15100000.ethernet: legacy DT: using hard-coded SRAM offset.
[    1.510519] mtk_soc_eth 15100000.ethernet: legacy DT: missing interrupt-names.
[    1.647422] mtk_soc_eth 15100000.ethernet eth0: mediatek frame engine at 0xffffffc081780000, irq 75
[    1.657314] mtk_soc_eth 15100000.ethernet eth1: mediatek frame engine at 0xffffffc081780000, irq 75
[    1.730447] FIT: Selected configuration: "config-1" (OpenWrt totolink_x6000r-nand)
[    1.747856] FIT:          flat_dt sub-image 0x00617000..0x0061c6ac "fdt-1" (ARM64 OpenWrt totolink_x6000r-nand device tree blob)
[    1.759520] FIT:       filesystem sub-image 0x0061d000..0x00b4cfff "rootfs-1" (ARM64 OpenWrt totolink_x6000r-nand rootfs)
[    1.945390] mtk_soc_eth 15100000.ethernet eth0: entered promiscuous mode
[    1.981398] Freeing unused kernel memory: 960K
[    2.686489] usbcore: registered new interface driver usbfs
[    2.692041] usbcore: registered new interface driver hub
[    2.697392] usbcore: registered new device driver usb
[    3.053903] mtk_soc_eth 15100000.ethernet wan: renamed from eth1
[    3.069370] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[    3.077842] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    8.924137] mt798x-wmac 18000000.wifi: HW/SW Version: 0x8a108a10, Build Time: 20240823161240a
[    9.100146] mt798x-wmac 18000000.wifi: WM Firmware Version: ____000000, Build Time: 20240823161304
[    9.194447] mt798x-wmac 18000000.wifi: WA Firmware Version: DEV_000000, Build Time: 20240823161841
[   15.837914] mtk_soc_eth 15100000.ethernet eth0: Link is Down
[   15.872369] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[   15.880991] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[   15.935852] mtk_soc_eth 15100000.ethernet eth0: entered allmulticast mode
[   16.202490] mtk_soc_eth 15100000.ethernet wan: PHY [mdio-bus:00] driver [MediaTek MT7981 PHY] (irq=POLL)
[   16.212594] mtk_soc_eth 15100000.ethernet wan: configuring for phy/gmii link mode
[   16.652152] mt798x-wmac 18000000.wifi phy0-ap0: entered allmulticast mode
[   16.659107] mt798x-wmac 18000000.wifi phy0-ap0: entered promiscuous mode
[   17.146263] mt798x-wmac 18000000.wifi phy1-ap0: entered allmulticast mode
[   17.153318] mt798x-wmac 18000000.wifi phy1-ap0: entered promiscuous mode
root@OpenWrt:~#