### PR TITLE
ath79: fix PHYs and device alt names for KuWfi CPE830 / Yuncore CPE830

### DIFF
--- a/target/linux/ath79/dts/qca9533_yuncore_cpe830.dts
+++ b/target/linux/ath79/dts/qca9533_yuncore_cpe830.dts
@@ -8,7 +8,7 @@
 
 / {
 	compatible = "yuncore,cpe830", "qca,qca9533";
-	model = "YunCore/KuWfi CPE830(D)";
+	model = "YunCore CPE830";
 
 	keys {
 		compatible = "gpio-keys";
@@ -135,6 +135,7 @@
 
 &eth1 {
 	status = "okay";
+//	phy-handle = <&swphy4>;
 	nvmem-cells = <&macaddr_art_6>;
 	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -3358,6 +3358,21 @@ define Device/yuncore_a930
 endef
 TARGET_DEVICES += yuncore_a930
 
+define Device/yuncore_cpe830
+  SOC := qca9533
+  DEVICE_VENDOR := YunCore
+  DEVICE_MODEL := CPE830
+  DEVICE_ALT0_VENDOR := KuWfi
+  DEVICE_ALT0_MODEL := CPE830
+  DEVICE_ALT1_VENDOR := KuWfi
+  DEVICE_ALT1_MODEL := CPE830D
+  IMAGE_SIZE := 16000k
+  IMAGES += tftp.bin
+  IMAGE/tftp.bin := $$(IMAGE/sysupgrade.bin) | yuncore-tftp-header-16m
+  DEVICE_PACKAGES := rssileds -swconfig
+endef
+TARGET_DEVICES += yuncore_cpe830
+
 define Device/yuncore_xd3200
   SOC := qca9563
   DEVICE_VENDOR := YunCore
@@ -3368,19 +3383,6 @@ define Device/yuncore_xd3200
   IMAGE/tftp.bin := $$(IMAGE/sysupgrade.bin) | yuncore-tftp-header-16m
 endef
 TARGET_DEVICES += yuncore_xd3200
-
-define Device/yuncore_cpe830
-  SOC := qca9533
-  DEVICE_VENDOR := YunCore
-  DEVICE_MODEL := CPE830(D)
-  DEVICE_ALT0_VENDOR = KuWfi
-  DEVICE_ALT0_MODEL = CPE830(D)
-  IMAGE_SIZE := 16000k
-  IMAGES += tftp.bin
-  IMAGE/tftp.bin := $$(IMAGE/sysupgrade.bin) | yuncore-tftp-header-16m
-  DEVICE_PACKAGES := rssileds -swconfig
-endef
-TARGET_DEVICES += yuncore_cpe830
 
 define Device/yuncore_xd4200
   SOC := qca9563


### PR DESCRIPTION
Cleanup names
Network adjustment for openwrt 25.x+

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
