### PR TITLE
airoha: disable afe by default for an7581

### DIFF
--- a/target/linux/airoha/dts/an7581-evb-emmc.dts
+++ b/target/linux/airoha/dts/an7581-evb-emmc.dts
@@ -28,6 +28,10 @@
 	};
 };
 
+&afe {
+	status = "okay";
+};
+
 &sound {
 	audio-routing = "Headphone", "HP_L",
 			"Headphone", "HP_R",

--- a/target/linux/airoha/dts/an7581.dtsi
+++ b/target/linux/airoha/dts/an7581.dtsi
@@ -439,6 +439,7 @@
 			reg = <0x0 0x1fbe2200 0x0 0x9000>;
 
 			interrupts = <GIC_SPI 48 IRQ_TYPE_LEVEL_HIGH>;
+			status = "disabled";
 		};
 
 		uart4: serial@1fbf0600 {


### PR DESCRIPTION
The audio should only be enabled when the sound
node is enabled. This fixes the following error:

an7581-audio 1fbe2200.afe: probe with driver an7581-audio failed with error -2

Fixes: 7b55651 ("airoha: enable I2S sound driver and add nodes for eMMC RFB board")

Link: https://github.com/openwrt/openwrt/pull/22660

(cherry picked from commit 5dbe94d972314ee26826c142822efd901e75dbf9)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
