### PR TITLE
mediatek: filogic: fix Totolink X6000R device tree

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-totolink-x6000r.dts
+++ b/target/linux/mediatek/dts/mt7981b-totolink-x6000r.dts
@@ -1,7 +1,8 @@
-// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
 /dts-v1/;
-
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
 #include <dt-bindings/leds/common.h>
 
 #include "mt7981b.dtsi"
@@ -11,55 +12,56 @@
 	compatible = "totolink,x6000r", "mediatek,mt7981";
 
 	aliases {
-		label-mac-device = &gmac0;
-		led-boot = &led_status;
-		led-failsafe = &led_status_red;
-		led-running = &led_status;
-		led-upgrade = &led_status;
 		serial0 = &uart0;
+		led-boot = &sys_blue;
+		led-failsafe = &sys_red;
+		led-running = &sys_blue;
+		led-upgrade = &sys_blue;
+		wan = &gmac1;
 	};
 
 	chosen {
 		stdout-path = "serial0:115200n8";
 	};
 
-	memory@40000000 {
+	memory {
 		reg = <0 0x40000000 0 0x10000000>;
-		device_type = "memory";
 	};
 
 	gpio-keys {
 		compatible = "gpio-keys";
 
-		reset {
+		button-0 {
 			label = "reset";
 			linux,code = <KEY_RESTART>;
 			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
 		};
 
-		wps {
+		button-1 {
 			label = "wps";
 			linux,code = <KEY_WPS_BUTTON>;
 			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
 		};
 	};
 
 	gpio-leds {
 		compatible = "gpio-leds";
 
-		led-0 {
-			function = LED_FUNCTION_WAN;
+		led-wan {
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
 			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
 		};
 
-		led_status_red: led-1 {
+		sys_red: led-status-red {
 			color = <LED_COLOR_ID_RED>;
 			function = LED_FUNCTION_STATUS;
 			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
 		};
 
-		led_status: led-2 {
+		sys_blue: led-status-blue {
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_STATUS;
 			gpios = <&pio 15 GPIO_ACTIVE_LOW>;
@@ -72,158 +74,26 @@
 	status = "okay";
 };
 
-&eth {
-	pinctrl-names = "default";
-	pinctrl-0 = <&mdio_pins>;
-	status = "okay";
-
-	gmac0: mac@0 {
-		compatible = "mediatek,eth-mac";
-		reg = <0>;
-		phy-mode = "2500base-x";
-
-		nvmem-cells = <&macaddr_factory_14>;
-		nvmem-cell-names = "mac-address";
-
-		fixed-link {
-			speed = <2500>;
-			full-duplex;
-			pause;
-		};
-	};
-
-	mac@1 {
-		compatible = "mediatek,eth-mac";
-		reg = <1>;
-		phy-mode = "gmii";
-		phy-handle = <&int_gbe_phy>;
-		label = "wan";
-
-		nvmem-cells = <&macaddr_factory_1a>;
-		nvmem-cell-names = "mac-address";
-	};
-};
-
-&mdio_bus {
-	switch: switch@1f {
-		compatible = "mediatek,mt7531";
-		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
-		interrupt-controller;
-		#interrupt-cells = <1>;
-		interrupt-parent = <&pio>;
-		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
-
-		ports {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			port@0 {
-				reg = <0>;
-				label = "lan4";
-			};
-
-			port@1 {
-				reg = <1>;
-				label = "lan3";
-			};
-
-			port@2 {
-				reg = <2>;
-				label = "lan2";
-			};
-
-			port@3 {
-				reg = <3>;
-				label = "lan1";
-			};
-
-			port@6 {
-				reg = <6>;
-				label = "cpu";
-				ethernet = <&gmac0>;
-				phy-mode = "2500base-x";
-
-				fixed-link {
-					speed = <2500>;
-					full-duplex;
-					pause;
-				};
-			};
-		};
-	};
-};
-
-&spi2 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&spi2_flash_pins>;
-	status = "okay";
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-
-		spi-max-frequency = <52000000>;
-		spi-tx-bus-width = <4>;
-		spi-rx-bus-width = <4>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "BL2";
-				reg = <0x00000 0x40000>;
-				read-only;
-			};
-
-			partition@40000 {
-				label = "u-boot-env";
-				reg = <0x40000 0x10000>;
-				read-only;
-			};
-
-			partition@50000 {
-				label = "Factory";
-				reg = <0x50000 0xb0000>;
-				read-only;
-
-				nvmem-layout {
-					compatible = "fixed-layout";
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					eeprom_factory_0: eeprom@0 {
-						reg = <0x0 0x1000>;
-					};
-
-					macaddr_factory_14: macaddr@14 {
-						reg = <0x14 0x6>;
-					};
-
-					macaddr_factory_1a: macaddr@1a {
-						reg = <0x1a 0x6>;
-					};
-				};
-			};
-
-			partition@100000 {
-				label = "FIP";
-				reg = <0x100000 0x80000>;
-				read-only;
-			};
-
-			partition@180000 {
-				compatible = "denx,fit";
-				label = "firmware";
-				reg = <0x180000 0xe00000>;
-			};
-		};
-	};
-};
-
 &pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+
 	spi2_flash_pins: spi2-pins {
 		mux {
 			function = "spi";
@@ -239,13 +109,194 @@
 		conf-pd {
 			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
 			drive-strength = <MTK_DRIVE_8mA>;
-			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+		broken-flash-reset;
+	};
+};
+
+&spi2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi2_flash_pins>;
+	status = "okay";
+
+	spi_nor: flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <48000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@00000 {
+				label = "BL2";
+				reg = <0x00000 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@50000 {
+				label = "Factory";
+				reg = <0x50000 0xb0000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					mac_lan: macaddr@4 {
+						reg = <0x04 0x6>;
+					};
+
+					mac_wan: macaddr@a {
+						reg = <0x0a 0x6>;
+					};
+
+					mac_wifi_2g: macaddr@14 {
+						reg = <0x14 0x6>;
+					};
+
+					mac_wifi_5g: macaddr@1a {
+						reg = <0x1a 0x6>;
+					};
+				};
+			};
+
+			partition@100000 {
+				label = "FIP";
+				reg = <0x100000 0x80000>;
+				read-only;
+			};
+
+			partition@180000 {
+				label = "firmware";
+				reg = <0x180000 0xe00000>;
+			};
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+		nvmem-cells = <&mac_lan>;
+		nvmem-cell-names = "mac-address";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		nvmem-cells = <&mac_wan>;
+		nvmem-cell-names = "mac-address";
+		phy-handle = <&int_gbe_phy>;
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		switch@1f {
+			compatible = "mediatek,mt7531";
+			reg = <31>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			interrupt-parent = <&pio>;
+			interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+					label = "lan1";
+				};
+
+				port@1 {
+					reg = <1>;
+					label = "lan2";
+				};
+
+				port@2 {
+					reg = <2>;
+					label = "lan3";
+				};
+
+				port@3 {
+					reg = <3>;
+					label = "lan4";
+				};
+
+				port@6 {
+					reg = <6>;
+					ethernet = <&gmac0>;
+					phy-mode = "2500base-x";
+
+					fixed-link {
+						speed = <2500>;
+						full-duplex;
+						pause;
+					};
+				};
+			};
 		};
 	};
 };
 
 &wifi {
 	status = "okay";
-	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";
+	nvmem-cells = <&eeprom_factory_0>;
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&mac_wifi_2g>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&mac_wifi_5g>;
+		nvmem-cell-names = "mac-address";
+	};
 };

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -295,7 +295,9 @@ teltonika,rutc50)
 	ucidef_set_led_netdev "wan-amber" "WAN" "mdio-bus:00:amber:wan" "wan" "link_100 link_10 tx rx"
 	;;
 totolink,x6000r)
