### PR TITLE
scripts: dhcpv6: don't report custom ip6class if default

### DIFF
--- a/package/network/ipv6/odhcp6c/files/dhcpv6.script
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.script
@@ -1,10 +1,12 @@
 #!/bin/sh
 [ -z "$2" ] && echo "Error: should be run by odhcpc6c" && exit 1
 . /lib/functions.sh
+. /lib/functions/network.sh
 . /lib/netifd/netifd-proto.sh
 
 setup_interface () {
 	local device="$1"
+	local iaid
 	local prefsig=""
 	local addrsig=""
 
@@ -42,7 +44,9 @@ setup_interface () {
 		proto_add_dns_search "$domain"
 	done
 
+	network_generate_iface_iaid iaid "$device"
 	for prefix in $PREFIXES; do
+		prefix="${prefix/,class=$iaid/}"
 		proto_add_ipv6_prefix "$prefix"
 		prefsig="$prefsig ${prefix%%,*}"
 		local entry="${prefix#*/}"


### PR DESCRIPTION
`odhcp6c` returns delegated prefixes with a `class=<IAID>` tag if a custom IAID was specified in the `-P` argument. This tag must then be used for any prefix filter (`network.<interface>.ip6class`) instead of the uplink i/f name.

OpenWrt by default uses the first eight digits of the uplink i/f name's MD5 hash as IAID. Don't report a custom `class` tag for this default IAID.

This is an amendment to #23758 due to regression with IPv6 prefix filters.

Fixes: #23965

Please merge into Main and 25.12, before 25.12.5 is being tagged, to prevent unwanted regressions. Thanks and sorry for the oversight.