### PR TITLE
mediatek: dts: fix MAC address offset for D-Link Aquila Pro AI M60

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-dlink-aquila-pro-ai-m60-a1.dts
+++ b/target/linux/mediatek/dts/mt7986a-dlink-aquila-pro-ai-m60-a1.dts
@@ -279,9 +279,9 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
-					macaddr_odm: macaddr@81 {
+					macaddr_odm: macaddr@83 {
 						compatible = "mac-base";
-						reg = <0x81 0x6>;
+						reg = <0x83 0x6>;
 						#nvmem-cell-cells = <1>;
 					};
 				};


### PR DESCRIPTION
The MAC address base was read from offset 0x81 instead of the correct 0x83, causing all units to derive their interface MACs from the same incorrect base (06:00:DC:EA:E7:AE). The two bytes at 0x81 are identical across all devices and precede the actual device-specific MAC data.

Changing the offset to 0x83 yields the correct base MAC with the registered D-Link OUI (DC:EA:E7), unique per device. Fix verified by recompiling and flashing the corrected DTS.

Update: Tested on 4 devices based on stable 25.12.4
I have compiled a custom image based on the latest stable release (25.12.4) with this patch applied and flashed it to all four of my D-Link M60 A1 units.
On all four devices the MAC addresses are now correctly derived from the device-specific base in the ODM partition. The resulting interface MACs match the expected values based on the label MAC printed on each device.
Tested on: D-Link M60 A1 × 4