### PR TITLE
thc-ipv6: fix compilation with GCC 15

### DIFF
--- a/package/network/ipv6/thc-ipv6/patches/102-fix-thc_open_ipv6-prototype.patch
+++ b/package/network/ipv6/thc-ipv6/patches/102-fix-thc_open_ipv6-prototype.patch
@@ -1,0 +1,37 @@
+From 0f6e30c03a093bba52f16570635b9f778925f2d7 Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Sat, 27 Jun 2026 00:34:23 +0200
+Subject: [PATCH] Fix thc_open_ipv6() prototype for GCC 15 / C23
+
+GCC 15 defaults to C23, where an empty parameter list "()" means
+"(void)" instead of an unspecified argument list. thc-ipv6.h declared
+
+    extern int thc_open_ipv6();
+
+so the prototype became "int(void)" and clashed with the actual
+definition "int thc_open_ipv6(char *interface)" and all of its callers:
+
+    thc-ipv6-lib.c:127: error: too many arguments to function
+    'thc_open_ipv6'; expected 0, have 1
+    thc-ipv6-lib.c:2555: error: conflicting types for 'thc_open_ipv6';
+    have 'int(char *)'
+
+Give the prototype its real signature.
+
+Assisted-by: Claude:claude-opus-4-8
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+---
+ thc-ipv6.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/thc-ipv6.h
++++ b/thc-ipv6.h
+@@ -208,7 +208,7 @@ extern int thc_generate_pkt(char *interf
+                             int *pkt_len);
+ extern int thc_send_pkt(char *interface, unsigned char *pkt, int *pkt_len);
+ extern unsigned char *thc_destroy_packet(unsigned char *pkt);
+-extern int            thc_open_ipv6();
++extern int            thc_open_ipv6(char *interface);
+ extern int            thc_is_dst_local(char *interface, unsigned char *dst);
+ extern int  checksum_pseudo_header(unsigned char *src, unsigned char *dst,
+                                    unsigned char type, unsigned char *data,

--- a/package/network/ipv6/thc-ipv6/patches/103-fix-signal-handler-prototypes.patch
+++ b/package/network/ipv6/thc-ipv6/patches/103-fix-signal-handler-prototypes.patch
@@ -1,0 +1,55 @@
+From 1e48ae83dddaca892d78025fdd1d3fe6652c8522 Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Sat, 27 Jun 2026 02:24:41 +0200
+Subject: [PATCH] Fix signal handler prototypes for GCC 15 / C23
+
+GCC 15 defaults to C23, where an empty parameter list "()" means
+"(void)" instead of an unspecified argument list. The alarming() SIGALRM
+handlers in detect_sniffer6.c and thcping6.c were declared with "()", so
+their type became "void (*)(void)" and no longer matched the
+"void (*)(int)" expected by signal():
+
+    detect_sniffer6.c:140:19: error: passing argument 2 of 'signal' from
+    incompatible pointer type [-Wincompatible-pointer-types]
+
+Give them the proper signal handler signature. Also pass an argument to
+the direct alarming() call in detect_sniffer6.c.
+
+Assisted-by: Claude:claude-opus-4-8
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+---
+ detect_sniffer6.c | 4 ++--
+ thcping6.c        | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+--- a/detect_sniffer6.c
++++ b/detect_sniffer6.c
+@@ -27,7 +27,7 @@ void help(char *prg) {
+   exit(-1);
+ }
+ 
+-void alarming() {
++void alarming(int sig) {
+   if (found == 0)
+     printf("No packets received, no vulnerable system seems to be sniffing.\n");
+   else
+@@ -63,7 +63,7 @@ void check_packets(u_char *pingdata, con
+       printf(" Sniffing host detected: %s\n", thc_ipv62notation(ptr + 8));
+       memcpy(doubles[found], thc_ipv62notation(ptr + 8), 16);
+       found++;
+-      if (oneonly) alarming();
++      if (oneonly) alarming(0);
+     }
+   }
+ }
+--- a/thcping6.c
++++ b/thcping6.c
+@@ -89,7 +89,7 @@ void help(char *prg, int help) {
+   exit(-1);
+ }
+ 
+-void alarming() {
++void alarming(int sig) {
+   if (done == 0) printf("No packet received, terminating.\n");
+   exit(resp_type);
+ }


### PR DESCRIPTION
GCC 15 defaults to C23, where an empty parameter list "()" means "(void)" instead of an unspecified argument list. thc-ipv6.h declared thc_open_ipv6() with an empty argument list, so its prototype became "int(void)" and conflicted with the actual definition "int thc_open_ipv6(char *interface)" and all of its callers:

  thc-ipv6-lib.c:127:36: error: too many arguments to function
  'thc_open_ipv6'; expected 0, have 1
  thc-ipv6-lib.c:2555:5: error: conflicting types for 'thc_open_ipv6';
  have 'int(char *)'

Add a patch giving the prototype its real signature.

Assisted-by: Claude:claude-opus-4-8
