### PR TITLE
mediatek: acer-predator-w6x: add LED boot status support

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-acer-predator-w6x.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-acer-predator-w6x.dtsi
@@ -11,6 +11,10 @@
 / {
 	aliases {
 		serial0 = &uart0;
+		led-boot = &led_status_rgb;
+		led-failsafe = &led_status_rgb;
+		led-running = &led_status_rgb;
+		led-upgrade = &led_status_rgb;
 	};
 
 	chosen: chosen {


### PR DESCRIPTION
Currently, the Acer Predator W6X system LED remains off during the boot process due to missing `led-boot`, `led-failsafe`, `led-running`, and `led-upgrade` definitions in the device DTSI. This pull request adds these definitions so the system LED reflects the standard OpenWrt boot and runtime states.

This change has been tested on an Acer Predator W6X unit.