### PR TITLE
bcm53xx: backport meraki mx6x warning fix

### DIFF
--- a/target/linux/bcm53xx/patches-6.12/331-v7.2-ARM-dts-NSP-Move-MX6X-pinctrl-config-to-PWM-node.patch
+++ b/target/linux/bcm53xx/patches-6.12/331-v7.2-ARM-dts-NSP-Move-MX6X-pinctrl-config-to-PWM-node.patch
@@ -1,0 +1,41 @@
+From d7b3f4a4eb23d82ef923cf17509292b719340378 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Wed, 29 Apr 2026 22:16:12 -0700
+Subject: [PATCH] ARM: dts: NSP: Move MX6X pinctrl config to PWM node
+
+On boot there is this warning:
+
+/axi@18000000/pinctrl@3f1c0: Fixed dependency cycle(s) with /axi@18000000/pinctrl@3f1c0/pwm_leds
+
+Fix by moving the pinctrl configuration to pwm, which is the actual
+consumer.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+Link: https://lore.kernel.org/r/20260430051612.700050-1-rosenp@gmail.com
+Signed-off-by: Florian Fainelli <florian.fainelli@broadcom.com>
+---
+ .../arm/boot/dts/broadcom/bcm958625-meraki-mx6x-common.dtsi | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/arch/arm/boot/dts/broadcom/bcm958625-meraki-mx6x-common.dtsi
++++ b/arch/arm/boot/dts/broadcom/bcm958625-meraki-mx6x-common.dtsi
+@@ -121,9 +121,6 @@
+ };
+ 
+ &pinctrl {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pwm_leds>;
+-
+ 	pwm_leds: pwm_leds {
+ 		function = "pwm";
+ 		groups = "pwm1_grp", "pwm2_grp", "pwm3_grp";
+@@ -131,6 +128,9 @@
+ };
+ 
+ &pwm {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pwm_leds>;
++
+ 	status = "okay";
+ 	#pwm-cells = <2>;
+ };

--- a/target/linux/bcm53xx/patches-6.18/331-v7.2-ARM-dts-NSP-Move-MX6X-pinctrl-config-to-PWM-node.patch
+++ b/target/linux/bcm53xx/patches-6.18/331-v7.2-ARM-dts-NSP-Move-MX6X-pinctrl-config-to-PWM-node.patch
@@ -1,0 +1,41 @@
+From d7b3f4a4eb23d82ef923cf17509292b719340378 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Wed, 29 Apr 2026 22:16:12 -0700
+Subject: [PATCH] ARM: dts: NSP: Move MX6X pinctrl config to PWM node
+
+On boot there is this warning:
+
+/axi@18000000/pinctrl@3f1c0: Fixed dependency cycle(s) with /axi@18000000/pinctrl@3f1c0/pwm_leds
+
+Fix by moving the pinctrl configuration to pwm, which is the actual
+consumer.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+Link: https://lore.kernel.org/r/20260430051612.700050-1-rosenp@gmail.com
+Signed-off-by: Florian Fainelli <florian.fainelli@broadcom.com>
+---
+ .../arm/boot/dts/broadcom/bcm958625-meraki-mx6x-common.dtsi | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/arch/arm/boot/dts/broadcom/bcm958625-meraki-mx6x-common.dtsi
++++ b/arch/arm/boot/dts/broadcom/bcm958625-meraki-mx6x-common.dtsi
+@@ -121,9 +121,6 @@
+ };
+ 
+ &pinctrl {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pwm_leds>;
+-
+ 	pwm_leds: pwm_leds {
+ 		function = "pwm";
+ 		groups = "pwm1_grp", "pwm2_grp", "pwm3_grp";
+@@ -131,6 +128,9 @@
+ };
+ 
+ &pwm {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pwm_leds>;
++
+ 	status = "okay";
+ };
+ 


### PR DESCRIPTION
The kernel ended up fixing this dts problem at runtime, but fix it directly instead. Upstream backport.

ping @jonasjelonek 