### PR TITLE
ath9k: enable dynack by default

### DIFF
--- a/package/kernel/mac80211/ath.mk
+++ b/package/kernel/mac80211/ath.mk
@@ -120,6 +120,7 @@ define KernelPackage/ath/config
 	config PACKAGE_ATH_DYNACK
 		bool "Enable Dynack support"
 		depends on PACKAGE_kmod-ath9k-common
+		default y
 		help
 		  Enables support for Dynamic ACK estimation, which allows the fastest possible speed
 		  at any distance automatically by increasing/decreasing the max frame ACK time for


### PR DESCRIPTION
Dynack already depends on ath9k-common since it is available only for ath9k.
It is also disabled unless 'auto' is set as the distance. 
According to the wiki, omitting the distance should instead fallback to the (driver default) value.

The size of the packages increases slightly, here with a recent snapshot:
- with dynack:
```
 14346 kmod-ath-6.12.91.6.18.26-r1.apk
 62650 kmod-ath9k-6.12.91.6.18.26-r1.apk
127917 kmod-ath9k-common-6.12.91.6.18.26-r1.apk
```
- without:
```
 14344 kmod-ath-6.12.91.6.18.26-r1.apk
 62313 kmod-ath9k-6.12.91.6.18.26-r1.apk
125859 kmod-ath9k-common-6.12.91.6.18.26-r1.apk
```