### PR TITLE
wifi-scripts: enforce WPA3 for all encryption types on 6 GHz

### DIFF
--- a/package/network/config/wifi-scripts/Makefile
+++ b/package/network/config/wifi-scripts/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wifi-scripts
 PKG_VERSION:=1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-2.0
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -563,9 +563,9 @@ export function generate(interface, data, config, vlans, stas, phy_features) {
 
 	iface.parse_encryption(config, data.config, phy_features);
 	if (data.config.band == '6g') {
-		if (config.auth_type == 'psk-sae')
+		if (config.auth_type in ['psk', 'psk-sae'])
 			config.auth_type = 'sae';
-		if (config.auth_type == 'eap-eap2')
+		if (config.auth_type in ['eap', 'eap-eap2'])
 			config.auth_type = 'eap2';
 	}
 


### PR DESCRIPTION
The existing 6 GHz auth_type override only covers mixed modes
(psk-sae, eap-eap2), upgrading them to their WPA3 equivalents.
However, if a user configures pure WPA2 (psk or eap) on a 6 GHz
radio, the configuration falls through unchanged and hostapd rejects
it with a confusing error about invalid AKM suite.

Extend the override to also cover pure WPA2 modes:
  - psk / psk-sae -> sae
  - eap / eap-eap2 -> eap2

This matches the existing silent-upgrade pattern and ensures the
radio comes up regardless of which legacy encryption the user
selected.

Companion UI change: https://github.com/openwrt/luci/pull/8723