### PR TITLE
kernel: replace deprecated functions

### DIFF
--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_bcm63xx.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_bcm63xx.c
@@ -127,7 +127,7 @@ static int bcm63xx_parse_partitions(struct mtd_info *master,
 	if (mtd_check_rootfs_magic(master, rootfs_offset, NULL))
 		pr_warn("rootfs magic not found\n");
 
-	parts = kzalloc(BCM63XX_NR_PARTS * sizeof(*parts), GFP_KERNEL);
+	parts = kcalloc(BCM63XX_NR_PARTS, sizeof(*parts), GFP_KERNEL);
 	if (!parts)
 		return -ENOMEM;
 

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_bcm_wfi.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_bcm_wfi.c
@@ -200,7 +200,7 @@ static int parse_bcm_wfi(struct mtd_info *master,
 	if (ret)
 		return ret;
 
-	parts = kzalloc(num_parts * sizeof(*parts), GFP_KERNEL);
+	parts = kcalloc(num_parts, sizeof(*parts), GFP_KERNEL);
 	if (!parts)
 		return -ENOMEM;
 
@@ -348,7 +348,7 @@ static int mtdsplit_parse_bcm_wfi_split(struct mtd_info *master,
 	kfree(buf);
 
 	if (ret > 0) {
-		parts = kzalloc((ret + 1) * sizeof(*parts), GFP_KERNEL);
+		parts = kcalloc(ret + 1, sizeof(*parts), GFP_KERNEL);
 		if (!parts)
 			return -ENOMEM;
 
@@ -362,7 +362,7 @@ static int mtdsplit_parse_bcm_wfi_split(struct mtd_info *master,
 
 		*pparts = parts;
 	} else {
-		parts = kzalloc(BCM_WFI_SPLIT_PARTS * sizeof(*parts), GFP_KERNEL);
+		parts = kcalloc(BCM_WFI_SPLIT_PARTS, sizeof(*parts), GFP_KERNEL);
 
 		parts[0].name = PART_IMAGE_1;
 		parts[0].offset = img1_off;
@@ -480,7 +480,7 @@ static int mtdsplit_parse_ser_wfi(struct mtd_info *master,
 	kfree(buf);
 
 	if (ret > 0) {
-		parts = kzalloc((ret + 1) * sizeof(*parts), GFP_KERNEL);
+		parts = kcalloc(ret + 1, sizeof(*parts), GFP_KERNEL);
 		if (!parts)
 			return -ENOMEM;
 
@@ -494,7 +494,7 @@ static int mtdsplit_parse_ser_wfi(struct mtd_info *master,
 
 		*pparts = parts;
 	} else {
-		parts = kzalloc(BCM_WFI_SPLIT_PARTS * sizeof(*parts), GFP_KERNEL);
+		parts = kcalloc(BCM_WFI_SPLIT_PARTS, sizeof(*parts), GFP_KERNEL);
 
 		parts[0].name = PART_IMAGE_1;
 		parts[0].offset = img1_off;

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_brnimage.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_brnimage.c
@@ -71,7 +71,7 @@ static int mtdsplit_parse_brnimage(struct mtd_info *master,
 	 */
 	rootfs_size = master->size - rootfs_offset - BRNIMAGE_FOOTER_SIZE;
 
-	parts = kzalloc(BRNIMAGE_NR_PARTS * sizeof(*parts), GFP_KERNEL);
+	parts = kcalloc(BRNIMAGE_NR_PARTS, sizeof(*parts), GFP_KERNEL);
 	if (!parts)
 		return -ENOMEM;
 

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_cfe_bootfs.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_cfe_bootfs.c
@@ -54,7 +54,7 @@ static int mtdsplit_cfe_bootfs_parse(struct mtd_info *mtd,
 	if (err)
 		return err;
 
-	parts = kzalloc(NR_PARTS * sizeof(*parts), GFP_KERNEL);
+	parts = kcalloc(NR_PARTS, sizeof(*parts), GFP_KERNEL);
 	if (!parts)
 		return -ENOMEM;
 

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_elf.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_elf.c
@@ -244,7 +244,7 @@ static int mtdsplit_parse_elf(struct mtd_info *mtd,
 		return -ENOENT;
 	}
 
-	parts = kzalloc(ELF_NR_PARTS * sizeof(*parts), GFP_KERNEL);
+	parts = kcalloc(ELF_NR_PARTS, sizeof(*parts), GFP_KERNEL);
 	if (!parts)
 		return -ENOMEM;
 

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_eva.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_eva.c
@@ -64,7 +64,7 @@ static int mtdsplit_parse_eva(struct mtd_info *master,
 	if (err)
 		return err;
 
-	parts = kzalloc(EVA_NR_PARTS * sizeof(*parts), GFP_KERNEL);
+	parts = kcalloc(EVA_NR_PARTS, sizeof(*parts), GFP_KERNEL);
 	if (!parts)
 		return -ENOMEM;
 

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_fit.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_fit.c
@@ -272,7 +272,7 @@ mtdsplit_fit_parse(struct mtd_info *mtd,
 
 		rootfs_size = mtd->size - rootfs_offset;
 
-		parts = kzalloc(2 * sizeof(*parts), GFP_KERNEL);
+		parts = kcalloc(2, sizeof(*parts), GFP_KERNEL);
 		if (!parts)
 			return -ENOMEM;
 

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_h3c_vfs.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_h3c_vfs.c
@@ -140,7 +140,7 @@ static int mtdsplit_h3c_vfs_parse(struct mtd_info *mtd,
 	if (err)
 		return err;
 
-	parts = kzalloc(NR_PARTS * sizeof(*parts), GFP_KERNEL);
+	parts = kcalloc(NR_PARTS, sizeof(*parts), GFP_KERNEL);
 	if (!parts)
 		return -ENOMEM;
 

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_jimage.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_jimage.c
@@ -108,7 +108,7 @@ static int __mtdsplit_parse_jimage(struct mtd_info *master,
 	enum mtdsplit_part_type type;
 
 	nr_parts = 2;
-	parts = kzalloc(nr_parts * sizeof(*parts), GFP_KERNEL);
+	parts = kcalloc(nr_parts, sizeof(*parts), GFP_KERNEL);
 	if (!parts)
 		return -ENOMEM;
 

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_lzma.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_lzma.c
@@ -69,7 +69,7 @@ static int mtdsplit_parse_lzma(struct mtd_info *master,
 	if (err)
 		return err;
 
-	parts = kzalloc(LZMA_NR_PARTS * sizeof(*parts), GFP_KERNEL);
+	parts = kcalloc(LZMA_NR_PARTS, sizeof(*parts), GFP_KERNEL);
 	if (!parts)
 		return -ENOMEM;
 

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_minor.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_minor.c
@@ -88,7 +88,7 @@ static int mtdsplit_parse_minor(struct mtd_info *master,
 	if (err)
 		return err;
 
-	parts = kzalloc(MINOR_NR_PARTS * sizeof(*parts), GFP_KERNEL);
+	parts = kcalloc(MINOR_NR_PARTS, sizeof(*parts), GFP_KERNEL);
 	if (!parts)
 		return -ENOMEM;
 

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_owrt_prolog.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_owrt_prolog.c
@@ -95,7 +95,7 @@ static int mtdsplit_parse_owrt_prolog(struct mtd_info *master,
 	if (ret)
 		return ret;
 
-	parts = kzalloc(OWRT_PROLOG_NR_PARTS * sizeof(*parts), GFP_KERNEL);
+	parts = kcalloc(OWRT_PROLOG_NR_PARTS, sizeof(*parts), GFP_KERNEL);
 	if (!parts)
 		return -ENOMEM;
 

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_seama.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_seama.c
@@ -75,7 +75,7 @@ static int mtdsplit_parse_seama(struct mtd_info *master,
 			return err;
 	}
 
-	parts = kzalloc(SEAMA_NR_PARTS * sizeof(*parts), GFP_KERNEL);
+	parts = kcalloc(SEAMA_NR_PARTS, sizeof(*parts), GFP_KERNEL);
 	if (!parts)
 		return -ENOMEM;
 

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_tplink.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_tplink.c
@@ -137,7 +137,7 @@ static int mtdsplit_parse_tplink(struct mtd_info *master,
 			return err;
 	}
 
-	parts = kzalloc(TPLINK_NR_PARTS * sizeof(*parts), GFP_KERNEL);
+	parts = kcalloc(TPLINK_NR_PARTS, sizeof(*parts), GFP_KERNEL);
 	if (!parts)
 		return -ENOMEM;
 

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_trx.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_trx.c
@@ -71,7 +71,7 @@ mtdsplit_parse_trx(struct mtd_info *master,
 	int ret;
 
 	nr_parts = 2;
-	parts = kzalloc(nr_parts * sizeof(*parts), GFP_KERNEL);
+	parts = kcalloc(nr_parts, sizeof(*parts), GFP_KERNEL);
 	if (!parts)
 		return -ENOMEM;
 

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_uimage.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_uimage.c
@@ -139,7 +139,7 @@ static int __mtdsplit_parse_uimage(struct mtd_info *master,
 	enum mtdsplit_part_type type;
 
 	nr_parts = 2;
-	parts = kzalloc(nr_parts * sizeof(*parts), GFP_KERNEL);
+	parts = kcalloc(nr_parts, sizeof(*parts), GFP_KERNEL);
 	if (!parts)
 		return -ENOMEM;
 

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_wrgg.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_wrgg.c
@@ -102,7 +102,7 @@ static int mtdsplit_parse_wrgg(struct mtd_info *master,
 	if (err)
 		return err;
 
-	parts = kzalloc(WRGG_NR_PARTS * sizeof(*parts), GFP_KERNEL);
+	parts = kcalloc(WRGG_NR_PARTS, sizeof(*parts), GFP_KERNEL);
 	if (!parts)
 		return -ENOMEM;
 

--- a/target/linux/generic/files/drivers/net/phy/ar8216.c
+++ b/target/linux/generic/files/drivers/net/phy/ar8216.c
@@ -2310,17 +2310,14 @@ next_attempt:
 static int
 ar8xxx_mib_init(struct ar8xxx_priv *priv)
 {
-	unsigned int len;
-
 	if (!ar8xxx_has_mib_counters(priv))
 		return 0;
 
 	if (WARN_ON(!priv->chip->mib_decs || !priv->chip->num_mibs))
 		return -EINVAL;
 
-	len = priv->dev.ports * priv->chip->num_mibs *
-	      sizeof(*priv->mib_stats);
-	priv->mib_stats = kzalloc(len, GFP_KERNEL);
+	priv->mib_stats = kcalloc(array_size(priv->dev.ports, priv->chip->num_mibs),
+				 sizeof(*priv->mib_stats), GFP_KERNEL);
 
 	if (!priv->mib_stats)
 		return -ENOMEM;

--- a/target/linux/generic/files/drivers/net/phy/ar8216.c
+++ b/target/linux/generic/files/drivers/net/phy/ar8216.c
@@ -2315,7 +2315,8 @@ ar8xxx_mib_init(struct ar8xxx_priv *priv)
 	if (!ar8xxx_has_mib_counters(priv))
 		return 0;
 
-	BUG_ON(!priv->chip->mib_decs || !priv->chip->num_mibs);
+	if (WARN_ON(!priv->chip->mib_decs || !priv->chip->num_mibs))
+		return -EINVAL;
 
 	len = priv->dev.ports * priv->chip->num_mibs *
 	      sizeof(*priv->mib_stats);

--- a/target/linux/generic/files/drivers/net/phy/rtl8306.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8306.c
@@ -898,19 +898,19 @@ rtl8306_config_init(struct phy_device *pdev)
 	switch(chiptype) {
 	case 0:
 	case 2:
-		strncpy(priv->hwname, RTL_NAME_S, sizeof(priv->hwname));
+		strscpy(priv->hwname, RTL_NAME_S, sizeof(priv->hwname));
 		priv->type = RTL_TYPE_S;
 		break;
 	case 1:
-		strncpy(priv->hwname, RTL_NAME_SD, sizeof(priv->hwname));
+		strscpy(priv->hwname, RTL_NAME_SD, sizeof(priv->hwname));
 		priv->type = RTL_TYPE_SD;
 		break;
 	case 3:
-		strncpy(priv->hwname, RTL_NAME_SDM, sizeof(priv->hwname));
+		strscpy(priv->hwname, RTL_NAME_SDM, sizeof(priv->hwname));
 		priv->type = RTL_TYPE_SDM;
 		break;
 	default:
-		strncpy(priv->hwname, RTL_NAME_UNKNOWN, sizeof(priv->hwname));
+		strscpy(priv->hwname, RTL_NAME_UNKNOWN, sizeof(priv->hwname));
 		break;
 	}
 

--- a/target/linux/generic/files/drivers/net/phy/rtl8306.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8306.c
@@ -266,7 +266,8 @@ rtl_set_page(struct rtl_priv *priv, unsigned int page)
 	if (priv->page == page)
 		return;
 
-	BUG_ON(page > RTL8306_NUM_PAGES);
+	if (WARN_ON_ONCE(page > RTL8306_NUM_PAGES))
+		return;
 	pgsel = bus->read(bus, 0, RTL8306_REG_PAGE);
 	pgsel &= ~(RTL8306_REG_PAGE_LO | RTL8306_REG_PAGE_HI);
 	if (page & (1 << 0))
@@ -320,7 +321,8 @@ rtl_get(struct switch_dev *dev, enum rtl_regidx s)
 	const struct rtl_reg *r = &rtl_regs[s];
 	u16 val;
 
-	BUG_ON(s >= ARRAY_SIZE(rtl_regs));
+	if (WARN_ON_ONCE(s >= ARRAY_SIZE(rtl_regs)))
+		return 0;
 	if (r->bits == 0) /* unimplemented */
 		return 0;
 
@@ -343,7 +345,8 @@ rtl_set(struct switch_dev *dev, enum rtl_regidx s, unsigned int val)
 	const struct rtl_reg *r = &rtl_regs[s];
 	u16 mask = 0xffff;
 
-	BUG_ON(s >= ARRAY_SIZE(rtl_regs));
+	if (WARN_ON_ONCE(s >= ARRAY_SIZE(rtl_regs)))
+		return -EINVAL;
 
 	if (r->bits == 0) /* unimplemented */
 		return 0;

--- a/target/linux/generic/files/drivers/net/phy/rtl8366_smi.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8366_smi.c
@@ -257,7 +257,8 @@ static int __rtl8366_mdio_read_reg(struct rtl8366_smi *smi, u32 addr, u32 *data)
 	u32 phy_id = smi->phy_id;
 	struct mii_bus *mbus = smi->ext_mbus;
 
-	BUG_ON(in_interrupt());
+	if (WARN_ON(in_interrupt()))
+		return -EPERM;
 
 	mutex_lock(&mbus->mdio_lock);
 	/* Write Start command to register 29 */
@@ -279,7 +280,7 @@ static int __rtl8366_mdio_read_reg(struct rtl8366_smi *smi, u32 addr, u32 *data)
 	mbus->write(mbus, phy_id, MDC_MDIO_CTRL1_REG, MDC_MDIO_READ_OP);
 
 	/* Write Start command to register 29 */
-	mbus->write(smi->ext_mbus, phy_id, MDC_MDIO_START_REG, MDC_MDIO_START_OP);
+	mbus->write(mbus, phy_id, MDC_MDIO_START_REG, MDC_MDIO_START_OP);
 
 	/* Read data from register 25 */
 	*data = mbus->read(mbus, phy_id, MDC_MDIO_DATA_READ_REG);
@@ -294,7 +295,8 @@ static int __rtl8366_mdio_write_reg(struct rtl8366_smi *smi, u32 addr, u32 data)
 	u32 phy_id = smi->phy_id;
 	struct mii_bus *mbus = smi->ext_mbus;
 
-	BUG_ON(in_interrupt());
+	if (WARN_ON(in_interrupt()))
+		return -EPERM;
 
 	mutex_lock(&mbus->mdio_lock);
 
@@ -1344,7 +1346,8 @@ struct rtl8366_smi *rtl8366_smi_alloc(struct device *parent)
 {
 	struct rtl8366_smi *smi;
 
-	BUG_ON(!parent);
+	if (WARN_ON(!parent))
+		return NULL;
 
 	smi = kzalloc(sizeof(*smi), GFP_KERNEL);
 	if (!smi) {

--- a/target/linux/generic/files/drivers/net/phy/swconfig.c
+++ b/target/linux/generic/files/drivers/net/phy/swconfig.c
@@ -1114,7 +1114,8 @@ register_switch(struct switch_dev *dev, struct net_device *netdev)
 		if (!dev->alias)
 			dev->alias = netdev->name;
 	}
-	BUG_ON(!dev->alias);
+	if (WARN_ON(!dev->alias))
+		return -EINVAL;
 
 	/* Make sure swdev_id doesn't overflow */
 	if (swdev_id == INT_MAX) {

--- a/target/linux/generic/files/drivers/net/phy/swconfig.c
+++ b/target/linux/generic/files/drivers/net/phy/swconfig.c
@@ -1123,12 +1123,10 @@ register_switch(struct switch_dev *dev, struct net_device *netdev)
 	}
 
 	if (dev->ports > 0) {
-		dev->portbuf = kzalloc(sizeof(struct switch_port) *
-				dev->ports, GFP_KERNEL);
+		dev->portbuf = kcalloc(dev->ports, sizeof(struct switch_port), GFP_KERNEL);
 		if (!dev->portbuf)
 			return -ENOMEM;
-		dev->portmap = kzalloc(sizeof(struct switch_portmap) *
-				dev->ports, GFP_KERNEL);
+		dev->portmap = kcalloc(dev->ports, sizeof(struct switch_portmap), GFP_KERNEL);
 		if (!dev->portmap) {
 			kfree(dev->portbuf);
 			return -ENOMEM;

--- a/target/linux/generic/files/drivers/net/phy/swconfig_leds.c
+++ b/target/linux/generic/files/drivers/net/phy/swconfig_leds.c
@@ -237,8 +237,7 @@ static ssize_t swconfig_trig_mode_store(struct device *dev,
 	char *p, *token;
 
 	/* take a copy since we don't want to trash the inbound buffer when using strsep */
-	strncpy(copybuf, buf, sizeof(copybuf));
-	copybuf[sizeof(copybuf) - 1] = 0;
+	strscpy(copybuf, buf, sizeof(copybuf));
 	p = copybuf;
 
 	while ((token = strsep(&p, " \t\n")) != NULL) {

--- a/target/linux/generic/hack-6.12/920-device_tree_cmdline.patch
+++ b/target/linux/generic/hack-6.12/920-device_tree_cmdline.patch
@@ -15,7 +15,7 @@ Subject: [PATCH] of/ftd: add device tree cmdline
  		strscpy(cmdline, p, min(l, COMMAND_LINE_SIZE));
 +	p = of_get_flat_dt_prop(node, "bootargs-append", &l);
 +	if (p != NULL && l > 0)
-+		strlcat(cmdline, p, min_t(int, strlen(cmdline) + (int)l, COMMAND_LINE_SIZE));
++		strlcat(cmdline, p, COMMAND_LINE_SIZE);
  
  handle_cmdline:
  	/*

--- a/target/linux/generic/hack-6.18/920-device_tree_cmdline.patch
+++ b/target/linux/generic/hack-6.18/920-device_tree_cmdline.patch
@@ -15,7 +15,7 @@ Subject: [PATCH] of/ftd: add device tree cmdline
  		strscpy(cmdline, p, min(l, COMMAND_LINE_SIZE));
 +	p = of_get_flat_dt_prop(node, "bootargs-append", &l);
 +	if (p != NULL && l > 0)
-+		strlcat(cmdline, p, min_t(int, strlen(cmdline) + (int)l, COMMAND_LINE_SIZE));
++		strlcat(cmdline, p, COMMAND_LINE_SIZE);
  
  handle_cmdline:
  	/*

--- a/target/linux/generic/pending-6.12/430-mtd-add-myloader-partition-parser.patch
+++ b/target/linux/generic/pending-6.12/430-mtd-add-myloader-partition-parser.patch
@@ -160,7 +160,7 @@ Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
 +	mtd_part = mtd_parts;
 +	names = (char *)&mtd_parts[num_parts];
 +
-+	strncpy(names, "myloader", PART_NAME_LEN);
++	strscpy_pad(names, "myloader", PART_NAME_LEN);
 +	mtd_part->name = names;
 +	mtd_part->offset = 0;
 +	mtd_part->size = offset;
@@ -168,7 +168,7 @@ Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
 +	mtd_part++;
 +	names += PART_NAME_LEN;
 +
-+	strncpy(names, "partition_table", PART_NAME_LEN);
++	strscpy_pad(names, "partition_table", PART_NAME_LEN);
 +	mtd_part->name = names;
 +	mtd_part->offset = offset;
 +	mtd_part->size = blocklen;
@@ -183,7 +183,7 @@ Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
 +			continue;
 +
 +		if ((buf->names[i][0]) && (buf->names[i][0] != '\xff'))
-+			strncpy(names, buf->names[i], PART_NAME_LEN);
++			strscpy_pad(names, buf->names[i], PART_NAME_LEN);
 +		else
 +			snprintf(names, PART_NAME_LEN, "partition%d", i);
 +

--- a/target/linux/generic/pending-6.12/430-mtd-add-myloader-partition-parser.patch
+++ b/target/linux/generic/pending-6.12/430-mtd-add-myloader-partition-parser.patch
@@ -149,8 +149,8 @@ Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
 +		num_parts++;
 +	}
 +
-+	mtd_parts = kzalloc((num_parts * sizeof(*mtd_part) +
-+				num_parts * PART_NAME_LEN), GFP_KERNEL);
++	mtd_parts = kzalloc(size_add(size_mul(num_parts, sizeof(*mtd_part)),
++				    size_mul(num_parts, PART_NAME_LEN)), GFP_KERNEL);
 +
 +	if (!mtd_parts) {
 +		ret = -ENOMEM;

--- a/target/linux/generic/pending-6.12/920-mangle_bootargs.patch
+++ b/target/linux/generic/pending-6.12/920-mangle_bootargs.patch
@@ -44,12 +44,12 @@ Signed-off-by: Imre Kaloz <kaloz@openwrt.org>
 +	rootdev = strstr(command_line, "root=/dev/mtdblock");
 +
 +	if (rootdev)
-+		strncpy(rootdev, "mangled_rootblock=", 18);
++		memcpy(rootdev, "mangled_rootblock=", 18);
 +
 +	rootfs = strstr(command_line, "rootfstype");
 +
 +	if (rootfs)
-+		strncpy(rootfs, "mangled_fs", 10);
++		memcpy(rootfs, "mangled_fs", 10);
 +
 +}
 +#else

--- a/target/linux/generic/pending-6.18/430-mtd-add-myloader-partition-parser.patch
+++ b/target/linux/generic/pending-6.18/430-mtd-add-myloader-partition-parser.patch
@@ -160,7 +160,7 @@ Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
 +	mtd_part = mtd_parts;
 +	names = (char *)&mtd_parts[num_parts];
 +
-+	strncpy(names, "myloader", PART_NAME_LEN);
++	strscpy_pad(names, "myloader", PART_NAME_LEN);
 +	mtd_part->name = names;
 +	mtd_part->offset = 0;
 +	mtd_part->size = offset;
@@ -168,7 +168,7 @@ Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
 +	mtd_part++;
 +	names += PART_NAME_LEN;
 +
-+	strncpy(names, "partition_table", PART_NAME_LEN);
++	strscpy_pad(names, "partition_table", PART_NAME_LEN);
 +	mtd_part->name = names;
 +	mtd_part->offset = offset;
 +	mtd_part->size = blocklen;
@@ -183,7 +183,7 @@ Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
 +			continue;
 +
 +		if ((buf->names[i][0]) && (buf->names[i][0] != '\xff'))
-+			strncpy(names, buf->names[i], PART_NAME_LEN);
++			strscpy_pad(names, buf->names[i], PART_NAME_LEN);
 +		else
 +			snprintf(names, PART_NAME_LEN, "partition%d", i);
 +

--- a/target/linux/generic/pending-6.18/430-mtd-add-myloader-partition-parser.patch
+++ b/target/linux/generic/pending-6.18/430-mtd-add-myloader-partition-parser.patch
@@ -149,8 +149,8 @@ Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
 +		num_parts++;
 +	}
 +
-+	mtd_parts = kzalloc((num_parts * sizeof(*mtd_part) +
-+				num_parts * PART_NAME_LEN), GFP_KERNEL);
++	mtd_parts = kzalloc(size_add(size_mul(num_parts, sizeof(*mtd_part)),
++				    size_mul(num_parts, PART_NAME_LEN)), GFP_KERNEL);
 +
 +	if (!mtd_parts) {
 +		ret = -ENOMEM;

--- a/target/linux/generic/pending-6.18/920-mangle_bootargs.patch
+++ b/target/linux/generic/pending-6.18/920-mangle_bootargs.patch
@@ -44,12 +44,12 @@ Signed-off-by: Imre Kaloz <kaloz@openwrt.org>
 +	rootdev = strstr(command_line, "root=/dev/mtdblock");
 +
 +	if (rootdev)
-+		strncpy(rootdev, "mangled_rootblock=", 18);
++		memcpy(rootdev, "mangled_rootblock=", 18);
 +
 +	rootfs = strstr(command_line, "rootfstype");
 +
 +	if (rootfs)
-+		strncpy(rootfs, "mangled_fs", 10);
++		memcpy(rootfs, "mangled_fs", 10);
 +
 +}
 +#else

--- a/target/linux/ipq806x/patches-6.12/900-arm-add-cmdline-override.patch
+++ b/target/linux/ipq806x/patches-6.12/900-arm-add-cmdline-override.patch
@@ -19,7 +19,7 @@
 +++ b/drivers/of/fdt.c
 @@ -1053,6 +1053,17 @@ int __init early_init_dt_scan_chosen(cha
  	if (p != NULL && l > 0)
- 		strlcat(cmdline, p, min_t(int, strlen(cmdline) + (int)l, COMMAND_LINE_SIZE));
+ 		strlcat(cmdline, p, COMMAND_LINE_SIZE);
  
 +    /* CONFIG_CMDLINE_OVERRIDE is used to fallback to a different
 +     * device tree option of chosen/bootargs-override. This is

--- a/target/linux/ipq806x/patches-6.12/900-arm-add-cmdline-override.patch
+++ b/target/linux/ipq806x/patches-6.12/900-arm-add-cmdline-override.patch
@@ -29,7 +29,7 @@
 +#ifdef CONFIG_CMDLINE_OVERRIDE
 +	p = of_get_flat_dt_prop(node, "bootargs-override", &l);
 +	if (p != NULL && l > 0)
-+		strscpy(cmdline, p, min((int)l, COMMAND_LINE_SIZE));
++		strscpy(cmdline, p, min(l, COMMAND_LINE_SIZE));
 +#endif
 +
  handle_cmdline:

--- a/target/linux/mediatek/patches-6.18/901-arm-add-cmdline-override.patch
+++ b/target/linux/mediatek/patches-6.18/901-arm-add-cmdline-override.patch
@@ -43,7 +43,7 @@ Signed-off-by: Yoonji Park <koreapyj@dcmys.kr>
 +#ifdef CONFIG_CMDLINE_OVERRIDE
 +	p = of_get_flat_dt_prop(node, "bootargs-override", &l);
 +	if (p != NULL && l > 0)
-+		strscpy(cmdline, p, min((int)l, COMMAND_LINE_SIZE));
++		strscpy(cmdline, p, min(l, COMMAND_LINE_SIZE));
 +#endif
 +
  handle_cmdline:

--- a/target/linux/mediatek/patches-6.18/901-arm-add-cmdline-override.patch
+++ b/target/linux/mediatek/patches-6.18/901-arm-add-cmdline-override.patch
@@ -33,7 +33,7 @@ Signed-off-by: Yoonji Park <koreapyj@dcmys.kr>
 +++ b/drivers/of/fdt.c
 @@ -1120,6 +1120,17 @@ int __init early_init_dt_scan_chosen(cha
  	if (p != NULL && l > 0)
- 		strlcat(cmdline, p, min_t(int, strlen(cmdline) + (int)l, COMMAND_LINE_SIZE));
+ 		strlcat(cmdline, p, COMMAND_LINE_SIZE);
  
 +    /* CONFIG_CMDLINE_OVERRIDE is used to fallback to a different
 +     * device tree option of chosen/bootargs-override. This is

--- a/target/linux/mpc85xx/patches-6.12/102-powerpc-add-cmdline-override.patch
+++ b/target/linux/mpc85xx/patches-6.12/102-powerpc-add-cmdline-override.patch
@@ -19,7 +19,7 @@
 +++ b/drivers/of/fdt.c
 @@ -1053,6 +1053,17 @@ int __init early_init_dt_scan_chosen(cha
  	if (p != NULL && l > 0)
- 		strlcat(cmdline, p, min_t(int, strlen(cmdline) + (int)l, COMMAND_LINE_SIZE));
+ 		strlcat(cmdline, p, COMMAND_LINE_SIZE);
  
 +    /* CONFIG_CMDLINE_OVERRIDE is used to fallback to a different
 +     * device tree option of chosen/bootargs-override. This is

--- a/target/linux/mpc85xx/patches-6.12/102-powerpc-add-cmdline-override.patch
+++ b/target/linux/mpc85xx/patches-6.12/102-powerpc-add-cmdline-override.patch
@@ -29,7 +29,7 @@
 +#ifdef CONFIG_CMDLINE_OVERRIDE
 +	p = of_get_flat_dt_prop(node, "bootargs-override", &l);
 +	if (p != NULL && l > 0)
-+		strscpy(cmdline, p, COMMAND_LINE_SIZE);
++		strscpy(cmdline, p, min(l, COMMAND_LINE_SIZE));
 +#endif
 +
  handle_cmdline:

--- a/target/linux/mpc85xx/patches-6.18/102-powerpc-add-cmdline-override.patch
+++ b/target/linux/mpc85xx/patches-6.18/102-powerpc-add-cmdline-override.patch
@@ -29,7 +29,7 @@
 +#ifdef CONFIG_CMDLINE_OVERRIDE
 +	p = of_get_flat_dt_prop(node, "bootargs-override", &l);
 +	if (p != NULL && l > 0)
-+		strscpy(cmdline, p, COMMAND_LINE_SIZE);
++		strscpy(cmdline, p, min(l, COMMAND_LINE_SIZE));
 +#endif
 +
  handle_cmdline:

--- a/target/linux/mpc85xx/patches-6.18/102-powerpc-add-cmdline-override.patch
+++ b/target/linux/mpc85xx/patches-6.18/102-powerpc-add-cmdline-override.patch
@@ -19,7 +19,7 @@
 +++ b/drivers/of/fdt.c
 @@ -1120,6 +1120,17 @@ int __init early_init_dt_scan_chosen(cha
  	if (p != NULL && l > 0)
- 		strlcat(cmdline, p, min_t(int, strlen(cmdline) + (int)l, COMMAND_LINE_SIZE));
+ 		strlcat(cmdline, p, COMMAND_LINE_SIZE);
  
 +    /* CONFIG_CMDLINE_OVERRIDE is used to fallback to a different
 +     * device tree option of chosen/bootargs-override. This is

--- a/target/linux/qualcommax/patches-6.12/0911-arm64-cmdline-replacement.patch
+++ b/target/linux/qualcommax/patches-6.12/0911-arm64-cmdline-replacement.patch
@@ -91,7 +91,7 @@ Signed-off-by: Qiyuan Zhang <zhang.github@outlook.com>
 +					*(cur_ptr + offset) = *cur_ptr;
 +			}
 +
-+			strncpy(s_ptr, p, r_len - 1);
++			memcpy(s_ptr, p, r_len - 1);
 +
 +			pr_info("Kernel command line after replacement: %s\n", cmdline);
 +		} else {

--- a/target/linux/qualcommax/patches-6.12/0911-arm64-cmdline-replacement.patch
+++ b/target/linux/qualcommax/patches-6.12/0911-arm64-cmdline-replacement.patch
@@ -102,4 +102,4 @@ Signed-off-by: Qiyuan Zhang <zhang.github@outlook.com>
 +
  	p = of_get_flat_dt_prop(node, "bootargs-append", &l);
  	if (p != NULL && l > 0)
- 		strlcat(cmdline, p, min_t(int, strlen(cmdline) + (int)l, COMMAND_LINE_SIZE));
+ 		strlcat(cmdline, p, COMMAND_LINE_SIZE);


### PR DESCRIPTION
strncpy recently got removed upstream. Handle some other ones to avoid future problems.