### PR TITLE
airoha: add pending patch for additional GPIO pins for PHY LED0

### DIFF
--- a/target/linux/airoha/patches-6.12/202-pinctrl-airoha-permit-GPIO43-46-for-PHY-LED0.patch
+++ b/target/linux/airoha/patches-6.12/202-pinctrl-airoha-permit-GPIO43-46-for-PHY-LED0.patch
@@ -1,0 +1,101 @@
+From 99816c896b07f743452e3be42b47f4df364e486f Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Tue, 10 Mar 2026 16:16:03 +0100
+Subject: [PATCH] pinctrl: airoha: permit GPIO43-46 for PHY LED0
+
+On some board it was found that also the GPIO pin range from 43 to 46 can be
+used for PHY LED0. Add these additional GPIO pins to the function groups.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ drivers/pinctrl/mediatek/pinctrl-airoha.c | 48 +++++++++++++++++++++--
+ 1 file changed, 44 insertions(+), 4 deletions(-)
+
+--- a/drivers/pinctrl/mediatek/pinctrl-airoha.c
++++ b/drivers/pinctrl/mediatek/pinctrl-airoha.c
+@@ -904,13 +904,21 @@ static const char *const pwm_groups[] =
+ 					  "gpio44", "gpio45",
+ 					  "gpio46", "gpio47" };
+ static const char *const phy1_led0_groups[] = { "gpio33", "gpio34",
+-						"gpio35", "gpio42" };
++						"gpio35", "gpio42",
++						"gpio43", "gpio44",
++						"gpio45", "gpio46" };
+ static const char *const phy2_led0_groups[] = { "gpio33", "gpio34",
+-						"gpio35", "gpio42" };
++						"gpio35", "gpio42",
++						"gpio43", "gpio44",
++						"gpio45", "gpio46" };
+ static const char *const phy3_led0_groups[] = { "gpio33", "gpio34",
+-						"gpio35", "gpio42" };
++						"gpio35", "gpio42",
++						"gpio43", "gpio44",
++						"gpio45", "gpio46" };
+ static const char *const phy4_led0_groups[] = { "gpio33", "gpio34",
+-						"gpio35", "gpio42" };
++						"gpio35", "gpio42",
++						"gpio43", "gpio44",
++						"gpio45", "gpio46" };
+ static const char *const phy1_led1_groups[] = { "gpio43", "gpio44",
+ 						"gpio45", "gpio46" };
+ static const char *const phy2_led1_groups[] = { "gpio43", "gpio44",
+@@ -1548,6 +1556,14 @@ static const struct airoha_pinctrl_func_
+ 				LAN2_LED_MAPPING_MASK, LAN2_PHY_LED_MAP(0)),
+ 	AIROHA_PINCTRL_PHY_LED0("gpio42", GPIO_LAN3_LED0_MODE_MASK,
+ 				LAN3_LED_MAPPING_MASK, LAN3_PHY_LED_MAP(0)),
++	AIROHA_PINCTRL_PHY_LED0("gpio43", GPIO_LAN0_LED0_MODE_MASK,
++				LAN0_LED_MAPPING_MASK, LAN0_PHY_LED_MAP(0)),
++	AIROHA_PINCTRL_PHY_LED0("gpio44", GPIO_LAN1_LED0_MODE_MASK,
++				LAN1_LED_MAPPING_MASK, LAN1_PHY_LED_MAP(0)),
++	AIROHA_PINCTRL_PHY_LED0("gpio45", GPIO_LAN2_LED0_MODE_MASK,
++				LAN2_LED_MAPPING_MASK, LAN2_PHY_LED_MAP(0)),
++	AIROHA_PINCTRL_PHY_LED0("gpio46", GPIO_LAN3_LED0_MODE_MASK,
++				LAN3_LED_MAPPING_MASK, LAN3_PHY_LED_MAP(0)),
+ };
+ 
+ static const struct airoha_pinctrl_func_group phy2_led0_func_group[] = {
+@@ -1559,6 +1575,14 @@ static const struct airoha_pinctrl_func_
+ 				LAN2_LED_MAPPING_MASK, LAN2_PHY_LED_MAP(1)),
+ 	AIROHA_PINCTRL_PHY_LED0("gpio42", GPIO_LAN3_LED0_MODE_MASK,
+ 				LAN3_LED_MAPPING_MASK, LAN3_PHY_LED_MAP(1)),
++	AIROHA_PINCTRL_PHY_LED0("gpio43", GPIO_LAN0_LED0_MODE_MASK,
++				LAN0_LED_MAPPING_MASK, LAN0_PHY_LED_MAP(1)),
++	AIROHA_PINCTRL_PHY_LED0("gpio44", GPIO_LAN1_LED0_MODE_MASK,
++				LAN1_LED_MAPPING_MASK, LAN1_PHY_LED_MAP(1)),
++	AIROHA_PINCTRL_PHY_LED0("gpio45", GPIO_LAN2_LED0_MODE_MASK,
++				LAN2_LED_MAPPING_MASK, LAN2_PHY_LED_MAP(1)),
++	AIROHA_PINCTRL_PHY_LED0("gpio46", GPIO_LAN3_LED0_MODE_MASK,
++				LAN3_LED_MAPPING_MASK, LAN3_PHY_LED_MAP(1)),
+ };
+ 
+ static const struct airoha_pinctrl_func_group phy3_led0_func_group[] = {
+@@ -1570,6 +1594,14 @@ static const struct airoha_pinctrl_func_
+ 				LAN2_LED_MAPPING_MASK, LAN2_PHY_LED_MAP(2)),
+ 	AIROHA_PINCTRL_PHY_LED0("gpio42", GPIO_LAN3_LED0_MODE_MASK,
+ 				LAN3_LED_MAPPING_MASK, LAN3_PHY_LED_MAP(2)),
++	AIROHA_PINCTRL_PHY_LED0("gpio43", GPIO_LAN0_LED0_MODE_MASK,
++				LAN0_LED_MAPPING_MASK, LAN0_PHY_LED_MAP(2)),
++	AIROHA_PINCTRL_PHY_LED0("gpio44", GPIO_LAN1_LED0_MODE_MASK,
++				LAN1_LED_MAPPING_MASK, LAN1_PHY_LED_MAP(2)),
++	AIROHA_PINCTRL_PHY_LED0("gpio45", GPIO_LAN2_LED0_MODE_MASK,
++				LAN2_LED_MAPPING_MASK, LAN2_PHY_LED_MAP(2)),
++	AIROHA_PINCTRL_PHY_LED0("gpio46", GPIO_LAN3_LED0_MODE_MASK,
++				LAN3_LED_MAPPING_MASK, LAN3_PHY_LED_MAP(2)),
+ };
+ 
+ static const struct airoha_pinctrl_func_group phy4_led0_func_group[] = {
+@@ -1581,6 +1613,14 @@ static const struct airoha_pinctrl_func_
+ 				LAN2_LED_MAPPING_MASK, LAN2_PHY_LED_MAP(3)),
+ 	AIROHA_PINCTRL_PHY_LED0("gpio42", GPIO_LAN3_LED0_MODE_MASK,
+ 				LAN3_LED_MAPPING_MASK, LAN3_PHY_LED_MAP(3)),
++	AIROHA_PINCTRL_PHY_LED0("gpio43", GPIO_LAN0_LED0_MODE_MASK,
++				LAN0_LED_MAPPING_MASK, LAN0_PHY_LED_MAP(3)),
++	AIROHA_PINCTRL_PHY_LED0("gpio44", GPIO_LAN1_LED0_MODE_MASK,
++				LAN1_LED_MAPPING_MASK, LAN1_PHY_LED_MAP(3)),
++	AIROHA_PINCTRL_PHY_LED0("gpio45", GPIO_LAN2_LED0_MODE_MASK,
++				LAN2_LED_MAPPING_MASK, LAN2_PHY_LED_MAP(3)),
++	AIROHA_PINCTRL_PHY_LED0("gpio46", GPIO_LAN3_LED0_MODE_MASK,
++				LAN3_LED_MAPPING_MASK, LAN3_PHY_LED_MAP(3)),
+ };
+ 
+ static const struct airoha_pinctrl_func_group phy1_led1_func_group[] = {


### PR DESCRIPTION
Add a pending patch that permits additional GPIO pins (43-46) for PHY LED0.
 (cherry-pick from master)

(cherry picked from commit 5f983981dbcca3971e2d7b4cdebb0860d688bbfc)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
