### PR TITLE
realtek: rtl930x: add support for Zyxel XGS1010-12 B1

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -102,7 +102,8 @@ realtek_setup_macs()
 	hasivo,f1100w-4sx-4xgt-512mb|\
 	hasivo,f5800w-12s-plus|\
 	tplink,tl-st1008f-v2|\
-	zyxel,xgs1010-12-a1)
+	zyxel,xgs1010-12-a1|\
+	zyxel,xgs1010-12-b1)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		mac_prefix=$(echo "$lan_mac" | cut -d: -f1-5)
 		[ -z "$lan_mac" ] || [ "$mac_prefix" = "00:e0:4c:00:00" ] && lan_mac=$(macaddr_random)

--- a/target/linux/realtek/base-files/etc/uci-defaults/99_fwenv-store-ethaddr
+++ b/target/linux/realtek/base-files/etc/uci-defaults/99_fwenv-store-ethaddr
@@ -56,7 +56,8 @@ tplink,tl-st1008f-v2)
 # that state, we don't want to modify it, because that would write the defaults
 # of the userspace U-Boot tools (which differ from the ones in the bootloader).
 # Thus, we don't do anything here if the ethaddr variable is empty.
-zyxel,xgs1010-12-a1)
+zyxel,xgs1010-12-a1|\
+zyxel,xgs1010-12-b1)
 	env_ethaddr=$(macaddr_canonicalize "$(fw_printenv -n ethaddr 2>/dev/null)")
 
 	if [ "$env_ethaddr" = "00:e0:4c:00:00:00" ]; then

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1010-12-a1.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1010-12-a1.dts
@@ -1,106 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 /dts-v1/;
 
