### PR TITLE
kernel: use module_mtd_part_parser for mtdsplit

### DIFF
--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_bcm63xx.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_bcm63xx.c
@@ -176,11 +176,4 @@ static struct mtd_part_parser mtdsplit_bcm63xx_parser = {
 	.type = MTD_PARSER_TYPE_FIRMWARE,
 };
 
-static int __init mtdsplit_bcm63xx_init(void)
-{
-	register_mtd_parser(&mtdsplit_bcm63xx_parser);
-
-	return 0;
-}
-
-module_init(mtdsplit_bcm63xx_init);
+module_mtd_part_parser(mtdsplit_bcm63xx_parser);

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_bcm_wfi.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_bcm_wfi.c
@@ -532,4 +532,12 @@ static int __init mtdsplit_bcm_wfi_init(void)
 	return 0;
 }
 
+static void __exit mtdsplit_bcm_wfi_exit(void)
+{
+	deregister_mtd_parser(&mtdsplit_bcm_wfi_parser);
+	deregister_mtd_parser(&mtdsplit_bcm_wfi_split_parser);
+	deregister_mtd_parser(&mtdsplit_ser_wfi_parser);
+}
+
 module_init(mtdsplit_bcm_wfi_init);
+module_exit(mtdsplit_bcm_wfi_exit);

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_brnimage.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_brnimage.c
@@ -94,11 +94,4 @@ static struct mtd_part_parser mtdsplit_brnimage_parser = {
 	.type = MTD_PARSER_TYPE_FIRMWARE,
 };
 
-static int __init mtdsplit_brnimage_init(void)
-{
-	register_mtd_parser(&mtdsplit_brnimage_parser);
-
-	return 0;
-}
-
-subsys_initcall(mtdsplit_brnimage_init);
+module_mtd_part_parser(mtdsplit_brnimage_parser);

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_elf.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_elf.c
@@ -277,11 +277,4 @@ static struct mtd_part_parser mtdsplit_elf_parser = {
 	.type = MTD_PARSER_TYPE_FIRMWARE,
 };
 
-static int __init mtdsplit_elf_init(void)
-{
-	register_mtd_parser(&mtdsplit_elf_parser);
-
-	return 0;
-}
-
-subsys_initcall(mtdsplit_elf_init);
+module_mtd_part_parser(mtdsplit_elf_parser);

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_eva.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_eva.c
@@ -93,11 +93,4 @@ static struct mtd_part_parser mtdsplit_eva_parser = {
 	.type = MTD_PARSER_TYPE_FIRMWARE,
 };
 
-static int __init mtdsplit_eva_init(void)
-{
-	register_mtd_parser(&mtdsplit_eva_parser);
-
-	return 0;
-}
-
-subsys_initcall(mtdsplit_eva_init);
+module_mtd_part_parser(mtdsplit_eva_parser);

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_fit.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_fit.c
@@ -351,15 +351,4 @@ static struct mtd_part_parser uimage_parser = {
 	.type = MTD_PARSER_TYPE_FIRMWARE,
 };
 
-/**************************************************
- * Init
- **************************************************/
-
-static int __init mtdsplit_fit_init(void)
-{
-	register_mtd_parser(&uimage_parser);
-
-	return 0;
-}
-
-module_init(mtdsplit_fit_init);
+module_mtd_part_parser(uimage_parser);

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_jimage.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_jimage.c
@@ -270,15 +270,4 @@ static struct mtd_part_parser jimage_generic_parser = {
 	.type = MTD_PARSER_TYPE_FIRMWARE,
 };
 
-/**************************************************
- * Init
- **************************************************/
-
-static int __init mtdsplit_jimage_init(void)
-{
-	register_mtd_parser(&jimage_generic_parser);
-
-	return 0;
-}
-
-module_init(mtdsplit_jimage_init);
+module_mtd_part_parser(jimage_generic_parser);

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_lzma.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_lzma.c
@@ -99,11 +99,4 @@ static struct mtd_part_parser mtdsplit_lzma_parser = {
 	.type = MTD_PARSER_TYPE_FIRMWARE,
 };
 
-static int __init mtdsplit_lzma_init(void)
-{
-	register_mtd_parser(&mtdsplit_lzma_parser);
-
-	return 0;
-}
-
-subsys_initcall(mtdsplit_lzma_init);
+module_mtd_part_parser(mtdsplit_lzma_parser);

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_minor.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_minor.c
@@ -118,11 +118,4 @@ static struct mtd_part_parser mtdsplit_minor_parser = {
 	.type = MTD_PARSER_TYPE_FIRMWARE,
 };
 
-static int __init mtdsplit_minor_init(void)
-{
-	register_mtd_parser(&mtdsplit_minor_parser);
-
-	return 0;
-}
-
-subsys_initcall(mtdsplit_minor_init);
+module_mtd_part_parser(mtdsplit_minor_parser);

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_owrt_prolog.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_owrt_prolog.c
@@ -124,11 +124,4 @@ static struct mtd_part_parser mtdsplit_owrt_prolog_parser = {
 	.type = MTD_PARSER_TYPE_FIRMWARE,
 };
 
-static int __init mtdsplit_owrt_prolog_init(void)
-{
-	register_mtd_parser(&mtdsplit_owrt_prolog_parser);
-
-	return 0;
-}
-
-subsys_initcall(mtdsplit_owrt_prolog_init);
+module_mtd_part_parser(mtdsplit_owrt_prolog_parser);

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_seama.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_seama.c
@@ -108,11 +108,4 @@ static struct mtd_part_parser mtdsplit_seama_parser = {
 	.type = MTD_PARSER_TYPE_FIRMWARE,
 };
 
