### PR TITLE
wifi-scripts: only set antenna when configured

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
@@ -75,6 +75,8 @@ function setup_phy(phy, config, data) {
 		system(`iw reg set ${config.country}`);
 	}
 
+	let antenna_configured = config.rxantenna != null || config.txantenna != null;
+
 	set_default(config, 'rxantenna', 0xffffffff);
 	set_default(config, 'txantenna', 0xffffffff);
 
@@ -99,7 +101,8 @@ function setup_phy(phy, config, data) {
 		config.txpower = 'auto';
 
 	log(`Configuring '${phy}' txantenna: ${config.txantenna}, rxantenna: ${config.rxantenna} distance: ${config.distance}`);
-	system(`iw phy ${phy} set antenna ${config.txantenna} ${config.rxantenna}`);
+	if (antenna_configured)
+		system(`iw phy ${phy} set antenna ${config.txantenna} ${config.rxantenna}`);
 	system(`iw phy ${phy} set distance ${config.distance}`);
 	system(`iw phy ${phy} set txpower ${config.txpower}`);
 


### PR DESCRIPTION
The mac80211 ucode setup path currently defaults rxantenna and txantenna to 0xffffffff, then always runs the antenna setup command.

This can produce a confusing "Not supported" warning on devices where the driver does not support manual antenna selection, even though the user did not configure any antenna option.

Only run the antenna setup command when rxantenna or txantenna was actually configured. Keep the existing default values for the explicit one-sided case, so setting only one antenna option still behaves as before.