### PR TITLE
realtek: rt-loader increase gcc optimization level

### DIFF
--- a/target/linux/realtek/image/rt-loader/Makefile
+++ b/target/linux/realtek/image/rt-loader/Makefile
@@ -73,7 +73,7 @@ LD		:= $(CROSS_COMPILE)ld
 OBJCOPY		:= $(CROSS_COMPILE)objcopy
 OBJDUMP		:= $(CROSS_COMPILE)objdump
 
-CFLAGS		= -fpic -mabicalls -O2 -fno-builtin-printf -Iinclude
+CFLAGS		= -fpic -mabicalls -O3 -fno-builtin-printf -Iinclude
 CFLAGS		+= -DFLASH_ADDR=$(FLASH_ADDR)
 CFLAGS		+= -DKERNEL_ADDR=$(KERNEL_ADDR)
 


### PR DESCRIPTION
Switch from -O2 to -O3. This increases the loader code size by 5KB and brings down the decompression time on RTL838x from ~6.5 seconds to ~3.5 seconds.
