### PR TITLE
openssl: update to 3.5.7

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
-PKG_VERSION:=3.5.6
+PKG_VERSION:=3.5.7
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
@@ -21,7 +21,7 @@ PKG_SOURCE_URL:= \
 	https://www.openssl.org/source/old/$(PKG_BASE)/ \
 	https://github.com/openssl/openssl/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
 
-PKG_HASH:=deae7c80cba99c4b4f940ecadb3c3338b13cb77418409238e57d7f31f2a3b736
+PKG_HASH:=a8c0d28a529ca480f9f36cf5792e2cd21984552a3c8e4aa11a24aa31aeac98e8
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE.txt

--- a/package/libs/openssl/patches/100-Configure-afalg-support.patch
+++ b/package/libs/openssl/patches/100-Configure-afalg-support.patch
@@ -10,7 +10,7 @@ Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
 
 --- a/Configure
 +++ b/Configure
-@@ -1811,7 +1811,9 @@ $config{CFLAGS} = [ map { $_ eq '--ossl-
+@@ -1816,7 +1816,9 @@ $config{CFLAGS} = [ map { $_ eq '--ossl-
  
  unless ($disabled{afalgeng}) {
      $config{afalgeng}="";

--- a/package/libs/openssl/patches/140-allow-prefer-chacha20.patch
+++ b/package/libs/openssl/patches/140-allow-prefer-chacha20.patch
@@ -16,7 +16,7 @@ Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
 
 --- a/ssl/ssl_ciph.c
 +++ b/ssl/ssl_ciph.c
-@@ -1471,11 +1471,29 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
+@@ -1475,11 +1475,29 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
      ssl_cipher_apply_rule(0, SSL_kECDHE, 0, 0, 0, 0, 0, CIPHER_DEL, -1, &head,
          &tail);
  
@@ -46,7 +46,7 @@ Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
  
      /*
       * ...and generally, our preferred cipher is AES.
-@@ -1530,7 +1548,7 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
+@@ -1534,7 +1552,7 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
       * Within each group, ciphers remain sorted by strength and previous
       * preference, i.e.,
       * 1) ECDHE > DHE
@@ -55,7 +55,7 @@ Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
       * 3) AES > rest
       * 4) TLS 1.2 > legacy
       *
-@@ -2232,7 +2250,13 @@ const char *OSSL_default_cipher_list(voi
+@@ -2236,7 +2254,13 @@ const char *OSSL_default_cipher_list(voi
   */
  const char *OSSL_default_ciphersuites(void)
  {


### PR DESCRIPTION
This release incorporates the following bug fixes and mitigations:

 * Fixed heap use-after-free in PKCS7_verify(). (CVE-2026-45447)
 * Fixed CMS AuthEnvelopedData processing may accept forged messages. (CVE-2026-34182)
 * Fixed unbounded memory growth in the QUIC PATH_CHALLENGE handler. (CVE-2026-34183)
 * Fixed NULL pointer dereference in QUIC server initial packet handling. (CVE-2026-42764)
 * Fixed AES-OCB IV ignored on EVP_Cipher() path. (CVE-2026-45445)
 * Fixed possible heap buffer overflow in ASN.1 multibyte string conversion. (CVE-2026-7383)
 * Fixed out-of-bounds read in CMS password-based decryption. (CVE-2026-9076)
 * Fixed heap buffer over-read in ASN.1 content parsing. (CVE-2026-34180)
 * Fixed PKCS#12 files with PBMAC1 are accepted with short HMAC keys. (CVE-2026-34181)
 * Fixed possible NULL dereference in password-dased CMS decryption. (CVE-2026-42766)
 * Fixed NULL pointer dereference in CRMF EncryptedValue decryption. (CVE-2026-42767)
 * Fixed multi-RecipientInfo Bleichenbacher Oracle in CMS_decrypt() and PKCS7_decrypt(). (CVE-2026-42768)
 * Fixed trust anchor substitution via cert/issuer typo in CMP rootCaKeyUpdate. (CVE-2026-42769)
 * Fixed FFC-DH peer validation uses attacker-supplied q. (CVE-2026-42770)
 * Fixed incorrect tag processing for empty messages in AES-GCM-SIV and AES-SIV modes. (CVE-2026-45446)