### PR TITLE
realtek: support configurable MTU / jumbo frames on rtl83xx DSA ports

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/dsa.c
@@ -3,6 +3,7 @@
 #include <net/dsa.h>
 #include <linux/etherdevice.h>
 #include <linux/if_bridge.h>
+#include <linux/if_vlan.h>
 #include <linux/pcs/pcs.h>
 #include <asm/mach-rtl-otto/mach-rtl-otto.h>
 
@@ -1135,6 +1136,40 @@ static void rtldsa_port_disable(struct dsa_switch *ds, int port)
 	priv->r->traffic_set(port, 0);
 
 	priv->ports[port].enable = false;
+}
+
+static int rtldsa_port_max_mtu(struct dsa_switch *ds, int port)
+{
+	return RTL83XX_MAX_MTU;
+}
+
+static int rtldsa_port_change_mtu(struct dsa_switch *ds, int port, int new_mtu)
+{
+	struct rtl838x_switch_priv *priv = ds->priv;
+	int frame_size, reg;
+
+	if (!priv->r->mac_max_len_reg)
+		return -EOPNOTSUPP;
+
+	/* new_mtu is the L2 payload size, but the MAC limit counts the whole
+	 * frame: the Ethernet header, up to two stacked VLAN tags (802.1ad
+	 * QinQ) and the FCS. That headroom also covers the 4-byte RTL Otto DSA
+	 * tail tag on the CPU port, which the DSA core programs with the largest
+	 * user-port MTU. The MAC TAG_INC bit is left at its reset default of 0,
+	 * so tag bytes are not counted twice.
+	 */
+	frame_size = new_mtu + VLAN_ETH_HLEN + VLAN_HLEN + ETH_FCS_LEN;
+
+	/* RTL930x/RTL931x have one register per port; RTL838x/RTL839x share a
+	 * single global one that mac_max_len_reg() returns only for the CPU
+	 * port (0 otherwise), so the shared limit is programmed exactly once.
+	 */
+	reg = priv->r->mac_max_len_reg(priv, port);
+	if (reg)
+		sw_w32_mask(RTL83XX_MAC_MAX_LEN_MASK,
+			    RTL83XX_MAC_MAX_LEN_VAL(frame_size), reg);
+
+	return 0;
 }
 
 static bool rtldsa_support_eee(struct dsa_switch *ds, int port)
