### PR TITLE
treewide: use _scoped for loops

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/b53/b53_common.c
+++ b/target/linux/generic/files/drivers/net/phy/b53/b53_common.c
@@ -566,6 +566,7 @@ static int b53_configure_ports_of(struct b53_device *dev)
 		}
 	}
 
+	of_node_put(dn);
 	return 0;
 }
 

--- a/target/linux/generic/hack-6.12/421-drivers-mtd-parsers-add-nvmem-support-to-cmdlinepart.patch
+++ b/target/linux/generic/hack-6.12/421-drivers-mtd-parsers-add-nvmem-support-to-cmdlinepart.patch
@@ -27,7 +27,7 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
  
  /* special size referring to all the remaining space in a partition */
  #define SIZE_REMAINING ULLONG_MAX
-@@ -315,6 +316,68 @@ static int mtdpart_setup_real(char *s)
+@@ -315,6 +316,67 @@ static int mtdpart_setup_real(char *s)
  	return 0;
  }
  
@@ -37,7 +37,6 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 +{
 +	struct device_node *mtd_node;
 +	struct device_node *ofpart_node;
-+	struct device_node *pp;
 +	struct mtd_partition part;
 +	const char *partname;
 +
@@ -47,7 +46,7 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 +
 +	ofpart_node = of_get_child_by_name(mtd_node, "partitions");
 +
-+	for_each_child_of_node(ofpart_node,  pp) {
++	for_each_child_of_node_scoped(ofpart_node, pp) {
 +		const __be32 *reg;
 +		int len;
 +		int a_cells, s_cells;
@@ -71,7 +70,7 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 +
 +		part.offset = of_read_number(reg, a_cells);
 +		part.size = of_read_number(reg + a_cells, s_cells);
-+		part.of_node = pp;
++		part.of_node = of_node_get(pp);
 +
 +		partname = of_get_property(pp, "label", &len);
 +		if (!partname)
@@ -96,7 +95,7 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
  /*
   * Main function to be called from the MTD mapping driver/device to
   * obtain the partitioning information. At this point the command line
-@@ -330,6 +393,7 @@ static int parse_cmdline_partitions(stru
+@@ -330,6 +392,7 @@ static int parse_cmdline_partitions(stru
  	int i, err;
  	struct cmdline_mtd_partition *part;
  	const char *mtd_id = master->name;
@@ -104,7 +103,7 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
  
  	/* parse command line */
  	if (!cmdline_parsed) {
-@@ -374,6 +438,13 @@ static int parse_cmdline_partitions(stru
+@@ -374,6 +437,13 @@ static int parse_cmdline_partitions(stru
  				sizeof(*part->parts) * (part->num_parts - i));
  			i--;
  		}

--- a/target/linux/generic/hack-6.12/800-GPIO-add-named-gpio-exports.patch
+++ b/target/linux/generic/hack-6.12/800-GPIO-add-named-gpio-exports.patch
@@ -15,7 +15,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  
  #include "gpiolib.h"
  #include "gpiolib-of.h"
-@@ -1205,3 +1207,73 @@ void of_gpiochip_remove(struct gpio_chip
+@@ -1205,3 +1207,72 @@ void of_gpiochip_remove(struct gpio_chip
  
  	of_node_put(np);
  }
@@ -30,11 +30,10 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +static int of_gpio_export_probe(struct platform_device *pdev)
 +{
 +	struct device_node *np = pdev->dev.of_node;
-+	struct device_node *cnp;
 +	u32 val;
 +	int nb = 0;
 +
-+	for_each_child_of_node(np, cnp) {
++	for_each_child_of_node_scoped(np, cnp) {
 +		const char *name = NULL;
 +		int gpio;
 +		bool dmc;

--- a/target/linux/generic/hack-6.18/421-drivers-mtd-parsers-add-nvmem-support-to-cmdlinepart.patch
+++ b/target/linux/generic/hack-6.18/421-drivers-mtd-parsers-add-nvmem-support-to-cmdlinepart.patch
@@ -27,7 +27,7 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
  
  /* special size referring to all the remaining space in a partition */
  #define SIZE_REMAINING ULLONG_MAX
-@@ -315,6 +316,68 @@ static int mtdpart_setup_real(char *s)
+@@ -315,6 +316,67 @@ static int mtdpart_setup_real(char *s)
  	return 0;
  }
  
@@ -37,7 +37,6 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 +{
 +	struct device_node *mtd_node;
 +	struct device_node *ofpart_node;
-+	struct device_node *pp;
 +	struct mtd_partition part;
 +	const char *partname;
 +
@@ -47,7 +46,7 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 +
 +	ofpart_node = of_get_child_by_name(mtd_node, "partitions");
 +
-+	for_each_child_of_node(ofpart_node,  pp) {
++	for_each_child_of_node_scoped(ofpart_node, pp) {
 +		const __be32 *reg;
 +		int len;
 +		int a_cells, s_cells;
@@ -71,7 +70,7 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 +
 +		part.offset = of_read_number(reg, a_cells);
 +		part.size = of_read_number(reg + a_cells, s_cells);
-+		part.of_node = pp;
++		part.of_node = of_node_get(pp);
 +
 +		partname = of_get_property(pp, "label", &len);
 +		if (!partname)
@@ -96,7 +95,7 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
  /*
   * Main function to be called from the MTD mapping driver/device to
   * obtain the partitioning information. At this point the command line
-@@ -330,6 +393,7 @@ static int parse_cmdline_partitions(stru
+@@ -330,6 +392,7 @@ static int parse_cmdline_partitions(stru
  	int i, err;
  	struct cmdline_mtd_partition *part;
  	const char *mtd_id = master->name;
@@ -104,7 +103,7 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
  
  	/* parse command line */
  	if (!cmdline_parsed) {
-@@ -374,6 +438,13 @@ static int parse_cmdline_partitions(stru
+@@ -374,6 +437,13 @@ static int parse_cmdline_partitions(stru
  				sizeof(*part->parts) * (part->num_parts - i));
  			i--;
  		}

--- a/target/linux/generic/hack-6.18/800-GPIO-add-named-gpio-exports.patch
+++ b/target/linux/generic/hack-6.18/800-GPIO-add-named-gpio-exports.patch
@@ -15,7 +15,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  
  #include "gpiolib.h"
  #include "gpiolib-of.h"
-@@ -1302,3 +1304,73 @@ bool of_gpiochip_instance_match(struct g
+@@ -1302,3 +1304,72 @@ bool of_gpiochip_instance_match(struct g
  
  	return false;
  }
@@ -30,11 +30,10 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +static int of_gpio_export_probe(struct platform_device *pdev)
 +{
 +	struct device_node *np = pdev->dev.of_node;
-+	struct device_node *cnp;
 +	u32 val;
 +	int nb = 0;
 +
-+	for_each_child_of_node(np, cnp) {
++	for_each_child_of_node_scoped(np, cnp) {
 +		const char *name = NULL;
 +		int gpio;
 +		bool dmc;


### PR DESCRIPTION
Done for local patches. Potential upstreaming will be using these anyway.