### PR TITLE
[25.12] mediatek: add WD-R3000N-G2A as ALT device for Bazis AX3000WM

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -785,6 +785,8 @@ TARGET_DEVICES += bananapi_bpi-r4-lite
 define Device/bazis_ax3000wm
   DEVICE_VENDOR := Bazis
   DEVICE_MODEL := AX3000WM
+  DEVICE_ALT0_VENDOR := Shenzhen Jia Yan Technology
+  DEVICE_ALT0_MODEL := WD-R3000N-G2A
   DEVICE_DTS := mt7981b-bazis-ax3000wm
   DEVICE_DTS_DIR := ../dts
   UBINIZE_OPTS := -E 5


### PR DESCRIPTION
The Bazis AX3000WM is an OEM variant of the Shenzhen Jia Yan Technology WD-R3000N-G2A (per EAEU certificate N RU Д-CN.РА04.В.23104/26). Hardware is identical. Added for the owners of this device so they can find it in firmware-selector.


Link: https://github.com/openwrt/openwrt/pull/23653

(cherry picked from commit e79df8aa0386a4b93f597a088ddb92273212dff6)