### PR TITLE
[25.12] mvebu: add support for Zyxel NAS326

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mvebu
+++ b/package/boot/uboot-tools/uboot-envtools/files/mvebu
@@ -75,6 +75,9 @@ methode,edpu)
 synology,ds213j)
 	ubootenv_add_mtd "u-boot-env" "0x0" "0x10000" "0x10000"
 	;;
+zyxel,nas326)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x80000"
+	;;
 esac
 
 config_load ubootenv

--- a/target/linux/mvebu/cortexa9/base-files/etc/board.d/02_network
+++ b/target/linux/mvebu/cortexa9/base-files/etc/board.d/02_network
@@ -15,7 +15,8 @@ mvebu_setup_interfaces()
 	ctera,c200-v2|\
 	synology,ds213j|\
 	wd,cloud-ex2-ultra|\
-	wd,cloud-mirror-gen2)
+	wd,cloud-mirror-gen2|\
+	zyxel,nas326)
 		ucidef_set_interface_lan "eth0" "dhcp"
 		;;
 	cznic,turris-omnia)
@@ -102,6 +103,10 @@ mvebu_setup_macs()
 		# mac address is on ubi "config" or ubi "reserve2" in text file.
 		# ubi "reserve2" /dev/mtd7 is twice small and only contains basic OEM factory info
 		label_mac=$(macaddr_canonicalize $(strings /dev/mtd7|grep -E '([0-9A-F]{2}[:])'))
+		lan_mac=$label_mac
+		;;
+	zyxel,nas326)
+		label_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		lan_mac=$label_mac
 		;;
 	esac

--- a/target/linux/mvebu/cortexa9/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mvebu/cortexa9/base-files/lib/upgrade/platform.sh
@@ -8,6 +8,14 @@ RAMFS_COPY_DATA='/etc/fw_env.config /var/lock/fw_printenv.lock'
 
 REQUIRE_IMAGE_METADATA=1
 
+nas326_initial_setup()
+{
+	# initialize UBI if it's running on initramfs
+	[ "$(rootfs_type)" = "tmpfs" ] || return 0
+
+	ubirmvol /dev/ubi0 -N ubi_rootfs1
+}
+
 platform_check_image() {
 	case "$(board_name)" in
 	cznic,turris-omnia|\
@@ -34,6 +42,10 @@ platform_do_upgrade() {
 	buffalo,ls421de|\
 	wd,cloud-ex2-ultra|\
 	wd,cloud-mirror-gen2)
+		nand_do_upgrade "$1"
+		;;
+	zyxel,nas326)
+		nas326_initial_setup
 		nand_do_upgrade "$1"
 		;;
 	ctera,c200-v2)