-#include "rtl9302_zyxel_xgs1x10-12-common.dtsi"
+#include "rtl9302_zyxel_xgs1010-12-common.dtsi"
 
 / {
 	compatible = "zyxel,xgs1010-12-a1", "realtek,rtl930x-soc";
 	model = "Zyxel XGS1010-12 A1";
-
-	virtual_flash {
-		compatible = "mtd-concat";
-
-		devices = <&fwconcat0 &fwconcat1 &fwconcat2>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "firmware";
-				reg = <0x0 0x0>;
-				compatible = "openwrt,uimage", "denx,uimage";
-				openwrt,ih-magic = <0x93001010>;
-			};
-		};
-	};
-};
-
-&spi0 {
-	status = "okay";
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <10000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "u-boot";
-				reg = <0x0 0xe0000>;
-				read-only;
-			};
-
-			partition@e0000 {
-				label = "u-boot-env";
-				reg = <0xe0000 0x10000>;
-			};
-
-			partition@f0000 {
-				label = "u-boot-env2";
-				reg = <0xf0000 0x10000>;
-				read-only;
-			};
-
-			/*
-			 * If additional space is needed in the future, the JFFS2 partitions could
-			 * be added to the concatenated firmware partition. They are only reserved
-			 * for now to allow running the XGS1210-12 firmware, which can be useful
-			 * as a reference during development.
-			 */
-
-			partition@100000 {
-				label = "jffs2-cfg";
-				reg = <0x100000 0x100000>;
-			};
-
-			partition@200000 {
-				label = "jffs2-log";
-				reg = <0x200000 0x100000>;
-			};
-
-			fwconcat1: partition@300000 {
-				label = "fwconcat1";
-				reg = <0x300000 0x510000>;
-			};
-
-			partition@810000 {
-				reg = <0x810000 0x10000>;
-				label = "htp-log";
-				read-only;
-			};
-
-			fwconcat2: partition@820000 {
-				label = "fwconcat2";
-				reg = <0x820000 0xd0000>;
-			};
-
-			partition@8f0000 {
-				reg = <0x8f0000 0x10000>;
-				label = "htp-flash-test";
-				read-only;
-			};
-
-			fwconcat0: partition@900000 {
-				label = "fwconcat0";
-				reg = <0x900000 0x700000>;
-			};
-		};
-	};
 };
 
 &mdio_bus1 {

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1010-12-b1.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1010-12-b1.dts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "rtl9302_zyxel_xgs1010-12-common.dtsi"
+
+/ {
+	compatible = "zyxel,xgs1010-12-b1", "realtek,rtl930x-soc";
+	model = "Zyxel XGS1010-12 B1";
+};
+
+&mdio_bus1 {
+	PHY_C45(24, 1)
+};
+
+&mdio_bus2 {
+	PHY_C45(25, 2)
+};

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1010-12-common.dtsi
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1010-12-common.dtsi
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "rtl9302_zyxel_xgs1x10-12-common.dtsi"
+
+/ {
+	virtual_flash {
+		compatible = "mtd-concat";
+
+		devices = <&fwconcat0 &fwconcat1 &fwconcat2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "firmware";
+				reg = <0x0 0x0>;
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <0x93001010>;
+			};
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0xe0000>;
+				read-only;
+			};
+
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0xe0000 0x10000>;
+			};
+
+			partition@f0000 {
+				label = "u-boot-env2";
+				reg = <0xf0000 0x10000>;
+				read-only;
+			};
+
+			/*
+			 * If additional space is needed in the future, the JFFS2 partitions could
+			 * be added to the concatenated firmware partition. They are only reserved
+			 * for now to allow running the XGS1210-12 firmware, which can be useful
+			 * as a reference during development.
+			 */
+
+			partition@100000 {
+				label = "jffs2-cfg";
+				reg = <0x100000 0x100000>;
+			};
+
+			partition@200000 {
+				label = "jffs2-log";
+				reg = <0x200000 0x100000>;
+			};
+
+			fwconcat1: partition@300000 {
+				label = "fwconcat1";
+				reg = <0x300000 0x510000>;
+			};
+
+			partition@810000 {
+				reg = <0x810000 0x10000>;
+				label = "htp-log";
+				read-only;
+			};
+
+			fwconcat2: partition@820000 {
+				label = "fwconcat2";
+				reg = <0x820000 0xd0000>;
+			};
+
+			partition@8f0000 {
+				reg = <0x8f0000 0x10000>;
+				label = "htp-flash-test";
+				read-only;
+			};
+
+			fwconcat0: partition@900000 {
+				label = "fwconcat0";
+				reg = <0x900000 0x700000>;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/common.mk
+++ b/target/linux/realtek/image/common.mk
@@ -101,6 +101,16 @@ define Device/zyxel_gs1900
 	check-size 6976k
 endef
 
+define Device/zyxel_xgs1010-12
+  SOC := rtl9302
+  UIMAGE_MAGIC := 0x93001010
+  DEVICE_VENDOR := Zyxel
+  DEVICE_MODEL := XGS1010-12
+  KERNEL_SIZE := 7168k
+  IMAGE_SIZE := 13184k
+  $(Device/kernel-lzma)
+endef
+
 define Device/zyxel_xgs1210-12
   SOC := rtl9302
   UIMAGE_MAGIC := 0x93001210

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -277,6 +277,12 @@ define Device/zyxel_xgs1010-12-a1
 endef
 TARGET_DEVICES += zyxel_xgs1010-12-a1
 
+define Device/zyxel_xgs1010-12-b1
+  $(Device/zyxel_xgs1010-12)
+  DEVICE_VARIANT := B1
+endef
+TARGET_DEVICES += zyxel_xgs1010-12-b1
+
 define Device/zyxel_xgs1210-12-a1
   $(Device/zyxel_xgs1210-12)
   SUPPORTED_DEVICES += zyxel,xgs1210-12

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -272,14 +272,8 @@ endef
 TARGET_DEVICES += xikestor_sks8310-8x
 
 define Device/zyxel_xgs1010-12-a1
-  SOC := rtl9302
-  UIMAGE_MAGIC := 0x93001010
-  DEVICE_VENDOR := Zyxel
-  DEVICE_MODEL := XGS1010-12
+  $(Device/zyxel_xgs1010-12)
   DEVICE_VARIANT := A1
-  KERNEL_SIZE := 7168k
-  IMAGE_SIZE := 13184k
-  $(Device/kernel-lzma)
 endef
 TARGET_DEVICES += zyxel_xgs1010-12-a1
 


### PR DESCRIPTION
This PR adds support for the Zyxel XGS1010-12 B1 revision, which is basically the unmanaged version of the XGS1210-12 B1. It features a newer uBoot build and slightly different 2.5G PHYs than the A1 revision of this model.

- SoC: RTL9302B
- RAM: 128MB DDR3
- Flash: 16MB SPI-NOR
- Ethernet: 8x 1GBE RJ45 (RTL8218D), 2x 2.5GBE (2x RTL8226B), 2x SFP+ cage (10G/2.5G/1G)
- UART: 3.3V 115200 8N1, accessible from the right side of the case (Pinout top to bottom: Vcc - Tx - Rx - Gnd)
- MAC address: The base MAC is stored in uBoot env variable `ethaddr`, which contains only a placeholder (`00:E0:4C:00:00:00`) in the factory default configuration. Will be generated randomly at boot unless manually preset (see installation instructions). Additional port MACs are assigned incrementally per port.

This contribution is based on the already existing support for the Zyxel XGS1010-12-A1 and XGS1210-12-B1.

**Installation instructions:**

1. Set your PC's IP address to 192.168.1.111 and serve the OpenWrt `initramfs` image via TFTP (e.g. as `initramfs.bin`)
2. Connect to the device via UART, power on and press Esc within 1 second after prompted.
3. (Optional) Set a unique MAC address: `setenv ethaddr AA:BB:CC:DD:EE:FF`
4. Populate the uBoot env partition with the command: `saveenv`
5. Enter the following command line to boot the `initramfs` OpenWrt image: `rtk network on; tftpboot 0x84f00000 initramfs.bin; bootm`
6. Wait until OpenWrt has booted and connect via SSH.
7. (Optional) Back up the original partitions (at least `mtd5`-`mtd9`) in order to be able to revert to stock later.
8. Update the boot command needed to boot OpenWrt: `fw_setenv bootcmd "rtk network on; bootm 0xb4900000"`
9. Install the OpenWrt `sysupgrade` image and wait for the device to boot OpenWrt from flash. Enjoy.

**Back to stock:**

1. Boot the `initramfs` image as described above.
2. Write the previously backed up `mtd5`-`mtd9` partitions to flash.
3. Restore the boot command to stock: `fw_setenv bootcmd boota`
5. Reboot into stock firmware.
