### PR TITLE
kernel: qca8k: Fix regression #21317

### DIFF
--- a/target/linux/generic/pending-6.12/711-05-net-dsa-qca8k-no-program-unicast-host-FDB-entries.patch
+++ b/target/linux/generic/pending-6.12/711-05-net-dsa-qca8k-no-program-unicast-host-FDB-entries.patch
@@ -33,7 +33,7 @@ board assigns its conduits.
 Disclaimer: patch generated via Fable 5 and tested by @xback
 
 Fixes: openwrt/openwrt#21317
-Signed-off-by: <lists@marzocchi.net>
+Signed-off-by: Olaf Marzocchi <lists@marzocchi.net>
 
 ---
  drivers/net/dsa/qca/qca8k-common.c | 14 ++++++++++++++

--- a/target/linux/generic/pending-6.12/target/linux/generic/pending-6.12/711-05-net-dsa-qca8k-no-program-unicast-host-FDB-entries.patch
+++ b/target/linux/generic/pending-6.12/target/linux/generic/pending-6.12/711-05-net-dsa-qca8k-no-program-unicast-host-FDB-entries.patch
@@ -1,0 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Olaf Marzocchi <olaf@marzocchi.net>
+Date: Fri, 26 Jun 2026 00:00:00 +0000
+Subject: [PATCH] net: dsa: qca8k: don't program unicast host FDB entries on
+ CPU ports
+
+DSA installs host FDB entries for the same {MAC, VID} once per CPU port
+in use. qca8k used to overwrite the single ATU entry, so the last CPU
+port won and host reachability broke for user ports served by the other
+CPU port (e.g. Netgear R7800 with wan bridged into br-lan). Merging the
+CPU port bits into the destination mask instead is no better: the ATU
+forwards a unicast hit to every port set in the mask, so a host entry
+spanning both CPU ports makes the switch deliver one copy of each
+host-bound frame per CPU port. This duplicated nearly all host traffic
+and halved throughput on TP-Link TGR1900, Archer C2600 and ASUS
+RT-AX89X, with "failed to delete ... from fdb: -22" log spam from the
+asymmetric delete path.
+
+Host FDB entries are a pure optimization on this switch: the unknown
+unicast forward mask in GLOBAL_FW_CTRL1 already contains all CPU ports
+and is filtered per ingress port by PORT_LOOKUP_CTRL members, so a
+host-bound frame with no ATU entry reaches exactly one CPU port, the
+conduit of its ingress port, and the tag parser delivers it to the
+correct user netdevice from either conduit. The conduits run in
+promiscuous mode (qca8k does not implement FDB isolation), so no RX
+filtering relies on these entries either.
+
+Skip programming unicast host FDB entries on CPU ports entirely. This
+fixes the multi-CPU bridged setups without ever creating a unicast
+destination mask with more than one CPU port bit, regardless of how a
+board assigns its conduits.
+
+Disclaimer: patch generated via Fable 5 and tested by @xback
+
+Fixes: openwrt/openwrt#21317
+Signed-off-by: <lists@marzocchi.net>
+
+---
+ drivers/net/dsa/qca/qca8k-common.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+--- a/drivers/net/dsa/qca/qca8k-common.c
++++ b/drivers/net/dsa/qca/qca8k-common.c
+@@ -836,6 +836,17 @@ int qca8k_port_fdb_add(struct dsa_switch
+ 	struct qca8k_priv *priv = ds->priv;
+ 	u16 port_mask = BIT(port);
+
++	/* The ATU forwards a unicast hit to every port set in the
++	 * destination mask, so a host entry spanning multiple CPU ports
++	 * would deliver one copy of each host-bound frame per CPU port.
++	 * Skip host entries entirely: unknown unicast is already forwarded
++	 * to all CPU ports by GLOBAL_FW_CTRL1 and filtered by the ingress
++	 * port LOOKUP_MEMBER, so host-bound frames reach exactly one CPU
++	 * port, the conduit of the ingress port.
++	 */
++	if (dsa_is_cpu_port(ds, port) || dsa_is_dsa_port(ds, port))
++		return 0;
++
+ 	return qca8k_port_fdb_insert(priv, addr, port_mask, vid);
+ }
+
+@@ -846,6 +857,9 @@ int qca8k_port_fdb_del(struct dsa_switch
+ 	struct qca8k_priv *priv = ds->priv;
+ 	u16 port_mask = BIT(port);
+
++	if (dsa_is_cpu_port(ds, port) || dsa_is_dsa_port(ds, port))
++		return 0;
++
+ 	if (!vid)
+ 		vid = QCA8K_PORT_VID_DEF;

--- a/target/linux/generic/pending-6.12/target/linux/generic/pending-6.12/711-05-net-dsa-qca8k-no-program-unicast-host-FDB-entries.patch
+++ b/target/linux/generic/pending-6.12/target/linux/generic/pending-6.12/711-05-net-dsa-qca8k-no-program-unicast-host-FDB-entries.patch
@@ -1,0 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Olaf Marzocchi <olaf@marzocchi.net>
+Date: Fri, 26 Jun 2026 00:00:00 +0000
+Subject: [PATCH] net: dsa: qca8k: don't program unicast host FDB entries on
+ CPU ports
+
+DSA installs host FDB entries for the same {MAC, VID} once per CPU port
+in use. qca8k used to overwrite the single ATU entry, so the last CPU
+port won and host reachability broke for user ports served by the other
+CPU port (e.g. Netgear R7800 with wan bridged into br-lan). Merging the
+CPU port bits into the destination mask instead is no better: the ATU
+forwards a unicast hit to every port set in the mask, so a host entry
+spanning both CPU ports makes the switch deliver one copy of each
+host-bound frame per CPU port. This duplicated nearly all host traffic
+and halved throughput on TP-Link TGR1900, Archer C2600 and ASUS
+RT-AX89X, with "failed to delete ... from fdb: -22" log spam from the
+asymmetric delete path.
+
+Host FDB entries are a pure optimization on this switch: the unknown
+unicast forward mask in GLOBAL_FW_CTRL1 already contains all CPU ports
+and is filtered per ingress port by PORT_LOOKUP_CTRL members, so a
+host-bound frame with no ATU entry reaches exactly one CPU port, the
+conduit of its ingress port, and the tag parser delivers it to the
+correct user netdevice from either conduit. The conduits run in
+promiscuous mode (qca8k does not implement FDB isolation), so no RX
+filtering relies on these entries either.
+
+Skip programming unicast host FDB entries on CPU ports entirely. This
+fixes the multi-CPU bridged setups without ever creating a unicast
+destination mask with more than one CPU port bit, regardless of how a
+board assigns its conduits.
+
+Disclaimer: patch generated via Fable 5 and tested by @xback
+
+Fixes: openwrt/openwrt#21317
+Signed-off-by: <olaf@marzocchi.net>
+
+---
+ drivers/net/dsa/qca/qca8k-common.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+--- a/drivers/net/dsa/qca/qca8k-common.c
++++ b/drivers/net/dsa/qca/qca8k-common.c
+@@ -836,6 +836,17 @@ int qca8k_port_fdb_add(struct dsa_switch
+ 	struct qca8k_priv *priv = ds->priv;
+ 	u16 port_mask = BIT(port);
+
++	/* The ATU forwards a unicast hit to every port set in the
++	 * destination mask, so a host entry spanning multiple CPU ports
++	 * would deliver one copy of each host-bound frame per CPU port.
++	 * Skip host entries entirely: unknown unicast is already forwarded
++	 * to all CPU ports by GLOBAL_FW_CTRL1 and filtered by the ingress
++	 * port LOOKUP_MEMBER, so host-bound frames reach exactly one CPU
++	 * port, the conduit of the ingress port.
++	 */
++	if (dsa_is_cpu_port(ds, port) || dsa_is_dsa_port(ds, port))
++		return 0;
++
+ 	return qca8k_port_fdb_insert(priv, addr, port_mask, vid);
+ }
+
+@@ -846,6 +857,9 @@ int qca8k_port_fdb_del(struct dsa_switch
+ 	struct qca8k_priv *priv = ds->priv;
+ 	u16 port_mask = BIT(port);
+
++	if (dsa_is_cpu_port(ds, port) || dsa_is_dsa_port(ds, port))
++		return 0;
++
+ 	if (!vid)
+ 		vid = QCA8K_PORT_VID_DEF;

--- a/target/linux/generic/pending-6.12/target/linux/generic/pending-6.12/711-05-net-dsa-qca8k-no-program-unicast-host-FDB-entries.patch
+++ b/target/linux/generic/pending-6.12/target/linux/generic/pending-6.12/711-05-net-dsa-qca8k-no-program-unicast-host-FDB-entries.patch
@@ -33,7 +33,7 @@ board assigns its conduits.
 Disclaimer: patch generated via Fable 5 and tested by @xback
 
 Fixes: openwrt/openwrt#21317
-Signed-off-by: <olaf@marzocchi.net>
+Signed-off-by: <lists@marzocchi.net>
 
 ---
  drivers/net/dsa/qca/qca8k-common.c | 14 ++++++++++++++


### PR DESCRIPTION
# Fixing the packet-duplication regression from openwrt/openwrt#21317

## 1. Background

### The original bug

On qca8k switches with two CPU ports (e.g. Netgear R7800: switch ports 0 and 6,
each wired to its own SoC ethernet MAC / DSA conduit), bridging user ports that
are served by *different* conduits (typical bridged-AP setup: `wan` added to
`br-lan`) broke host reachability. DSA installs the same host FDB entry
({MAC, VID} of the bridge / local addresses) once per CPU port in use, but
`qca8k_port_fdb_add()` programs the ATU with `qca8k_fdb_add()`, which
**overwrites** the existing {MAC, VID} entry. The last CPU port wins; frames
ingressing user ports whose `LOOKUP_MEMBER` only contains the *other* CPU port
hit the ATU entry, get a destination they are not allowed to reach, and are
dropped.

### The merged fix (PR #21317 → `711-04-net-dsa-qca8k-merge-host-fdb-for-multi-cpu.patch`)

For CPU/DSA ports, `qca8k_port_fdb_add()`/`_del()` now use the
search-and-insert / search-and-del helpers so the destination port mask is
**merged** (`fdb.port_mask |= BIT(port)`) instead of replaced. The host entry
ends up with a destination mask containing *both* CPU ports, e.g.
`BIT(0) | BIT(6)`.

### The regression

Reported on TP-Link TGR1900/OnHub, Archer C2600, ASUS RT-AX89X:

* nearly every ping duplicated (`DUP!`), RTT inflated (19 ms → 47 ms),
* throughput roughly halved (~184 Mbps → ~90 Mbps),
* log spam: `port 6 failed to delete <MAC> vid 0 from fdb: -22`.

**Mechanism:** the QCA8337 ATU treats the destination field of a unicast entry
as a plain port bitmap and forwards a hit to *every* port in it. A unicast
host entry whose mask contains two CPU ports is therefore replicated like a
multicast entry. Whenever the ingress path allows the frame to reach more than
one of those CPU ports (devices where a user port's effective reachability
covers both CPU ports — shared lookup membership, CPU-LAG conduits, etc.),
the host receives **two copies** of every host-bound frame; the software
bridge then processes (and answers) both. The `-22` errors are the
asymmetric delete path of the merge helpers (`qca8k_fdb_search_and_del()`
returns `-EINVAL` when the entry is already gone).

### The design contract the OpenWrt multi-CPU series already established

`711-02-net-dsa-qca8k-enable-flooding-to-both-CPU-port.patch` sets the
`GLOBAL_FW_CTRL1` IGMP/broadcast/multicast/**unknown-unicast** forward masks to
`dsa_cpu_ports(ds)` — i.e. *all* CPU ports — and its commit message explicitly
states that **per-port `LOOKUP_MEMBER` is what prevents duplicate delivery**:
each user port's member mask is supposed to contain exactly one CPU port (its
conduit), so a flooded frame passes the ingress filter toward exactly one CPU
port. This contract already carries every ARP, DHCP, broadcast and
unknown-unicast frame on all of these devices, without duplication.

Note also that on qca8k the unknown-frame forward masks contain **only CPU
ports** — hardware never floods unknown unicast to other user ports; it punts
to the CPU and the software bridge re-floods. This detail matters below.

## 2. Proposed fix: stop programming unicast host FDB entries on CPU ports altogether

```c
if (dsa_is_cpu_port(ds, port) || dsa_is_dsa_port(ds, port))
        return 0;
```

in both `qca8k_port_fdb_add()` and `qca8k_port_fdb_del()` — i.e. replace
`711-04` with a patch that makes host FDB programming a no-op for CPU ports
(full patch in `711-04-net-dsa-qca8k-skip-host-fdb-on-cpu-ports.patch`).

### Why this is correct on this hardware

A unicast host FDB entry on a CPU port is supposed to *steer* host-bound
frames to the CPU instead of letting them flood. On qca8k that optimization
buys exactly nothing, because the unknown-unicast flood mask **already
contains only CPU ports** (711-02): with no ATU entry, a frame addressed to
the host is unknown unicast and is forwarded to
`FW_CTRL1.UC mask ∩ LOOKUP_MEMBER(ingress port)` = **the ingress port's own
conduit, exactly one copy** — the same proven path every ARP/DHCP/broadcast
frame already takes on these devices today. The conduit interfaces run in
promiscuous mode (qca8k does not implement `fdb_isolation`/unicast filtering,
so DSA never relies on hardware host entries for RX filtering), and the tagger
demuxes by *source port*, so the frame is delivered to the correct user
netdevice regardless of which conduit it arrived on.

This resolves both problems at once:

* **Original R7800 bridged-AP bug: fixed.** There is no longer a stale
  single-CPU ATU entry steering host traffic toward a CPU port the ingress
  port cannot reach. Host-bound frames follow each ingress port's conduit via
  the flood path, for every bridge topology.
* **Duplication regression: structurally impossible.** No unicast ATU entry
  ever carries more than one CPU port bit, because none is created. The fix
  does not depend on how a particular board wires/assigns its conduits
  (separate conduits, shared membership, CPU LAG) — the flood path is the one
  path all of these configurations already exercise without duplication.
* **`-22` log spam: gone.** No host-entry delete is ever attempted.

It is also how qca8k actually behaved for years before DSA grew host-FDB
offload (and how it still behaves for any host MAC that simply was never
installed): host-terminated traffic has always ridden the unknown-unicast
punt path on this switch.

### Interaction with `712-...-enable-assisted-learning-on-CPU-port.patch`

Assisted learning installs MACs learned on *foreign* interfaces (e.g. Wi-Fi
clients in the same bridge) as host FDB entries on the CPU port. With this
proposal those installs become no-ops, so LAN→Wi-Fi frames stay unknown
unicast in hardware. That is functionally identical: the unknown-unicast
egress set (CPU ports, member-filtered to the conduit) is the same single CPU
port the FDB entry would have pointed at, and hardware learning on the CPU
port stays disabled either way, so there is no flood-to-user-ports penalty.

### Limitations / things to keep in mind

1. The argument relies on the `GLOBAL_FW_CTRL1` unknown-unicast mask covering
   all CPU ports — guaranteed since 711-02, which this series already depends
   on. The code comment in the patch documents the dependency.
2. If qca8k ever implements `fdb_isolation` / standalone unicast filtering
   (non-promiscuous conduits), host entries become functionally required and
   this needs revisiting — at that point the proper fix is a refcounted host
   address table like mv88e6xxx's, which is upstream-grade work.
3. `bridge fdb show … self` will list host entries as offloaded even though
   they are not in the ATU (cosmetic; true for any driver returning 0).
4. **Host multicast (MDB) entries are left untouched** by this proposal, but
   note they have the same latent issue: `qca8k_port_mdb_add()` merges CPU
   port bits into one multicast entry, so multicast destined to the host can
   be delivered once per CPU port too. If reporters confirm duplicated
   multicast (mDNS, IGMP queries), the same remedy applies — skip host MDB on
   CPU ports and rely on the MC flood mask from 711-02. Kept separate to keep
   the regression fix minimal.

## 4. Suggested testing

* **R7800 (original bug):** bridged AP with `wan` in `br-lan`; verify host
  reachability from clients on both conduits (the original PR #21317 test
  case), plus `bridge fdb`, ARP, DHCP.
* **TGR1900 / Archer C2600 / RT-AX89X (regression):** `ping -c 100 <router>`
  from a wired client — expect 0 `DUP!`; iperf3 client↔router and
  client↔client expect pre-21317 throughput; `dmesg` clean of
  `failed to delete … from fdb: -22`.
* Routed (non-bridged) WAN default config sanity on all of the above.
* Optional: `ip link set lan1 type dsa master eth0/eth1` (711-03 path) while
  pinging, to confirm conduit changes need no FDB rework at all under this
  scheme.

----

Coded by Fable 5 (max)
Signed-off-by: <lists@marzocchi.net>
Tested-by: Koen Vandeputte <koen.vandeputte@citymesh.com>
