### PR TITLE
bcm27xx/rockchip/x86: don't destroy user partitions on sysupgrade

### DIFF
--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -14,7 +14,7 @@ COMMAND=/lib/upgrade/do_stage2
 ADD_PROVISIONING=0
 SAVE_OVERLAY=0
 SAVE_OVERLAY_PATH=
-SAVE_PARTITIONS=1
+export SAVE_PARTITIONS=1
 SAVE_INSTALLED_PKGS=0
 SKIP_UNCHANGED=0
 CONF_IMAGE=
@@ -45,7 +45,7 @@ while [ -n "$1" ]; do
 		-n) export SAVE_CONFIG=0;;
 		-c) SAVE_OVERLAY=1 SAVE_OVERLAY_PATH=/etc;;
 		-o) SAVE_OVERLAY=1 SAVE_OVERLAY_PATH=/;;
-		-p) SAVE_PARTITIONS=0;;
+		-p) export SAVE_PARTITIONS=0;;
 		-P) ADD_PROVISIONING=1;;
 		-k) SAVE_INSTALLED_PKGS=1;;
 		-u) SKIP_UNCHANGED=1;;
@@ -81,6 +81,9 @@ upgrade-option:
 	-u           skip from backup files that are equal to those in /rom
 	-n           do not save configuration over reflash
 	-p           do not attempt to restore the partition table after flash.
+	             On targets that detect a changed partition layout (e.g. x86)
+	             this also opts in to rewriting the partition table, which
+	             erases any non-default (user-created) partitions.
 	-k           include in backup a list of current installed packages at
 	             $INSTALLED_PACKAGES
 	-s           stay on current partition (for dual firmware devices)

