### PR TITLE
package: arm-trusted-firmware-tools: add proper patch header

### DIFF
--- a/package/boot/arm-trusted-firmware-tools/patches/003-fiptool_musl_fix.patch
+++ b/package/boot/arm-trusted-firmware-tools/patches/003-fiptool_musl_fix.patch
@@ -1,6 +1,31 @@
+From 6f51da2bb799a8b77da0167eeea45d5d5125f39c Mon Sep 17 00:00:00 2001
+From: Shine <4c.fce2@proton.me>
+Date: Mon, 22 Jun 2026 14:45:39 +0200
+Subject: fix fiptool build on musl host
+
+Due to POSIX style ioctl(int,int,...) declaration, building fiptool under
+MUSL generates a compiler warning (BLKGETSIZE64 == 0x80081272, ie. integer
+overflow). This causes a build failure when compiling with -Werror and
+-pedantic GCC switches enabled.
+
+Selectively cast the parameter to (int) when hinted to be running on a
+MUSL based build host.
+
+Requires a __MUSL__ macro to be defined. MUSL does not provide such a
+predefined macro, so this has to be passed explicitly to GCC, e.g. with
+-D__MUSL__ during build.
+
+For OpenWrt, this is done in the arm-trusted-firmware-tools Makefile,
+see commit e42e9c8133fbd0dce7abfe1ec696383745448078
+
+Signed-off-by: Shine <4c.fce2@proton.me>
+---
+ tools/fiptool/fiptool.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
 --- a/tools/fiptool/fiptool.c
 +++ b/tools/fiptool/fiptool.c
-@@ -318,7 +318,11 @@
+@@ -318,7 +318,11 @@ static int parse_fip(const char *filename, fip_toc_header_t *toc_header_out)
  
  #ifdef BLKGETSIZE64
  	if ((st.st_mode & S_IFBLK) != 0)


### PR DESCRIPTION
As requested, this PR adds a proper patch header to the compilation-fix of `fiptool` under MUSL.

Ping @jonasjelonek @BKPepe 

Fixes: #21957