### PR TITLE
wifi-scripts: rename phys to board.json names at detection time

### DIFF
--- a/package/network/config/wifi-scripts/files/usr/share/hostap/wifi-detect.uc
+++ b/package/network/config/wifi-scripts/files/usr/share/hostap/wifi-detect.uc
@@ -2,6 +2,7 @@
 'use strict';
 import { readfile, writefile, realpath, glob, basename, unlink, open, rename } from "fs";
 import { is_equal } from "/usr/share/hostap/common.uc";
+import { rename_board_phys } from "wifi.utils";
 let nl = require("nl80211");
 
 let board_file = "/etc/board.json";
@@ -246,6 +247,11 @@ function wiphy_detect() {
 	}
 }
 
+// Apply the persistent phy names from board.json (e.g. phyN -> wlN) up
+// front, so the names are correct after 'wifi config' even when netifd
+// never brings up the radio. Otherwise tools resolving a uci wifi-device
+// by its 'phy' option (e.g. iwinfo) fail until the radio is set up.
+rename_board_phys();
 cleanup();
 wiphy_detect();
 if (!is_equal(prev_board_data, board_data)) {

--- a/package/network/config/wifi-scripts/files/usr/share/ucode/wifi/utils.uc
+++ b/package/network/config/wifi-scripts/files/usr/share/ucode/wifi/utils.uc
@@ -110,3 +110,18 @@ export function find_phy(config, rename) {
 	       find_phy_by_macaddr(phys, config.macaddr) ??
 	       find_phy_by_name(phys, config.phy, rename);
 };
+
+// Rename all kernel phys to the persistent names assigned in board.json,
+// matched by device path. find_phy_by_path() does the actual rename; it is
+// a no-op for phys that already carry their board.json name (e.g. fallback
+// "phyN" entries), so only entries that describe a phy by path are relevant.
+export function rename_board_phys() {
+	let wlan = json(readfile("/etc/board.json"))?.wlan;
+	if (!wlan)
+		return;
+
+	let phys = lsdir("/sys/class/ieee80211");
+	for (let name, data in wlan)
+		if (data.path)
+			find_phy_by_path(phys, data.path);
+};


### PR DESCRIPTION
The wifi-device sections generated by `wifi config` reference radios by their board.json name through the 'phy' option (e.g. phy='wl0'). That name is only applied to the kernel phy lazily, by netifd when the radio is brought up. Until then the phy keeps its default name (phy0), so `wifi config` emits a config that points at a phy which does not yet exist - it is not self-consistent.

Consequently anything that resolves a wifi-device to a phy before bringup fails. iwinfo's nl80211_phy_idx_from_uci() reads the 'phy' option and finds no /sys/class/ieee80211/wl0, so `iwinfo nl80211 phyname radio0` (and its iwinfo-lua variant used by LuCI) returns nothing. This is the problem originally reported in #14207.

Commit 4b7323e3bf ("netifd: always call setup for disabled radios") covers the netifd-managed case by renaming even disabled radios on setup, but the phy name is still wrong whenever the radios are not brought up through netifd at all.

Rename the phys to their board.json names in wifi-detect.uc, which runs as part of `wifi config` (at boot and on the ieee80211 hotplug), so the names are correct regardless of netifd bringup. This is the ucode equivalent of the approach in the abandoned PR #17821. A new rename_board_phys() helper in wifi/utils.uc reuses the existing find_phy_by_path() logic; the rename is idempotent and leaves the generated board.json unchanged.

Link: https://github.com/openwrt/openwrt/issues/14207

Link: https://github.com/freifunk-gluon/gluon/pull/3598#issuecomment-4724135661

Tested using Unifi 6 LR v3 in gluon config mode (which does not start netifd) 