--- a/target/linux/bcm27xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/bcm27xx/base-files/lib/upgrade/platform.sh
@@ -5,7 +5,7 @@ REQUIRE_IMAGE_METADATA=1
 # copied from x86's platform.sh
 
 platform_check_image() {
-	local diskdev partdev diff
+	local diskdev partdev diff extra_parts
 
 	[ "$#" -gt 1 ] && return 1
 
@@ -24,15 +24,40 @@ platform_check_image() {
 	#compare tables
 	diff="$(grep -F -x -v -f /tmp/partmap.bootdisk /tmp/partmap.image)"
 
+	# Detect partitions beyond the two defaults
+	extra_parts="$(awk '$1 > 2 { printf "%s ", $1 }' /tmp/partmap.bootdisk)"
+
 	rm -f /tmp/image.bs /tmp/partmap.bootdisk /tmp/partmap.image
 
 	if [ -n "$diff" ]; then
-		echo "Partition layout has changed. Full image will be written."
-		ask_bool 0 "Abort" && exit 1
-		return 0
+		# Applying a changed layout requires rewriting the whole disk. If
+		# non-default partitions exist, that destroys them, so refuse
+		# unless the user opted in with -p (SAVE_PARTITIONS=0). The refusal
+		# marks the image invalid-but-forceable, so sysupgrade aborts
+		# unless -p or -F/--force is given.
+		#
+		# SAVE_PARTITIONS is exported by sysupgrade so it reaches this
+		# (validate_firmware_image child) process. If it is unset, this is
+		# not a sysupgrade run (e.g. a GUI image check), so default to the
+		# safe choice and refuse: "$SAVE_PARTITIONS" != "0" is then true.
+		if [ -n "$extra_parts" ] && [ "$SAVE_PARTITIONS" != "0" ]; then
+			# Report the reason to GUI/RPC callers, which only see the
+			# JSON test results and not the messages printed below.
+			notify_firmware_test_result "partition_layout" 0
+			v "Partition layout changed; refusing to erase non-default partition(s): ${extra_parts}"
+			echo "The new image uses a different partition layout than the one"       >&2
+			echo "currently installed. Applying it requires rewriting the partition"  >&2
+			echo "table, which will DESTROY these non-default partition(s) and all"   >&2
+			echo "data on them: ${extra_parts}"                                        >&2
+			echo "Re-run sysupgrade with -p to proceed and erase them."                >&2
+			return 1
+		fi
+		# Either only the default partitions are present or the user opted in with -p.
+		notify_firmware_test_result "partition_layout" 1
+		v "Partition layout has changed, full image will be written."
 	fi
 
-	return 0;
+	return 0
 }
 
 platform_do_upgrade() {

--- a/target/linux/rockchip/armv8/base-files/lib/upgrade/platform.sh
+++ b/target/linux/rockchip/armv8/base-files/lib/upgrade/platform.sh
@@ -1,7 +1,7 @@
 REQUIRE_IMAGE_METADATA=1
 
 platform_check_image() {
-	local diskdev partdev diff
+	local diskdev partdev diff extra_parts
 
 	export_bootdevice && export_partdevice diskdev 0 || {
 		echo "Unable to determine upgrade device"
@@ -18,13 +18,40 @@ platform_check_image() {
 	#compare tables
 	diff="$(grep -F -x -v -f /tmp/partmap.bootdisk /tmp/partmap.image)"
 
+	# Detect partitions beyond the two defaults
+	extra_parts="$(awk '$1 > 2 { printf "%s ", $1 }' /tmp/partmap.bootdisk)"
+
 	rm -f /tmp/image.bs /tmp/partmap.bootdisk /tmp/partmap.image
 
 	if [ -n "$diff" ]; then
-		echo "Partition layout has changed. Full image will be written."
-		ask_bool 0 "Abort" && exit 1
-		return 0
+		# Applying a changed layout requires rewriting the whole disk. If
+		# non-default partitions exist, that destroys them, so refuse
+		# unless the user opted in with -p (SAVE_PARTITIONS=0). The refusal
+		# marks the image invalid-but-forceable, so sysupgrade aborts
+		# unless -p or -F/--force is given.
+		#
+		# SAVE_PARTITIONS is exported by sysupgrade so it reaches this
+		# (validate_firmware_image child) process. If it is unset, this is
+		# not a sysupgrade run (e.g. a GUI image check), so default to the
+		# safe choice and refuse: "$SAVE_PARTITIONS" != "0" is then true.
+		if [ -n "$extra_parts" ] && [ "$SAVE_PARTITIONS" != "0" ]; then
+			# Report the reason to GUI/RPC callers, which only see the
+			# JSON test results and not the messages printed below.
+			notify_firmware_test_result "partition_layout" 0
+			v "Partition layout changed; refusing to erase non-default partition(s): ${extra_parts}"
+			echo "The new image uses a different partition layout than the one"       >&2
+			echo "currently installed. Applying it requires rewriting the partition"  >&2
+			echo "table, which will DESTROY these non-default partition(s) and all"   >&2
+			echo "data on them: ${extra_parts}"                                        >&2
+			echo "Re-run sysupgrade with -p to proceed and erase them."                >&2
+			return 1
+		fi
+		# Either only the default partitions are present or the user opted in with -p.
+		notify_firmware_test_result "partition_layout" 1
+		v "Partition layout has changed, full image will be written."
 	fi
+
+	return 0
 }
 
 platform_copy_config() {

--- a/target/linux/x86/base-files/lib/upgrade/platform.sh
+++ b/target/linux/x86/base-files/lib/upgrade/platform.sh
@@ -81,7 +81,7 @@ platform_do_upgrade_onie() {
 }
 
 platform_check_image() {
-	local diskdev partdev diff
+	local diskdev partdev diff extra_parts
 	[ "$#" -gt 1 ] && return 1
 
 	if is_onie_install; then
@@ -119,13 +119,40 @@ platform_check_image() {
 	#compare tables
 	diff="$(grep -F -x -v -f /tmp/partmap.bootdisk /tmp/partmap.image)"
 
+	# Detect partitions beyond the two defaults
+	extra_parts="$(awk '$1 > 2 { printf "%s ", $1 }' /tmp/partmap.bootdisk)"
+
 	rm -f /tmp/image.bs /tmp/partmap.bootdisk /tmp/partmap.image
 
 	if [ -n "$diff" ]; then
-		v "Partition layout has changed. Full image will be written."
-		ask_bool 0 "Abort" && exit 1
-		return 0
+		# Applying a changed layout requires rewriting the whole disk. If
+		# non-default partitions exist, that destroys them, so refuse
+		# unless the user opted in with -p (SAVE_PARTITIONS=0). The refusal
+		# marks the image invalid-but-forceable, so sysupgrade aborts
+		# unless -p or -F/--force is given.
+		#
+		# SAVE_PARTITIONS is exported by sysupgrade so it reaches this
+		# (validate_firmware_image child) process. If it is unset, this is
+		# not a sysupgrade run (e.g. a GUI image check), so default to the
+		# safe choice and refuse: "$SAVE_PARTITIONS" != "0" is then true.
+		if [ -n "$extra_parts" ] && [ "$SAVE_PARTITIONS" != "0" ]; then
+			# Report the reason to GUI/RPC callers, which only see the
+			# JSON test results and not the messages printed below.
+			notify_firmware_test_result "partition_layout" 0
+			v "Partition layout changed; refusing to erase non-default partition(s): ${extra_parts}"
+			echo "The new image uses a different partition layout than the one"       >&2
+			echo "currently installed. Applying it requires rewriting the partition"  >&2
+			echo "table, which will DESTROY these non-default partition(s) and all"   >&2
+			echo "data on them: ${extra_parts}"                                        >&2
+			echo "Re-run sysupgrade with -p to proceed and erase them."                >&2
+			return 1
+		fi
+		# Either only the default partitions are present or the user opted in with -p.
+		notify_firmware_test_result "partition_layout" 1
+		v "Partition layout has changed, full image will be written."
 	fi
+
+	return 0
 }
 
 platform_copy_config() {


### PR DESCRIPTION
A changed partition layout (e.g. a resized rootfs/boot partition) makes platform_do_upgrade rewrite the whole disk, wiping any user-created partitions beyond the two OpenWrt defaults. Refuse such an upgrade in platform_check_image when extra partitions are present, unless the user opts in with -p (or -F). When only the default partitions exist, flash as before. The opt-in is read via an exported SAVE_PARTITIONS so it reaches the validate_firmware_image check.

This PR should be merged before the pending PR to resize several target's rootfs[1]. Once that happens, the pending PR to enable early loading of firmware for x86 can be merged[2].
    
Reference discussion: https://github.com/openwrt/openwrt/pull/18203
    
1. https://github.com/openwrt/openwrt/pull/19388
2. https://github.com/openwrt/openwrt/pull/18203