### PR TITLE
package: add missing release bump for button-hotplug

### DIFF
--- a/package/kernel/button-hotplug/Makefile
+++ b/package/kernel/button-hotplug/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=button-hotplug
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
This commit fixes "286f377389a button-hotplug: add KEY_SETUP and KEY_VENDOR handling" which changed the code without bumping the PKG_RELEASE, resulting in different binaries under the same version.