-	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan" "link tx rx"
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1" "link tx rx"
+	ucidef_set_led_default "sys_red" "SYS RED" "red:status" "0"
+	ucidef_set_led_default "sys_blue" "SYS BLUE" "blue:status" "1"
 	;;
 tplink,archer-ax80-v1-eu)
 	ucidef_set_led_netdev "lan" "LAN" "white:lan" "br-lan" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -222,6 +222,9 @@ mediatek_setup_interfaces()
 	tplink,re6000xd)
 		ucidef_set_interface_lan "lan1 lan2 eth1"
 		;;
+	totolink,x6000r)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" eth1
+		;;
 	xiaomi,mi-router-ax3000t|\
 	xiaomi,mi-router-ax3000t-ubootmod|\
 	xiaomi,mi-router-wr30u-stock|\


### PR DESCRIPTION
The vendor DTS contains several hardware definitions that differ from the current OpenWrt device tree. Update the DTS using values verified from the vendor firmware and tested on real hardware.

## Changes:
- Fix switch reset GPIO assignment
- Fix WAN LED GPIO mapping
- Fix LAN, WAN and WiFi MAC address assignments using Factory partition
  NVMEM data
- Add WiFi MAC address definitions for both bands
- Configure the blue status LED as the boot/running indicator
- Add CPU thermal zone definition
- Fix default WAN interface assignment
- Convert status LEDs to use function/color-based LED definitions

