### PR TITLE
airoha: an7581: fix GPS support on Gemtek W1700k

### DIFF
--- a/target/linux/airoha/dts/an7581-w1700k-ubi.dts
+++ b/target/linux/airoha/dts/an7581-w1700k-ubi.dts
@@ -123,25 +123,6 @@
 		};
 	};
 
-	/* W1700K does not use the built-in LED controller. Instead, it uses GPIO.
-	 * The driver fails to probe without gswpX_led0_pins defined, so put a dummy
-	 * here.
-	 */
-
-	gswp1_led0_pins: gswp1-led0-pins {
-		mux {
-			function = "phy1_led0";
-			pins = "gpio33";
-		};
-	};
-
-	gswp2_led0_pins: gswp2-led0-pins {
-		mux {
-			function = "phy2_led0";
-			pins = "gpio34";
-		};
-	};
-
 	uart2_pins: uart2-pins {
 		mux {
 			function = "uart";
@@ -387,8 +368,6 @@
 &gsw_phy1 {
 	status = "okay";
 	interrupts = <1>;
-	pinctrl-names = "gbe-led";
-	pinctrl-0 = <&gswp1_led0_pins>;
 };
 
 &gsw_port1 {
@@ -399,8 +378,6 @@
 &gsw_phy2 {
 	status = "okay";
 	interrupts = <2>;
-	pinctrl-names = "gbe-led";
-	pinctrl-0 = <&gswp2_led0_pins>;
 };
 
 &gsw_port2 {


### PR DESCRIPTION
This commit removes unnecessary pinctrl nodes for the PHY LEDs. The LEDs are controlled directly via GPIO pins. Alternate function of gpio33/34 is CTS/RTS for UART2. It looks like this pinctrl is somehow conflicting with HSUART. This is likely an errata in the early silicon revision. HSUART is connected to GPS. The comment incorrectly states that the PHY driver doesn't attach. The driver attaches correctly, the only drawback is a warning in the log.

Warning:
~~~
[   10.463371] mdio_bus mt7530-0: Failed to setup PHY LED pinctrl
[   10.494230] mdio_bus mt7530-0: Failed to setup PHY LED pinctrl
[   10.926028] mt7530-mmio 1fb58000.switch: configuring for fixed/internal link mode
[   10.933640] mt7530-mmio 1fb58000.switch lan3 (uninitialized): PHY [mt7530-0:09] driver [Airoha AN7581 PHY] (irq=50)
[   10.944890] mt7530-mmio 1fb58000.switch lan4 (uninitialized): PHY [mt7530-0:0a] driver [Airoha AN7581 PHY] (irq=51)
~~~

GPS test:
~~~
root@OpenWrt:~# minicom -D /dev/ttyS2 -b 460800
...
$GNGGA,000106.012,,,,,0,0,,,M,,M,,*52
$GNGLL,,,,,000106.012,V,N*60
$GNGSA,A,1,,,,,,,,,,,,,,,,1*1D
$GNGSA,A,1,,,,,,,,,,,,,,,,2*1E
$GNGSA,A,1,,,,,,,,,,,,,,,,3*1F
$GNGSA,A,1,,,,,,,,,,,,,,,,4*18
$GPGSV,1,1,00,1*64
...
~~~

Fixes: 99307582dea2 ("airoha: add support for Gemtek W1700K")
Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>