### PR TITLE
wifi-scripts: add detect_band option for multi-radio phy

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
@@ -8,7 +8,7 @@ import * as supplicant from 'wifi.supplicant';
 import * as hostapd from 'wifi.hostapd';
 import * as netifd from 'wifi.netifd';
 import * as iface from 'wifi.iface';
-import { find_phy } from 'wifi.utils';
+import { find_phy, find_radio_by_band } from 'wifi.utils';
 import * as nl80211 from 'nl80211';
 import * as fs from 'fs';
 
@@ -166,6 +166,34 @@ function setup() {
 		netifd.set_retry(false);
 		return 1;
 	}
+
+	if (!data.config.band) {
+		switch (data.config.hwmode) {
+		case 'a':
+		case '11a':
+			data.config.band = '5g';
+			break;
+		case 'ad':
+		case '11ad':
+			data.config.band = '60g';
+			break;
+		case 'b':
+		case 'g':
+		case '11b':
+		case '11g':
+		default:
+			data.config.band = '2g';
+			break;
+		}
+	}
+	delete data.config.hwmode;
+
+	if (data.config.detect_band && data.config.radio == null) {
+		let radio = find_radio_by_band(data.phy, data.config.band);
+		if (radio != null)
+			data.config.radio = radio;
+	}
+
 	data.phy_suffix = phy_suffix(data.config.radio, ":");
 	data.vif_phy_suffix = phy_suffix(data.config.radio, ".");
 	data.ifname_prefix = data.config.ifname_prefix;
@@ -176,27 +204,6 @@ function setup() {
 	log('Starting');
 
 	let config = data.config;
-
-	if (!config.band) {
-		switch (config.hwmode) {
-		case 'a':
-		case '11a':
-			config.band = '5g';
-			break;
-		case 'ad':
-		case '11ad':
-			config.band = '60g';
-			break;
-		case 'b':
-		case 'g':
-		case '11b':
-		case '11g':
-		default:
-			config.band = '2g';
-			break;
-		}
-	}
-	delete config.hwmode;
 
 	validate('device', config);
 	setup_phy(data.phy, data.config, data.data);

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-device.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-device.json
@@ -51,6 +51,11 @@
 				"60g"
 			]
 		},