-static int __init mtdsplit_seama_init(void)
-{
-	register_mtd_parser(&mtdsplit_seama_parser);
-
-	return 0;
-}
-
-subsys_initcall(mtdsplit_seama_init);
+module_mtd_part_parser(mtdsplit_seama_parser);

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_squashfs.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_squashfs.c
@@ -62,11 +62,4 @@ static struct mtd_part_parser mtdsplit_squashfs_parser = {
 	.type = MTD_PARSER_TYPE_ROOTFS,
 };
 
-static int __init mtdsplit_squashfs_init(void)
-{
-	register_mtd_parser(&mtdsplit_squashfs_parser);
-
-	return 0;
-}
-
-subsys_initcall(mtdsplit_squashfs_init);
+module_mtd_part_parser(mtdsplit_squashfs_parser);

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_tplink.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_tplink.c
@@ -166,11 +166,4 @@ static struct mtd_part_parser mtdsplit_tplink_parser = {
 	.type = MTD_PARSER_TYPE_FIRMWARE,
 };
 
-static int __init mtdsplit_tplink_init(void)
-{
-	register_mtd_parser(&mtdsplit_tplink_parser);
-
-	return 0;
-}
-
-subsys_initcall(mtdsplit_tplink_init);
+module_mtd_part_parser(mtdsplit_tplink_parser);

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_trx.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_trx.c
@@ -145,11 +145,4 @@ static struct mtd_part_parser trx_parser = {
 	.type = MTD_PARSER_TYPE_FIRMWARE,
 };
 
-static int __init mtdsplit_trx_init(void)
-{
-	register_mtd_parser(&trx_parser);
-
-	return 0;
-}
-
-module_init(mtdsplit_trx_init);
+module_mtd_part_parser(trx_parser);

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_uimage.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_uimage.c
@@ -269,15 +269,4 @@ static struct mtd_part_parser uimage_generic_parser = {
 	.type = MTD_PARSER_TYPE_FIRMWARE,
 };
 
-/**************************************************
- * Init
- **************************************************/
-
-static int __init mtdsplit_uimage_init(void)
-{
-	register_mtd_parser(&uimage_generic_parser);
-
-	return 0;
-}
-
-module_init(mtdsplit_uimage_init);
+module_mtd_part_parser(uimage_generic_parser);

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_wrgg.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_wrgg.c
@@ -132,11 +132,4 @@ static struct mtd_part_parser mtdsplit_wrgg_parser = {
 	.type = MTD_PARSER_TYPE_FIRMWARE,
 };
 
-static int __init mtdsplit_wrgg_init(void)
-{
-	register_mtd_parser(&mtdsplit_wrgg_parser);
-
-	return 0;
-}
-
-subsys_initcall(mtdsplit_wrgg_init);
+module_mtd_part_parser(mtdsplit_wrgg_parser);

--- a/target/linux/generic/pending-6.12/430-mtd-add-myloader-partition-parser.patch
+++ b/target/linux/generic/pending-6.12/430-mtd-add-myloader-partition-parser.patch
@@ -45,7 +45,7 @@ Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
  ofpart-$(CONFIG_MTD_OF_PARTS_BCM4908)	+= ofpart_bcm4908.o
 --- /dev/null
 +++ b/drivers/mtd/parsers/myloader.c
-@@ -0,0 +1,181 @@
+@@ -0,0 +1,168 @@
 +/*
 + *  Parse MyLoader-style flash partition tables and produce a Linux partition
 + *  array to match.
@@ -209,20 +209,7 @@ Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
 +	.name		= "MyLoader",
 +};
 +
-+static int __init myloader_mtd_parser_init(void)
-+{
-+	register_mtd_parser(&myloader_mtd_parser);
-+
-+	return 0;
-+}
-+
-+static void __exit myloader_mtd_parser_exit(void)
-+{
-+	deregister_mtd_parser(&myloader_mtd_parser);
-+}
-+
-+module_init(myloader_mtd_parser_init);
-+module_exit(myloader_mtd_parser_exit);
++module_mtd_part_parser(myloader_mtd_parser);
 +
 +MODULE_AUTHOR("Gabor Juhos <juhosg@openwrt.org>");
 +MODULE_DESCRIPTION("Parsing code for MyLoader partition tables");

--- a/target/linux/generic/pending-6.18/430-mtd-add-myloader-partition-parser.patch
+++ b/target/linux/generic/pending-6.18/430-mtd-add-myloader-partition-parser.patch
@@ -45,7 +45,7 @@ Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
  ofpart-$(CONFIG_MTD_OF_PARTS_BCM4908)	+= ofpart_bcm4908.o
 --- /dev/null
 +++ b/drivers/mtd/parsers/myloader.c
-@@ -0,0 +1,181 @@
+@@ -0,0 +1,168 @@
 +/*
 + *  Parse MyLoader-style flash partition tables and produce a Linux partition
 + *  array to match.
@@ -209,20 +209,7 @@ Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
 +	.name		= "MyLoader",
 +};
 +
-+static int __init myloader_mtd_parser_init(void)
-+{
-+	register_mtd_parser(&myloader_mtd_parser);
-+
-+	return 0;
-+}
-+
-+static void __exit myloader_mtd_parser_exit(void)
-+{
-+	deregister_mtd_parser(&myloader_mtd_parser);
-+}
-+
-+module_init(myloader_mtd_parser_init);
-+module_exit(myloader_mtd_parser_exit);
++module_mtd_part_parser(myloader_mtd_parser);
 +
 +MODULE_AUTHOR("Gabor Juhos <juhosg@openwrt.org>");
 +MODULE_DESCRIPTION("Parsing code for MyLoader partition tables");


### PR DESCRIPTION
Remove boilerplate.

Also added deregister for bcm_wifi for consistency. Not needed as it's builtin but still good to have.