### PR TITLE
generic: net: phy: realtek: select rtl826x phy patch table by chip version

### DIFF
--- a/package/firmware/rtl826x-firmware/Makefile
+++ b/package/firmware/rtl826x-firmware/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rtl826x-firmware
 PKG_SOURCE_DATE:=2026-01-24
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=https://github.com/balika011/realtek_phy_firmware
 PKG_SOURCE_VERSION:=0cd4abe2b0bf197f75c27088f86a74c7ddb103b4
@@ -30,47 +30,37 @@ define Package/rtl826x-firmware/Default
   PKGARCH:=all
 endef
 
-define Package/rtl8261n-firmware
+define Package/rtl826x-firmware
   $(call Package/rtl826x-firmware/Default)
-  TITLE:=Realtek RTL8251L/RTL8261BE/RTL8261N firmware
+  TITLE:=Realtek RTL8251L/RTL8261BE/RTL8261N/RTL8254B/RTL8264/RTL8264B firmware
   VERSION:=20221115
 endef
 
-define Package/rtl8261n-lp-firmware
+define Package/rtl826x-lp-firmware
   $(call Package/rtl826x-firmware/Default)
-  TITLE:=Realtek RTL8251L/RTL8261BE/RTL8261N low-power firmware
+  TITLE:=Realtek RTL8251L/RTL8261BE/RTL8261N/RTL8254B/RTL8264/RTL8264B low-power firmware
   VERSION:=20240729
-  PROVIDES:=rtl8261n-firmware
-  CONFLICTS:=rtl8261n-firmware
+  PROVIDES:=rtl826x-firmware
+  CONFLICTS:=rtl826x-firmware
 endef
 
-define Package/rtl8264b-firmware
-  $(call Package/rtl826x-firmware/Default)
-  TITLE:=Realtek RTL8254B/RTL8264/RTL8264B firmware
-  VERSION:=20221215
-endef
-
-define Package/rtl8261n-firmware/install
+define Package/rtl826x-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware
 	$(INSTALL_DATA) \
 		$(PKG_BUILD_DIR)/rtl8261n.bin \
+		$(PKG_BUILD_DIR)/rtl8264b.bin \
 		$(1)/lib/firmware/
 endef
 
-define Package/rtl8261n-lp-firmware/install
+define Package/rtl826x-lp-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware
 	$(INSTALL_DATA) \
 		$(PKG_BUILD_DIR)/rtl8261n_lp.bin \
 		$(1)/lib/firmware/rtl8261n.bin
-endef
-
-define Package/rtl8264b-firmware/install
-	$(INSTALL_DIR) $(1)/lib/firmware
 	$(INSTALL_DATA) \
 		$(PKG_BUILD_DIR)/rtl8264b.bin \
 		$(1)/lib/firmware/
 endef
 
-$(eval $(call BuildPackage,rtl8261n-firmware))
-$(eval $(call BuildPackage,rtl8261n-lp-firmware))
-$(eval $(call BuildPackage,rtl8264b-firmware))
+$(eval $(call BuildPackage,rtl826x-firmware))
+$(eval $(call BuildPackage,rtl826x-lp-firmware))

--- a/target/linux/airoha/image/an7581.mk
+++ b/target/linux/airoha/image/an7581.mk
@@ -103,7 +103,7 @@ define Device/gemtek_w1700k-ubi
        the end of flash. A reinstall including corrected chainloader is needed.
   DEVICE_PACKAGES := airoha-en7581-mt7996-npu-firmware fitblk kmod-i2c-an7581 \
 		    kmod-hwmon-nct7802 kmod-mt7996-firmware wpad-basic-mbedtls \
-		    rtl8261n-firmware
+		    rtl826x-firmware
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 128k
   PAGESIZE := 2048

--- a/target/linux/generic/pending-6.18/742-net-phy-realtek-add-5G-and-10G-PHY-support.patch
+++ b/target/linux/generic/pending-6.18/742-net-phy-realtek-add-5G-and-10G-PHY-support.patch
@@ -64,7 +64,7 @@ Signed-off-by: Balázs Triszka <info@balika011.hu>
  #include <linux/string_choices.h>
  #include <net/phy/realtek_phy.h>
  
-@@ -205,10 +207,26 @@
+@@ -205,10 +207,27 @@
  #define RTL_8221B_VM_CG				0x001cc84a
  #define RTL_8251B				0x001cc862
  #define RTL_8261C				0x001cc890
