### PR TITLE
realtek: pcs: unify SerDes setup sequence

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3066,9 +3066,24 @@ static int rtpcs_930x_sds_cmu_band_get(struct rtpcs_serdes *sds)
 	return cmu_band;
 }
 
+static int rtpcs_930x_sds_config_media(struct rtpcs_serdes *sds, enum rtpcs_sds_media media,
+				       enum rtpcs_sds_mode hw_mode)
+{
+	/*
+	 * dal_longan_construct_mac_default_10gmedia_fiber: set medium to fiber.
+	 * TODO: this is unconditional regardless of hw_mode; needs mode-aware
+	 * handling.
+	 */
+	rtpcs_sds_write_bits(sds, 0x1f, 11, 1, 1, 1);
+
+	rtpcs_930x_sds_tx_config(sds, hw_mode);
+	return 0;
+}
+
 static int rtpcs_930x_setup_serdes(struct rtpcs_serdes *sds,
 				   enum rtpcs_sds_mode hw_mode)
 {
+	enum rtpcs_sds_media sds_media;
 	int ret;
 
 	/* Apply configuration for a hardware mode to SerDes */
@@ -3078,14 +3093,13 @@ static int rtpcs_930x_setup_serdes(struct rtpcs_serdes *sds,
 
 	/* Maybe use dal_longan_sds_init */
 
-	/*
-	 * dal_longan_construct_mac_default_10gmedia_fiber: set medium to fiber.
-	 * TODO: this is unconditional regardless of hw_mode; needs mode-aware
-	 * handling.
-	 */
-	rtpcs_sds_write_bits(sds, 0x1f, 11, 1, 1, 1);
+	ret = rtpcs_sds_select_media(hw_mode, &sds_media);
+	if (ret < 0)
+		return ret;
 
-	rtpcs_930x_sds_tx_config(sds, hw_mode);
+	ret = rtpcs_930x_sds_config_media(sds, sds_media, hw_mode);
+	if (ret < 0)
+		return ret;
 
 	return 0;
 }

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3852,7 +3852,7 @@ static int rtpcs_931x_sds_config_hw_mode(struct rtpcs_serdes *sds,
 		return -ENOTSUPP;
 	}
 
-	return 0;
+	return rtpcs_93xx_sds_config_cmu(sds, hw_mode);
 }
 
 static int rtpcs_931x_setup_serdes(struct rtpcs_serdes *sds,
@@ -3861,10 +3861,6 @@ static int rtpcs_931x_setup_serdes(struct rtpcs_serdes *sds,
 	int ret;
 
 	ret = rtpcs_931x_sds_config_hw_mode(sds, hw_mode);
-	if (ret < 0)
-		return ret;
-
-	ret = rtpcs_93xx_sds_config_cmu(sds, hw_mode);
 	if (ret < 0)
 		return ret;
 

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -512,6 +512,26 @@ static int rtpcs_sds_determine_hw_mode(struct rtpcs_serdes *sds,
 	return 0;
 }
 
+static int rtpcs_sds_select_media(enum rtpcs_sds_mode hw_mode, enum rtpcs_sds_media *media)
+{
+	switch (hw_mode) {
+	case RTPCS_SDS_MODE_OFF:
+		*media = RTPCS_SDS_MEDIA_NONE;
+		break;
+	case RTPCS_SDS_MODE_SGMII:
+	case RTPCS_SDS_MODE_1000BASEX:
+	case RTPCS_SDS_MODE_2500BASEX:
+	case RTPCS_SDS_MODE_10GBASER:
+		*media = RTPCS_SDS_MEDIA_FIBER;
+		break;
+	default:
+		*media = RTPCS_SDS_MEDIA_PCB;
+		break;
+	}
+
+	return 0;
+}
+
 static bool rtpcs_sds_mode_is_usxgmii(enum rtpcs_sds_mode hw_mode)
 {
 	return (hw_mode == RTPCS_SDS_MODE_USXGMII_10GSXGMII ||
@@ -3842,20 +3862,10 @@ static int rtpcs_931x_setup_serdes(struct rtpcs_serdes *sds,
 	if (ret < 0)
 		return ret;
 
-	switch (hw_mode) {
-	case RTPCS_SDS_MODE_OFF:
-		sds_media = RTPCS_SDS_MEDIA_NONE;
-		break;
-	case RTPCS_SDS_MODE_SGMII:
-	case RTPCS_SDS_MODE_1000BASEX:
-	case RTPCS_SDS_MODE_2500BASEX:
-	case RTPCS_SDS_MODE_10GBASER:
-		sds_media = RTPCS_SDS_MEDIA_FIBER;
-		break;
-	default:
-		sds_media = RTPCS_SDS_MEDIA_PCB;
-		break;
-	}
+	ret = rtpcs_sds_select_media(hw_mode, &sds_media);
+	if (ret < 0)
+		return ret;
+
 	ret = rtpcs_931x_sds_set_media(sds, sds_media, hw_mode);
 	if (ret < 0) {
 		dev_err(ctrl->dev, "failed to config SerDes for media: %d\n", ret);

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3689,8 +3689,8 @@ static int rtpcs_931x_sds_config_rx(struct rtpcs_serdes *sds,
 	return 0;
 }
 
-static int rtpcs_931x_sds_set_media(struct rtpcs_serdes *sds, enum rtpcs_sds_media sds_media,
-				    enum rtpcs_sds_mode hw_mode)
+static int rtpcs_931x_sds_config_media(struct rtpcs_serdes *sds, enum rtpcs_sds_media sds_media,
+				       enum rtpcs_sds_mode hw_mode)
 {
 	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
 	bool is_dac, is_10g;
@@ -3880,7 +3880,7 @@ static int rtpcs_931x_setup_serdes(struct rtpcs_serdes *sds,
 	if (ret < 0)
 		return ret;
 
-	ret = rtpcs_931x_sds_set_media(sds, sds_media, hw_mode);
+	ret = rtpcs_931x_sds_config_media(sds, sds_media, hw_mode);
 	if (ret < 0) {
 		dev_err(ctrl->dev, "failed to config SerDes for media: %d\n", ret);
 		return ret;

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -768,6 +768,8 @@ static int rtpcs_838x_sds_activate(struct rtpcs_serdes *sds)
 {
 	int ret;
 
+	rtpcs_838x_sds_reset(sds);
+
 	/* CFG_FIB_PDOWN / BMCR_PDOWN */
 	ret = rtpcs_sds_write_bits(sds, 2, MII_BMCR, 11, 11, 0x0);
 	if (ret)
@@ -902,8 +904,6 @@ static int rtpcs_838x_setup_serdes(struct rtpcs_serdes *sds,
 		return ret;
 
 	sds->hw_mode = hw_mode;
-
-	rtpcs_838x_sds_reset(sds);
 	return 0;
 }
 
@@ -1152,6 +1152,7 @@ static int rtpcs_839x_sds_deactivate(struct rtpcs_serdes *sds)
 
 static int rtpcs_839x_sds_activate(struct rtpcs_serdes *sds)
 {
+	rtpcs_839x_sds_reset(sds);
 	return 0;
 }
 
@@ -1172,8 +1173,6 @@ static int rtpcs_839x_setup_serdes(struct rtpcs_serdes *sds,
 		return ret;
 
 	sds->hw_mode = hw_mode;
-
-	rtpcs_839x_sds_reset(sds);
 	return 0;
 }
 

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -199,6 +199,8 @@ struct rtpcs_sds_ops {
 	int (*deactivate)(struct rtpcs_serdes *sds);
 	/* required: power back up */
 	int (*activate)(struct rtpcs_serdes *sds);
+	/* required: set hardware mode */
+	int (*set_hw_mode)(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode);
 	/* optional: finalization that must follow power-up, e.g. RX calibration */
 	int (*post_config)(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode);
 };
@@ -895,16 +897,7 @@ static int rtpcs_838x_init(struct rtpcs_ctrl *ctrl)
 static int rtpcs_838x_setup_serdes(struct rtpcs_serdes *sds,
 				   enum rtpcs_sds_mode hw_mode)
 {
-	int ret;
-
-	rtpcs_838x_sds_patch(sds, hw_mode);
-
-	ret = rtpcs_838x_sds_set_mode(sds, hw_mode);
-	if (ret)
-		return ret;
-
-	sds->hw_mode = hw_mode;
-	return 0;
+	return rtpcs_838x_sds_patch(sds, hw_mode);
 }
 
 static int rtpcs_838x_sds_post_config(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode)
@@ -1159,20 +1152,6 @@ static int rtpcs_839x_sds_activate(struct rtpcs_serdes *sds)
 static int rtpcs_839x_setup_serdes(struct rtpcs_serdes *sds,
 				   enum rtpcs_sds_mode hw_mode)
 {
-	int ret;
-
-	/* Don't touch 5G SerDes, they are already properly configured
-	 * at startup for QSGMII. Thus, connected PHYs should work out
-	 * of the box.
-	 */
-	if (sds->type == RTPCS_SDS_TYPE_5G)
-		return 0;
-
-	ret = rtpcs_sds_set_mac_mode(sds, hw_mode);
-	if (ret < 0)
-		return ret;
-
-	sds->hw_mode = hw_mode;
 	return 0;
 }
 
@@ -3088,13 +3067,6 @@ static int rtpcs_930x_setup_serdes(struct rtpcs_serdes *sds,
 
 	rtpcs_930x_sds_tx_config(sds, hw_mode);
 
-	/* Enable SDS in desired mode */
-	ret = rtpcs_930x_sds_set_mode(sds, hw_mode);
-	if (ret < 0)
-		return ret;
-
-	sds->hw_mode = hw_mode;
-
 	return 0;
 }
 
@@ -3890,12 +3862,6 @@ static int rtpcs_931x_setup_serdes(struct rtpcs_serdes *sds,
 		return ret;
 	}
 
-	ret = rtpcs_931x_sds_set_mode(sds, hw_mode);
-	if (ret < 0)
-		return ret;
-
-	sds->hw_mode = hw_mode;
-
 	return 0;
 }
 
@@ -4127,6 +4093,12 @@ static int rtpcs_pcs_config(struct phylink_pcs *pcs, unsigned int neg_mode,
 			ret = ctrl->cfg->setup_serdes(sds, hw_mode);
 			if (ret < 0)
 				return ret;
+
+			ret = sds->ops->set_hw_mode(sds, hw_mode);
+			if (ret < 0)
+				return ret;
+
+			sds->hw_mode = hw_mode;
 
 			ret = sds->ops->activate(sds);
 			if (ret < 0)
@@ -4417,6 +4389,7 @@ static const struct rtpcs_sds_ops rtpcs_838x_sds_ops = {
 	.restart_autoneg	= rtpcs_generic_sds_restart_autoneg,
 	.deactivate		= rtpcs_838x_sds_deactivate,
 	.activate		= rtpcs_838x_sds_activate,
+	.set_hw_mode		= rtpcs_838x_sds_set_mode,
 	.post_config		= rtpcs_838x_sds_post_config,
 };
 
@@ -4457,6 +4430,7 @@ static const struct rtpcs_sds_ops rtpcs_839x_sds_ops = {
 	.restart_autoneg	= rtpcs_generic_sds_restart_autoneg,
 	.deactivate		= rtpcs_839x_sds_deactivate,
 	.activate		= rtpcs_839x_sds_activate,
+	.set_hw_mode		= rtpcs_sds_set_mac_mode,
 };
 
 static const struct rtpcs_sds_regs rtpcs_839x_sds_regs = {
@@ -4502,6 +4476,7 @@ static const struct rtpcs_sds_ops rtpcs_930x_sds_ops = {
 	.config_polarity	= rtpcs_930x_sds_config_polarity,
 	.deactivate		= rtpcs_930x_sds_deactivate,
 	.activate		= rtpcs_930x_sds_activate,
+	.set_hw_mode		= rtpcs_930x_sds_set_mode,
 	.post_config		= rtpcs_930x_sds_post_config,
 };
 
@@ -4547,6 +4522,7 @@ static const struct rtpcs_sds_ops rtpcs_931x_sds_ops = {
 	.config_polarity	= rtpcs_931x_sds_config_polarity,
 	.deactivate		= rtpcs_931x_sds_deactivate,
 	.activate		= rtpcs_931x_sds_activate,
+	.set_hw_mode		= rtpcs_931x_sds_set_mode,
 };
 
 static const struct rtpcs_sds_regs rtpcs_931x_sds_regs = {

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -199,6 +199,8 @@ struct rtpcs_sds_ops {
 	int (*deactivate)(struct rtpcs_serdes *sds);
 	/* required: power back up */
 	int (*activate)(struct rtpcs_serdes *sds);
+	/* required: configure SerDes for hardware mode */
+	int (*config_hw_mode)(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode);
 	/* required: set hardware mode */
 	int (*set_hw_mode)(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode);
 	/* optional: configure media-specific parameters */
@@ -278,7 +280,6 @@ struct rtpcs_config {
 
 	int (*init)(struct rtpcs_ctrl *ctrl);
 	int (*sds_probe)(struct rtpcs_serdes *sds);
-	int (*setup_serdes)(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode);
 };
 
 struct rtpcs_sds_config {
@@ -843,8 +844,7 @@ static int rtpcs_838x_sds_set_mode(struct rtpcs_serdes *sds, enum rtpcs_sds_mode
 				 0x7 << int_mode_shift, int_mode_val << int_mode_shift);
 }
 
-static int rtpcs_838x_sds_patch(struct rtpcs_serdes *sds,
-				enum rtpcs_sds_mode hw_mode)
+static int rtpcs_838x_sds_config_hw_mode(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode)
 {
 	struct rtpcs_ctrl *ctrl = sds->ctrl;
 	u8 sds_id = sds->id;
@@ -915,12 +915,6 @@ static int rtpcs_838x_init(struct rtpcs_ctrl *ctrl)
 	regmap_write(ctrl->map, RTPCS_838X_SDS_CFG_REG, 0x3f);
 	regmap_write(ctrl->map, RTPCS_838X_RST_GLB_CTRL_0, 0x10); /* SW_SERDES_RST */
 	return 0;
-}
-
-static int rtpcs_838x_setup_serdes(struct rtpcs_serdes *sds,
-				   enum rtpcs_sds_mode hw_mode)
-{
-	return rtpcs_838x_sds_patch(sds, hw_mode);
 }
 
 static int rtpcs_838x_sds_post_config(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode)
@@ -1172,8 +1166,11 @@ static int rtpcs_839x_sds_activate(struct rtpcs_serdes *sds)
 	return 0;
 }
 
-static int rtpcs_839x_setup_serdes(struct rtpcs_serdes *sds,
-				   enum rtpcs_sds_mode hw_mode)
+/*
+ * Keep this as a no-op stub until RTL839x is extended to do proper configuration
+ * here. E.g., the still missing SGMII, 100BASEX and 1000BASEX setup should go here.
+ */
+static int rtpcs_839x_sds_config_hw_mode(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode)
 {
 	return 0;
 }
@@ -3083,21 +3080,6 @@ static int rtpcs_930x_sds_config_media(struct rtpcs_serdes *sds, enum rtpcs_sds_
 	return 0;
 }
 
-static int rtpcs_930x_setup_serdes(struct rtpcs_serdes *sds,
-				   enum rtpcs_sds_mode hw_mode)
-{
-	int ret;
-
-	/* Apply configuration for a hardware mode to SerDes */
-	ret = rtpcs_930x_sds_config_hw_mode(sds, hw_mode);
-	if (ret < 0)
-		return ret;
-
-	/* Maybe use dal_longan_sds_init */
-
-	return 0;
-}
-
 static int rtpcs_930x_sds_post_config(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode)
 {
 	int calib_tries = 0;
@@ -3855,18 +3837,6 @@ static int rtpcs_931x_sds_config_hw_mode(struct rtpcs_serdes *sds,
 	return rtpcs_93xx_sds_config_cmu(sds, hw_mode);
 }
 
-static int rtpcs_931x_setup_serdes(struct rtpcs_serdes *sds,
-				   enum rtpcs_sds_mode hw_mode)
-{
-	int ret;
-
-	ret = rtpcs_931x_sds_config_hw_mode(sds, hw_mode);
-	if (ret < 0)
-		return ret;
-
-	return 0;
-}
-
 /**
  * rtpcs_931x_init_mac_groups - Initialize MAC groups
  *
@@ -4093,7 +4063,7 @@ static int rtpcs_pcs_config(struct phylink_pcs *pcs, unsigned int neg_mode,
 			if (ret < 0)
 				return ret;
 
-			ret = ctrl->cfg->setup_serdes(sds, hw_mode);
+			ret = sds->ops->config_hw_mode(sds, hw_mode);
 			if (ret < 0)
 				return ret;
 
@@ -4402,6 +4372,7 @@ static const struct rtpcs_sds_ops rtpcs_838x_sds_ops = {
 	.restart_autoneg	= rtpcs_generic_sds_restart_autoneg,
 	.deactivate		= rtpcs_838x_sds_deactivate,
 	.activate		= rtpcs_838x_sds_activate,
+	.config_hw_mode		= rtpcs_838x_sds_config_hw_mode,
 	.set_hw_mode		= rtpcs_838x_sds_set_mode,
 	.post_config		= rtpcs_838x_sds_post_config,
 };
@@ -4427,7 +4398,6 @@ static const struct rtpcs_config rtpcs_838x_cfg = {
 	.sds_hw_mode_vals	= rtpcs_838x_sds_hw_mode_vals,
 	.init			= rtpcs_838x_init,
 	.sds_probe		= rtpcs_838x_sds_probe,
-	.setup_serdes		= rtpcs_838x_setup_serdes,
 };
 
 static const struct phylink_pcs_ops rtpcs_839x_pcs_ops = {
@@ -4443,6 +4413,7 @@ static const struct rtpcs_sds_ops rtpcs_839x_sds_ops = {
 	.restart_autoneg	= rtpcs_generic_sds_restart_autoneg,
 	.deactivate		= rtpcs_839x_sds_deactivate,
 	.activate		= rtpcs_839x_sds_activate,
+	.config_hw_mode		= rtpcs_839x_sds_config_hw_mode,
 	.set_hw_mode		= rtpcs_sds_set_mac_mode,
 };
 
@@ -4467,7 +4438,6 @@ static const struct rtpcs_config rtpcs_839x_cfg = {
 	.sds_hw_mode_vals	= rtpcs_839x_sds_hw_mode_vals,
 	.init			= rtpcs_839x_init,
 	.sds_probe		= rtpcs_839x_sds_probe,
-	.setup_serdes		= rtpcs_839x_setup_serdes,
 };
 
 static const struct phylink_pcs_ops rtpcs_930x_pcs_ops = {
@@ -4489,6 +4459,7 @@ static const struct rtpcs_sds_ops rtpcs_930x_sds_ops = {
 	.config_polarity	= rtpcs_930x_sds_config_polarity,
 	.deactivate		= rtpcs_930x_sds_deactivate,
 	.activate		= rtpcs_930x_sds_activate,
+	.config_hw_mode		= rtpcs_930x_sds_config_hw_mode,
 	.set_hw_mode		= rtpcs_930x_sds_set_mode,
 	.config_media		= rtpcs_930x_sds_config_media,
 	.post_config		= rtpcs_930x_sds_post_config,
@@ -4515,7 +4486,6 @@ static const struct rtpcs_config rtpcs_930x_cfg = {
 	.sds_hw_mode_vals	= rtpcs_93xx_sds_hw_mode_vals,
 	.init			= rtpcs_93xx_init,
 	.sds_probe		= rtpcs_930x_sds_probe,
-	.setup_serdes		= rtpcs_930x_setup_serdes,
 };
 
 static const struct phylink_pcs_ops rtpcs_931x_pcs_ops = {
@@ -4536,6 +4506,7 @@ static const struct rtpcs_sds_ops rtpcs_931x_sds_ops = {
 	.config_polarity	= rtpcs_931x_sds_config_polarity,
 	.deactivate		= rtpcs_931x_sds_deactivate,
 	.activate		= rtpcs_931x_sds_activate,
+	.config_hw_mode		= rtpcs_931x_sds_config_hw_mode,
 	.set_hw_mode		= rtpcs_931x_sds_set_mode,
 	.config_media		= rtpcs_931x_sds_config_media,
 };
@@ -4561,7 +4532,6 @@ static const struct rtpcs_config rtpcs_931x_cfg = {
 	.sds_hw_mode_vals	= rtpcs_93xx_sds_hw_mode_vals,
 	.init			= rtpcs_931x_init,
 	.sds_probe		= rtpcs_931x_sds_probe,
-	.setup_serdes		= rtpcs_931x_setup_serdes,
 };
 
 static const struct of_device_id rtpcs_of_match[] = {

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -201,6 +201,9 @@ struct rtpcs_sds_ops {
 	int (*activate)(struct rtpcs_serdes *sds);
 	/* required: set hardware mode */
 	int (*set_hw_mode)(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode);
+	/* optional: configure media-specific parameters */
+	int (*config_media)(struct rtpcs_serdes *sds, enum rtpcs_sds_media media,
+			    enum rtpcs_sds_mode hw_mode);
 	/* optional: finalization that must follow power-up, e.g. RX calibration */
 	int (*post_config)(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode);
 };
@@ -3083,7 +3086,6 @@ static int rtpcs_930x_sds_config_media(struct rtpcs_serdes *sds, enum rtpcs_sds_
 static int rtpcs_930x_setup_serdes(struct rtpcs_serdes *sds,
 				   enum rtpcs_sds_mode hw_mode)
 {
-	enum rtpcs_sds_media sds_media;
 	int ret;
 
 	/* Apply configuration for a hardware mode to SerDes */
@@ -3092,14 +3094,6 @@ static int rtpcs_930x_setup_serdes(struct rtpcs_serdes *sds,
 		return ret;
 
 	/* Maybe use dal_longan_sds_init */
-
-	ret = rtpcs_sds_select_media(hw_mode, &sds_media);
-	if (ret < 0)
-		return ret;
-
-	ret = rtpcs_930x_sds_config_media(sds, sds_media, hw_mode);
-	if (ret < 0)
-		return ret;
 
 	return 0;
 }
@@ -3864,8 +3858,6 @@ static int rtpcs_931x_sds_config_hw_mode(struct rtpcs_serdes *sds,
 static int rtpcs_931x_setup_serdes(struct rtpcs_serdes *sds,
 				   enum rtpcs_sds_mode hw_mode)
 {
-	struct rtpcs_ctrl *ctrl = sds->ctrl;
-	enum rtpcs_sds_media sds_media;
 	int ret;
 
 	ret = rtpcs_931x_sds_config_hw_mode(sds, hw_mode);
@@ -3875,16 +3867,6 @@ static int rtpcs_931x_setup_serdes(struct rtpcs_serdes *sds,
 	ret = rtpcs_93xx_sds_config_cmu(sds, hw_mode);
 	if (ret < 0)
 		return ret;
-
-	ret = rtpcs_sds_select_media(hw_mode, &sds_media);
-	if (ret < 0)
-		return ret;
-
-	ret = rtpcs_931x_sds_config_media(sds, sds_media, hw_mode);
-	if (ret < 0) {
-		dev_err(ctrl->dev, "failed to config SerDes for media: %d\n", ret);
-		return ret;
-	}
 
 	return 0;
 }
@@ -4088,6 +4070,7 @@ static int rtpcs_pcs_config(struct phylink_pcs *pcs, unsigned int neg_mode,
 	struct rtpcs_link *link = rtpcs_phylink_pcs_to_link(pcs);
 	struct rtpcs_ctrl *ctrl = link->ctrl;
 	struct rtpcs_serdes *sds = link->sds;
+	enum rtpcs_sds_media sds_media;
 	enum rtpcs_sds_mode hw_mode;
 	int ret;
 
@@ -4117,6 +4100,16 @@ static int rtpcs_pcs_config(struct phylink_pcs *pcs, unsigned int neg_mode,
 			ret = ctrl->cfg->setup_serdes(sds, hw_mode);
 			if (ret < 0)
 				return ret;
+
+			if (sds->ops->config_media) {
+				ret = rtpcs_sds_select_media(hw_mode, &sds_media);
+				if (ret < 0)
+					return ret;
+
+				ret = sds->ops->config_media(sds, sds_media, hw_mode);
+				if (ret < 0)
+					return ret;
+			}
 
 			ret = sds->ops->set_hw_mode(sds, hw_mode);
 			if (ret < 0)
@@ -4501,6 +4494,7 @@ static const struct rtpcs_sds_ops rtpcs_930x_sds_ops = {
 	.deactivate		= rtpcs_930x_sds_deactivate,
 	.activate		= rtpcs_930x_sds_activate,
 	.set_hw_mode		= rtpcs_930x_sds_set_mode,
+	.config_media		= rtpcs_930x_sds_config_media,
 	.post_config		= rtpcs_930x_sds_post_config,
 };
 
@@ -4547,6 +4541,7 @@ static const struct rtpcs_sds_ops rtpcs_931x_sds_ops = {
 	.deactivate		= rtpcs_931x_sds_deactivate,
 	.activate		= rtpcs_931x_sds_activate,
 	.set_hw_mode		= rtpcs_931x_sds_set_mode,
+	.config_media		= rtpcs_931x_sds_config_media,
 };
 
 static const struct rtpcs_sds_regs rtpcs_931x_sds_regs = {


### PR DESCRIPTION
This series brings more unification steps to the PCS driver. The setup sequence is now fully orchestrated by pcs_config() and setup_serdes can be dropped.

Tested on 838x, 839x, 930x and 931x.