### PR TITLE
libxcrypt: use host/perl for build

### DIFF
--- a/package/libs/xcrypt/libcrypt-compat/Makefile
+++ b/package/libs/xcrypt/libcrypt-compat/Makefile
@@ -8,6 +8,9 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/libcrypt-compat/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 
+PKG_BUILD_DEPENDS:=perl/host
+DISABLE_NLS:=
+
 define Package/libcrypt-compat
 $(Package/libxcrypt/Default)
   TITLE+= - libc compatibility
@@ -22,6 +25,9 @@ CONFIGURE_ARGS += \
 	--disable-xcrypt-compat-files \
 	--enable-obsolete-api=glibc \
 	--enable-hashes=glibc
+
+CONFIGURE_VARS += \
+	PERL=$(STAGING_DIR_HOSTPKG)/usr/bin/perl
 
 define Package/libcrypt-compat/install
 	$(INSTALL_DIR) $(1)/usr/lib

--- a/package/libs/xcrypt/libxcrypt-common.mk
+++ b/package/libs/xcrypt/libxcrypt-common.mk
@@ -1,6 +1,6 @@
 PKG_SOURCE_NAME:=libxcrypt
 PKG_VERSION:=4.4.38
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/besser82/$(PKG_SOURCE_NAME)/releases/download/v$(PKG_VERSION)

--- a/package/libs/xcrypt/libxcrypt/Makefile
+++ b/package/libs/xcrypt/libxcrypt/Makefile
@@ -8,6 +8,9 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 
+PKG_BUILD_DEPENDS:=perl/host
+DISABLE_NLS:=
+
 define Package/libxcrypt
 $(Package/libxcrypt/Default)
   BUILDONLY:=1
@@ -31,6 +34,9 @@ CONFIGURE_ARGS += \
 	--disable-failure-tokens \
 	--disable-obsolete-api \
 	--enable-hashes=solaris
+
+CONFIGURE_VARS += \
+	PERL=$(STAGING_DIR_HOSTPKG)/usr/bin/perl
 
 define Package/libxcrypt/install
 	true


### PR DESCRIPTION
The included packages don't build when `USE_GLIBC` is selected.

Fixes: https://github.com/openwrt/openwrt/issues/23909