### PR TITLE
wifi-scripts: fix cipher pinning in client mode

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
@@ -189,11 +189,12 @@ function setup_sta(data, config) {
 
 	}
 
-	if (config.wpa_pairwise == 'GCMP') {
-		config.pairwise = 'GCMP';
-		config.group = 'GCMP';
-	} else if (config.wpa_pairwise) {
+	if (config.wpa_pairwise) {
 		config.pairwise = config.wpa_pairwise;
+
+		if (wildcard(config.wpa_pairwise, '*GCMP*') ||
+		    wildcard(config.wpa_pairwise, '*CCMP-256*'))
+			config.group = config.wpa_pairwise;
 	}
 
 	config.key_mgmt ??= 'NONE';

--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -1609,9 +1609,14 @@ wpa_supplicant_add_network() {
 		;;
 	esac
 
-	[ "$wpa_cipher" = GCMP ] && {
-		append network_data "pairwise=GCMP" "$N$T"
-		append network_data "group=GCMP" "$N$T"
+	[ -n "$wpa_cipher" ] && {
+		append network_data "pairwise=$wpa_cipher" "$N$T"
+
+		case "$wpa_cipher" in
+			*GCMP*|*CCMP-256*)
+				append network_data "group=$wpa_cipher" "$N$T"
+			;;
+		esac
 	}
 
 	[ "$mode" = mesh ] || {


### PR DESCRIPTION
For anything other than plain GCMP, we were not setting pairwise/group to the configured cipher. Now we always pin pairwise to ${config.wpa_pairwise} and also do so for group cipher except in the CCMP case as the group cipher might be set to TKIP on the AP's end in the mixed-mode case.

This makes CCMP-256 and GCMP-256 work for the supplicant in both WPA2 and WPA3, and also fixes the default WPA3 cipher on HE/EHT radios which previously fell back to CCMP only.