### PR TITLE
qualcommbe: fold PPE and QCA8084 fixes

### DIFF
--- a/target/linux/qualcommbe/patches-6.18/0312-net-phy-qca808x-Add-QCA8084-SerDes-speed-config.patch
+++ b/target/linux/qualcommbe/patches-6.18/0312-net-phy-qca808x-Add-QCA8084-SerDes-speed-config.patch
@@ -13,8 +13,8 @@ Signed-off-by: Alexandru Gagniuc <mr.nuke.me@gmail.com>
 ---
  drivers/net/phy/qcom/qca8084_serdes.c | 159 ++++++++++++++++++++++++++
  drivers/net/phy/qcom/qca8084_serdes.h |   3 +
- drivers/net/phy/qcom/qca808x.c        |  15 ++-
- 3 files changed, 175 insertions(+), 2 deletions(-)
+ drivers/net/phy/qcom/qca808x.c        |  16 ++-
+ 3 files changed, 176 insertions(+), 2 deletions(-)
 
 --- a/drivers/net/phy/qcom/qca8084_serdes.c
 +++ b/drivers/net/phy/qcom/qca8084_serdes.c
@@ -102,7 +102,7 @@ Signed-off-by: Alexandru Gagniuc <mr.nuke.me@gmail.com>
 +	unsigned long rate;
 +
 +	for (i = 0; i < QCA8084_CHANNEL_MAX; i++) {
-+		xpcs_ch = &(xpcs_data->xpcs_ch[channel]);
++		xpcs_ch = &xpcs_data->xpcs_ch[i];
 +		if (channel == xpcs_ch->ch_id)
 +			break;
 +	}
@@ -222,7 +222,7 @@ Signed-off-by: Alexandru Gagniuc <mr.nuke.me@gmail.com>
  	int ret;
  
  	/* Assert the FIFO between PHY and MAC. */
-@@ -1028,14 +1029,24 @@ static void qca8084_link_change_notify(s
+@@ -1028,14 +1029,25 @@ static void qca8084_link_change_notify(s
  		}
  	}
  
@@ -233,8 +233,9 @@ Signed-off-by: Alexandru Gagniuc <mr.nuke.me@gmail.com>
  	 */
 -	if (phydev->interface == PHY_INTERFACE_MODE_10G_QXGMII)
 +	if (phydev->interface == PHY_INTERFACE_MODE_10G_QXGMII) {
-+		shared_priv = phy_package_get_priv(phydev);
 +		struct qca808x_priv *priv = phydev->priv;
++
++		shared_priv = phy_package_get_priv(phydev);
 +
  		phy_modify_mmd(phydev, MDIO_MMD_AN, QCA8084_MMD7_IPG_OP,
  			       QCA8084_IPG_10_TO_11_EN,

--- a/target/linux/qualcommbe/patches-6.18/0342-net-qualcomm-Update-IPQ9574-PPE-driver.patch
+++ b/target/linux/qualcommbe/patches-6.18/0342-net-qualcomm-Update-IPQ9574-PPE-driver.patch
@@ -2288,7 +2288,7 @@ Signed-off-by: Alexandru Gagniuc <mr.nuke.me@gmail.com>
 -	if (ret)
 -		goto error;
 +	for (i = PPE_PORT_CLK_RST_MAC; i < PPE_PORT_CLK_RST_MAX; i++) {
-+		ret = reset_control_assert(ppe_port->rstcs[PPE_PORT_CLK_RST_MAC]);
++		ret = reset_control_assert(ppe_port->rstcs[i]);
 +		if (ret)
 +			return ret;
 +	}
@@ -2300,7 +2300,7 @@ Signed-off-by: Alexandru Gagniuc <mr.nuke.me@gmail.com>
  
 -	return ret;
 +	for (i = PPE_PORT_CLK_RST_MAC; i < PPE_PORT_CLK_RST_MAX; i++) {
-+		ret = reset_control_deassert(ppe_port->rstcs[PPE_PORT_CLK_RST_MAC]);
++		ret = reset_control_deassert(ppe_port->rstcs[i]);
 +		if (ret)
 +			return ret;
 +	}


### PR DESCRIPTION
Move the QCA8084 XPCS channel lookup fix into the SerDes speed config patch, so qca8084_qxgmii_set_speed() walks the channel table with the loop index from the start.

Move the PPE port reset loop fix into the PPE driver update patch, so ppe_port_mac_reset() asserts and deasserts each reset control instead of reusing the MAC reset for every iteration.