### PR TITLE
build: don't store timestamps in APK packages

### DIFF
--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -605,7 +605,7 @@ else
 		exit 1; \
 	fi
 
-	$(FAKEROOT) $(STAGING_DIR_HOST)/bin/apk mkpkg \
+	SOURCE_DATE_EPOCH=0 $(FAKEROOT) $(STAGING_DIR_HOST)/bin/apk mkpkg \
 	  --info "name:$(1)$$(ABIV_$(1))" \
 	  --info "version:$(VERSION)" \
 	  $$(if $$(APK_TAGS_$(1)),--info "tags:$$(APK_TAGS_$(1))") \


### PR DESCRIPTION
This commit statically sets SOURCE_DATE_EPOCH to 0, which causes `apk mkpkg` to drop the date from generated packages. This improves reproducibility while leaving package specific SOURCE_DATE_EPOCH untouched. The latter can be interesting for i.e. packages like busybox, which prominently show that date on the login shell.

Without this commit, packages that live inside feed repositories (openwrt.git, packages.git etc) like `mtd` or `attendedsysupgrade-common` would have random timestamps since no "full" git log was available.

Below an example with different source dates (0, 1):

```
│  0755  root:wheel    -                           -  /
│  0755  root:wheel    -                           -  lib/
│  0755  root:wheel    -                           -  lib/apk/
│  0755  root:wheel    -                           -  lib/apk/packages/
│ -0644  root:wheel    1970-01-01T00:00:01Z       10  lib/apk/packages/mtd.list
│ +0644  root:wheel    -                          10  lib/apk/packages/mtd.list
│  0755  root:wheel    -                           -  sbin/
│ -0755  root:wheel    1970-01-01T00:00:01Z    24595  sbin/mtd
│ +0755  root:wheel    -                       24595  sbin/mtd
```