### PR TITLE
ead: fix compilation with GCC 15

### DIFF
--- a/package/network/services/ead/src/tinysrp/t_defines.h
+++ b/package/network/services/ead/src/tinysrp/t_defines.h
@@ -79,19 +79,8 @@
 #endif
 #endif
 
-#if STDC_HEADERS
 #include <stdlib.h>
 #include <string.h>
-#else /* not STDC_HEADERS */
-#ifndef HAVE_STRCHR
-#define strchr index
-#define strrchr rindex
-#endif
-char *strchr(), *strrchr(), *strtok();
-#ifndef HAVE_MEMCPY
-#define memcpy(d, s, n) bcopy((s), (d), (n))
-#endif
-#endif /* not STDC_HEADERS */
 
 #include <sys/types.h>
 

--- a/package/network/services/ead/src/tinysrp/t_truerand.c
+++ b/package/network/services/ead/src/tinysrp/t_truerand.c
@@ -86,7 +86,7 @@ tick()
 }
 
 static void
-interrupt()
+interrupt(int sig)
 {
 	if (count) {
 #ifdef OLD_TRUERAND


### PR DESCRIPTION
GCC 15 defaults to C23, where an empty parameter list "()" means "(void)" instead of an unspecified argument list. This broke two spots in the bundled tinysrp sources:

  - The interrupt() signal handler in t_truerand.c was declared with "()", so its type became "void (*)(void)" and no longer matched the "void (*)(int)" expected by signal():

      t_truerand.c:100:32: error: passing argument 2 of 'signal' from
      incompatible pointer type [-Wincompatible-pointer-types]

    Give it the proper signal handler signature instead.

  - The pre-ANSI fallback in t_defines.h declared strchr(), strrchr() and strtok() with "()". ead.c is compiled without -DHAVE_CONFIG_H, so STDC_HEADERS is undefined and that legacy branch is taken, where the zero-argument prototypes now conflict with the declarations in the standard headers:

      tinysrp/t_defines.h:90:30: error: conflicting types for 'strtok';
      have 'char *(void)'

    Drop the dead K&R branch and include <stdlib.h> and <string.h> unconditionally; the library's own objects already take this path via config.h.

Assisted-by: Claude:claude-opus-4-8