@@ -81,6 +81,7 @@ Signed-off-by: Balázs Triszka <info@balika011.hu>
 +
 +#define RTL826X_VEND1_PKG_MODEL			0x103
 +#define RTL826X_VEND1_VERSION_ID		0x104
++#define   RTL826X_VEND1_VERSION_ID_VARIANT	GENMASK(2, 0)
 +
 +#define RTL826X_VND2_INER			0xA424
 +#define   RTL826X_VND2_INER_LINK_STATUS		BIT(4)
@@ -91,7 +92,7 @@ Signed-off-by: Balázs Triszka <info@balika011.hu>
  MODULE_DESCRIPTION("Realtek PHY driver");
  MODULE_AUTHOR("Johnson Leung");
  MODULE_LICENSE("GPL");
-@@ -1993,6 +2011,125 @@ static int rtl8251b_c45_match_phy_device
+@@ -1993,6 +2012,125 @@ static int rtl8251b_c45_match_phy_device
  	return rtlgen_is_c45_match(phydev, RTL_8251B, true);
  }
  
@@ -217,14 +218,29 @@ Signed-off-by: Balázs Triszka <info@balika011.hu>
  static int rtlgen_resume(struct phy_device *phydev)
  {
  	int ret = genphy_resume(phydev);
-@@ -2214,6 +2351,493 @@ static int rtlgen_sfp_config_aneg(struct
+@@ -2214,6 +2352,482 @@ static int rtlgen_sfp_config_aneg(struct
  	return 0;
  }
  
++static int rtl826x_patch_db_init(struct phy_device *phydev)
++{
++	int ver;
++
++	ver = phy_read_mmd(phydev, MDIO_MMD_VEND1, RTL826X_VEND1_VERSION_ID);
++	if (ver < 0)
++		return ver;
++
++	if (ver & RTL826X_VEND1_VERSION_ID_VARIANT)
++		return rtl8261n_phy_patch_db_init(phydev);
++	else
++		return rtl8264b_phy_patch_db_init(phydev);
++}
++
 +static int rtl826x_probe(struct phy_device *phydev)
 +{
 +	struct device *dev = &phydev->mdio.dev;
 +	struct rtl826x_priv *priv;
++	int ret;
 +
 +	priv = devm_kzalloc(dev, sizeof(struct rtl826x_priv), GFP_KERNEL);
 +	if (!priv)
@@ -240,38 +256,12 @@ Signed-off-by: Balázs Triszka <info@balika011.hu>
 +	phy_disable_eee_mode(phydev, ETHTOOL_LINK_MODE_100baseT_Full_BIT);
 +	phy_disable_eee_mode(phydev, ETHTOOL_LINK_MODE_1000baseT_Full_BIT);
 +
++	ret = rtl826x_patch_db_init(phydev);
++	if (ret < 0)
++		return ret;
++
 +	if (IS_ENABLED(CONFIG_REALTEK_PHY_HWMON))
 +		return rtl822x_hwmon_init(phydev);
-+
-+	return 0;
-+}
-+
-+static int rtl8261n_probe(struct phy_device *phydev)
-+{
-+	int ret;
-+
-+	ret = rtl826x_probe(phydev);
-+	if (ret < 0)
-+		return ret;
-+
-+	ret = rtl8261n_phy_patch_db_init(phydev);
-+	if (ret < 0)
-+		return ret;
-+
-+	return 0;
-+}
-+
-+static int rtl8264b_probe(struct phy_device *phydev)
-+{
-+	int ret;
-+
-+	ret = rtl826x_probe(phydev);
-+	if (ret < 0)
-+		return ret;
-+
-+	ret = rtl8264b_phy_patch_db_init(phydev);
-+	if (ret < 0)
-+		return ret;
 +
 +	return 0;
 +}
@@ -711,14 +701,14 @@ Signed-off-by: Balázs Triszka <info@balika011.hu>
  static struct phy_driver realtek_drvs[] = {
  	{
  		PHY_ID_MATCH_EXACT(0x00008201),
-@@ -2520,6 +3144,108 @@ static struct phy_driver realtek_drvs[]
+@@ -2520,6 +3134,108 @@ static struct phy_driver realtek_drvs[]
  		.resume		= genphy_resume,
  		.read_mmd	= genphy_read_mmd_unsupported,
  		.write_mmd	= genphy_write_mmd_unsupported,
 +	}, {
 +		.name           = "RTL8251L 5Gbps PHY",
 +		.config_init    = rtl826x_config_init,
-+		.probe          = rtl8261n_probe,
++		.probe          = rtl826x_probe,
 +		.get_features   = rtl825xb_get_features,
 +		.suspend        = rtl826x_suspend,
 +		.resume         = rtlgen_c45_resume,
@@ -735,7 +725,7 @@ Signed-off-by: Balázs Triszka <info@balika011.hu>
 +	}, {
 +		.name           = "RTL8254B 5Gbps PHY",
 +		.config_init    = rtl826x_config_init,
-+		.probe          = rtl8264b_probe,
++		.probe          = rtl826x_probe,
 +		.get_features   = rtl825xb_get_features,
 +		.suspend        = rtl826x_suspend,
 +		.resume         = rtlgen_c45_resume,
@@ -752,7 +742,7 @@ Signed-off-by: Balázs Triszka <info@balika011.hu>
 +	}, {
 +		.name           = "RTL8261BE 10Gbps PHY",
 +		.config_init    = rtl826x_config_init,
-+		.probe          = rtl8261n_probe,
++		.probe          = rtl826x_probe,
 +		.get_features   = rtl826x_get_features,
 +		.suspend        = rtl826x_suspend,
 +		.resume         = rtlgen_c45_resume,
@@ -769,7 +759,7 @@ Signed-off-by: Balázs Triszka <info@balika011.hu>
 +	}, {
 +		.name           = "RTL8261N 10Gbps PHY",
 +		.config_init    = rtl826x_config_init,
-+		.probe          = rtl8261n_probe,
++		.probe          = rtl826x_probe,
 +		.get_features   = rtl826x_get_features,
 +		.suspend        = rtl826x_suspend,
 +		.resume         = rtlgen_c45_resume,
@@ -787,7 +777,7 @@ Signed-off-by: Balázs Triszka <info@balika011.hu>
 +		PHY_ID_MATCH_EXACT(RTL_8264),
 +		.name           = "RTL8264 10Gbps PHY",
 +		.config_init    = rtl826x_config_init,
-+		.probe          = rtl8264b_probe,
++		.probe          = rtl826x_probe,
 +		.get_features   = rtl826x_get_features,
 +		.suspend        = rtl826x_suspend,
 +		.resume         = rtlgen_c45_resume,
@@ -803,7 +793,7 @@ Signed-off-by: Balázs Triszka <info@balika011.hu>
 +	}, {
 +		.name           = "RTL8264B 10Gbps PHY",
 +		.config_init    = rtl826x_config_init,
-+		.probe          = rtl8264b_probe,
++		.probe          = rtl826x_probe,
 +		.get_features   = rtl826x_get_features,
 +		.suspend        = rtl826x_suspend,
 +		.resume         = rtlgen_c45_resume,

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2107,7 +2107,7 @@ define Device/keenetic_kn-1812-common
   DEVICE_DTS_DIR := ../dts
   DEVICE_PACKAGES := kmod-mt7992-firmware kmod-usb3 \
 		mt7988-2p5g-phy-firmware mt7988-wo-firmware \
-		kmod-phy-realtek rtl8261n-firmware
+		kmod-phy-realtek rtl826x-firmware
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 128k
   PAGESIZE := 2048
@@ -3111,7 +3111,7 @@ define Device/tplink_be450
   DEVICE_DTS_DIR := ../dts
   DEVICE_PACKAGES := kmod-mt7992-firmware kmod-usb3 \
 	    mt7988-2p5g-phy-firmware mt7988-wo-firmware \
-	    kmod-phy-realtek rtl8261n-firmware
+	    kmod-phy-realtek rtl826x-firmware
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 128k
   PAGESIZE := 2048

--- a/target/linux/qualcommbe/image/ipq95xx.mk
+++ b/target/linux/qualcommbe/image/ipq95xx.mk
@@ -9,7 +9,7 @@ define Device/8devices_kiwi-dvk
 	SOC := ipq9570
 	DEVICE_PACKAGES := kmod-ath12k ath12k-firmware-qcn9274 \
 		ipq-wifi-8devices_kiwi f2fsck mkf2fs kmod-sfp \
-		kmod-phy-maxlinear kmod-phy-realtek rtl8261n-firmware
+		kmod-phy-maxlinear kmod-phy-realtek rtl826x-firmware
 	IMAGE/factory.bin := qsdk-ipq-factory-nor
 endef
 TARGET_DEVICES += 8devices_kiwi-dvk

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -17,7 +17,7 @@ define Device/sirivision_sr-st3408f
   UIMAGE_MAGIC := 0x93000000
   DEVICE_VENDOR := Sirivision
   DEVICE_MODEL := SR-ST3408F
-  DEVICE_PACKAGES := kmod-phy-realtek rtl8261n-firmware
+  DEVICE_PACKAGES := kmod-phy-realtek rtl826x-firmware
   IMAGE_SIZE := 13312k
   $(Device/kernel-lzma)
 endef
@@ -33,7 +33,7 @@ define Device/hasivo_f1100w-4sx-4xgt-common
   DEVICE_ALT1_MODEL := F1100WP-4SX-4XGT
   DEVICE_ALT2_VENDOR := Hasivo
   DEVICE_ALT2_MODEL := F1100WP-4SX-4XGT-SE
-  DEVICE_PACKAGES := kmod-phy-realtek rtl8261n-firmware
+  DEVICE_PACKAGES := kmod-phy-realtek rtl826x-firmware
   IMAGE_SIZE := 29696k
   $(Device/kernel-lzma)
 endef
@@ -57,7 +57,7 @@ define Device/hasivo_s1100w-8xgt-se
   DEVICE_VENDOR := Hasivo
   DEVICE_MODEL := S1100W-8XGT-SE
   IMAGE_SIZE := 12288k
-  DEVICE_PACKAGES := rtl8264b-firmware
+  DEVICE_PACKAGES := rtl826x-firmware
   $(Device/kernel-lzma)
 endef
 TARGET_DEVICES += hasivo_s1100w-8xgt-se
@@ -204,7 +204,7 @@ define Device/xikestor_sks8300-8t
   UIMAGE_MAGIC := 0x93000000
   DEVICE_VENDOR := XikeStor
   DEVICE_MODEL := SKS8300-8T
-  DEVICE_PACKAGES := kmod-hwmon-lm75 rtl8261n-firmware
+  DEVICE_PACKAGES := kmod-hwmon-lm75 rtl826x-firmware
   IMAGE_SIZE := 20480k
   $(Device/kernel-lzma)
   IMAGE/sysupgrade.bin := \
@@ -238,7 +238,7 @@ define Device/xikestor_sks8300-12e2t2x
   UIMAGE_MAGIC := 0x93000000
   DEVICE_VENDOR := XikeStor
   DEVICE_MODEL := SKS8300-12E2T2X
-  DEVICE_PACKAGES := rtl8261n-firmware
+  DEVICE_PACKAGES := rtl826x-firmware
   IMAGE_SIZE := 20480k
   $(Device/kernel-lzma)
   IMAGE/sysupgrade.bin := \
@@ -329,7 +329,7 @@ TARGET_DEVICES += zyxel_xgs1250-12-a1
 define Device/zyxel_xgs1250-12-b1
   $(Device/zyxel_xgs1250-12-common)
   DEVICE_VARIANT := B1
-  DEVICE_PACKAGES += rtl8261n-firmware
+  DEVICE_PACKAGES += rtl826x-firmware
 endef
 TARGET_DEVICES += zyxel_xgs1250-12-b1
 

--- a/target/linux/realtek/patches-6.18/024-02-v7.1-net-phy-realtek-add-RTL8224-pair-order-support.patch
+++ b/target/linux/realtek/patches-6.18/024-02-v7.1-net-phy-realtek-add-RTL8224-pair-order-support.patch
@@ -54,7 +54,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  #define RTL8366RB_POWER_SAVE			0x15
  #define RTL8366RB_POWER_SAVE_ON			BIT(12)
  
-@@ -1889,6 +1892,66 @@ static int rtl8224_cable_test_get_status
+@@ -1890,6 +1893,66 @@ static int rtl8224_cable_test_get_status
  	return rtl8224_cable_test_report(phydev, finished);
  }
  
@@ -121,7 +121,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  static bool rtlgen_supports_2_5gbps(struct phy_device *phydev)
  {
  	int val;
-@@ -3096,6 +3159,8 @@ static struct phy_driver realtek_drvs[]
+@@ -3086,6 +3149,8 @@ static struct phy_driver realtek_drvs[]
  		PHY_ID_MATCH_EXACT(0x001ccad0),
  		.name		= "RTL8224 2.5Gbps PHY",
  		.flags		= PHY_POLL_CABLE_TEST,

--- a/target/linux/realtek/patches-6.18/024-04-v7.1-net-phy-realtek-add-RTL8224-polarity-support.patch
+++ b/target/linux/realtek/patches-6.18/024-04-v7.1-net-phy-realtek-add-RTL8224-polarity-support.patch
@@ -32,7 +32,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  
  #define RTL8366RB_POWER_SAVE			0x15
  #define RTL8366RB_POWER_SAVE_ON			BIT(12)
-@@ -1940,9 +1941,40 @@ static int rtl8224_mdi_config_order(stru
+@@ -1941,9 +1942,40 @@ static int rtl8224_mdi_config_order(stru
  					  order ? BIT(port_offset) : 0);
  }
  

--- a/target/linux/realtek/patches-6.18/030-v7.2-net-phy-realtek-support-MDI-swapping-for-RTL8226-CG.patch
+++ b/target/linux/realtek/patches-6.18/030-v7.2-net-phy-realtek-support-MDI-swapping-for-RTL8226-CG.patch
@@ -60,7 +60,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  #define RTL8366RB_POWER_SAVE			0x15
  #define RTL8366RB_POWER_SAVE_ON			BIT(12)
  
-@@ -1391,6 +1406,144 @@ static int rtl822x_init_phycr1(struct ph
+@@ -1392,6 +1407,144 @@ static int rtl822x_init_phycr1(struct ph
  				      mask, val);
  }
  
@@ -205,7 +205,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  static int rtl822x_set_serdes_option_mode(struct phy_device *phydev, bool gen1)
  {
  	bool has_2500, has_sgmii;
-@@ -3083,6 +3236,7 @@ static struct phy_driver realtek_drvs[]
+@@ -3073,6 +3226,7 @@ static struct phy_driver realtek_drvs[]
  		.soft_reset	= rtl822x_c45_soft_reset,
  		.get_features	= rtl822x_c45_get_features,
  		.config_aneg	= rtl822x_c45_config_aneg,

--- a/target/linux/realtek/patches-6.18/743-net-realtek-serdes-configuration.patch
+++ b/target/linux/realtek/patches-6.18/743-net-realtek-serdes-configuration.patch
@@ -42,7 +42,7 @@
  #define RTL8221B_PHYCR1				0xa430
  #define RTL8221B_PHYCR1_ALDPS_EN		BIT(2)
  #define RTL8221B_PHYCR1_ALDPS_XTAL_OFF_EN	BIT(12)
-@@ -2069,6 +2104,147 @@ exit:
+@@ -2070,6 +2105,147 @@ exit:
  	return ret;
  }
  
@@ -190,7 +190,7 @@
  static int rtl8224_mdi_config_order(struct phy_device *phydev)
  {
  	struct device_node *np = phydev->mdio.dev.of_node;
-@@ -2123,6 +2299,10 @@ static int rtl8224_config_init(struct ph
+@@ -2124,6 +2300,10 @@ static int rtl8224_config_init(struct ph
  {
  	int ret;
  


### PR DESCRIPTION
The in-tree realtek 5G/10G driver picks the firmware patch table from the PHY ID (RTL8264 -> rtl8264b.bin). The vendor driver instead picks it from `VEND1` `0x104[2:0]` (`0` = RTL8264B, else RTL8261N-C), independent of PHY ID.

On the S1300WP, the RTL8264 dies read `0x104=0xf802` (`[2:0]=2`), so they need the RTL8261N-C table; the RTL8264B table leaves the PCS unlocked (`0xA600` stuck `0x1000`) and config_init fails with `-ETIME`. Read `0x104[2:0]` and load `rtl8261n.bin` when non-zero.

See https://github.com/openwrt/openwrt/blob/e4c35c2eec665f3f74a2b2f587fd2a1324b31841/target/linux/generic/files-6.12/drivers/net/phy/rtl8261n/phy_rtl826xb_patch.c#L880

A split in an RTL8261N and an RTL8264B firmware package is therefore misleading. And it could even be that a product ships an RTL8264B but switches the revision of the chip in the middle of its product lifetime. In this case, the first identification based on the chip ID or the actual chip ID for the OpenWrt porter might fail for another user with a later/earlier
produced device.

Shipping both files in the same package avoids this problem. Only the "low power" firmware package is slightly misleading because there is only a RTL8261N firmware binary for low power but no corresponding RTL8264B version. It will ship simply the non-low power version for RTL8264B.

(This is an alternative approach for #23726)