### PR TITLE
ath79: add support for newer Nanostation Loco M5

### DIFF
--- a/target/linux/ath79/dts/ar9342_ubnt_nanostation-loco-m-xw-v2.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_nanostation-loco-m-xw-v2.dts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9342_ubnt_xw_rssileds.dtsi"
+
+/ {
+	compatible = "ubnt,nanostation-loco-m-xw-v2", "ubnt,xw", "qca,ar9342";
+	model = "Ubiquiti Nanostation Loco M (XW) v2";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	/* default for ar934x, except for 1000M and 10M */
+	pll-data = <0x02000000 0x00000101 0x00001313>;
+
+	phy-mode = "rgmii-id";
+	phy-handle = <&phy4>;
+
+	gmac-config {
+		device = <&gmac>;
+		rxd-delay = <3>;
+		rxdv-delay = <3>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -511,6 +511,7 @@ ubnt,powerbeam-5ac-gen2)
 	;;
 ubnt,bullet-m-xw|\
 ubnt,nanostation-loco-m-xw|\
+ubnt,nanostation-loco-m-xw-v2|\
 ubnt,nanostation-m-xw|\
 ubnt,powerbeam-m2-xw|\
 ubnt,powerbeam-m5-xw|\

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -111,6 +111,7 @@ ath79_setup_interfaces()
 	ubnt,nanobeam-ac-xc|\
 	ubnt,nanostation-ac-loco|\
 	ubnt,nanostation-loco-m-xw|\
+	ubnt,nanostation-loco-m-xw-v2|\
 	ubnt,powerbeam-5ac-500|\
 	ubnt,powerbeam-5ac-gen2|\
 	ubnt,powerbeam-m2-xw|\

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -143,6 +143,14 @@ define Device/ubnt_nanostation-loco-m-xw
 endef
 TARGET_DEVICES += ubnt_nanostation-loco-m-xw
 
+define Device/ubnt_nanostation-loco-m-xw-v2
+  $(Device/ubnt-xw)
+  DEVICE_MODEL := Nanostation Loco M
+  DEVICE_VARIANT := XW v2
+  DEVICE_PACKAGES += rssileds -kmod-usb2
+endef
+TARGET_DEVICES += ubnt_nanostation-loco-m-xw-v2
+
 define Device/ubnt_nanostation-m-xw
   $(Device/ubnt-xw)
   DEVICE_MODEL := Nanostation M


### PR DESCRIPTION
This patch supports a newer hardware version of the Ubiquity Nanostation Loco M5 (XW v2). It uses a different PHY (AR8035) but appears to be otherwise identical.

This patch adds the kconfig entry, DTS, and LED declarations.
