### PR TITLE
nilfs-utils: update to 2.3.1

### DIFF
--- a/package/utils/nilfs-utils/Makefile
+++ b/package/utils/nilfs-utils/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nilfs-utils
-PKG_VERSION:=2.3.0
+PKG_VERSION:=2.3.1
 PKG_RELEASE:=1
 PKG_URL:=https://nilfs.sourceforge.io
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://nilfs.sourceforge.io/download/
-PKG_HASH:=c0876a7ecd13d4b54cb65abb9ad6cd0bf1ed102d03ca12738f12eab9bd84e67b
+PKG_HASH:=bf89d7ff4579c0df294b3493ed412cd4970b0a1eaaecb658e8f6c730153f0148
 
 PKG_MAINTAINER:=Pavlo Samko <bulldozerbsg@gmail.com>
 PKG_LICENSE:=GPL-2.0


### PR DESCRIPTION
Release notes v2.3.1 (from https://nilfs.sourceforge.io/download/ChangeLog-utils-v2):
nilfs-utils-2.3.1  Fri Jun 19, 2026 JST

	* Backport a fix for a potential overflow in the library function that
	  determines if a superblock is valid (CVE-2026-55392):
	  - lib/sb: validate s_log_block_size in nilfs_sb_is_valid()
	* Backport a cleanerd fix:
	  - cleanerd: apply missing fix for swapped segment count reduction
	* Backport a minor correction to a footnote in the README file:
	  - README: mention libselinux-dev as a newer package name