### PR TITLE
airoha: correct node addresses for crypto and thermal-sensor, align ethernet-phy node name with reg property

### DIFF
--- a/target/linux/airoha/dts/an7581.dtsi
+++ b/target/linux/airoha/dts/an7581.dtsi
@@ -632,14 +632,14 @@
 			#phy-cells = <1>;
 		};
 
-		crypto@1e004000 {
+		crypto@1fb70000 {
 			compatible = "inside-secure,safexcel-eip93ies";
 			reg = <0x0 0x1fb70000 0x0 0x1000>;
 
 			interrupts = <GIC_SPI 44 IRQ_TYPE_LEVEL_HIGH>;
 		};
 
-		thermal: thermal-sensor@1efbd800 {
+		thermal: thermal-sensor@1efbd000 {
 			compatible = "airoha,en7581-thermal";
 			reg = <0x0 0x1efbd000 0x0 0xd5c>;
 			interrupts = <GIC_SPI 23 IRQ_TYPE_LEVEL_HIGH>;

--- a/target/linux/airoha/dts/an7583.dtsi
+++ b/target/linux/airoha/dts/an7583.dtsi
@@ -539,7 +539,7 @@
 			status = "disabled";
 		};
 
-		crypto@1e004000 {
+		crypto@1fb70000 {
 			compatible = "inside-secure,safexcel-eip93ies";
 			reg = <0x0 0x1fb70000 0x0 0x1000>;
 

--- a/target/linux/airoha/dts/an7583.dtsi
+++ b/target/linux/airoha/dts/an7583.dtsi
@@ -751,7 +751,7 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 
-				gsw_phy1: ethernet-phy@1 {
+				gsw_phy1: ethernet-phy@9 {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <9>;
 					phy-mode = "internal";
@@ -774,7 +774,7 @@
 					};
 				};
 
-				gsw_phy2: ethernet-phy@2 {
+				gsw_phy2: ethernet-phy@a {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <10>;
 					phy-mode = "internal";
@@ -797,7 +797,7 @@
 					};
 				};
 
-				gsw_phy3: ethernet-phy@3 {
+				gsw_phy3: ethernet-phy@b {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <11>;
 					phy-mode = "internal";
@@ -820,7 +820,7 @@
 					};
 				};
 
-				gsw_phy4: ethernet-phy@4 {
+				gsw_phy4: ethernet-phy@c {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <12>;
 					phy-mode = "internal";


### PR DESCRIPTION
Update the @ address suffix of crypto and thermal-sensor nodes in the device tree to match the reg properties for consistency.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
