### PR TITLE
ncurses: fix macOS compilation failures by forcing system awk

### DIFF
--- a/package/libs/ncurses/Makefile
+++ b/package/libs/ncurses/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=ncurses
 PKG_CPE_ID:=cpe:/a:gnu:ncurses
 PKG_VERSION:=6.4
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
@@ -92,6 +92,10 @@ HOST_CONFIGURE_ARGS += \
 	--without-tests \
 	--without-curses-h
 
+ifeq ($(HOST_OS),Darwin)
+  HOST_CONFIGURE_ARGS += AWK="/usr/bin/awk"
+  CONFIGURE_ARGS += AWK="/usr/bin/awk"
+endif
 
 ifeq ($(HOST_OS),FreeBSD)
 	CONFIGURE_ARGS +=


### PR DESCRIPTION
⚠️ This is more of a workaround than a proper fix, but it does the job. 🤷 I'm submitting it to see if you're okay with it, because finding a better solution is tough when it's so hard to replicate locally.

___

When building ncurses (both host and target) on macOS, we hit various weird compilation failures where build tasks would fail to locate libraries or rules. Initially, we tried to work around this by forcing single-threaded compilation (-j1) or manually hacking directories, but the core issue was a malformed Makefile lacking rules to compile shared libraries.

The root cause is that OpenWrt's feed scripts prepend Homebrew's GNU 'gawk' to PATH (which is needed because scan.awk uses GNU-specific 'asort'). However, when the ncurses autoconf configure script detects 'gawk' on macOS, it gets confused and generates a broken Makefile (lacking proper shared library build rules).

We resolve this cleanly by passing AWK="/usr/bin/awk" in CONFIGURE_ARGS and HOST_CONFIGURE_ARGS. This forces the configure script to write the path to the standard, native macOS system awk into the Makefiles. With this change, the correct Makefiles are generated and ncurses builds cleanly without any parallel build (-j1) hacks or directory workarounds.

____

I was able to reproduce the issue on a GitHub runner using the ``macos-26`` image, which I will add soon to[action-shared-workflows](https://github.com/openwrt/actions-shared-workflows). However, I can't reproduce it locally, even though I tried using act to run the runner image. 🤷

Fixes: https://github.com/openwrt/openwrt/issues/22634
It was suggested by @Moxuan6 in https://github.com/openwrt/openwrt/issues/22634#issuecomment-4260782408

cc: MacOS users: @robimarko , @httpstorm 