@@ -2643,6 +2678,9 @@ const struct dsa_switch_ops rtldsa_83xx_switch_ops = {
 	.port_enable		= rtldsa_port_enable,
 	.port_disable		= rtldsa_port_disable,
 
+	.port_change_mtu	= rtldsa_port_change_mtu,
+	.port_max_mtu		= rtldsa_port_max_mtu,
+
 	.support_eee		= rtldsa_support_eee,
 	.set_mac_eee		= rtldsa_set_mac_eee,
 
@@ -2701,6 +2739,9 @@ const struct dsa_switch_ops rtldsa_93xx_switch_ops = {
 
 	.port_enable		= rtldsa_port_enable,
 	.port_disable		= rtldsa_port_disable,
+
+	.port_change_mtu	= rtldsa_port_change_mtu,
+	.port_max_mtu		= rtldsa_port_max_mtu,
 
 	.support_eee		= rtldsa_support_eee,
 	.set_mac_eee		= rtldsa_set_mac_eee,

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl-otto.h
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl-otto.h
@@ -15,6 +15,40 @@
 #define RTL930X_MAC_L2_PORT_CTRL(port)		(0x3268 + (((port) << 6)))
 #define RTL931X_MAC_L2_PORT_CTRL		(0x6000)
 
+/* MAC maximum packet length (jumbo frame) control.
+ *
+ * The switch MAC drops frames whose L2 length exceeds the configured maximum.
+ * RTL930x/RTL931x have one register per user port plus a dedicated register for
+ * the internal CPU port, while RTL838x/RTL839x use a single global register that
+ * applies to every port. The length is a direct byte value held in two 14-bit
+ * fields (high-speed links in [13:0], 10/100M links in [27:14]); bit 28 selects
+ * whether VLAN tag bytes count towards the limit. Register offsets taken from
+ * the reverse-engineered Realtek register maps at https://svanheule.net/realtek/
+ */
+#define RTL930X_MAC_L2_PORT_MAX_LEN_CTRL(port)	(0x326C + (((port) << 6)))
+#define RTL930X_MAC_L2_CPU_MAX_LEN_CTRL		(0xA3A0)
+#define RTL931X_MAC_L2_PORT_MAX_LEN_CTRL(port)	(0x5554 + (((port) << 2)))
+#define RTL931X_MAC_L2_CPU_MAX_LEN_CTRL		(0x1368)
+#define RTL838X_MAC_MAX_LEN_CTRL		(0xA9E0)
+#define RTL839X_MAC_MAX_LEN_CTRL		(0x02B0)
+
+/* Both length fields are 14 bits wide (hardware maximum 16383 bytes). */
+#define RTL83XX_MAC_MAX_LEN_FIELD		GENMASK(13, 0)
+/* Mask of both length fields, leaving the tag-inclusion bit (28) untouched. */
+#define RTL83XX_MAC_MAX_LEN_MASK \
+	(RTL83XX_MAC_MAX_LEN_FIELD | (RTL83XX_MAC_MAX_LEN_FIELD << 14))
+/* Encode @len into both the high-speed and the 10/100M length field. */
+#define RTL83XX_MAC_MAX_LEN_VAL(len) \
+	(((len) & RTL83XX_MAC_MAX_LEN_FIELD) | (((len) & RTL83XX_MAC_MAX_LEN_FIELD) << 14))
+
+/*
+ * Largest L2 MTU advertised on the DSA user ports. The MAC length field would
+ * allow much larger frames, but 9000 is the de-facto jumbo MTU; the effective
+ * value is additionally bounded by the DSA conduit (the rtl838x_eth CPU
+ * interface) which advertises a 9000-byte maximum.
+ */
+#define RTL83XX_MAX_MTU				9000
+
 #define RTL838X_RST_GLB_CTRL_0			(0x003c)
 
 #define RTL838X_MAC_FORCE_MODE_CTRL		(0xa104)
@@ -1388,6 +1422,15 @@ struct rtldsa_config {
 	int mac_link_sts;
 	int  (*mac_force_mode_ctrl)(int port);
 	int  (*mac_port_ctrl)(int port);
+
+	/**
+	 * @mac_max_len_reg: Return the switch register holding the MAC maximum
+	 * accepted L2 frame length for @port, or 0 if @port has none. Families
+	 * with one register per port return the matching register; those with a
+	 * single global register return it only for the CPU port (which the DSA
+	 * core always updates with the largest user-port MTU) and 0 otherwise.
+	 */
+	int  (*mac_max_len_reg)(struct rtl838x_switch_priv *priv, int port);
 	int  (*l2_port_new_salrn)(int port);
 	int  (*l2_port_new_sa_fwd)(int port);
 	int (*set_ageing_time)(unsigned long msec);

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl838x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl838x.c
@@ -311,6 +311,17 @@ static inline int rtl838x_mac_port_ctrl(int p)
 	return RTL838X_MAC_PORT_CTRL(p);
 }
 
+static int rtldsa_838x_mac_max_len_reg(struct rtl838x_switch_priv *priv, int port)
+{
+	/* A single global max-length register, programmed once via the CPU port
+	 * (which the DSA core reprograms with the largest user-port MTU); return
+	 * 0 for the other ports so the shared limit is not shrunk. */
+	if (port != priv->r->cpu_port)
+		return 0;
+
+	return RTL838X_MAC_MAX_LEN_CTRL;
+}
+
 static inline int rtl838x_l2_port_new_salrn(int p)
 {
 	return RTL838X_L2_PORT_NEW_SALRN(p);
@@ -1818,6 +1829,7 @@ const struct rtldsa_config rtldsa_838x_cfg = {
 	.stp_get = rtldsa_838x_stp_get,
 	.stp_set = rtl838x_stp_set,
 	.mac_port_ctrl = rtl838x_mac_port_ctrl,
+	.mac_max_len_reg = rtldsa_838x_mac_max_len_reg,
 	.l2_port_new_salrn = rtl838x_l2_port_new_salrn,
 	.l2_port_new_sa_fwd = rtl838x_l2_port_new_sa_fwd,
 	.get_mirror_config = rtldsa_838x_get_mirror_config,

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl839x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl839x.c
@@ -348,6 +348,17 @@ static inline int rtl839x_mac_port_ctrl(int p)
 	return RTL839X_MAC_PORT_CTRL(p);
 }
 
+static int rtldsa_839x_mac_max_len_reg(struct rtl838x_switch_priv *priv, int port)
+{
+	/* A single global max-length register, programmed once via the CPU port
+	 * (which the DSA core reprograms with the largest user-port MTU); return
+	 * 0 for the other ports so the shared limit is not shrunk. */
+	if (port != priv->r->cpu_port)
+		return 0;
+
+	return RTL839X_MAC_MAX_LEN_CTRL;
+}
+
 static inline int rtl839x_l2_port_new_salrn(int p)
 {
 	return RTL839X_L2_PORT_NEW_SALRN(p);
@@ -1730,6 +1741,7 @@ const struct rtldsa_config rtldsa_839x_cfg = {
 	.mac_force_mode_ctrl = rtl839x_mac_force_mode_ctrl,
 	.mac_link_sts = RTL839X_MAC_LINK_STS,
 	.mac_port_ctrl = rtl839x_mac_port_ctrl,
+	.mac_max_len_reg = rtldsa_839x_mac_max_len_reg,
 	.l2_port_new_salrn = rtl839x_l2_port_new_salrn,
 	.l2_port_new_sa_fwd = rtl839x_l2_port_new_sa_fwd,
 	.get_mirror_config = rtldsa_839x_get_mirror_config,

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -669,6 +669,16 @@ static inline int rtl930x_mac_port_ctrl(int p)
 	return RTL930X_MAC_L2_PORT_CTRL(p);
 }
 
+static int rtldsa_930x_mac_max_len_reg(struct rtl838x_switch_priv *priv, int port)
+{
+	/* One max-length register per user port plus a dedicated one for the
+	 * internal CPU port. */
+	if (port == priv->r->cpu_port)
+		return RTL930X_MAC_L2_CPU_MAX_LEN_CTRL;
+
+	return RTL930X_MAC_L2_PORT_MAX_LEN_CTRL(port);
+}
+
 static u64 rtl930x_l2_hash_seed(u64 mac, u32 vid)
 {
 	u64 v = vid;
@@ -2544,6 +2554,7 @@ const struct rtldsa_config rtldsa_930x_cfg = {
 	.mac_link_sts = RTL930X_MAC_LINK_STS,
 	.mac_force_mode_ctrl = rtl930x_mac_force_mode_ctrl,
 	.mac_port_ctrl = rtl930x_mac_port_ctrl,
+	.mac_max_len_reg = rtldsa_930x_mac_max_len_reg,
 	.l2_port_new_salrn = rtl930x_l2_port_new_salrn,
 	.l2_port_new_sa_fwd = rtl930x_l2_port_new_sa_fwd,
 	.get_mirror_config = rtldsa_930x_get_mirror_config,

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl931x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl931x.c
@@ -374,6 +374,16 @@ static inline int rtl931x_mac_port_ctrl(int p)
 	return RTL931X_MAC_L2_PORT_CTRL + (p << 7);
 }
 
+static int rtldsa_931x_mac_max_len_reg(struct rtl838x_switch_priv *priv, int port)
+{
+	/* One max-length register per user port plus a dedicated one for the
+	 * internal CPU port. */
+	if (port == priv->r->cpu_port)
+		return RTL931X_MAC_L2_CPU_MAX_LEN_CTRL;
+
+	return RTL931X_MAC_L2_PORT_MAX_LEN_CTRL(port);
+}
+
 static inline int rtl931x_l2_port_new_salrn(int p)
 {
 	return RTL931X_L2_PORT_NEW_SALRN(p);
@@ -2000,6 +2010,7 @@ const struct rtldsa_config rtldsa_931x_cfg = {
 	.mac_force_mode_ctrl = rtl931x_mac_force_mode_ctrl,
 	.mac_link_sts = RTL931X_MAC_LINK_STS,
 	.mac_port_ctrl = rtl931x_mac_port_ctrl,
+	.mac_max_len_reg = rtldsa_931x_mac_max_len_reg,
 	.l2_port_new_salrn = rtl931x_l2_port_new_salrn,
 	.l2_port_new_sa_fwd = rtl931x_l2_port_new_sa_fwd,
 	.get_mirror_config = rtldsa_931x_get_mirror_config,

--- a/target/linux/realtek/files-6.18/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.18/drivers/net/ethernet/rtl838x_eth.c
@@ -7,6 +7,7 @@
 #include <linux/dma-mapping.h>
 #include <linux/etherdevice.h>
 #include <linux/interrupt.h>
+#include <linux/if_vlan.h>
 #include <linux/io.h>
 #include <linux/mfd/syscon.h>
 #include <linux/minmax.h>
@@ -42,12 +43,14 @@
 #define RX_TRUNCATE_EN_93XX		BIT(6)
 #define RX_TRUNCATE_EN_83XX		BIT(4)
 #define TX_PAD_EN_838X			BIT(5)
-#define RING_BUFFER			1600
-
-/* Define page pool that holds 2KB fragments in 4KB pages and has 8 safety pages */
-#define PPOOL_FRAG_SIZE			2048
-#define PPOOL_SIZE			(DIV_ROUND_UP(RTETH_RX_RING_SIZE, \
-					 PAGE_SIZE / PPOOL_FRAG_SIZE) + 8)
+/*
+ * One page (group) holds exactly one RX frame, so the page_pool needs to cache
+ * at most one page per RX descriptor plus a few spares for in-flight recycling.
+ * The page order is derived from the MTU (see rteth_rx_page_order()) and the
+ * pool is rebuilt in .ndo_change_mtu when it changes, so standard 1500-byte
+ * traffic keeps small order-0 buffers and only jumbo MTUs allocate big ones.
+ */
+#define RTETH_PPOOL_SIZE		(RTETH_RX_RING_SIZE + 8)
 
 struct rteth_packet {
 	/* hardware header part as required by SoC */
@@ -123,7 +126,44 @@ struct rteth_ctrl {
 	dma_addr_t		tx_dma;
 	spinlock_t		tx_lock;
 	struct rteth_tx		*tx_data;
+	/* RX buffer geometry, sized from the current MTU (see rteth_change_mtu) */
+	unsigned int		rx_frag_size;
+	unsigned int		rx_buf_size;
+	unsigned int		rx_page_order;
 };
+
+/* Largest L2 frame the conduit must receive for a netdev @mtu: Ethernet header,
+ * up to two VLAN tags, the payload and the FCS. */
+static unsigned int rteth_rx_frame_len(unsigned int mtu)
+{
+	return mtu + ETH_HLEN + 2 * VLAN_HLEN + ETH_FCS_LEN;
+}
+
+/*
+ * page_pool fragment size needed to hold one such frame plus the reserved skb
+ * headroom and the trailing skb_shared_info used by napi_build_skb(). For a
+ * standard 1500 byte MTU this stays below half a page, so the page_pool keeps
+ * packing two buffers per page exactly as before; jumbo MTUs grow the fragment
+ * (and, via rteth_rx_page_order(), the backing page order).
+ */
+static unsigned int rteth_rx_frag_size(unsigned int mtu)
+{
+	return SKB_DATA_ALIGN(RTETH_SKB_HEADROOM + rteth_rx_frame_len(mtu)) +
+	       SKB_DATA_ALIGN(sizeof(struct skb_shared_info));
+}
+
+/* Backing page order for a fragment of @frag_size (0 for anything <= one page). */
+static unsigned int rteth_rx_page_order(unsigned int frag_size)
+{
+	return get_order(frag_size);
+}
+
+/* DMA-writable region within a fragment of @frag_size. */
+static unsigned int rteth_rx_buf_size(unsigned int frag_size)
+{
+	return frag_size - RTETH_SKB_HEADROOM -
+	       SKB_DATA_ALIGN(sizeof(struct skb_shared_info));
+}
 
 static void rteth_838x_create_tx_header(struct rteth_packet *h, unsigned int port, int prio)
 {
@@ -530,9 +570,9 @@ static void rteth_hw_ring_setup(struct rteth_ctrl *ctrl)
 
 static void rteth_838x_hw_en_rxtx(struct rteth_ctrl *ctrl)
 {
-	/* Truncate RX buffer to DEFAULT_MTU bytes, pad TX */
+	/* Truncate RX at the current buffer capacity, pad TX */
 	regmap_write(ctrl->map, ctrl->r->dma_if_ctrl,
-		     (DEFAULT_MTU << 16) | RX_TRUNCATE_EN_83XX | TX_PAD_EN_838X);
+		     (ctrl->rx_buf_size << 16) | RX_TRUNCATE_EN_83XX | TX_PAD_EN_838X);
 
 	rteth_enable_all_rx_irqs(ctrl);
 
@@ -555,8 +595,8 @@ static void rteth_838x_hw_en_rxtx(struct rteth_ctrl *ctrl)
 
 static void rteth_839x_hw_en_rxtx(struct rteth_ctrl *ctrl)
 {
-	/* Setup CPU-Port: RX Buffer */
-	regmap_write(ctrl->map, ctrl->r->dma_if_ctrl, (DEFAULT_MTU << 5) | RX_TRUNCATE_EN_83XX);
+	/* Setup CPU-Port: truncate RX at the current buffer capacity */
+	regmap_write(ctrl->map, ctrl->r->dma_if_ctrl, (ctrl->rx_buf_size << 5) | RX_TRUNCATE_EN_83XX);
 
 	rteth_enable_all_rx_irqs(ctrl);
 
@@ -579,8 +619,8 @@ static void rteth_839x_hw_en_rxtx(struct rteth_ctrl *ctrl)
 
 static void rteth_930x_hw_en_rxtx(struct rteth_ctrl *ctrl)
 {
-	/* Setup CPU-Port: RX Buffer truncated at DEFAULT_MTU Bytes */
-	regmap_write(ctrl->map, ctrl->r->dma_if_ctrl, (DEFAULT_MTU << 16) | RX_TRUNCATE_EN_93XX);
+	/* Setup CPU-Port: truncate RX at the current buffer capacity */
+	regmap_write(ctrl->map, ctrl->r->dma_if_ctrl, (ctrl->rx_buf_size << 16) | RX_TRUNCATE_EN_93XX);
 
 	rteth_enable_all_rx_irqs(ctrl);
 
@@ -596,8 +636,8 @@ static void rteth_930x_hw_en_rxtx(struct rteth_ctrl *ctrl)
 
 static void rteth_931x_hw_en_rxtx(struct rteth_ctrl *ctrl)
 {
-	/* Setup CPU-Port: RX Buffer truncated at DEFAULT_MTU Bytes */
-	regmap_write(ctrl->map, ctrl->r->dma_if_ctrl, (DEFAULT_MTU << 16) | RX_TRUNCATE_EN_93XX);
+	/* Setup CPU-Port: truncate RX at the current buffer capacity */
+	regmap_write(ctrl->map, ctrl->r->dma_if_ctrl, (ctrl->rx_buf_size << 16) | RX_TRUNCATE_EN_93XX);
 
 	rteth_enable_all_rx_irqs(ctrl);
 
@@ -645,6 +685,44 @@ static void rteth_free_rx_buffers(struct rteth_ctrl *ctrl)
 	}
 }
 
+static void rteth_destroy_page_pools(struct rteth_ctrl *ctrl)
+{
+	for (int i = 0; i < RTETH_RX_RINGS; i++) {
+		if (!ctrl->rx_qs[i].page_pool)
+			continue;
+
+		page_pool_destroy(ctrl->rx_qs[i].page_pool);
+		ctrl->rx_qs[i].page_pool = NULL;
+	}
+}
+
+static int rteth_create_page_pools(struct rteth_ctrl *ctrl)
+{
+	struct page_pool_params pp_params = {
+		.order = ctrl->rx_page_order,
+		.flags = PP_FLAG_DMA_MAP | PP_FLAG_DMA_SYNC_DEV,
+		.pool_size = RTETH_PPOOL_SIZE,
+		.nid = dev_to_node(&ctrl->pdev->dev),
+		.dev = &ctrl->pdev->dev,
+		.dma_dir = DMA_FROM_DEVICE,
+		.max_len = PAGE_SIZE << ctrl->rx_page_order,
+	};
+
+	for (int i = 0; i < RTETH_RX_RINGS; i++) {
+		pp_params.napi = &ctrl->rx_qs[i].napi;
+		ctrl->rx_qs[i].page_pool = page_pool_create(&pp_params);
+		if (IS_ERR(ctrl->rx_qs[i].page_pool)) {
+			int err = PTR_ERR(ctrl->rx_qs[i].page_pool);
+
+			ctrl->rx_qs[i].page_pool = NULL;
+			rteth_destroy_page_pools(ctrl);
+			return err;
+		}
+	}
+
+	return 0;
+}
+
 static int rteth_setup_ring_buffer(struct rteth_ctrl *ctrl)
 {
 	struct rteth_packet *packet;
@@ -653,19 +731,11 @@ static int rteth_setup_ring_buffer(struct rteth_ctrl *ctrl)
 	unsigned int offset;
 	struct page *page;
 
-	/*
-	 * The conversion to page_pool raised some questions about the memory consumption of SKBs
-	 * and the DMA capabilities of the network adapter. Be defensive and add some checks to
-	 * assist further error analysis.
-	 */
-	BUILD_BUG_ON(RTETH_SKB_HEADROOM + RING_BUFFER +
-		     SKB_DATA_ALIGN(sizeof(struct skb_shared_info)) > PPOOL_FRAG_SIZE);
-
 	for (int r = 0; r < RTETH_RX_RINGS; r++) {
 		for (int i = 0; i < RTETH_RX_RING_SIZE; i++) {
 			packet = &ctrl->rx_data[r].packet[i];
 			page = page_pool_dev_alloc_frag(ctrl->rx_qs[r].page_pool,
-							&offset, PPOOL_FRAG_SIZE);
+							&offset, ctrl->rx_frag_size);
 			if (!page) {
 				dev_err(&ctrl->pdev->dev,
 					"Failed to allocate RX fragment from pool\n");
@@ -676,7 +746,7 @@ static int rteth_setup_ring_buffer(struct rteth_ctrl *ctrl)
 			highmem |= PageHighMem(page);
 			paddr = max(paddr, page_to_phys(page));
 
-			packet->size = RING_BUFFER;
+			packet->size = ctrl->rx_buf_size;
 			packet->dma = page_pool_get_dma_addr(page) + RTETH_SKB_HEADROOM + offset;
 			packet->page = page;
 			packet->page_offset = offset;
@@ -1003,6 +1073,93 @@ static void rteth_tx_timeout(struct net_device *dev, unsigned int txqueue)
 	}
 }
 
+static int rteth_change_mtu(struct net_device *dev, int new_mtu)
+{
+	struct rteth_ctrl *ctrl = netdev_priv(dev);
+	unsigned int new_frag = rteth_rx_frag_size(new_mtu);
+	unsigned int new_order = rteth_rx_page_order(new_frag);
+	int err = 0;
+
+	/* Same fragment size: the existing buffers already fit, just record it. */
+	if (new_frag == ctrl->rx_frag_size) {
+		WRITE_ONCE(dev->mtu, new_mtu);
+		return 0;
+	}
+
+	/* Interface down: the rings are (re)filled on the next open, but the page
+	 * pools must already match the new order so that the open-time fragment
+	 * allocation (which requires frag_size <= PAGE_SIZE << order) succeeds.
+	 * Rebuild them on an order change before committing the new geometry, and
+	 * roll back to the previous (working) order if the allocation fails, so a
+	 * later open() never dereferences a NULL page pool.
+	 */
+	if (!netif_running(dev)) {
+		if (new_order != ctrl->rx_page_order) {
+			unsigned int old_order = ctrl->rx_page_order;
+
+			rteth_destroy_page_pools(ctrl);
+			ctrl->rx_page_order = new_order;
+			err = rteth_create_page_pools(ctrl);
+			if (err) {
+				ctrl->rx_page_order = old_order;
+				if (rteth_create_page_pools(ctrl))
+					netdev_err(dev, "failed to restore RX page pools after mtu %d\n",
+						   new_mtu);
+				return err;
+			}
+		}
+		ctrl->rx_frag_size = new_frag;
+		ctrl->rx_buf_size = rteth_rx_buf_size(new_frag);
+		WRITE_ONCE(dev->mtu, new_mtu);
+		return 0;
+	}
+
+	/* Otherwise the RX buffers must be reallocated. NAPI has to be stopped
+	 * and the page pools (re)created in process context, the ring refill and
+	 * register programming under the device lock - mirroring rteth_open().
+	 */
+	for (int i = 0; i < RTETH_RX_RINGS; i++)
+		napi_disable(&ctrl->rx_qs[i].napi);
+
+	scoped_guard(spinlock_irqsave, &ctrl->lock) {
+		regmap_clear_bits(ctrl->map, ctrl->r->dma_if_ctrl, ctrl->r->tx_rx_enable);
+		rteth_free_rx_buffers(ctrl);
+	}
+
+	rteth_destroy_page_pools(ctrl);
+	ctrl->rx_frag_size = new_frag;
+	ctrl->rx_page_order = new_order;
+	ctrl->rx_buf_size = rteth_rx_buf_size(new_frag);
+
+	err = rteth_create_page_pools(ctrl);
+	if (err)
+		goto out_detach;
+
+	scoped_guard(spinlock_irqsave, &ctrl->lock) {
+		err = rteth_setup_ring_buffer(ctrl);
+		if (err)
+			break;
+
+		rteth_hw_ring_setup(ctrl);
+		ctrl->r->hw_en_rxtx(ctrl);
+	}
+	if (err)
+		goto out_detach;
+
+	WRITE_ONCE(dev->mtu, new_mtu);
+
+	for (int i = 0; i < RTETH_RX_RINGS; i++)
+		napi_enable(&ctrl->rx_qs[i].napi);
+
+	return 0;
+
+out_detach:
+	netdev_err(dev, "failed to resize RX buffers for mtu %d, bringing interface down\n",
+		   new_mtu);
+	netif_device_detach(dev);
+	return err;
+}
+
 static int rteth_get_dsa_port(struct sk_buff *skb, struct net_device *dev)
 {
 	struct rteth_ctrl *ctrl = netdev_priv(dev);
@@ -1119,14 +1276,14 @@ static int rteth_hw_receive(struct net_device *dev, int ring, int budget)
 		packet = &ctrl->rx_data[ring].packet[slot];
 		len = packet->len - ETH_FCS_LEN;
 
-		if (unlikely(len > RING_BUFFER)) {
+		if (unlikely(len > ctrl->rx_buf_size)) {
 			netdev_err(dev, "invalid packet with %d bytes received\n", len);
 			dev->stats.rx_errors++;
 			goto recycle;
 		}
 
 		new_page = page_pool_dev_alloc_frag(ctrl->rx_qs[ring].page_pool,
-						    &new_offset, PPOOL_FRAG_SIZE);
+						    &new_offset, ctrl->rx_frag_size);
 		if (unlikely(!new_page)) {
 			dev->stats.rx_dropped++;
 			goto recycle;
@@ -1142,7 +1299,7 @@ static int rteth_hw_receive(struct net_device *dev, int ring, int budget)
 		page_pool_dma_sync_for_cpu(ctrl->rx_qs[ring].page_pool, old_page,
 					   old_offset + RTETH_SKB_HEADROOM, len);
 
-		skb = napi_build_skb(page_address(old_page) + old_offset, PPOOL_FRAG_SIZE);
+		skb = napi_build_skb(page_address(old_page) + old_offset, ctrl->rx_frag_size);
 		if (unlikely(!skb)) {
 			page_pool_put_full_page(ctrl->rx_qs[ring].page_pool, old_page, true);
 			dev->stats.rx_dropped++;
@@ -1418,6 +1575,7 @@ static const struct net_device_ops rteth_838x_netdev_ops = {
 	.ndo_validate_addr = eth_validate_addr,
 	.ndo_set_rx_mode = rteth_838x_set_rx_mode,
 	.ndo_tx_timeout = rteth_tx_timeout,
+	.ndo_change_mtu = rteth_change_mtu,
 	.ndo_set_features = rteth_83xx_set_features,
 	.ndo_fix_features = rteth_fix_features,
 	.ndo_setup_tc = rteth_setup_tc,
@@ -1464,6 +1622,7 @@ static const struct net_device_ops rteth_839x_netdev_ops = {
 	.ndo_validate_addr = eth_validate_addr,
 	.ndo_set_rx_mode = rteth_839x_set_rx_mode,
 	.ndo_tx_timeout = rteth_tx_timeout,
+	.ndo_change_mtu = rteth_change_mtu,
 	.ndo_set_features = rteth_83xx_set_features,
 	.ndo_fix_features = rteth_fix_features,
 	.ndo_setup_tc = rteth_setup_tc,
@@ -1509,6 +1668,7 @@ static const struct net_device_ops rteth_930x_netdev_ops = {
 	.ndo_validate_addr = eth_validate_addr,
 	.ndo_set_rx_mode = rteth_930x_set_rx_mode,
 	.ndo_tx_timeout = rteth_tx_timeout,
+	.ndo_change_mtu = rteth_change_mtu,
 	.ndo_set_features = rteth_93xx_set_features,
 	.ndo_fix_features = rteth_fix_features,
 	.ndo_setup_tc = rteth_setup_tc,
@@ -1554,6 +1714,7 @@ static const struct net_device_ops rteth_931x_netdev_ops = {
 	.ndo_validate_addr = eth_validate_addr,
 	.ndo_set_rx_mode = rteth_931x_set_rx_mode,
 	.ndo_tx_timeout = rteth_tx_timeout,
+	.ndo_change_mtu = rteth_change_mtu,
 	.ndo_set_features = rteth_93xx_set_features,
 	.ndo_fix_features = rteth_fix_features,
 	.ndo_setup_tc = rteth_setup_tc,
@@ -1630,16 +1791,6 @@ static void rteth_metadata_dst_free(struct rteth_ctrl *ctrl)
 
 static int rteth_probe(struct platform_device *pdev)
 {
-	struct page_pool_params pp_params = {
-		.order = 0,
-		.flags = PP_FLAG_DMA_MAP | PP_FLAG_DMA_SYNC_DEV,
-		.pool_size = PPOOL_SIZE,
-		.max_len = PAGE_SIZE,
-		.nid = dev_to_node(&pdev->dev),
-		.dev = &pdev->dev,
-		.dma_dir = DMA_FROM_DEVICE,
-	};
-
 	struct device_node *dn = pdev->dev.of_node;
 	const struct rteth_config *cfg;
 	u8 mac_addr[ETH_ALEN] = {0};
@@ -1686,7 +1837,11 @@ static int rteth_probe(struct platform_device *pdev)
 
 	dev->ethtool_ops = &rteth_ethtool_ops;
 	dev->min_mtu = ETH_ZLEN;
-	dev->max_mtu = DEFAULT_MTU;
+	dev->max_mtu = RTETH_MAX_MTU;
+	dev->mtu = DEFAULT_MTU;
+	ctrl->rx_frag_size = rteth_rx_frag_size(dev->mtu);
+	ctrl->rx_page_order = rteth_rx_page_order(ctrl->rx_frag_size);
+	ctrl->rx_buf_size = rteth_rx_buf_size(ctrl->rx_frag_size);
 	dev->features = NETIF_F_RXCSUM;
 	dev->hw_features = NETIF_F_RXCSUM;
 	dev->netdev_ops = ctrl->r->netdev_ops;
@@ -1773,15 +1928,10 @@ static int rteth_probe(struct platform_device *pdev)
 		goto cleanup;
 	}
 
-	for (int i = 0; i < RTETH_RX_RINGS; i++) {
-		pp_params.napi = &ctrl->rx_qs[i].napi;
-		ctrl->rx_qs[i].page_pool = page_pool_create(&pp_params);
-		if (IS_ERR(ctrl->rx_qs[i].page_pool)) {
-			err = dev_err_probe(&pdev->dev, PTR_ERR(ctrl->rx_qs[i].page_pool),
-					    "Failed to create page pool for ring %d\n", i);
-			ctrl->rx_qs[i].page_pool = NULL;
-			goto cleanup;
-		}
+	err = rteth_create_page_pools(ctrl);
+	if (err) {
+		dev_err_probe(&pdev->dev, err, "Failed to create RX page pools\n");
+		goto cleanup;
 	}
 
 	err = rteth_metadata_dst_alloc(ctrl);
@@ -1798,11 +1948,9 @@ cleanup:
 	rteth_metadata_dst_free(ctrl);
 	if (ctrl->phylink)
 		phylink_destroy(ctrl->phylink);
-	for (int i = 0; i < RTETH_RX_RINGS; i++) {
+	for (int i = 0; i < RTETH_RX_RINGS; i++)
 		netif_napi_del(&ctrl->rx_qs[i].napi);
-		if (ctrl->rx_qs[i].page_pool)
-			page_pool_destroy(ctrl->rx_qs[i].page_pool);
-	}
+	rteth_destroy_page_pools(ctrl);
 
 	return err;
 }
@@ -1819,11 +1967,9 @@ static void rteth_remove(struct platform_device *pdev)
 	if (ctrl->phylink)
 		phylink_destroy(ctrl->phylink);
 
-	for (int i = 0; i < RTETH_RX_RINGS; i++) {
+	for (int i = 0; i < RTETH_RX_RINGS; i++)
 		netif_napi_del(&ctrl->rx_qs[i].napi);
-		if (ctrl->rx_qs[i].page_pool)
-			page_pool_destroy(ctrl->rx_qs[i].page_pool);
-	}
+	rteth_destroy_page_pools(ctrl);
 }
 
 static const struct of_device_id rteth_of_ids[] = {

--- a/target/linux/realtek/files-6.18/drivers/net/ethernet/rtl838x_eth.h
+++ b/target/linux/realtek/files-6.18/drivers/net/ethernet/rtl838x_eth.h
@@ -181,8 +181,14 @@
 
 #define RTL93XX_CPU_TAG1_IGNORE_STP_MASK	GENMASK(2, 2)
 
-/* Default MTU with jumbo frames support */
-#define DEFAULT_MTU 9000
+/* Default MTU the conduit comes up with (one standard frame per RX buffer). */
+#define DEFAULT_MTU 1500
+
+/* Largest MTU the conduit advertises. The RX buffers are resized on demand in
+ * .ndo_change_mtu, so this only needs to be large enough for the jumbo frames
+ * the switch MAC can forward to the CPU (the rtl83xx ports default to 12 KB).
+ */
+#define RTETH_MAX_MTU 9216
 
 struct p_hdr;
 struct dsa_tag;


### PR DESCRIPTION
Fixes #23969

## What this does

The out-of-tree `rtl83xx` DSA driver never implemented `port_change_mtu` /
`port_max_mtu`, so the DSA core capped every user port at MTU 1500 and rejected
anything larger, even though the Realtek Otto switch MACs accept far larger
frames (the rtl930x ports power up with a 12 KB limit). Two commits.

### 1) realtek: support configurable MTU / jumbo frames on rtl83xx DSA ports
- Adds `.port_max_mtu` (9000) and `.port_change_mtu` to the rtl83xx
  `dsa_switch_ops`.
- A single per-SoC `mac_max_len_reg()` callback returns the MAC max-length
  register for a port and abstracts the family differences: RTL930x/RTL931x have
  one register per user port plus a dedicated CPU-port register; RTL838x/RTL839x
  expose a single global register, returned only for the CPU port (0 otherwise),
  which the DSA core always programs with the largest user-port MTU. The common
  register write lives once in `port_change_mtu()`.
- The programmed frame limit allows for the Ethernet header, two stacked VLAN
  tags (802.1ad/QinQ) and the FCS; on the CPU port that headroom also covers the
  4-byte RTL Otto DSA tail tag.

### 2) realtek: rtl838x-eth: support jumbo frame reception
- The conduit NIC advertised `max_mtu = 9000` but only allocated 1600-byte RX
  fragments, so jumbo frames to the CPU were dropped. It now sizes the RX
  `page_pool` fragments from the MTU (with a `.ndo_change_mtu` that rebuilds the
  pools) and raises `max_mtu` to 9216, so that after the 4-byte DSA tag the user
  ports reach a full 9000. At the default 1500 MTU the fragments stay sub-2 KB,
  two per page, so behaviour and memory use for existing devices are unchanged.

## Hardware validation

Test device: **Hasivo S1100W-8XGT-SE (RTL9303 / rtl930x)**.

Validated on **6.18** (the PR target), with #23947 applied so this board's
RTL8264 PHYs come up (see *Known limitations*). Read live from the running SoC:
- All lan ports register; no PHY/DSA errors.
- `ip link set lanN mtu 9000` → succeeds and `eth0` tracks to 9004; `9001` is
  rejected (`port_max_mtu = 9000`).
- Per-port MAC max-length register (rtl930x `0x326c`, lan1): power-up default
  `0x0c003000` (12 KB on both 14-bit fields) → programmed to `0x08d0a342`
  (= frame 9026 = `9000 + ETH_HLEN + 2*VLAN_HLEN + FCS`) at MTU 9000; the
  CPU-port register `0xa3a0` tracks it.
- `eth0` accepts up to 9216 and rejects 9217. No oops/Call Trace.

The same switch-side behaviour and register values were also confirmed earlier on
**6.12** (25.12.4) by backporting the identical commit-1 logic.

## Known limitations / not (yet) tested

- **End-to-end data-plane jumbo *reception* was not exercised on hardware.** On
  the 6.18 test bench the host↔switch link on the test port turned out to be
  one-directional (the host receives the switch's frames — ~1.9M frames counted —
  but its own frames never reach the switch; a lab cable/transceiver problem that
  persisted across forced link speeds and bridge/VLAN configurations), so a
  CPU-terminated jumbo `ping` could not be completed. The switch itself forwards
  fine (another port linked at 10G and entered forwarding), and **a control build
  with commit 2 reverted showed the *identical* connectivity behaviour**, so this
  is a lab issue unrelated to the change and commit 2 does not regress the conduit
  RX path. On 6.12 the conduit is the older pre-`page_pool` driver, so commit 2's
  RX path cannot be exercised there at all.
- **Master 6.18 does not bring this board's RTL8264 PHYs up without #23947** (the
  826xb patch table is selected by PHY ID instead of chip version, leaving the PCS
  unlocked → `-ETIME`); that separate, in-flight fix is why the runtime validation
  above was done with #23947 applied.
- **Only rtl930x (RTL9303) was tested on hardware.** The rtl838x / rtl839x /
  rtl931x register offsets come from the reverse-engineered Otto maps and their
  code paths mirror the validated rtl930x one.

## Risk / compatibility

At the default 1500 MTU nothing changes for existing rtl83xx devices; larger
buffers and register values are only programmed when an MTU above the default is
explicitly configured.
