### PR TITLE
rtl8367b: fix RTL8367S-VB vlan mc memory handling

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/rtl8367b.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8367b.c
@@ -565,7 +565,11 @@ static int rtl8367b_init_regs(struct rtl8366_smi *smi)
 		count = ARRAY_SIZE(rtl8367c_initvals);
 		if ((smi->rtl8367b_chip == RTL8367B_CHIP_RTL8367S_VB) && (smi->emu_vlanmc == NULL)) {
 			smi->emu_vlanmc = kzalloc(sizeof(struct rtl8366_vlan_mc) * smi->num_vlan_mc, GFP_KERNEL);
-			dev_info(smi->parent, "alloc vlan mc emulator");
+			if (!smi->emu_vlanmc) {
+				dev_err(smi->parent, "failed to allocate vlan mc emulator\n");
+				return -ENOMEM;
+			}
+			dev_info(smi->parent, "alloc vlan mc emulator\n");
 		}
 		break;
 	default:
@@ -1586,6 +1590,7 @@ static void rtl8367b_remove(struct platform_device *pdev)
 		rtl8367b_switch_cleanup(smi);
 		platform_set_drvdata(pdev, NULL);
 		rtl8366_smi_cleanup(smi);
+		kfree(smi->emu_vlanmc);
 		kfree(smi);
 	}
 }


### PR DESCRIPTION
The RTL8367S-VB (Family D) uses a software-emulated VLAN MC table
(emu_vlanmc) since it lacks hardware support for the VLAN MC registers
used by earlier chips.

- Add missing NULL check after kzalloc() in rtl8367b_init_regs() to
  prevent NULL pointer dereference on allocation failure.
- Add missing kfree(smi->emu_vlanmc) in rtl8367b_remove() to prevent
  memory leak on driver unload.