### PR TITLE
ramips: mt76x8: add Teltonika RUT206 support

### DIFF
--- a/target/linux/ramips/dts/mt7628an_teltonika_rut206.dts
+++ b/target/linux/ramips/dts/mt7628an_teltonika_rut206.dts
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include "mt7628an.dtsi"
+
+/ {
+	compatible = "teltonika,rut206", "teltonika,rute", "mediatek,mt7628an-soc";
+	model = "Teltonika RUT206";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	aliases {
+		led-boot = &rssi1;
+		led-failsafe = &rssi1;
+		led-upgrade = &rssi1;
+	};
+
+	gpio_spi {
+		compatible = "spi-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sck-gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;  /* SRCLK */
+		mosi-gpios = <&gpio 1 GPIO_ACTIVE_HIGH>; /* SER */
+		cs-gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;   /* RCLK */
+		num-chipselects = <1>;
+
+		gpio_hc595: gpio_hc595@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			registers-number = <1>;
+			spi-max-frequency = <10000000>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		gpio_modem_reset {
+			gpio-export,name = "modem_reset";
+			gpio-export,output = <0>;
+			gpios = <&gpio_hc595 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_modem_power {
+			gpio-export,name = "modem_power";
+			gpio-export,output = <0>;
+			gpios = <&gpio_hc595 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_sim_select {
+			gpio-export,name = "sim_sel";
+			gpio-export,output = <0>;
+			gpios = <&gpio_hc595 6 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		modem_2g {
+			function = "2G";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 39 GPIO_ACTIVE_HIGH>;
+		};
+
+		modem_3g {
+			function = "3G";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 40 GPIO_ACTIVE_HIGH>;
+		};
+
+		modem_4g {
+			function = "4G";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 41 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssi1: rssi1 {
+			function = "rssi-1";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssi3 {
+			function = "rssi-3";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssi5 {
+			function = "rssi-5";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 2 GPIO_ACTIVE_HIGH>;
+		};
+
+		power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 0 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+			retain-state-shutdown;
+		};
+
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2s", "p4led_an", "p3led_an", "p2led_an", "p1led_an", "p0led_an", "gpio", "wled_an", "perst";
+		function = "gpio";
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			boot: partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			config: partition@40000 {
+				label = "config";
+				reg = <0x040000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_config_0: macaddr@0 {
+						reg = <0x0 0x6>;
+						compatible = "mac-base";
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			factory: partition@50000 {
+				label = "factory";
+				reg = <0x050000 0x030000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+				};
+			};
+
+			partition@80000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x080000 0x1ED0000>;
+			};
+
+			partition@1f50000 {
+				label = "event-log";
+				reg = <0x1F50000 0xB0000>;
+			};
+		};
+	};
+};
+
+/* WiFi MAC: "config" partition, offset 0x0 + 2 (xx:xx:xx:xx:xx:xx + 2) */
+&wmac {
+	status = "okay";
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_config_0 2>;
+	nvmem-cell-names = "eeprom", "mac-address";
+};
+
+/* LAN MAC: "config" partition, offset 0x0 + 0 (xx:xx:xx:xx:xx:xx) */
+/* WAN MAC: "config" partition, offset 0x0 + 0 (xx:xx:xx:xx:xx:xx) — eth0 shared via ESW VLAN */
+&ethernet {
+	nvmem-cells = <&macaddr_config_0 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+};
+
+&uart1 {
+	status = "okay";
+};
+
+&uart2 {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -1530,6 +1530,19 @@ define Device/teltonika_rut200
 endef
 TARGET_DEVICES += teltonika_rut200
 
+define Device/teltonika_rut206
+  DEVICE_VENDOR := Teltonika
+  DEVICE_MODEL := RUT206
+  IMAGE_SIZE := 31552k
+  BLOCKSIZE := 64k
+  SUPPORTED_TELTONIKA_DEVICES := teltonika,rut206
+  DEVICE_PACKAGES += kmod-mt76x2 kmod-usb2 kmod-usb-ohci kmod-usb-serial-option kmod-usb-net-cdc-ether kmod-spi-gpio kmod-usb-serial-ch341 kmod-usb-storage kmod-gpio-nxp-74hc164
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-teltonika-metadata
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-metadata
+endef
+TARGET_DEVICES += teltonika_rut206
+
 define Device/teltonika_rut241
   DEVICE_VENDOR := Teltonika
   DEVICE_MODEL := RUT241

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -102,6 +102,7 @@ tama,w06)
 	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
 	;;
 teltonika,rut200|\
+teltonika,rut206|\
 teltonika,rut241)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x02"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x01"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -126,6 +126,7 @@ ramips_setup_interfaces()
 	glinet,gl-mt300n-v2|\
 	hongdian,h7920-v40|\
 	teltonika,rut200|\
+	teltonika,rut206|\
 	teltonika,rut241)
 		ucidef_add_switch "switch0" \
 			"1:lan" "0:wan" "6@eth0"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/03_gpio_switches
@@ -22,6 +22,11 @@ teltonika,rut241)
 	ucidef_add_gpio_switch "modem_power" "Modem power" "modem_power" "1"
 	ucidef_add_gpio_switch "modem_reset" "Modem reset" "modem_reset" "0"
 	;;
+teltonika,rut206)
+	ucidef_add_gpio_switch "modem_power" "Modem power" "modem_power" "1"
+	ucidef_add_gpio_switch "modem_reset" "Modem reset" "modem_reset" "0"
+	ucidef_add_gpio_switch "sim_sel" "SIM select" "sim_sel" "0"
+	;;
 teltonika,rut9x1)
 	ucidef_add_gpio_switch "digital_output" "Digital output 1" "digital_output1" "0"
 	ucidef_add_gpio_switch "modem_power" "Modem power button" "modem_power" "1"


### PR DESCRIPTION
This commit adds support for the Teltonika RUT206.

Specifications:
- MediaTek MT7628NN SoC
- 128MB DDR2 RAM (Winbond W971GG6NB 25)
- 32MB Flash (Winbond 25Q256JVEQ)
- 2x 10/100 Mbps Ethernet, with passive PoE support on "LAN" port
- MediaTek MT7628NN 2.4 GHz 802.11n WiFi
- Quectel EC200 4G Modem
- RS/EIA/TIA-232E (/dev/ttyS1)
- RS/EIA/TIA-485 (/dev/ttyUSB0)
- microSD card slot (Genesys GL835 USB 2.0 to LUN SD3.0)
- 2x SIM slot (sim selection via GPIO)

GPIO:
- button (reset)
- 8 LEDs (power, LAN, WAN, RSSI 1,3,5, Modem status)

Flashing via OEM Web UI:
- Obtain firmware image *-squashfs-factory.bin
- Upload firmware image via OEM Web UI firmware update

To revert back to OEM firmware:
https://wiki.teltonika-networks.com/view/Bootloader_menu

Mobile data connection:
The modem supports ECM and RNIDS, the default configuration is ECM.
https://openwrt.org/docs/guide-user/network/wan/wwan/ethernetoverusb_cdc

Signed-off-by: Alexandra Burmistrova <github@alexandras.space>