### PR TITLE
[25.12] mediatek: acer-predator-w6x: add LED boot status support

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-acer-predator-w6x.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-acer-predator-w6x.dtsi
@@ -11,6 +11,10 @@
 / {
 	aliases {
 		serial0 = &uart0;
+		led-boot = &led_status_rgb;
+		led-failsafe = &led_status_rgb;
+		led-running = &led_status_rgb;
+		led-upgrade = &led_status_rgb;
 	};
 
 	chosen: chosen {


### PR DESCRIPTION
Backport of a fix for Acer Predator W6X that adds `led-boot`, `led-failsafe`, `led-running`, and `led-upgrade` to the device DTSI so the system LED reflects the standard OpenWrt loading states.

Tested on an Acer Predator W6X.

Link: https://github.com/openwrt/openwrt/pull/23958

(cherry picked from commit 002e7613e06fdc32e3b339b7a281528bd4106193)

