### PR TITLE
qualcommax: add support for TP-Link RE700X

### DIFF
--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -100,6 +100,7 @@ ALLWIFIBOARDS:= \
 	tplink_eap623-outdoor-hd-v1 \
 	tplink_eap625-outdoor-hd-v1 \
 	tplink_eap660hd-v1 \
+	tplink_re700x \
 	tplink_tl-wa1201-v2 \
 	wallys_dr40x9 \
 	xiaomi_aiot-ac2350 \
@@ -297,6 +298,7 @@ $(eval $(call generate-ipq-wifi-package,tplink_eap620hd-v1,TP-Link EAP620 HD v1)
 $(eval $(call generate-ipq-wifi-package,tplink_eap623-outdoor-hd-v1,TP-Link EAP623-Outdoor HD v1))
 $(eval $(call generate-ipq-wifi-package,tplink_eap625-outdoor-hd-v1,TP-Link EAP625-Outdoor HD v1))
 $(eval $(call generate-ipq-wifi-package,tplink_eap660hd-v1,TP-Link EAP660 HD v1))
+$(eval $(call generate-ipq-wifi-package,tplink_re700x,TP-Link RE700X))
 $(eval $(call generate-ipq-wifi-package,tplink_tl-wa1201-v2,TP-Link TL-WA1201 V2))
 $(eval $(call generate-ipq-wifi-package,wallys_dr40x9,Wallys DR40X9))
 $(eval $(call generate-ipq-wifi-package,xiaomi_aiot-ac2350,Xiaomi AIoT AC2350))

--- a/package/kernel/mac80211/patches/ath11k/953-wifi-ath11k-pick-dp-ring-sizes-at-runtime.patch
+++ b/package/kernel/mac80211/patches/ath11k/953-wifi-ath11k-pick-dp-ring-sizes-at-runtime.patch
@@ -1,0 +1,153 @@
+From: Eduard Hart <eduard.hart@etik.com>
+Date: Sun, 28 Jun 2026 19:00:00 +0200
+Subject: [PATCH] wifi: ath11k: pick DP ring sizes at runtime based on total RAM
+
+ath11k pre-allocates large RX/TX-completion DP rings (~94 MB of skbs with
+two radios). On 256 MB IPQ5018 devices (e.g. TP-Link RE700X) running both
+radios this OOMs. Mirror ath12k's runtime memory detection: read the total
+RAM via si_meminfo() and, below 256 MB of usable RAM, use smaller DP ring
+sizes. Devices with more RAM keep the existing defaults, so their behaviour
+is unchanged. The threshold is < SZ_256M rather than SZ_512M because reserved
+memory regions are subtracted from totalram, so a 512 MB board reports well
+under 512 MB and must not be downgraded.
+
+The small-memory ring sizes match openwrt/openwrt#21495.
+
+Signed-off-by: Eduard Hart <eduard.hart@etik.com>
+---
+--- a/drivers/net/wireless/ath/ath11k/dp.c
++++ b/drivers/net/wireless/ath/ath11k/dp.c
+@@ -415,7 +415,7 @@
+ 
+ 		ret = ath11k_dp_srng_setup(ab, &dp->tx_ring[i].tcl_comp_ring,
+ 					   HAL_WBM2SW_RELEASE, wbm_num, 0,
+-					   DP_TX_COMP_RING_SIZE);
++					   dp->tx_comp_ring_size);
+ 		if (ret) {
+ 			ath11k_warn(ab, "failed to set up tcl_comp ring (%d) :%d\n",
+ 				    i, ret);
+@@ -1047,6 +1047,34 @@
+ 	/* Deinit any SOC level resource */
+ }
+ 
++static void ath11k_dp_set_ring_sizes(struct ath11k_dp *dp)
++{
++	struct sysinfo si;
++
++	/*
++	 * ath11k pre-allocates large RX/TX-completion DP rings; on low-memory
++	 * (256 MB) devices running two radios this OOMs. Mirror ath12k and pick
++	 * smaller ring sizes at runtime below 256 MB of usable RAM. Devices with
++	 * more RAM keep the existing defaults. The threshold is < SZ_256M (not
++	 * SZ_512M) because reserved memory regions are subtracted from totalram,
++	 * so a 512 MB board reports well under 512 MB and must not be caught.
++	 */
++	si_meminfo(&si);
++	if (si.totalram * si.mem_unit < SZ_256M) {
++		dp->tx_comp_ring_size = 2048;
++		dp->rxdma_buf_ring_size = 1024;
++		dp->rxdma_mon_status_ring_size = 512;
++		dp->rxdma_mon_buf_ring_size = 128;
++		dp->rxdma_mon_dst_ring_size = 128;
++	} else {
++		dp->tx_comp_ring_size = DP_TX_COMP_RING_SIZE;
++		dp->rxdma_buf_ring_size = DP_RXDMA_BUF_RING_SIZE;
++		dp->rxdma_mon_status_ring_size = DP_RXDMA_MON_STATUS_RING_SIZE;
++		dp->rxdma_mon_buf_ring_size = DP_RXDMA_MONITOR_BUF_RING_SIZE;
++		dp->rxdma_mon_dst_ring_size = DP_RXDMA_MONITOR_DST_RING_SIZE;
++	}
++}
++
+ int ath11k_dp_alloc(struct ath11k_base *ab)
+ {
+ 	struct ath11k_dp *dp = &ab->dp;
+@@ -1058,6 +1084,8 @@
+ 
+ 	dp->ab = ab;
+ 
++	ath11k_dp_set_ring_sizes(dp);
++
+ 	INIT_LIST_HEAD(&dp->reo_cmd_list);
+ 	INIT_LIST_HEAD(&dp->reo_cmd_cache_flush_list);
+ 	INIT_LIST_HEAD(&dp->dp_full_mon_mpdu_list);
+@@ -1084,7 +1112,7 @@
+ 	if (ret)
+ 		goto fail_link_desc_cleanup;
+ 
+-	size = sizeof(struct hal_wbm_release_ring) * DP_TX_COMP_RING_SIZE;
++	size = sizeof(struct hal_wbm_release_ring) * dp->tx_comp_ring_size;
+ 
+ 	for (i = 0; i < ab->hw_params.max_tx_ring; i++) {
+ 		idr_init(&dp->tx_ring[i].txbuf_idr);
+@@ -1092,7 +1120,7 @@
+ 		dp->tx_ring[i].tcl_data_ring_id = i;
+ 
+ 		dp->tx_ring[i].tx_status_head = 0;
+-		dp->tx_ring[i].tx_status_tail = DP_TX_COMP_RING_SIZE - 1;
++		dp->tx_ring[i].tx_status_tail = dp->tx_comp_ring_size - 1;
+ 		dp->tx_ring[i].tx_status = kmalloc(size, GFP_KERNEL);
+ 		if (!dp->tx_ring[i].tx_status) {
+ 			ret = -ENOMEM;
+--- a/drivers/net/wireless/ath/ath11k/dp.h
++++ b/drivers/net/wireless/ath/ath11k/dp.h
+@@ -257,6 +257,11 @@
+ 
+ struct ath11k_dp {
+ 	struct ath11k_base *ab;
++	u32 tx_comp_ring_size;
++	u32 rxdma_buf_ring_size;
++	u32 rxdma_mon_status_ring_size;
++	u32 rxdma_mon_buf_ring_size;
++	u32 rxdma_mon_dst_ring_size;
+ 	enum ath11k_htc_ep_id eid;
+ 	struct completion htt_tgt_version_received;
+ 	u8 htt_tgt_ver_major;
+--- a/drivers/net/wireless/ath/ath11k/dp_rx.c
++++ b/drivers/net/wireless/ath/ath11k/dp_rx.c
+@@ -578,7 +578,7 @@
+ 	ret = ath11k_dp_srng_setup(ar->ab,
+ 				   &dp->rx_refill_buf_ring.refill_buf_ring,
+ 				   HAL_RXDMA_BUF, 0,
+-				   dp->mac_id, DP_RXDMA_BUF_RING_SIZE);
++				   dp->mac_id, ar->ab->dp.rxdma_buf_ring_size);
+ 	if (ret) {
+ 		ath11k_warn(ar->ab, "failed to setup rx_refill_buf_ring\n");
+ 		return ret;
+@@ -613,7 +613,7 @@
+ 		ret = ath11k_dp_srng_setup(ar->ab,
+ 					   srng,
+ 					   HAL_RXDMA_MONITOR_STATUS, 0, dp->mac_id + i,
+-					   DP_RXDMA_MON_STATUS_RING_SIZE);
++					   ar->ab->dp.rxdma_mon_status_ring_size);
+ 		if (ret) {
+ 			ath11k_warn(ar->ab,
+ 				    "failed to setup rx_mon_status_refill_ring %d\n", i);
+@@ -636,7 +636,7 @@
+ 	ret = ath11k_dp_srng_setup(ar->ab,
+ 				   &dp->rxdma_mon_buf_ring.refill_buf_ring,
+ 				   HAL_RXDMA_MONITOR_BUF, 0, dp->mac_id,
+-				   DP_RXDMA_MONITOR_BUF_RING_SIZE);
++				   ar->ab->dp.rxdma_mon_buf_ring_size);
+ 	if (ret) {
+ 		ath11k_warn(ar->ab,
+ 			    "failed to setup HAL_RXDMA_MONITOR_BUF\n");
+@@ -645,7 +645,7 @@
+ 
+ 	ret = ath11k_dp_srng_setup(ar->ab, &dp->rxdma_mon_dst_ring,
+ 				   HAL_RXDMA_MONITOR_DST, 0, dp->mac_id,
+-				   DP_RXDMA_MONITOR_DST_RING_SIZE);
++				   ar->ab->dp.rxdma_mon_dst_ring_size);
+ 	if (ret) {
+ 		ath11k_warn(ar->ab,
+ 			    "failed to setup HAL_RXDMA_MONITOR_DST\n");
+--- a/drivers/net/wireless/ath/ath11k/dp_tx.c
++++ b/drivers/net/wireless/ath/ath11k/dp_tx.c
+@@ -122,7 +122,7 @@
+ 
+ 	spin_lock_bh(&tx_ring->tx_idr_lock);
+ 	ret = idr_alloc(&tx_ring->txbuf_idr, skb, 0,
+-			DP_TX_IDR_SIZE - 1, GFP_ATOMIC);
++			dp->tx_comp_ring_size - 1, GFP_ATOMIC);
+ 	spin_unlock_bh(&tx_ring->tx_idr_lock);
+ 
+ 	if (unlikely(ret < 0)) {

--- a/scripts/tplink-re700x-factory.py
+++ b/scripts/tplink-re700x-factory.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Wrap an OpenWrt rootfs UBI into a TP-Link RE700X web-UI-flashable factory
+# image. The image is accepted by the stock RE700X "nvrammanager" (the stock
+# "Firmware Upgrade" web page), so OpenWrt can be installed without UART.
+#
+# This is the same TP-Link "tplink2022" container family as
+# scripts/tplink-mkimage-2022.py (identical 16-byte salt, 0x1014 table /
+# 0x1814 data layout, MD5(salt + image[0x14:]) header checksum), but with the
+# RE700X "FwUpTbl" table variant: a 12-byte table header (rootfs-size, count,
+# 0) followed by 0x2c-byte entries (name[32], offset, size, type). The rootfs
+# UBI occupies the data region first (no table entry) and is flashed with
+# "ubiformat -o 0x1814 -S <rootfs-size>" into the inactive dual-boot slot.
+#
+# The support-list and (anti-downgrade-bumped) soft-version are the generic
+# RE700X EU/region metadata recovered from stock firmware; no per-device data.
+
+import argparse
+import hashlib
+import struct
+
+SALT = bytes([0x7a, 0x2b, 0x15, 0xed, 0x9b, 0x98, 0x59, 0x6d,
+              0xe5, 0x04, 0xab, 0x44, 0xac, 0x2a, 0x9f, 0x4e])
+
+TABLE_OFF = 0x1014
+DATA_OFF = 0x1814          # TABLE_OFF + 0x800
+ENTRY_SZ = 0x2c
+MAX_ENT = 32
+TABLE_SZ = 12 + MAX_ENT * ENTRY_SZ      # 0x58c, fixed memcpy size in nm_readFwUpTbl
+
+SUPPORT_LIST = (
+    "SupportList:\n"
+    "{product_name:RE700X,product_ver:1.0.0,special_id:00000000}\n"
+    "{product_name:RE700X,product_ver:1.0.0,special_id:4A500000}\n"
+    "{product_name:RE700X,product_ver:1.0.0,special_id:554B0000}\n"
+    "{product_name:RE700X,product_ver:1.0.0,special_id:45550000}\n"
+    "{product_name:RE700X,product_ver:1.0.0,special_id:41550000}\n"
+    "{product_name:RE700X,product_ver:1.0.0,special_id:41530000}\n"
+).encode()
+
+# soft_ver bumped to 9.9.9 so the image always passes the stock anti-downgrade
+# check; fw_id / cfg_ver are the stock RE700X strings.
+SOFT_VERSION = (
+    "soft_ver:9.9.9 Build 20991231 Rel. 99999\n"
+    "fw_id:\n"
+    "cfg_ver:RE700Xh1.0.0V1.1.4P1-9CF02F8DEC4552218A6D58A4B9F5D8F1\n"
+).encode()
+
+
+def make_entry(name, base, size, field):
+    nm = name.encode()
+    if len(nm) >= 32:
+        raise ValueError("section name too long: %r" % name)
+    return nm + b'\x00' * (32 - len(nm)) + struct.pack('>III', base, size, field)
+
+
+def build_image(os_data, meta):
+    field0 = len(os_data)                       # rootfs size (ubiformat -S)
+    blob = bytearray(os_data)
+    bases, cur = [], field0
+    for s in meta:
+        bases.append(cur)
+        blob += s['data']
+        cur += len(s['data'])
+
+    tbl = struct.pack('>III', field0, len(meta), 0)
+    for i, s in enumerate(meta):
+        tbl += make_entry(s['name'], bases[i], len(s['data']), s.get('field', 0))
+    tbl += b'\x00' * (TABLE_SZ - len(tbl))
+
+    img = bytearray(b'\xff' * (DATA_OFF + len(blob)))
+    img[TABLE_OFF:TABLE_OFF + TABLE_SZ] = tbl
+    img[DATA_OFF:DATA_OFF + len(blob)] = blob
+    struct.pack_into('>I', img, 0, len(img))
+    img[4:0x14] = hashlib.md5(SALT + bytes(img[0x14:])).digest()
+    return bytes(img)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--rootfs', required=True, help='OpenWrt rootfs UBI image')
+    ap.add_argument('-o', '--output', required=True, help='factory image output')
+    args = ap.parse_args()
+
+    with open(args.rootfs, 'rb') as f:
+        os_data = f.read()
+    meta = [
+        {'name': 'support-list', 'data': SUPPORT_LIST, 'field': 0},
+        {'name': 'soft-version', 'data': SOFT_VERSION, 'field': 0},
+    ]
+    with open(args.output, 'wb') as f:
+        f.write(build_image(os_data, meta))
+
+
+if __name__ == '__main__':
+    main()

--- a/target/linux/qualcommax/dts/ipq5018-re700x.dts
+++ b/target/linux/qualcommax/dts/ipq5018-re700x.dts
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "ipq5018.dtsi"
+#include "ipq5018-ess.dtsi"
+#include "ipq5018-qcn6122.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "TP-Link RE700X";
+	compatible = "tplink,re700x", "qcom,ipq5018";
+
+	aliases {
+		serial0 = &blsp1_uart1;
+		led-boot = &led_wps_blue;
+		led-failsafe = &led_wps_blue;
+		led-running = &led_wps_blue;
+		led-upgrade = &led_wps_blue;
+	};
+
+	chosen {
+		/*
+		 * Slot-aware dual-boot: the stock U-Boot passes a slot-correct
+		 * cmdline ("ubi.mtd=rootfs" or "ubi.mtd=rootfs_1" depending on
+		 * tp_boot_idx) but with "root=mtd:ubi_rootfs", which mainline
+		 * cannot mount. Inherit U-Boot's slot-correct ubi.mtd and only
+		 * append our own root= (last root= wins, overriding the bogus
+		 * one) plus coherent_pool for the ath11k 2.4 GHz DMA. This boots
+		 * OpenWrt from whichever slot the flasher wrote -> no more brick.
+		 */
+		bootargs-append = " root=/dev/ubiblock0_1 coherent_pool=2M";
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		button-reset {
+			label = "reset";
+			gpios = <&tlmm 19 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		button-wps {
+			label = "wps";
+			gpios = <&tlmm 20 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+
+		/*
+		 * All five front-panel LEDs confirmed by GPIO output sweep:
+		 * power 31, wps-red 32, wps-blue 22, wlan2g 33, wlan5g 34
+		 * (all active-high). The stock DTB LED GPIOs were all wrong.
+		 */
+		led_power: power {
+			gpios = <&tlmm 31 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			default-state = "on";
+		};
+
+		led_wps_red: wps-red {
+			gpios = <&tlmm 32 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WPS;
+			default-state = "off";
+		};
+
+		led_wps_blue: wps-blue {
+			gpios = <&tlmm 22 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WPS;
+			default-state = "off";
+		};
+
+		led_wlan2g: wlan-2g {
+			gpios = <&tlmm 33 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			default-state = "off";
+		};
+
+		led_wlan5g: wlan-5g {
+			gpios = <&tlmm 34 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			default-state = "off";
+		};
+	};
+};
+
+&sleep_clk {
+	clock-frequency = <32000>;
+};
+
+&xo_board_clk {
+	clock-div = <4>;
+	clock-mult = <1>;
+};
+
+&blsp1_uart1 {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&qfprom {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	pinctrl-0 = <&qpic_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		nand-ecc-engine = <&qpic_nand>;
+
+		/* strength=8 breaks NAND I/O, use 4 instead */
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "qcom,smem-part";
+
+			partition-0-appsblenv {
+				label = "0:appsblenv";
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+					env-size = <0x40000>;
+
+					macaddr_appsblenv_ethaddr: ethaddr {
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+		};
+	};
+};
+
+/*
+ * Ethernet: a single Gigabit port.
+ *
+ *   IPQ5018 MAC1 --- SGMII (uniphy0) ---> Realtek RTL8211F @ MDIO1 addr 6
+ *
+ * The SoC's internal GE PHY (MAC0/gmac0) is not wired to any external
+ * port on this device, so only MAC1 is enabled. U-Boot enumerates this
+ * port as eth1/MAC1 with PHY ID 0x001cc916 (RTL8211F).
+ */
+&uniphy0 {
+	status = "okay";
+
+	assigned-clocks = <&uniphy0 UNIPHY_CLK_REF>;
+	assigned-clock-rates = <UNIPHY_REFCLK_25MHZ>;
+};
+
+/* MAC1 --- SGMII ---> RTL8211F */
+&gmac1 {
+	status = "okay";
+
+	label = "lan";
+
+	phy-mode = "sgmii";
+	phy-handle = <&rtl8211f_6>;
+
+	nvmem-cells = <&macaddr_appsblenv_ethaddr 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio1 {
+	status = "okay";
+
+	pinctrl-0 = <&mdio1_pins>;
+	pinctrl-names = "default";
+
+	rtl8211f_6: ethernet-phy@6 {
+		compatible = "ethernet-phy-id001c.c916";
+		reg = <6>;
+		/*
+		 * No reset-gpios: the stock DTB claimed gpio33 as the PHY
+		 * reset, but gpio33 is actually the 2.4G LED (confirmed by
+		 * GPIO sweep). U-Boot brings the PHY up and the link is
+		 * stable without a Linux-side reset.
+		 */
+	};
+};
+
+&tlmm {
+	button_pins: button-state {
+		pins = "gpio19", "gpio20";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-up;
+	};
+
+	led_pins: led-state {
+		pins = "gpio22", "gpio31", "gpio32", "gpio33", "gpio34";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-down;
+	};
+
+	mdio1_pins: mdio-state {
+		mdc-pins {
+			pins = "gpio36";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio-pins {
+			pins = "gpio37";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	qpic_pins: qpic-state {
+		clock-pins {
+			pins = "gpio9";
+			function = "qspi_clk";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		cs-pins {
+			pins = "gpio8";
+			function = "qspi_cs";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		data-pins {
+			pins = "gpio4", "gpio5", "gpio6", "gpio7";
+			function = "qspi_data";
+			drive-strength = <8>;
+			bias-disable;
+		};
+	};
+};
+
+&q6v5_wcss {
+	/*
+	 * Stock boot-args, decoded from the stock FIT config@mp02.1 DTB.
+	 * Format per radio: <PCIE-index, length, userPD-id, reset-gpio,
+	 * resv, resv>. Group A (UPD3): PCIE0, gpio15. Group B (UPD2 = our
+	 * QCN6122): PCIE1, reset gpio27 (0x1b) - a board-specific override
+	 * of the firmware UPD2 default gpio18. This is what lets the QCN6122
+	 * userpd finish init instead of stalling in the DOG watchdog.
+	 */
+	boot-args = <0x1 4 3 15 0 0  0x2 4 2 0x1b 0 0>;
+};
+
+&wifi {
+	status = "okay";
+
+	qcom,rproc = <&q6_wcss_pd1>;
+	qcom,ath11k-calibration-variant = "TP-Link-RE700X";
+	qcom,ath11k-fw-memory-mode = <1>;
+	qcom,bdf-addr = <0x4c400000>;
+
+	ieee80211-freq-limit = <2400000 2483000>;
+};
+
+&wifi1 {
+	/*
+	 * QCN6122 5 GHz. Uses the canonical OpenWrt PD2 memory layout
+	 * (bdf 0x4d100000 / m3-dump 0x4df00000) and the stock-derived
+	 * q6v5_wcss boot-args above, which put UPD2 on PCIE1 with reset
+	 * GPIO 27. This combination lets the userpd finish init and keeps
+	 * both ath11k radios online.
+	 *
+	 * 5 GHz stays enabled because the ath11k DP rings are shrunk at
+	 * runtime on this 256 MB board (mac80211 patch 953), so both radios
+	 * fit in RAM.
+	 */
+	status = "okay";
+
+	qcom,rproc = <&q6_wcss_pd2>;
+	qcom,userpd-subsys-name = "q6v5_wcss_userpd2";
+	qcom,ath11k-calibration-variant = "TP-Link-RE700X";
+	qcom,ath11k-fw-memory-mode = <1>;
+	qcom,bdf-addr = <0x4d100000>;
+	qcom,m3-dump-addr = <0x4df00000>;
+
+	ieee80211-freq-limit = <5150000 5730000>;
+};

--- a/target/linux/qualcommax/image/Makefile
+++ b/target/linux/qualcommax/image/Makefile
@@ -36,6 +36,11 @@ define Device/UbiFit
 	IMAGE/factory.ubi := append-ubi
 endef
 
+define Build/tplink-re700x-factory
+	$(TOPDIR)/scripts/tplink-re700x-factory.py --rootfs $@ --output $@.factory
+	mv $@.factory $@
+endef
+
 include $(SUBTARGET).mk
 
 $(eval $(call BuildImage))

--- a/target/linux/qualcommax/image/ipq50xx.mk
+++ b/target/linux/qualcommax/image/ipq50xx.mk
@@ -240,6 +240,25 @@ define Device/xiaomi_redmi-ax5400
 endef
 TARGET_DEVICES += xiaomi_redmi-ax5400
 
+define Device/tplink_re700x
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := TP-Link
+	DEVICE_MODEL := RE700X
+	DEVICE_VARIANT := v1
+	SOC := ipq5018
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	NAND_SIZE := 128m
+	IMAGE_SIZE := 43008k
+	DEVICE_DTS_CONFIG := config@mp02.1
+	IMAGES += factory-webflash.bin
+	IMAGE/factory-webflash.bin := append-ubi | tplink-re700x-factory
+	DEVICE_PACKAGES := ath11k-firmware-ipq5018-qcn6122 \
+		ipq-wifi-tplink_re700x kmod-phy-realtek
+endef
+TARGET_DEVICES += tplink_re700x
+
 define Device/yuncore_ax830
 	$(call Device/FitImage)
 	$(call Device/UbiFit)

--- a/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/platform.sh
@@ -232,6 +232,11 @@ platform_do_upgrade() {
 		CI_DATA_UBIPART="rootfs"
 		nand_do_upgrade "$1"
 		;;
+	tplink,re700x)
+		CI_UBIPART="rootfs"
+		remove_oem_ubi_volume ubi_rootfs
+		nand_do_upgrade "$1"
+		;;
 	yuncore,ax830|\
 	yuncore,ax850|\
 	zyxel,scr50axe)


### PR DESCRIPTION
Adds support for the TP-Link RE700X — a dual-band Wi-Fi 6 (AX3000) range
extender (Qualcomm IPQ5018 + QCN6122) — on the existing qualcommax/ipq50xx
target.

Two commits:
1. **mac80211: ath11k: pick DP ring sizes at runtime based on total RAM** —
   ath11k's large default DP rings (~94 MB of skbs with two radios) OOM 256 MB
   IPQ5018 devices. Mirrors ath12k's runtime memory detection (`si_meminfo`,
   `< 512 MB` → smaller rings); devices with ≥ 512 MB are unaffected. This is
   what lets the RE700X (256 MB) run both radios.
2. **qualcommax: add support for TP-Link RE700X** — the device.

## Hardware status
- Verified: NAND boot, Ethernet (RTL8211F), 5 LEDs, 2 buttons, 2.4 GHz +
  5 GHz 802.11ax, clean boot from **both** dual-boot slots (`rootfs` /
  `rootfs_1`).
- Both radios run stably on the 256 MB device with the reduced DP rings; the
  runtime patch (commit 1) produces the same ring sizes at ≤ 256 MB as the
  reduction it is modelled on.

## Installation (no UART/soldering)
Flash `…-squashfs-factory-webflash.bin` from the stock TP-Link web UI.
`scripts/tplink-re700x-factory.py` wraps the rootfs UBI into the stock
`nvrammanager` upload container (same "tplink2022"/safeloader family as
`scripts/tplink-mkimage-2022.py`). Alternatively RAM-boot the initramfs via
U-Boot/TFTP and `sysupgrade`.

## Board data
QCN6122/IPQ5018 board-2.bin is in the companion PR (must merge first):
openwrt/firmware_qca-wireless#141

## Notes for reviewers
- The stock U-Boot passes a slot-correct `ubi.mtd=` but an unmountable
  `root=mtd:ubi_rootfs`; the DTS `/chosen` appends `root=/dev/ubiblock0_1`.
- The factory packer output is byte-identical to a packer previously verified
  end-to-end on hardware (stock web-GUI install → boots OpenWrt).
- The runtime ring-size approach follows ath12k — the direction suggested for
  the stalled openwrt/openwrt#21495.

Draft until the board-data PR lands (CI build needs it).