## Tested on Totolink X6000R (SPI NOR variant):
- Device boots successfully
- MT7531 switch initializes correctly
- LAN1-LAN4 ports operate normally
- WAN interface operates normally
- 2.4 GHz and 5 GHz radios initialize correctly
- Factory MAC addresses are assigned correctly
- Status and WAN LEDs operate correctly
- Sysupgrade completes successfully

## Boot log
```[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Linux version 6.12.93 (ayra@Tedy-PC) (aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 14.3.0 r32969-3f59bc0e14) 14.3.0, GNU ld (GNU Binutils) 2.44) #0 SMP Tue Jun 16 23:55:50 2026
[    0.000000] Machine model: Totolink X6000R
[    0.000000] OF: reserved mem: 0x0000000042ff0000..0x0000000042ffffff (64 KiB) map non-reusable ramoops@42ff0000
[    0.000000] OF: reserved mem: 0x0000000043000000..0x000000004302ffff (192 KiB) nomap non-reusable secmon@43000000
[    0.000000] OF: reserved mem: 0x0000000047c80000..0x0000000047d7ffff (1024 KiB) nomap non-reusable wmcpu-reserved@47c80000
[    0.000000] OF: reserved mem: 0x0000000047d80000..0x0000000047dbffff (256 KiB) nomap non-reusable wo-emi@47d80000
[    0.000000] OF: reserved mem: 0x0000000047dc0000..0x0000000047ffffff (2304 KiB) nomap non-reusable wo-data@47dc0000
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000040000000-0x000000004fffffff]
[    0.000000]   DMA32    empty
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000040000000-0x0000000042ffffff]
[    0.000000]   node   0: [mem 0x0000000043000000-0x000000004302ffff]
[    0.000000]   node   0: [mem 0x0000000043030000-0x0000000047c7ffff]
[    0.000000]   node   0: [mem 0x0000000047c80000-0x0000000047ffffff]
[    0.000000]   node   0: [mem 0x0000000048000000-0x000000004fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000040000000-0x000000004fffffff]
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.1 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] psci: SMC Calling Convention v1.2
[    0.000000] percpu: Embedded 20 pages/cpu s42520 r8192 d31208 u81920
[    0.000000] pcpu-alloc: s42520 r8192 d31208 u81920 alloc=20*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: GIC system register CPU interface
[    0.000000] CPU features: kernel page table isolation disabled by kernel configuration
[    0.000000] alternatives: applying boot alternatives
[    0.000000] Kernel command line:
[    0.000000] Dentry cache hash table entries: 32768 (order: 6, 262144 bytes, linear)
[    0.000000] Inode-cache hash table entries: 16384 (order: 5, 131072 bytes, linear)
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 65536
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] software IO TLB: SWIOTLB bounce buffer size adjusted to 0MB
[    0.000000] software IO TLB: area num 2.
[    0.000000] software IO TLB: SWIOTLB bounce buffer size roundup to 0MB
[    0.000000] software IO TLB: mapped [mem 0x000000004fe49000-0x000000004fec9000] (0MB)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=2, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] rcu:     RCU restricting CPUs from NR_CPUS=4 to nr_cpu_ids=2.
[    0.000000]  Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=2
[    0.000000] RCU Tasks Trace: Setting shift to 1 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=2.
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] GICv3: GIC: Using split EOI/Deactivate mode
[    0.000000] GICv3: 640 SPIs implemented
[    0.000000] GICv3: 0 Extended SPIs implemented
[    0.000000] Root IRQ handler: gic_handle_irq
[    0.000000] GICv3: GICv3 features: 16 PPIs
[    0.000000] GICv3: GICD_CTRL.DS=0, SCR_EL3.FIQ=0
[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x000000000c080000
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] arch_timer: cp15 timer(s) running at 13.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x2ff89eacb, max_idle_ns: 440795202429 ns
[    0.000000] sched_clock: 56 bits at 13MHz, resolution 76ns, wraps every 4398046511101ns
[    0.000075] Calibrating delay loop (skipped), value calculated using timer frequency.. 26.00 BogoMIPS (lpj=130000)
[    0.000083] pid_max: default: 32768 minimum: 301
[    0.003027] Mount-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.003034] Mountpoint-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.005142] cacheinfo: Unable to detect cache hierarchy for CPU 0
[    0.005967] rcu: Hierarchical SRCU implementation.
[    0.005973] rcu:     Max phase no-delay instances is 1000.
[    0.006180] Timer migration: 1 hierarchy levels; 8 children per group; 1 crossnode level
[    0.006404] smp: Bringing up secondary CPUs ...
[    0.006787] Detected VIPT I-cache on CPU1
[    0.006836] GICv3: CPU1: found redistributor 1 region 0:0x000000000c0a0000
[    0.006866] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
[    0.006950] smp: Brought up 1 node, 2 CPUs
[    0.006956] SMP: Total of 2 processors activated.
[    0.006959] CPU: All CPU(s) started at EL2
[    0.006961] CPU features: detected: 32-bit EL0 Support
[    0.006966] CPU features: detected: CRC32 instructions
[    0.006989] alternatives: applying system-wide alternatives
[    0.007119] CPU features: emulated: Privileged Access Never (PAN) using TTBR0_EL1 switching
[    0.007254] Memory: 236896K/262144K available (9216K kernel code, 984K rwdata, 2764K rodata, 448K init, 300K bss, 23604K reserved, 0K cma-reserved)
[    0.010366] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.010383] futex hash table entries: 512 (order: 3, 32768 bytes, linear)
[    0.010442] 29296 pages in range for non-PLT usage
[    0.010445] 520816 pages in range for PLT usage
[    0.011943] pinctrl core: initialized pinctrl subsystem
[    0.013137] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.013439] DMA: preallocated 128 KiB GFP_KERNEL pool for atomic allocations
[    0.013464] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
[    0.013485] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
[    0.013891] thermal_sys: Registered thermal governor 'fair_share'
[    0.013895] thermal_sys: Registered thermal governor 'bang_bang'
[    0.013898] thermal_sys: Registered thermal governor 'step_wise'
[    0.013901] thermal_sys: Registered thermal governor 'user_space'
[    0.013949] ASID allocator initialised with 65536 entries
[    0.014605] pstore: Using crash dump compression: deflate
[    0.014610] pstore: Registered ramoops as persistent store backend
[    0.014612] ramoops: using 0x10000@0x42ff0000, ecc: 0
[    0.016175] /soc/interrupt-controller@c000000: Fixed dependency cycle(s) with /soc/interrupt-controller@c000000
[    0.032710] cryptd: max_cpu_qlen set to 1000
[    0.035089] SCSI subsystem initialized
[    0.035246] libata version 3.00 loaded.
[    0.036948] clocksource: Switched to clocksource arch_sys_counter
[    0.039254] NET: Registered PF_INET protocol family
[    0.039353] IP idents hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.040474] tcp_listen_portaddr_hash hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.040489] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.040500] TCP established hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.040520] TCP bind hash table entries: 2048 (order: 4, 65536 bytes, linear)
[    0.040570] TCP: Hash tables configured (established 2048 bind 2048)
[    0.040787] MPTCP token hash table entries: 256 (order: 1, 6144 bytes, linear)
[    0.040891] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.040906] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.041097] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.041130] PCI: CLS 0 bytes, default 64
[    0.042367] workingset: timestamp_bits=46 max_order=16 bucket_order=0
[    0.047452] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.047461] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.113997] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[    0.115167] printk: legacy console [ttyS0] disabled
[    0.135547] 11002000.serial: ttyS0 at MMIO 0x11002000 (irq = 72, base_baud = 2500000) is a ST16650V2
[    0.135591] printk: legacy console [ttyS0] enabled
[    0.898121] random: crng init done
[    0.904542] loop: module loaded
[    0.909911] 5 fixed-partitions partitions found on MTD device spi0.0
[    0.916269] Creating 5 MTD partitions on "spi0.0":
[    0.921106] 0x000000000000-0x000000040000 : "BL2"
[    0.926193] 0x000000040000-0x000000050000 : "u-boot-env"
[    0.931937] 0x000000050000-0x000000100000 : "Factory"
[    0.938251] 0x000000100000-0x000000180000 : "FIP"
[    0.943287] 0x000000180000-0x000000f80000 : "firmware"
[    0.948952] 2 fit-fw partitions found on MTD device firmware
[    0.954616] 0x000000180000-0x0000005d0000 : "kernel"
[    0.960021] 0x0000005e0000-0x000000f80000 : "rootfs"
[    0.965287] mtd: setting mtd6 (rootfs) as root device
[    0.970509] 1 squashfs-split partitions found on MTD device rootfs
[    0.976685] 0x000000ab0000-0x000000f80000 : "rootfs_data"
[    0.985710] spi-nor spi1.0: unrecognized JEDEC id bytes: ff ff ff ff ff ff
[    1.124877] mtk_soc_eth 15100000.ethernet eth0: mediatek frame engine at 0xffffffc081400000, irq 76
[    1.134780] mtk_soc_eth 15100000.ethernet eth1: mediatek frame engine at 0xffffffc081400000, irq 76
[    1.144626] i2c_dev: i2c /dev entries driver
[    1.150641] mtk-wdt 1001c000.watchdog: Watchdog enabled (timeout=31 sec, nowayout=0)
[    1.159419] NET: Registered PF_INET6 protocol family
[    1.165258] Segment Routing with IPv6
[    1.168966] In-situ OAM (IOAM) with IPv6
[    1.172926] NET: Registered PF_PACKET protocol family
[    1.178344] 8021q: 802.1Q VLAN Support v1.8
[    1.236583] mt7530-mdio mdio-bus:1f: configuring for fixed/2500base-x link mode
[    1.245723] mt7530-mdio mdio-bus:1f: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    1.255319] mt7530-mdio mdio-bus:1f lan1 (uninitialized): PHY [mt7530-0:00] driver [MediaTek MT7531 PHY] (irq=80)
[    1.276628] mt7530-mdio mdio-bus:1f lan2 (uninitialized): PHY [mt7530-0:01] driver [MediaTek MT7531 PHY] (irq=81)
[    1.297634] mt7530-mdio mdio-bus:1f lan3 (uninitialized): PHY [mt7530-0:02] driver [MediaTek MT7531 PHY] (irq=82)
[    1.318565] mt7530-mdio mdio-bus:1f lan4 (uninitialized): PHY [mt7530-0:03] driver [MediaTek MT7531 PHY] (irq=83)
[    1.330057] mtk_soc_eth 15100000.ethernet eth0: entered promiscuous mode
[    1.336791] DSA: tree 0 setup
[    1.340117] clk: Disabling unused clocks
[    1.344310] PM: genpd: Disabling unused power domains
[    1.354445] VFS: Mounted root (squashfs filesystem) readonly on device 31:6.
[    1.361705] Freeing unused kernel memory: 448K
[    1.366182] Run /sbin/init as init process
[    1.370282]   with arguments:
[    1.373237]     /sbin/init
[    1.375932]   with environment:
[    1.379135]     HOME=/
[    1.381484]     TERM=linux
[    1.650638] init: Console is alive
[    1.654176] init: - watchdog -
[    2.132239] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    2.185702] gpio_button_hotplug: loading out-of-tree module taints kernel.
[    2.195907] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    2.212001] init: - preinit -
[    2.546083] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[    2.554579] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    2.576888] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
[    2.593018] mt7530-mdio mdio-bus:1f lan1: Link is Up - 1Gbps/Full - flow control off
[    6.814199] mount_root: jffs2 not ready yet, using temporary tmpfs overlay
[    6.821605] overlayfs: null uuid detected in lower fs '/', falling back to xino=off,index=off,nfs_export=off.
[    6.832857] urandom-seed: Seed file not found (/etc/urandom.seed)
[    7.529138] mt7530-mdio mdio-bus:1f lan1: Link is Down
[    7.538571] procd: - early -
[    7.541515] procd: - watchdog -
[    8.082085] procd: - watchdog -
[    8.130543] procd: - ubus -
[    8.195659] procd: - init -
[    8.735497] urngd: v1.0.2 started.
[    8.912662] kmodloader: loading kernel modules from /etc/modules.d/*
[    8.977801] crypto-safexcel 10320000.crypto: EIP97:230(0,1,4,4)-HIA:270(0,5,5),PE:150/433(alg:7fcdfc00)/0/0/0
[    8.993891] Loading modules backported from Linux version v6.18.26-0-g1fe060681
[    9.001237] Backport generated by backports.git 6ecbb44
[    9.381899] mt798x-wmac 18000000.wifi: HW/SW Version: 0x8a108a10, Build Time: 20240823161240a
[    9.637721] mt798x-wmac 18000000.wifi: WM Firmware Version: ____000000, Build Time: 20240823161304
[    9.759399] mt798x-wmac 18000000.wifi: WA Firmware Version: DEV_000000, Build Time: 20240823161841
[    9.857374] mt798x-wmac 18000000.wifi: registering led 'mt76-phy0'
[    9.909045] mt798x-wmac 18000000.wifi: registering led 'mt76-phy1'
[    9.993485] PPP generic driver version 2.4.2
[    9.998879] NET: Registered PF_PPPOX protocol family
[   10.007317] kmodloader: done loading kernel modules from /etc/modules.d/*
[   16.288632] mtk_soc_eth 15100000.ethernet eth0: Link is Down
[   16.304876] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[   16.313997] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[   16.320682] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
[   16.334473] br-lan: port 1(lan1) entered blocking state
[   16.339794] br-lan: port 1(lan1) entered disabled state
[   16.345064] mt7530-mdio mdio-bus:1f lan1: entered allmulticast mode
[   16.351408] mtk_soc_eth 15100000.ethernet eth0: entered allmulticast mode
[   16.374298] mt7530-mdio mdio-bus:1f lan1: entered promiscuous mode
[   16.398079] mt7530-mdio mdio-bus:1f lan2: configuring for phy/gmii link mode
[   16.412137] br-lan: port 2(lan2) entered blocking state
[   16.417438] br-lan: port 2(lan2) entered disabled state
[   16.422719] mt7530-mdio mdio-bus:1f lan2: entered allmulticast mode
[   16.431299] mt7530-mdio mdio-bus:1f lan2: entered promiscuous mode
[   16.458302] mt7530-mdio mdio-bus:1f lan3: configuring for phy/gmii link mode
[   16.471489] br-lan: port 3(lan3) entered blocking state
[   16.476727] br-lan: port 3(lan3) entered disabled state
[   16.482046] mt7530-mdio mdio-bus:1f lan3: entered allmulticast mode
[   16.491497] mt7530-mdio mdio-bus:1f lan3: entered promiscuous mode
[   16.509084] mt7530-mdio mdio-bus:1f lan4: configuring for phy/gmii link mode
[   16.520924] br-lan: port 4(lan4) entered blocking state
[   16.526163] br-lan: port 4(lan4) entered disabled state
[   16.531504] mt7530-mdio mdio-bus:1f lan4: entered allmulticast mode
[   16.540765] mt7530-mdio mdio-bus:1f lan4: entered promiscuous mode
[   16.581757] mtk_soc_eth 15100000.ethernet eth1: PHY [mdio-bus:00] driver [MediaTek MT7981 PHY] (irq=POLL)
[   16.591413] mtk_soc_eth 15100000.ethernet eth1: configuring for phy/gmii link mode
[   16.602557] mtk_soc_eth 15100000.ethernet eth1: Link is Up - 1Gbps/Full - flow control rx/tx
[   17.146879] jffs2_scan_eraseblock(): End of filesystem marker found at 0x0
[   17.154335] jffs2_build_filesystem(): unlocking the mtd device...
[   17.154349] done.
[   17.162510] jffs2_build_filesystem(): erasing all blocks after the end marker...
[   18.780073] mt7530-mdio mdio-bus:1f lan1: Link is Up - 1Gbps/Full - flow control off
[   18.780104] br-lan: port 1(lan1) entered blocking state
[   18.800514] br-lan: port 1(lan1) entered forwarding state
[   33.624895] done.
[   33.626835] jffs2: notice: (2396) jffs2_build_xattr_subsystem: complete building xattr subsystem, 0 of xdatum (0 unchecked, 0 orphan) and 0 of xref (0 dead, 0 orphan) found.
[   33.738047] overlayfs: upper fs does not support tmpfile.
[   33.745231] overlayfs: null uuid detected in lower fs '/', falling back to xino=off,index=off,nfs_export=off.
```