### PR TITLE
realtek: minor DTS cleanups

### DIFF
--- a/target/linux/realtek/dts/rtl9303_hasivo_f1100w-4sx-4xgt-common.dtsi
+++ b/target/linux/realtek/dts/rtl9303_hasivo_f1100w-4sx-4xgt-common.dtsi
@@ -55,7 +55,6 @@
 		compatible = "sff,sfp";
 		i2c-bus = <&i2c0>;
 		mod-def0-gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
-		maximum-power-milliwatt = <2000>;
 		#thermal-sensor-cells = <0>;
 	};
 
@@ -63,7 +62,6 @@
 		compatible = "sff,sfp";
 		i2c-bus = <&i2c1>;
 		mod-def0-gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
-		maximum-power-milliwatt = <2000>;
 		#thermal-sensor-cells = <0>;
 	};
 
@@ -71,7 +69,6 @@
 		compatible = "sff,sfp";
 		i2c-bus = <&i2c2>;
 		mod-def0-gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
-		maximum-power-milliwatt = <2000>;
 		#thermal-sensor-cells = <0>;
 	};
 
@@ -79,7 +76,6 @@
 		compatible = "sff,sfp";
 		i2c-bus = <&i2c3>;
 		mod-def0-gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
-		maximum-power-milliwatt = <2000>;
 		#thermal-sensor-cells = <0>;
 	};
 };

--- a/target/linux/realtek/dts/rtl9313_xikestor_sks8300-12x-v1.dts
+++ b/target/linux/realtek/dts/rtl9313_xikestor_sks8300-12x-v1.dts
@@ -90,7 +90,6 @@
 		los-gpio = <&gpio1 0 GPIO_ACTIVE_HIGH>;
 		mod-def0-gpio = <&gpio1 1 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio1 2 GPIO_ACTIVE_HIGH>;
-		#thermal-sensor-cells = <0>;
 	};
 
 	sfp2: sfp-p2 {
@@ -99,7 +98,6 @@
 		los-gpio = <&gpio1 3 GPIO_ACTIVE_HIGH>;
 		mod-def0-gpio = <&gpio1 4 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio1 5 GPIO_ACTIVE_HIGH>;
-		#thermal-sensor-cells = <0>;
 	};
 
 	sfp3: sfp-p3 {
@@ -108,7 +106,6 @@
 		los-gpio = <&gpio1 6 GPIO_ACTIVE_HIGH>;
 		mod-def0-gpio = <&gpio1 7 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio1 8 GPIO_ACTIVE_HIGH>;
-		#thermal-sensor-cells = <0>;
 	};
 
 	sfp4: sfp-p4 {
@@ -117,7 +114,6 @@
 		los-gpio = <&gpio1 9 GPIO_ACTIVE_HIGH>;
 		mod-def0-gpio = <&gpio1 10 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio1 11 GPIO_ACTIVE_HIGH>;
-		#thermal-sensor-cells = <0>;
 	};
 
 	sfp5: sfp-p5 {
@@ -126,7 +122,6 @@
 		los-gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
 		mod-def0-gpio = <&gpio1 13 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio1 14 GPIO_ACTIVE_HIGH>;
-		#thermal-sensor-cells = <0>;
 	};
 
 	sfp6: sfp-p6 {
@@ -135,7 +130,6 @@
 		los-gpio = <&gpio1 21 GPIO_ACTIVE_HIGH>;
 		mod-def0-gpio = <&gpio1 22 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio1 23 GPIO_ACTIVE_HIGH>;
-		#thermal-sensor-cells = <0>;
 	};
 
 	sfp7: sfp-p7 {
@@ -144,7 +138,6 @@
 		los-gpio = <&gpio1 24 GPIO_ACTIVE_HIGH>;
 		mod-def0-gpio = <&gpio1 25 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio1 26 GPIO_ACTIVE_HIGH>;
-		#thermal-sensor-cells = <0>;
 	};
 
 	sfp8: sfp-p8 {
@@ -153,7 +146,6 @@
 		los-gpio = <&gpio1 27 GPIO_ACTIVE_HIGH>;
 		mod-def0-gpio = <&gpio1 28 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio1 29 GPIO_ACTIVE_HIGH>;
-		#thermal-sensor-cells = <0>;
 	};
 
 	sfp9: sfp-p9 {
@@ -162,7 +154,6 @@
 		los-gpio = <&gpio2 3 GPIO_ACTIVE_HIGH>;
 		mod-def0-gpio = <&gpio2 4 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio2 5 GPIO_ACTIVE_HIGH>;
-		#thermal-sensor-cells = <0>;
 	};
 
 	sfp10: sfp-p10 {
@@ -171,7 +162,6 @@
 		los-gpio = <&gpio2 0 GPIO_ACTIVE_HIGH>;
 		mod-def0-gpio = <&gpio2 1 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio2 2 GPIO_ACTIVE_HIGH>;
-		#thermal-sensor-cells = <0>;
 	};
 
 	sfp11: sfp-p11 {
@@ -180,7 +170,6 @@
 		los-gpio = <&gpio2 9 GPIO_ACTIVE_HIGH>;
 		mod-def0-gpio = <&gpio2 10 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio2 11 GPIO_ACTIVE_HIGH>;
-		#thermal-sensor-cells = <0>;
 	};
 
 	sfp12: sfp-p12 {
@@ -189,7 +178,6 @@
 		los-gpio = <&gpio2 6 GPIO_ACTIVE_HIGH>;
 		mod-def0-gpio = <&gpio2 7 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio2 8 GPIO_ACTIVE_HIGH>;
-		#thermal-sensor-cells = <0>;
 	};
 };
 


### PR DESCRIPTION
Remove `maximum-power-milliwatt` from Hasivo F1100W-4SX-4XGT
> I think these were copied from a different device's DTS at the very beginning of the porting work. We don't know the actual maximums of these SFP ports, so let's stick with the 1W default, unless someone researches what the Hasivo vendor firmware does for this setting.

Remove `thermal-sensor-cells` from XikeStor SKS8300-12X
> Quote @jonasjelonek: It's all not really wired up correctly, the thermal driver has no support for RTL931x and nothing else really links e.g. SFP slots with a fan or whatever.