### PR TITLE
airoha: remove KERNEL_LOADADDR from airoha_an7583-evb device definition

### DIFF
--- a/target/linux/airoha/image/an7583.mk
+++ b/target/linux/airoha/image/an7583.mk
@@ -11,7 +11,6 @@ define Device/airoha_an7583-evb
   DEVICE_PACKAGES := kmod-phy-aeonsemi-as21xxx kmod-leds-pwm kmod-pwm-airoha kmod-input-gpio-keys-polled
   DEVICE_DTS := an7583-evb
   DEVICE_DTS_CONFIG := config@1
-  KERNEL_LOADADDR := 0x80088000
   IMAGE/sysupgrade.bin := append-kernel | pad-to 128k | append-rootfs | pad-rootfs | append-metadata
 endef
 TARGET_DEVICES += airoha_an7583-evb


### PR DESCRIPTION
Delete the KERNEL_LOADADDR assignment from the airoha_an7583-evb device definition. The kernel load address is now centrally managed in image Makefile with, just using the default in image makefile:

    loadaddr-$(CONFIG_TARGET_airoha_an7583) := 0x80200000

This ensures the load address configuration is maintained in a single location. Removing the duplicate assignment prevents confusion and potential misconfiguration.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
