### PR TITLE
mediatek: filogic: fix Globitel BT-R320 FIT rootfs mapping

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-globitel-bt-r320.dts
+++ b/target/linux/mediatek/dts/mt7981b-globitel-bt-r320.dts
@@ -17,8 +17,9 @@
 	};
 
 	chosen {
-		bootargs = "root=PARTLABEL=rootfs rootwait";
+		bootargs-override = "root=/dev/fit0 rootwait";
 		stdout-path = "serial0:115200n8";
+		rootdisk = <&emmc_rootdisk>;
 	};
 
 	memory@40000000 {
@@ -149,35 +150,37 @@
 		compatible = "mmc-card";
 		reg = <0>;
 
-		block {
-			compatible = "block-device";
+		partitions {
+			compatible = "gpt-partitions";
 
-			partitions {
-				block-partition-factory {
-					partname = "factory";
+			block-partition-factory {
+				partname = "factory";
 
-					nvmem-layout {
-						compatible = "fixed-layout";
-						#address-cells = <1>;
-						#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-						eeprom_factory_0: eeprom@0 {
-							reg = <0x0 0x1000>;
-						};
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
 
-						macaddr_factory_24: macaddr@24 {
-							compatible = "mac-base";
-							reg = <0x24 0x6>;
-							#nvmem-cell-cells = <1>;
-						};
+					macaddr_factory_24: macaddr@24 {
+						compatible = "mac-base";
+						reg = <0x24 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
 
-						macaddr_factory_2a: macaddr@2a {
-							compatible = "mac-base";
-							reg = <0x2a 0x6>;
-							#nvmem-cell-cells = <1>;
-						};
+					macaddr_factory_2a: macaddr@2a {
+						compatible = "mac-base";
+						reg = <0x2a 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
+			};
+
+			emmc_rootdisk: block-partition-production {
+				partname = "production";
 			};
 		};
 	};

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -157,6 +157,7 @@ platform_do_upgrade() {
 	cudy,wr3000h-v1-ubootmod|\
 	cudy,wr3000p-v1-ubootmod|\
 	gatonetworks,gdsp|\
+	globitel,bt-r320|\
 	h3c,magic-nx30-pro|\
 	imou,hx21|\
 	jcg,q30-pro|\
@@ -200,7 +201,6 @@ platform_do_upgrade() {
 	glinet,gl-mt6000|\
 	glinet,gl-x3000|\
 	glinet,gl-xe3000|\
-	globitel,bt-r320|\
 	huasifei,wh3000|\
 	huasifei,wh3000-pro-emmc|\
 	smartrg,sdg-8612|\
@@ -373,6 +373,7 @@ platform_check_image() {
 	cudy,wr3000h-v1-ubootmod|\
 	cudy,wr3000p-v1-ubootmod|\
 	gatonetworks,gdsp|\
+	globitel,bt-r320|\
 	h3c,magic-nx30-pro|\
 	jcg,q30-pro|\
 	jdcloud,re-cp-03|\


### PR DESCRIPTION
This fixes BT-R320 booting from the OpenWrt eMMC/FIT layout.

Current snapshots reach eMMC, but `fitblk` does not map the rootfs
subimage and the boot waits forever on:

```
Waiting for root device /dev/fit0...
```

The device tree did not describe the `production` GPT partition and
`/chosen/rootdisk` did not point at the FIT container. Describing the
eMMC GPT partitions and pointing `/chosen/rootdisk` at `production` gives
`fitblk` the device it expects.

The board also needs the FIT sysupgrade path, since `production` contains
the full sysupgrade FIT image.

Tested on a BT-R320 V1.2 with a sysupgrade image built from this patch:

```
Kernel command line: root=/dev/fit0 rootwait
FIT: Selected configuration: "config-1" (OpenWrt globitel_bt-r320)
block mmcblk0p5: mapped 1 uImage.FIT filesystem sub-image as /dev/fit0
block mmcblk0p5: mapped remaining space as /dev/fitrw
VFS: Mounted root (squashfs filesystem) readonly on device 259:1.
```

Also verified the sysupgrade image check on the running system:

```
sysupgrade -T /tmp/openwrt-mediatek-filogic-globitel_bt-r320-squashfs-sysupgrade.itb
echo $?
0
```
