### PR TITLE
mediatek: qihoo: fix WMAC eeprom

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-qihoo-360t7.dts
+++ b/target/linux/mediatek/dts/mt7981b-qihoo-360t7.dts
@@ -14,10 +14,20 @@
 		read-only;
 	};
 
-	factory: partition@180000 {
+	partition@180000 {
 		label = "Factory";
 		reg = <0x180000 0x200000>;
 		read-only;
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x1000>;
+			};
+		};
 	};
 
 	partition@380000 {
@@ -48,16 +58,6 @@
 		label = "factory";
 		reg = <0x7280000 0x80000>;
 		read-only;
-
-		nvmem-layout {
-			compatible = "fixed-layout";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			eeprom_factory_0: eeprom@0 {
-				reg = <0x0 0x1000>;
-			};
-		};
 	};
 
 	partition@7300000 {


### PR DESCRIPTION
Wrong factory partition was used.

Fixes: 53fa04d2619f ("mediatek: filogic: replace mtd-eeprom with nvmem")

Fixes: https://github.com/openwrt/openwrt/issues/23994