### PR TITLE
[25.12] ramips: pax1800-lite: do not attach both ubi partitions on boot

### DIFF
--- a/target/linux/ramips/dts/mt7621_plasmacloud_pax1800-lite.dts
+++ b/target/linux/ramips/dts/mt7621_plasmacloud_pax1800-lite.dts
@@ -154,13 +154,11 @@
 			partition@0 {
 				label = "firmware1";
 				reg = <0x0 0x4000000>;
-				compatible = "linux,ubi";
 			};
 
 			partition@4000000 {
 				label = "firmware2";
 				reg = <0x4000000 0x4000000>;
-				compatible = "linux,ubi";
 			};
 		};
 	};


### PR DESCRIPTION
The dual-boot mechanism depends on the fact that the bootloader specifies the ubi.mtd= of the currently active slot. And the Linux is expected to only attach the specified ubi-partition. Otherwise the kernel will use the "rootfs" partition of the initially attached ubi partition as its root partition. Which is of course wrong when the kernel parameter specified ubi.mtd=firmware2.

Fixes: c7c54f313425 ("ramips: add support for Plasma Cloud PAX1800-Lite")
Backports: https://github.com/openwrt/openwrt/pull/23857