### PR TITLE
busybox: enable shell history reverse search

### DIFF
--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -264,7 +264,7 @@ config BUSYBOX_DEFAULT_FEATURE_EDITING_SAVE_ON_EXIT
 	default y
 config BUSYBOX_DEFAULT_FEATURE_REVERSE_SEARCH
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_TAB_COMPLETION
 	bool
 	default y

--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=busybox
 PKG_VERSION:=1.38.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_FLAGS:=essential
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2


### PR DESCRIPTION
Following on from e23b37b, it makes sense to also enable searching the history rather that just relying on up and down arrow while scanning the results.

On both x86 and ath79, busybox binary is ~4.2k bigger.  The resulting x86 .apk is 447 bytes bigger and mips_24kc .apk is 324 bytes bigger.

---
@hnyman Got any feelings about the increase in size?