+		"detect_band": {
+			"description": "Radio is matched to the phy by band rather than by radio index (for multi-radio phys whose radio order is non-deterministic across reboots)",
+			"type": "boolean",
+			"default": false
+		},
 		"basic_rate": {
 			"type": "alias",
 			"default": "basic_rates"

--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless.uc
+++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless.uc
@@ -7,7 +7,7 @@ import {
 	parse_attribute_list, parse_bool, parse_array,
 	TYPE_ARRAY, TYPE_STRING, TYPE_INT, TYPE_BOOL
 } from "./utils.uc";
-import { find_phy } from "wifi.utils";
+import { find_phy, find_radio_by_band } from "wifi.utils";
 import * as wdev from "./wireless-device.uc";
 
 let wireless = netifd.wireless = {
@@ -139,6 +139,7 @@ function config_init(uci)
 			list[name] = data;
 	}
 
+	let band_ordinal = {};
 	for (let name, data in sections.device) {
 		if (!data.type)
 			continue;
@@ -147,10 +148,24 @@ function config_init(uci)
 		if (!handler)
 			continue;
 
-		if (data.radio != null)
-			radio_idx[name] = +data.radio;
-
 		let config = parse_attribute_list(data, handler.device);
+
+		if (data.radio != null) {
+			radio_idx[name] = +data.radio;
+		} else if (config.detect_band && config.band) {
+			/* Radios on a multi-radio phy whose index shuffles across
+			 * reboots are matched by band. Bind this section to the Nth
+			 * radio carrying its band, in config order. */
+			let phy = find_phy(config, true);
+			let key = phy + "|" + lc(config.band);
+			let ordinal = band_ordinal[key] ?? 0;
+			band_ordinal[key] = ordinal + 1;
+
+			let radio = find_radio_by_band(phy, config.band, ordinal);
+			if (radio != null)
+				radio_idx[name] = config.radio = radio;
+		}
+
 		devices[name] = {
 			name,
 			config,

--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
@@ -27,6 +27,7 @@ drv_mac80211_init_device_config() {
 	hostapd_common_add_device_config
 
 	config_add_string path phy 'macaddr:macaddr'
+	config_add_boolean detect_band
 	config_add_string tx_burst
 	config_add_string distance
 	config_add_string ifname_prefix

--- a/package/network/config/wifi-scripts/files/lib/wifi/mac80211.uc
+++ b/package/network/config/wifi-scripts/files/lib/wifi/mac80211.uc
@@ -14,10 +14,20 @@ let commit;
 
 let config = uci.cursor().get_all("wireless") ?? {};
 
-function radio_exists(path, macaddr, phy, radio) {
+let detect_band = false;
+for (let name, s in config)
+	if (s[".type"] == "wifi-config" && s.detect_band == "1")
+		detect_band = true;
+
+function radio_exists(path, macaddr, phy, radio, band) {
 	for (let name, s in config) {
 		if (s[".type"] != "wifi-device")
 			continue;
+		if (band != null) {
+			if (s.phy == phy && lc(s.band ?? "") == band)
+				return true;
+			continue;
+		}
 		if (radio != null && int(s.radio) != radio)
 			continue;
 		if (s.macaddr && lc(s.macaddr) == lc(macaddr))
@@ -69,11 +79,11 @@ for (let phy_name, phy in board.wlan) {
 			continue;
 
 		let macaddr = trim(readfile(`/sys/class/ieee80211/${phy_name}/macaddress`));
-		if (radio_exists(phy.path, macaddr, phy_name, radio.index))
+		if (radio_exists(phy.path, macaddr, phy_name, radio.index, detect_band ? lc(band_name) : null))
 			continue;
 
 		let id = `phy='${phy_name}'`;
-		if (match(phy_name, /^phy[0-9]/))
+		if (!detect_band && match(phy_name, /^phy[0-9]/))
 			id = `path='${phy.path}'`;
 
 		band_name = lc(band_name);
@@ -93,7 +103,9 @@ for (let phy_name, phy in board.wlan) {
 			num_global_macaddr = board.wlan.defaults.ssids?.[band_name]?.mac_count;
 		}
 
-		if (length(info.radios) > 0)
+		if (detect_band)
+			id += `\nset ${s}.detect_band='1'`;
+		else if (length(info.radios) > 0)
 			id += `\nset ${s}.radio='${radio.index}'`;
 
 		print(`set ${s}=wifi-device

--- a/package/network/config/wifi-scripts/files/usr/share/ucode/wifi/utils.uc
+++ b/package/network/config/wifi-scripts/files/usr/share/ucode/wifi/utils.uc
@@ -32,6 +32,8 @@ function __find_phy_by_path(phys, path) {
 }
 
 function find_phy_by_macaddr(phys, macaddr) {
+	if (!macaddr)
+		return null;
 	macaddr = lc(macaddr);
 	return filter(phys, (phy) => phy_file(phy, "macaddr") == macaddr)[0];
 }
@@ -109,4 +111,32 @@ export function find_phy(config, rename) {
 	return find_phy_by_path(phys, config.path) ??
 	       find_phy_by_macaddr(phys, config.macaddr) ??
 	       find_phy_by_name(phys, config.phy, rename);
+};
+
+export function find_radio_by_band(phy, band, ordinal) {
+	if (!phy || !band)
+		return null;
+
+	band = uc(band);
+	ordinal ??= 0;
+
+	let data = json(readfile("/etc/board.json")).wlan;
+	if (!data)
+		return null;
+
+	let info = data[phy]?.info;
+	if (!info)
+		for (let name, entry in data)
+			if (entry.path && phy_path_match(phy, entry.path)) {
+				info = entry.info;
+				break;
+			}
+
+	let matches = [];
+	for (let radio in info?.radios)
+		if (radio.bands?.[band] != null)
+			push(matches, radio.index);
+	sort(matches, (a, b) => a - b);
+
+	return matches[ordinal] ?? null;
 };


### PR DESCRIPTION
Add a detect_band option that binds a radio configuration to a phy + band pair rather than to a path or radio index.

Some devices (e.g. ath12k-wsi) enumerate their radios at non- deterministic PCI addresses, so neither the device path nor the radio index is stable across reboots. Matching by band keeps the per-band configuration attached to the correct radio regardless of enumeration order.

The behavior is opt-in: detection only switches to band matching when a 'wifi-config' section sets detect_band='1'. Devices seed it from a per-device uci-defaults script, e.g.:

```
. /lib/functions.sh

case "$(board_name)" in
askey,sbe1v1k)
	if ! uci -q get wireless.detect_band >/dev/null; then
		uci set wireless.detect_band=wifi-config
		uci set wireless.detect_band.detect_band='1'
		uci commit wireless
	fi
	;;
esac
```
Link: openwrt#22157
Signed-off-by: Kenneth Kasilag <kenneth@kasilag.me>