### PR TITLE
nilfs-utils: update to 2.2.17

### DIFF
--- a/package/utils/nilfs-utils/Makefile
+++ b/package/utils/nilfs-utils/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nilfs-utils
-PKG_VERSION:=2.2.12
+PKG_VERSION:=2.2.17
 PKG_RELEASE:=1
 PKG_URL:=https://nilfs.sourceforge.io
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://nilfs.sourceforge.io/download/
-PKG_HASH:=fc9a8520b68928d43fffa465c3b3845cc9b7d4973f4fbde4b3c7ecf25ce52d09
+PKG_HASH:=cc53a2aa7d4f6878d4cdbace5140f2877fb38cf69136d534049534ffb327c51e
 
 PKG_MAINTAINER:=Pavlo Samko <bulldozerbsg@gmail.com>
 PKG_LICENSE:=GPL-2.0
@@ -121,6 +121,7 @@ endef
 # libmount is used and support of the selinux context mount options
 # depends on the libmount that distro provides.
 CONFIGURE_ARGS += \
+	--enable-usrmerge=no \
 	--without-selinux
 
 define Package/nilfs-mkfs/install


### PR DESCRIPTION
openwrt-master version has been updated to 2.3.X
openwrt-25.10.X uses version 2.2.X

Release notes v2.2.13-2.2.17 (from https://github.com/nilfs-dev/nilfs-utils/blob/v2.2.17/ChangeLog):
nilfs-utils-2.2.17  Fri Jun 19, 2026 JST

	* Backport a fix for a potential overflow in the library function that
	  determines if a superblock is valid (CVE-2026-55392):
	  - lib/sb: validate s_log_block_size in nilfs_sb_is_valid()
	* Fix a bug in the GC fallback logic during memory shortage:
	  - cleanerd: apply missing fix for swapped segment count reduction

nilfs-utils-2.2.16  Sun Jan 25, 2026 JST

	* Fix a build issue on distributions with fully merged bin/sbin:
	  - build: avoid overwriting binaries with compat symlinks on
	    merged-/usr (e.g., Fedora Rawhide)
	* Backport some kernel-doc warning fixes

nilfs-utils-2.2.15  Wed Jan 21, 2026 JST

	* Fix a regression introduced in nilfs-utils-2.2.12:
	  - chcp: fix inverted logic in argument parsing
	* Backport miscellaneous fixes:
	  - libparser: reject negative values in
	    nilfs_parse_protection_period()
	  - mkfs.nilfs2: remove stray debug print
	* Backport manual page updates:
	  - man: fix typos, grammatical errors and style
	  - man: update examples in nilfs.8

nilfs-utils-2.2.14  Sat Jan 17, 2026 JST

	* Fix various error handling issues in libmount-based mount/umount
	  helpers:
	  - mount.nilfs2: fix broken overlapping rw-mount protection
	  - mount.nilfs2: fix ignored error on remount target mismatch
	  - umount.nilfs2: fix assertion failure when unmounting multiple
	    targets
	  - umount.nilfs2: fix incorrect error code handling in libmount-based
	    umount
	  - mount.nilfs2: fix error code handling in nilfs_do_mount_one()
	  - mount.nilfs2: fix error return in nilfs_mount_attrs_parse() and
	    its caller
	  - umount.nilfs2: fix exit code accumulation and reorganize status
	    codes
	  - umount.nilfs2: fix broken empty string check
	  - {mount,umount}.nilfs2: check return values of mnt_context_set_*()
	  - mount.nilfs2: check return value of mnt_fs_set_root()
	* Fix a build warning for mkfs.nilfs2:
	  - Remove unnecessary local variables in prepare_dat()
	* Build updates:
	  - Ignore actmp files

nilfs-utils-2.2.13  Sun Dec 28, 2025 JST

	* Build updates:
	  - Support UsrMerge and Bin-Sbin merge with automatic detection
	  - Autodetect architecture-specific library directory
	  - Fix installation of missing header file nilfs_gc.h
	  - Remove unused UTIL_CHECK_LIB macro
	  - Add a few autoconf temporary artifacts to .gitignore
	* Fix a build warning for legacy mount helpers
	  - mount.nilfs2: do not use security_context_t in the legacy variant
	* Documentation:
	  - Modernize description regarding libmount and mtab handling
	  - Reorganize build instructions and consolidate legacy info
	  - Add instruction to use 'make distclean' when changing config
	  - Update troubleshooting guide for build issues
	  - Add installation and uninstallation instructions to README
	  - Add a new section to explain cross-compilation and deployment
	  - Remove inappropriate example for --libdir option
	  - Fix some grammatical errors and inappropriate expressions