### PR TITLE
tools: conditionally skip building llvm-bpf

### DIFF
--- a/config/Config-devel.in
+++ b/config/Config-devel.in
@@ -62,6 +62,17 @@ menuconfig DEVEL
 		  Compile all host host tools even if not needed. This is needed to prepare a
 		  universal precompiled host tools archive to use in another buildroot.
 
+	if BUILD_ALL_HOST_TOOLS
+
+	config BUILD_LLVM_BPF
+		bool "Build LLVM toolchain for eBPF"
+		default y
+		depends on !USE_LLVM_BUILD
+		help
+		  Build LLVM toolchain for eBPF even if it's already provided.
+
+	endif
+
 	menuconfig OPTIMIZE_HOST_TOOLS
 		bool "Host Tools compile options" if DEVEL
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -85,7 +85,7 @@ tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_TARGET_realtek),y) += 7z
 tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_TARGET_tegra),y) += cbootimage cbootimage-configs
 tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_USES_MINOR),y) += yafut
 tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_USE_SPARSE),y) += sparse
-tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_USE_LLVM_BUILD),y) += llvm-bpf
+tools-$(if $(CONFIG_BUILD_LLVM_BPF)$(CONFIG_USE_LLVM_BUILD),y) += llvm-bpf
 tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_USE_MOLD),y) += mold
 
 # builddir dependencies


### PR DESCRIPTION
Make llvm-bpf build conditional on `BUILD_LLVM_BPF` instead of `BUILD_ALL_HOST_TOOLS`, allowing it to be skipped when not needed.

The LLVM BPF toolchain can now be skipped when:
 - it is already provided (`CONFIG_BPF_TOOLCHAIN_PREBUILT=y` or `CONFIG_BPF_TOOLCHAIN_HOST=y`);
 - it is not desired at all (`CONFIG_BPF_TOOLCHAIN_NONE=y`).

Affects commit ebabdff4017f ("tools: add option BUILD_ALL_HOST_TOOLS to compile all host tools").