### PR TITLE
kernel: move flowtable fix to backport-6.18

### DIFF
--- a/target/linux/generic/backport-6.18/704-v7.2-netfilter-flowtable-fix-offloaded-ct-timeout-never-b.patch
+++ b/target/linux/generic/backport-6.18/704-v7.2-netfilter-flowtable-fix-offloaded-ct-timeout-never-b.patch
@@ -1,7 +1,7 @@
+From 53b3e60edb674b442b2b3bbdba484667b0f47a5d Mon Sep 17 00:00:00 2001
 From: Adrian Bente <adibente@gmail.com>
 Date: Thu, 28 May 2026 10:08:51 +0300
-Subject: [PATCH v2 net] netfilter: flowtable: fix offloaded ct timeout never being extended
-Message-ID: <20260528070851.3913-1-adibente@gmail.com>
+Subject: [PATCH] netfilter: flowtable: fix offloaded ct timeout never being extended
 
 OpenWrt has recently migrated many platforms to kernel 6.18. On the
 MediaTek platform, which supports hardware network offloading, WiFi
@@ -29,10 +29,11 @@ snapshot and compare against that same absolute snapshot in the
 cmpxchg, so the timeout extension actually takes effect while the
 datapath remains authoritative if it updates ct->timeout concurrently.
 
-Suggested-by: Florian Westphal <fw@strlen.de>
 Fixes: 03428ca5cee9 ("netfilter: conntrack: rework offload nf_conn timeout extension logic")
 Cc: stable@vger.kernel.org
+Suggested-by: Florian Westphal <fw@strlen.de>
 Signed-off-by: Adrian Bente <adibente@gmail.com>
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
 ---
  net/netfilter/nf_flow_table_core.c | 13 +++++++++----
  1 file changed, 9 insertions(+), 4 deletions(-)

--- a/target/linux/generic/pending-6.18/700-netfilter-nft_flow_offload-handle-netdevice-events-f.patch
+++ b/target/linux/generic/pending-6.18/700-netfilter-nft_flow_offload-handle-netdevice-events-f.patch
@@ -10,7 +10,7 @@ Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
 
 --- a/net/netfilter/nf_flow_table_core.c
 +++ b/net/netfilter/nf_flow_table_core.c
-@@ -805,6 +805,23 @@ static struct pernet_operations nf_flow_
+@@ -810,6 +810,23 @@ static struct pernet_operations nf_flow_
  	.exit_batch = nf_flow_table_pernet_exit,
  };
  
@@ -34,7 +34,7 @@ Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
  static int __init nf_flow_table_module_init(void)
  {
  	int ret;
-@@ -821,6 +838,10 @@ static int __init nf_flow_table_module_i
+@@ -826,6 +843,10 @@ static int __init nf_flow_table_module_i
  	if (ret)
  		goto out_bpf;
  
@@ -45,7 +45,7 @@ Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
  	return 0;
  
  out_bpf:
-@@ -832,6 +853,7 @@ out_offload:
+@@ -837,6 +858,7 @@ out_offload:
  
  static void __exit nf_flow_table_module_exit(void)
  {


### PR DESCRIPTION
The patch is accepted upstream, so move it to backport-6.18 and update its headers.