### PR TITLE
toolchain/glibc: fix PowerPC IFUNC crash with BIND_NOW (glibc 2.41 regression)

### DIFF
--- a/toolchain/glibc/patches/300-fix-powerpc-ifunc-bind-now-crash.patch
+++ b/toolchain/glibc/patches/300-fix-powerpc-ifunc-bind-now-crash.patch
@@ -1,0 +1,22 @@
+--- a/sysdeps/powerpc/powerpc32/power4/multiarch/init-arch.h
++++ b/sysdeps/powerpc/powerpc32/power4/multiarch/init-arch.h
+@@ -35,9 +35,15 @@
+ 
+ /* Get the hardware information post the tunables set, the macro checks
+    it and fills the previous ones.  */
++/* Use __GLRO for hwcap access so that IFUNC resolvers in libm (and other
++   libraries) do not crash when _rtld_global_ro has not been relocated yet.
++   This can happen with BIND_NOW (full RELRO) when a library's IFUNC
++   resolver runs during relocation of a dependent that was processed before
++   the library's own GOT was set up.  glibc 2.38 used __GLRO here; the
++   switch to &GLRO(dl_powerpc_cpu_features) in 2.41 lost the NULL guard.  */
+ #define INIT_ARCH() \
+-  const struct cpu_features *features = &GLRO(dl_powerpc_cpu_features);	\
+-  unsigned long int hwcap = features->hwcap;				\
+-  unsigned long int __attribute__((unused)) hwcap2 = features->hwcap2; \
++  unsigned long int hwcap = __GLRO(dl_powerpc_cpu_features.hwcap);	\
++  unsigned long int __attribute__((unused)) hwcap2 =			\
++    __GLRO(dl_powerpc_cpu_features.hwcap2);				\
+   bool __attribute__((unused)) use_cached_memopt =		\
+     __GLRO(dl_powerpc_cpu_features.use_cached_memopt);		\
+   if (hwcap & PPC_FEATURE_ARCH_2_06)				\


### PR DESCRIPTION
## Problem

glibc 2.41 changed the PowerPC `INIT_ARCH()` macro in
`sysdeps/powerpc/powerpc32/power4/multiarch/init-arch.h` to access
`hwcap`/`hwcap2` via `&GLRO(dl_powerpc_cpu_features)` directly,
dropping the `__GLRO()` wrapper that was used in glibc 2.38.

The `__GLRO` macro includes a NULL check for `_rtld_global_ro` that
is essential when IFUNC resolvers run before a library's GOT has been
relocated. This can happen with `CONFIG_PKG_RELRO_FULL` (BIND_NOW):
if library A references an IFUNC symbol from library B but does not have
B in its `DT_NEEDED`, the dynamic linker may process A's relocations
before B's GOT is set up. The IFUNC resolver then dereferences
NULL + 0x78, causing a segfault.

## Observed crash

rsyslogd crashes immediately on startup on PowerPC64 BE (e5500) with
glibc 2.41. The crash path is:
rsyslogd → librsyslog → libfastjson → `modf()` IFUNC resolver in libm → `INIT_ARCH()` → NULL deref.

A previous attempt to work around this in the packages feed by adding a
`libm` package dependency to libfastjson was reverted because `libm` is
not a separately installable package in OpenWrt
(openwrt/packages#29161). The root cause is in glibc, not in any
individual package.

## Fix

Restore `__GLRO()` for `hwcap` and `hwcap2` in `INIT_ARCH()` to make
IFUNC resolvers safe regardless of library relocation order. This
matches the behaviour of glibc 2.38 and is consistent with how
`use_cached_memopt` is already accessed in the same macro.

Regression introduced by glibc commit `21841f0d562f` (2023-08-01).
Not yet fixed in glibc upstream as of 2026-06.

## Testing

Verified on PowerPC64 BE (NXP T1042 / e5500 core) with glibc 2.41:
rsyslogd starts successfully with this patch applied.