--- a/target/linux/mvebu/files/arch/arm/boot/dts/marvell/armada-380-zyxel-nas326.dts
+++ b/target/linux/mvebu/files/arch/arm/boot/dts/marvell/armada-380-zyxel-nas326.dts
@@ -1,0 +1,383 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include "armada-380.dtsi"
+
+/ {
+	model = "Zyxel NAS326";
+	compatible = "zyxel,nas326", "marvell,armada380";
+
+	aliases {
+		led-boot = &status_white;
+		led-failsafe = &status_red;
+		led-running = &status_white;
+		led-upgrade = &status_white;
+		label-mac-device = &eth0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		append-rootblock = "nullparameter="; /* override the bootloader args */
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x20000000>; /* 512MB */
+	};
+
+	soc {
+		ranges = <MBUS_ID(0xf0, 0x01) 0 0xf1000000 0x100000
+			  MBUS_ID(0x01, 0x1d) 0 0xfff00000 0x100000
+			  MBUS_ID(0x09, 0x19) 0 0xf1100000 0x10000
+			  MBUS_ID(0x09, 0x15) 0 0xf1110000 0x10000
+			  MBUS_ID(0x0c, 0x04) 0 0xf1200000 0x100000>;
+
+		internal-regs {
+			timer@c200 {
+				status = "okay";
+			};
+
+			pcie {
+				status = "okay";
+
+				pcie@1,0 {
+					status = "okay";
+				};
+
+				pcie@2,0 {
+					status = "okay";
+				};
+			};
+		};
+	};
+
+	usb2_phy: usb2_phy {
+		compatible = "usb-nop-xceiv";
+		vcc-supply = <&usb2_power>;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+		pinctrl-names = "default";
+		pinctrl-0 = <&button_pins>;
+
+		power {
+			label = "Power Button";
+			linux,code = <KEY_POWER>;
+			gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		copy {
+			label = "Copy Button";
+			linux,code = <KEY_COPY>;
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		};
+
+		reset {
+			label = "Reset Button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio1 17 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&led_pins>;
+
+		sata1white {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_DISK_ACTIVITY;
+			function-enumerator = <1>;
+			gpios = <&gpio1 18 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "ata1";
+		};
+
+		sata1red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_DISK_ERR;
+			function-enumerator = <1>;
+			gpios = <&gpio1 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		sata2white {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_DISK_ACTIVITY;
+			function-enumerator = <2>;
+			gpios = <&gpio1 21 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "ata2";
+		};
+
+		sata2red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_DISK_ERR;
+			function-enumerator = <2>;
+			gpios = <&gpio1 22 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_USB;
+			gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "usb-host";
+		};
+
+		status_white: status_white {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio1 20 GPIO_ACTIVE_HIGH>;
+		};
+
+		status_red: status_red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+		};
+
+		copy_white {
+			color = <LED_COLOR_ID_WHITE>;
+			function = "copy";
+			gpios = <&gpio0 26 GPIO_ACTIVE_HIGH>;
+		};
+
+		copy_red {
+			color = <LED_COLOR_ID_RED>;
+			function = "copy";
+			gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	regulators {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		usb2_power: regulator@1 {
+			compatible = "regulator-fixed";
+			reg = <1>;
+			regulator-name = "USB2 Power";
+			regulator-min-microvolt = <5000000>;
+			regulator-max-microvolt = <5000000>;
+			enable-active-high;
+			regulator-always-on;
+			regulator-boot-on;
+			gpio = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+		};
+
+		reg_sata0: regulator@2 {
+			compatible = "regulator-fixed";
+			regulator-name = "pwr_en_sata0";
+			regulator-min-microvolt = <12000000>;
+			regulator-max-microvolt = <12000000>;
+			enable-active-high;
+			regulator-boot-on;
+			gpio = <&gpio1 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		reg_5v_sata0: v5-sata0 {
+			compatible = "regulator-fixed";
+			regulator-name = "v5.0-sata0";
+			regulator-min-microvolt = <5000000>;
+			regulator-max-microvolt = <5000000>;
+			vin-supply = <&reg_sata0>;
+		};
+
+		reg_12v_sata0: v12-sata0 {
+			compatible = "regulator-fixed";
+			regulator-name = "v12.0-sata0";
+			regulator-min-microvolt = <12000000>;
+			regulator-max-microvolt = <12000000>;
+			vin-supply = <&reg_sata0>;
+		};
+
+		reg_sata1: regulator@3 {
+			regulator-name = "pwr_en_sata1";
+			compatible = "regulator-fixed";
+			regulator-min-microvolt = <12000000>;
+			regulator-max-microvolt = <12000000>;
+			enable-active-high;
+			regulator-boot-on;
+			gpio = <&gpio0 29 GPIO_ACTIVE_HIGH>;
+		};
+
+		reg_5v_sata1: v5-sata1 {
+			compatible = "regulator-fixed";
+			regulator-name = "v5.0-sata1";
+			regulator-min-microvolt = <5000000>;
+			regulator-max-microvolt = <5000000>;
+			vin-supply = <&reg_sata1>;
+		};
+
+		reg_12v_sata1: v12-sata1 {
+			compatible = "regulator-fixed";
+			regulator-name = "v12.0-sata1";
+			regulator-min-microvolt = <12000000>;
+			regulator-max-microvolt = <12000000>;
+			vin-supply = <&reg_sata1>;
+		};
+	};
+
+	gpio-poweroff {
+		compatible = "gpio-poweroff";
+		pinctrl-0 = <&pwr_off>;
+		pinctrl-names = "default";
+		gpios = <&gpio0 20 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&ahci0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	sata-port@0 {
+		reg = <0>;
+		target-supply = <&reg_sata0>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sata-port@1 {
+		reg = <1>;
+		target-supply = <&reg_sata1>;
+		#thermal-sensor-cells = <1>;
+	};
+};
+
+&bm {
+	status = "okay";
+};
+
+&bm_bppi {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&ge0_rgmii_pins>;
+	phy = <&phy0>;
+	phy-mode = "rgmii-id";
+};
+
+&i2c0 {
+	status = "okay";
+	clock-frequency = <100000>;
+};
+
+&i2c1 {
+	status = "okay";
+	clock-frequency = <100000>;
+};
+
+&mdio {
+	phy0: ethernet-phy@1 {
+		marvell,reg-init = <0x01 0x16 0x00 0x03 0x01 0x10 0x00 0x1817 0x01 0x11 0x00 0x442a 0x01 0x16 0x00 0x00 0x01 0x00 0x00 0x1140 0x01 0x04 0x00 0x1e1 0x01 0x10 0x00 0x3860 0x01 0x00 0x00 0x9140>;
+		reg = <1>;
+	};
+};
+
+&nand_controller {
+	status = "okay";
+
+	nand: nand@0 {
+		reg = <0>;
+		label = "pxa3xx_nand-0";
+		nand-rb = <0>;
+		marvell,nand-keep-config;
+		nand-on-flash-bbt;
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "U-Boot";
+				reg = <0x0 0x200000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "u-boot-env";
+				reg = <0x200000 0x200000>;
+			};
+
+			partition@400000 {
+				label = "Config";
+				reg = <0x400000 0xa00000>;
+				read-only;
+			};
+
+			partition@e00000 {
+				label = "kernel";
+				reg = <0xe00000 0xf00000>;/*  15 MB */
+			};
+
+			partition@1d00000 {
+				label = "ubi";
+				reg = <0x1d00000 0x6a00000>;/*  106 MB */
+			};
+
+			partition@8700000 {
+				label = "Kernel-2";
+				reg = <0x8700000 0xf00000>;
+				read-only;
+			};
+
+			partition@9600000 {
+				label = "RootFS-2";
+				reg = <0x9600000 0x6a00000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pinctrl {
+	button_pins: button_pins {
+		marvell,pins = "mpp39", "mpp46", "mpp49";
+		marvell,function = "gpio";
+	};
+
+	led_pins: led_pins {
+		marvell,pins = "mpp21", "mpp26", "mpp37",
+					"mpp48", "mpp50", "mpp52",
+					"mpp53", "mpp54", "mpp55";
+		marvell,function = "gpio";
+	};
+
+	pwr_off: pwr_off {
+		marvell,pins = "mpp20";
+		marvell,function = "gpio";
+	};
+};
+
+&sdhci {
+	broken-cd;
+	wp-inverted;
+	bus-width = <8>;
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb3_0 {
+	status = "okay";
+};
+
+&usb3_1 {
+	status = "okay";
+};

--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -496,3 +496,17 @@ define Device/wd_cloud-mirror-gen2
   IMAGE/uImage-factory.bin := append-kernel
 endef
 TARGET_DEVICES += wd_cloud-mirror-gen2
+
+define Device/zyxel_nas326
+  $(Device/NAND-128K)
+  DEVICE_VENDOR := Zyxel
+  DEVICE_MODEL := NAS326
+  DEVICE_PACKAGES += mkf2fs e2fsprogs \
+	partx-utils kmod-hwmon-drivetemp -ppp -kmod-nft-offload -dnsmasq \
+	-odhcpd-ipv6only
+  DEVICE_DTS := armada-380-zyxel-nas326
+  FILESYSTEMS := squashfs ubifs
+  KERNEL := kernel-bin | append-dtb
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | uImage none
+endef
+TARGET_DEVICES += zyxel_nas326


### PR DESCRIPTION
-----
Hardware:
CPU: ARMADA 380 1x1332Mhz
RAM: 512MB DDR3
FLASH: 256MB MX30LF2G18AC
2x SATA III
2x USB3.0
1x USB2.0
i2c to control various states.
RTC with battery
1Gbit LAN (WoL capable)
9x LED
RESET button at back
Power button at front (gpio-poweroff)
Copy button at front

-----
Doesn't work
FAN control
buzzer

-----
UART connections

Connect UART to port J3 115200
+----+----+----+----+----+
|3.3V| TX | RX |    | GND|
+----+----+----+    +----+
Depend of UART adapter board can fail to boot when adapter is attached. (all leds are dimmed) .
In that case disconnect UART for an < second and after that all leds should be white.
Stop u-boot by ctrl-c within 3s window. (bootdelay 7s or more helps)
setenv bootdelay 7
saveenv

-----
Instalation via UART

Boot initramfs-kernel.bin
setenv ethact egiga0
setenv serverip 192.168.1.11
setenv ipaddr 192.168.1.12
tftpboot 0x02000000 *initramfs-kernel.bin
bootm 0x02000000 -

Device is DHCP client by default ( as the other supported NAS)

do backup into safe space
/dev/mtd3 Kernel-1
/dev/mtd4 RootFS-1

use sysupgrade in console or via luci

-----
MAC addresses

mac stored in u-boot-env ethaddr
label mac = eth0 mac =  5c:6a:80:xx:xx:xx

-----
Setting up u-boot  dual boot

u-boot contain two banks contain two OEM copies
To boot OpenWrt from bank1
setenv next_bootfrom 1
saveenv

To boot OEM from bank2
setenv next_bootfrom 2
saveenv

-----
Configuration via i2c
install i2c-tools

Enable WoL
i2cset -y 0x0 0xa 0xa 0x0006 w

Disable WoL
i2cset -y 0x0 0xa 0xa 0x0306 w

Enable auto power on
i2cset -y 0x0 0x0a 0x0a 0x0107 w

Disable auto power on
i2cset -y 0x0 0x0a 0x0a 0x0007 w


Link: https://github.com/openwrt/openwrt/pull/23228

(cherry picked from commit 1c8c05ca98ee9f7b67d8160a8cb059be3b2714a1)

