### PR TITLE
[24.10] openssl: update to version 3.0.21

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
-PKG_VERSION:=3.0.20
+PKG_VERSION:=3.0.21
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
@@ -21,7 +21,7 @@ PKG_SOURCE_URL:= \
 	https://www.openssl.org/source/old/$(PKG_BASE)/ \
 	https://github.com/openssl/openssl/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
 
-PKG_HASH:=c80a01dfc70ece4dc21168932c37739042d404d46ccc81a5986dd75314ecda6f
+PKG_HASH:=617e29af8e421f46649484a4937e48c685e47f46488167c982f88bc4ec1d522f
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE.txt

--- a/package/libs/openssl/patches/140-allow-prefer-chacha20.patch
+++ b/package/libs/openssl/patches/140-allow-prefer-chacha20.patch
@@ -16,7 +16,7 @@ Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
 
 --- a/ssl/ssl_ciph.c
 +++ b/ssl/ssl_ciph.c
-@@ -1490,11 +1490,29 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
+@@ -1494,11 +1494,29 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
      ssl_cipher_apply_rule(0, SSL_kECDHE, 0, 0, 0, 0, 0, CIPHER_DEL, -1, &head,
          &tail);
  
@@ -46,7 +46,7 @@ Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
  
      /*
       * ...and generally, our preferred cipher is AES.
-@@ -1549,7 +1567,7 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
+@@ -1553,7 +1571,7 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
       * Within each group, ciphers remain sorted by strength and previous
       * preference, i.e.,
       * 1) ECDHE > DHE
@@ -55,7 +55,7 @@ Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
       * 3) AES > rest
       * 4) TLS 1.2 > legacy
       *
-@@ -2222,7 +2240,13 @@ const char *OSSL_default_cipher_list(voi
+@@ -2226,7 +2244,13 @@ const char *OSSL_default_cipher_list(voi
   */
  const char *OSSL_default_ciphersuites(void)
  {


### PR DESCRIPTION
OpenSSL 3.0.21 is a security patch release. The most severe CVE fixed in this release is High.

This release incorporates the following bug fixes and mitigations:

 * Fixed heap use-after-free in PKCS7_verify(). (CVE-2026-45447)

 * Fixed CMS AuthEnvelopedData processing may accept forged messages. (CVE-2026-34182)

 * Fixed AES-OCB IV ignored on EVP_Cipher() path. (CVE-2026-45445)

 * Fixed possible heap buffer overflow in ASN.1 multibyte string conversion. (CVE-2026-7383)

 * Fixed out-of-bounds read in CMS password-based decryption. (CVE-2026-9076)

 * Fixed heap buffer over-read in ASN.1 content parsing. (CVE-2026-34180)

 * Fixed possible NULL dereference in password-dased CMS decryption. (CVE-2026-42766)

 * Fixed FFC-DH peer validation uses attacker-supplied q. (CVE-2026-42770)

 * Fixed incorrect tag processing for empty messages in AES-GCM-SIV and AES-SIV modes. (CVE-2026-45446)
