### PR TITLE
[25.12]: fritz-tools: fix out-of-bounds memset in TFFS segment expansion

### DIFF
--- a/package/utils/fritz-tools/Makefile
+++ b/package/utils/fritz-tools/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fritz-tools
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 CMAKE_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk

--- a/package/utils/fritz-tools/src/fritz_tffs_nand_read.c
+++ b/package/utils/fritz-tools/src/fritz_tffs_nand_read.c
@@ -245,7 +245,7 @@ static int find_entry(uint32_t id, struct tffs_entry *entry)
 				uint32_t new_num_segs = next_seg == 0 ? seg + 1 : next_seg + 1;
 				if (new_num_segs > num_segments) {
 					segments = realloc(segments, new_num_segs * sizeof(struct tffs_entry_segment));
-					memset(segments + (num_segments * sizeof(struct tffs_entry_segment)), 0x0,
+					memset(segments + num_segments, 0x0,
 							(new_num_segs - num_segments) * sizeof(struct tffs_entry_segment));
 					num_segments = new_num_segs;
 				}


### PR DESCRIPTION
When growing the segment array in find_entry(), the memset() that zeroes the newly allocated slots computed the destination with redundant sizeof scaling:

  memset(segments + (num_segments * sizeof(struct tffs_entry_segment)), ...)

segments is a typed pointer, so pointer arithmetic already scales by the element size. Multiplying the offset by sizeof again advances the destination by num_segments * sizeof^2 bytes, landing far outside the realloc()'d buffer and zeroing unrelated heap memory whenever a TFFS entry spans multiple segments that require array expansion.

Drop the redundant multiplication so the memset targets segments[num_segments].

This is a robustness fix for malformed/corrupt TFFS content; the parser only reads the on-device nand-tffs MTD partition as root, so it is not considered security relevant.

Reported-by: @Vasco0x4
Assisted-by: Claude:claude-opus-4-8
Link: https://github.com/openwrt/openwrt/pull/23763

(cherry picked from commit 7e7bd602ea8967858267c2a6929f4dbaffe90839)