### PR TITLE
realtek: generate lan_list from device tree to avoid startup race

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -246,9 +246,31 @@ realtek_setup_poe()
 	esac
 }
 
+realtek_lan_list()
+{
+	local label labels
+
+	labels="$(
+			find /sys/firmware/devicetree/base -path '*/ethernet-ports/port@*/label' -print 2>/dev/null |
+					while read -r label; do
+							label="$(strings "$label")"
+							case "$label" in
+							lan*) echo "$label" ;;
+							esac
+					done |
+					sort -V |
+					uniq |
+					xargs
+	)"
+
+	[ -n "$labels" ] || labels="$(ls -1 -v -d /sys/class/net/lan* 2>/dev/null | xargs -n1 basename | xargs)"
+
+	echo "$labels"
+}
+
 board=$(board_name)
 board_config_update
-lan_list=$(ls -1 -v -d /sys/class/net/lan* | xargs -n1 basename | xargs)
+lan_list=$(realtek_lan_list)
 realtek_setup_interfaces "$board" "$lan_list"
 realtek_setup_macs "$board" "$lan_list"
 realtek_setup_poe "$board" "$lan_list"


### PR DESCRIPTION
Currently, 02_network discovers lan ports from /sys/class/net/lan*. When booting on some devices, DSA ends up registering ports _after_ config generation has started, producing a board.json/network config that is missing those ports.

Read labels from the device tree instead; they already exist as static board data. If they are missing, fall back to the previous behavior.

Verified on a XikeStor SKS8300-8T (a rtl930x platform).