### PR TITLE
toolchain: binutils: change default to 2.46

### DIFF
--- a/toolchain/binutils/Config.version
+++ b/toolchain/binutils/Config.version
@@ -1,12 +1,12 @@
 
 config BINUTILS_VERSION_2_44
-	default y if !TOOLCHAINOPTS
 	bool
 
 config BINUTILS_VERSION_2_45
 	bool
 
 config BINUTILS_VERSION_2_46
+	default y if !TOOLCHAINOPTS
 	bool
 
 config BINUTILS_VERSION


### PR DESCRIPTION
Change default to latest upstream release, skipping 2.45.

taking over from #20885 