### PR TITLE
backport patches from 7.1 for MT

### DIFF
--- a/target/linux/generic/backport-6.18/802-v7.1-net-dsa-mt7530-fix-CPU-port-VLAN-not-being-reset-to-
+++ b/target/linux/generic/backport-6.18/802-v7.1-net-dsa-mt7530-fix-CPU-port-VLAN-not-being-reset-to-
@@ -1,0 +1,205 @@
+From 2c4c76cacc9d5553f4c3342eb332d7123a4c3f14 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Thu, 14 May 2026 15:04:50 +0100
+Subject: [PATCH 3/4] net: dsa: mt7530: fix CPU port VLAN not being reset to
+ unaware
+
+After a VLAN-aware bridge is destroyed, creating any VLAN-unaware
+bridge loses all connectivity. The VID 0 VLAN table entry used by
+VLAN-unaware ports in FALLBACK mode gets corrupted during VLAN-aware
+operation: mt7530_hw_vlan_add() overwrites its EG_CON flag with
+VTAG_EN and bridge teardown removes ports from its PORT_MEM.
+
+The cleanup code that should restore it never runs because the current
+port's dp->vlan_filtering flag is still true when checked (DSA updates
+it only after the driver callback returns). Even when restored, the
+deferred VLAN deletion events from the switchdev workqueue can corrupt
+VID 0 again after the restoration.
+
+Skip the current port in the all_user_ports_removed check, call
+mt7530_setup_vlan0() to restore the VID 0 entry, and protect VID 0
+from being modified by bridge VLAN operations in port_vlan_add and
+port_vlan_del since it is managed exclusively by mt7530_setup_vlan0().
+
+Remove the CPU port PCR and PVC register writes which were clobbering
+PORT_VLAN mode and VLAN_ATTR with wrong values.
+
+Fixes: 83163f7dca56 ("net: dsa: mediatek: add VLAN support for MT7530")
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+Link: https://patch.msgid.link/da8bdaf08b2427a9057e6cb33e26d41f8a8d5000.1778766629.git.daniel@makrotopia.org
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ drivers/net/dsa/mt7530.c | 111 ++++++++++++++++++++++-----------------
+ 1 file changed, 62 insertions(+), 49 deletions(-)
+
+Index: linux-6.18.37/drivers/net/dsa/mt7530.c
+===================================================================
+--- linux-6.18.37.orig/drivers/net/dsa/mt7530.c
++++ linux-6.18.37/drivers/net/dsa/mt7530.c
+@@ -1573,6 +1573,49 @@ mt7530_port_bridge_join(struct dsa_switc
+ 	return 0;
+ }
+ 
++static int
++mt7530_vlan_cmd(struct mt7530_priv *priv, enum mt7530_vlan_cmd cmd, u16 vid)
++{
++	struct mt7530_dummy_poll p;
++	u32 val;
++	int ret;
++
++	val = VTCR_BUSY | VTCR_FUNC(cmd) | vid;
++	mt7530_write(priv, MT7530_VTCR, val);
++
++	INIT_MT7530_DUMMY_POLL(&p, priv, MT7530_VTCR);
++	ret = readx_poll_timeout(_mt7530_read, &p, val,
++				 !(val & VTCR_BUSY), 20, 20000);
++	if (ret < 0) {
++		dev_err(priv->dev, "poll timeout\n");
++		return ret;
++	}
++
++	val = mt7530_read(priv, MT7530_VTCR);
++	if (val & VTCR_INVALID) {
++		dev_err(priv->dev, "read VTCR invalid\n");
++		return -EINVAL;
++	}
++
++	return 0;
++}
++
++static int
++mt7530_setup_vlan0(struct mt7530_priv *priv)
++{
++	u32 val;
++
++	/* Validate the entry with independent learning, keep the original
++	 * ingress tag attribute.
++	 */
++	val = IVL_MAC | EG_CON | PORT_MEM(MT7530_ALL_MEMBERS) | FID(FID_BRIDGED) |
++	      VLAN_VALID;
++	mt7530_write(priv, MT7530_VAWD1, val);
++	mt7530_write(priv, MT7530_VAWD2, 0);
++
++	return mt7530_vlan_cmd(priv, MT7530_VTCR_WR_VID, 0);
++}
++
+ static void
+ mt7530_port_set_vlan_unaware(struct dsa_switch *ds, int port)
+ {
+@@ -1598,6 +1641,8 @@ mt7530_port_set_vlan_unaware(struct dsa_
+ 		   G0_PORT_VID_DEF);
+ 
+ 	for (i = 0; i < priv->ds->num_ports; i++) {
++		if (i == port)
++			continue;
+ 		if (dsa_is_user_port(ds, i) &&
+ 		    dsa_port_is_vlan_filtering(dsa_to_port(ds, i))) {
+ 			all_user_ports_removed = false;
+@@ -1609,13 +1654,9 @@ mt7530_port_set_vlan_unaware(struct dsa_
+ 	 * the CPU port get out of VLAN filtering mode.
+ 	 */
+ 	if (all_user_ports_removed) {
+-		struct dsa_port *dp = dsa_to_port(ds, port);
+-		struct dsa_port *cpu_dp = dp->cpu_dp;
+-
+-		mt7530_write(priv, MT7530_PCR_P(cpu_dp->index),
+-			     PCR_MATRIX(dsa_user_ports(priv->ds)));
+-		mt7530_write(priv, MT7530_PVC_P(cpu_dp->index), PORT_SPEC_TAG
+-			     | PVC_EG_TAG(MT7530_VLAN_EG_CONSISTENT));
++		mutex_lock(&priv->reg_mutex);
++		mt7530_setup_vlan0(priv);
++		mutex_unlock(&priv->reg_mutex);
+ 	}
+ }
+ 
+@@ -1804,33 +1845,6 @@ mt7530_port_mdb_del(struct dsa_switch *d
+ }
+ 
+ static int
+-mt7530_vlan_cmd(struct mt7530_priv *priv, enum mt7530_vlan_cmd cmd, u16 vid)
+-{
+-	struct mt7530_dummy_poll p;
+-	u32 val;
+-	int ret;
+-
+-	val = VTCR_BUSY | VTCR_FUNC(cmd) | vid;
+-	mt7530_write(priv, MT7530_VTCR, val);
+-
+-	INIT_MT7530_DUMMY_POLL(&p, priv, MT7530_VTCR);
+-	ret = readx_poll_timeout(_mt7530_read, &p, val,
+-				 !(val & VTCR_BUSY), 20, 20000);
+-	if (ret < 0) {
+-		dev_err(priv->dev, "poll timeout\n");
+-		return ret;
+-	}
+-
+-	val = mt7530_read(priv, MT7530_VTCR);
+-	if (val & VTCR_INVALID) {
+-		dev_err(priv->dev, "read VTCR invalid\n");
+-		return -EINVAL;
+-	}
+-
+-	return 0;
+-}
+-
+-static int
+ mt7530_port_vlan_filtering(struct dsa_switch *ds, int port, bool vlan_filtering,
+ 			   struct netlink_ext_ack *extack)
+ {
+@@ -1935,21 +1949,6 @@ mt7530_hw_vlan_update(struct mt7530_priv
+ }
+ 
+ static int
+-mt7530_setup_vlan0(struct mt7530_priv *priv)
+-{
+-	u32 val;
+-
+-	/* Validate the entry with independent learning, keep the original
+-	 * ingress tag attribute.
+-	 */
+-	val = IVL_MAC | EG_CON | PORT_MEM(MT7530_ALL_MEMBERS) | FID(FID_BRIDGED) |
+-	      VLAN_VALID;
+-	mt7530_write(priv, MT7530_VAWD1, val);
+-
+-	return mt7530_vlan_cmd(priv, MT7530_VTCR_WR_VID, 0);
+-}
+-
+-static int
+ mt7530_port_vlan_add(struct dsa_switch *ds, int port,
+ 		     const struct switchdev_obj_port_vlan *vlan,
+ 		     struct netlink_ext_ack *extack)
+@@ -1961,9 +1960,18 @@ mt7530_port_vlan_add(struct dsa_switch *
+ 
+ 	mutex_lock(&priv->reg_mutex);
+ 
++	/* VID 0 is managed exclusively by mt7530_setup_vlan0() for
++	 * VLAN-unaware bridge operation. Don't let the bridge overwrite
++	 * its EG_CON flag with VTAG_EN and corrupt PORT_MEM.
++	 */
++	if (vlan->vid == 0)
++		goto skip_vlan_table;
++
+ 	mt7530_hw_vlan_entry_init(&new_entry, port, untagged);
+ 	mt7530_hw_vlan_update(priv, vlan->vid, &new_entry, mt7530_hw_vlan_add);
+ 
++skip_vlan_table:
++
+ 	if (pvid) {
+ 		priv->ports[port].pvid = vlan->vid;
+ 
+@@ -2003,10 +2011,15 @@ mt7530_port_vlan_del(struct dsa_switch *
+ 
+ 	mutex_lock(&priv->reg_mutex);
+ 
++	/* VID 0 is managed exclusively by mt7530_setup_vlan0(). */
++	if (vlan->vid == 0)
++		goto skip_vlan_table;
++
+ 	mt7530_hw_vlan_entry_init(&target_entry, port, 0);
+ 	mt7530_hw_vlan_update(priv, vlan->vid, &target_entry,
+ 			      mt7530_hw_vlan_del);
+ 
++skip_vlan_table:
+ 	/* PVID is being restored to the default whenever the PVID port
+ 	 * is being removed from the VLAN.
+ 	 */

--- a/target/linux/generic/backport-6.18/803-v7.1-net-dsa-mt7530-untag-VLAN-aware-bridge-PVID
+++ b/target/linux/generic/backport-6.18/803-v7.1-net-dsa-mt7530-untag-VLAN-aware-bridge-PVID
@@ -1,0 +1,55 @@
+From 4cb3cd670b2a29e52dd3cfd6463e44121674c9b8 Mon Sep 17 00:00:00 2001
+From: Edward Parker <edward@topnotchit.com>
+Date: Thu, 14 May 2026 15:05:12 +0100
+Subject: [PATCH 4/4] net: dsa: mt7530: untag VLAN-aware bridge PVID
+
+With bridge VLAN filtering enabled on a port configured as untagged
+member of the bridge PVID, ingress untagged frames do not reach the
+corresponding bridge VLAN upper interface (br-lan.<vid>). ARP and
+similar traffic is visible on the physical port but not delivered
+to the VLAN sub-interface.
+
+The MT7530/MT7531 forwards frames to the CPU port with the user
+port's PVID tag applied even when the frame ingressed untagged on
+the wire, because the CPU port is set to MT7530_VLAN_EG_CONSISTENT
+and is a tagged member of the VLAN entry created for the bridge
+VLAN. The DSA core then sees a hwaccel-tagged frame whose VID
+matches the port's PVID, which the bridge does not treat as the
+untagged-on-the-wire frame that the user expects.
+
+Set ds->untag_vlan_aware_bridge_pvid in the mt7530 and mt7531
+setup paths so the DSA core strips that hwaccel tag in software
+when the parsed VID matches the bridge port's PVID, restoring the
+on-the-wire frame as the bridge expects to see it.
+
+Link: https://github.com/openwrt/openwrt/issues/18576
+Fixes: 83163f7dca56 ("net: dsa: mediatek: add VLAN support for MT7530")
+Signed-off-by: Edward Parker <edward@topnotchit.com>
+[daniel@makrotopia.org: improve commit message]
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+Link: https://patch.msgid.link/85d25ea1b26d3c907f815649f2e0bde6560282a3.1778766629.git.daniel@makrotopia.org
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ drivers/net/dsa/mt7530.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+Index: linux-6.18.37/drivers/net/dsa/mt7530.c
+===================================================================
+--- linux-6.18.37.orig/drivers/net/dsa/mt7530.c
++++ linux-6.18.37/drivers/net/dsa/mt7530.c
+@@ -2397,6 +2397,7 @@ mt7530_setup(struct dsa_switch *ds)
+ 	}
+ 
+ 	ds->assisted_learning_on_cpu_port = true;
++	ds->untag_vlan_aware_bridge_pvid = true;
+ 	ds->mtu_enforcement_ingress = true;
+ 	ds->ageing_time_min = 2 * 1000;
+ 	ds->ageing_time_max = (AGE_CNT_MAX + 1) * (AGE_UNIT_MAX + 1) * 1000;
+@@ -2588,6 +2589,7 @@ mt7531_setup_common(struct dsa_switch *d
+ 	int ret, i;
+ 
+ 	ds->assisted_learning_on_cpu_port = true;
++	ds->untag_vlan_aware_bridge_pvid = true;
+ 	ds->mtu_enforcement_ingress = true;
+ 	ds->ageing_time_min = 2 * 1000;
+ 	ds->ageing_time_max = (AGE_CNT_MAX + 1) * (AGE_UNIT_MAX + 1) * 1000;


### PR DESCRIPTION
Backported/Applied two changes from linux 7.1  to current snapshot kernel to make  VLANS work on MT7350. 