### PR TITLE
an7581/base-files: use IPKG_INSTROOT when sourcing functions.sh

### DIFF
--- a/target/linux/airoha/an7581/base-files/etc/init.d/airoha_fan
+++ b/target/linux/airoha/an7581/base-files/etc/init.d/airoha_fan
@@ -5,7 +5,7 @@
 
 START=99
 
-. /lib/functions.sh
+. "$IPKG_INSTROOT/lib/functions.sh"
 
 find_nct7802()
 {


### PR DESCRIPTION
Description:
* fixes the following error message when using image builder to create an image for an7581 devices:

```
build_dir/target-aarch64_cortex-a53_musl/root-airoha/etc/init.d/airoha_fan: line 8: /lib/functions.sh: No such file or directory
```