### PR TITLE
[25.12] rockchip: add support for FriendlyARM NanoPi R2S Plus

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -71,6 +71,13 @@ define U-Boot/nanopi-r2s-rk3328
     friendlyarm_nanopi-r2s
 endef
 
+define U-Boot/nanopi-r2s-plus-rk3328
+  $(U-Boot/rk3328/Default)
+  NAME:=NanoPi R2S Plus
+  BUILD_DEVICES:= \
+    friendlyarm_nanopi-r2s-plus
+endef
+
 define U-Boot/orangepi-r1-plus-rk3328
   $(U-Boot/rk3328/Default)
   NAME:=Orange Pi R1 Plus
@@ -421,6 +428,7 @@ UBOOT_TARGETS := \
   nanopi-r2c-rk3328 \
   nanopi-r2c-plus-rk3328 \
   nanopi-r2s-rk3328 \
+  nanopi-r2s-plus-rk3328 \
   orangepi-r1-plus-rk3328 \
   orangepi-r1-plus-lts-rk3328 \
   roc-cc-rk3328 \

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds
@@ -11,6 +11,7 @@ case $board in
 friendlyarm,nanopi-r2c|\
 friendlyarm,nanopi-r2c-plus|\
 friendlyarm,nanopi-r2s|\
+friendlyarm,nanopi-r2s-plus|\
 friendlyarm,nanopi-r3s|\
 friendlyarm,nanopi-r4s|\
 friendlyarm,nanopi-r4s-enterprise|\

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -11,6 +11,7 @@ rockchip_setup_interfaces()
 	friendlyarm,nanopi-r2c|\
 	friendlyarm,nanopi-r2c-plus|\
 	friendlyarm,nanopi-r2s|\
+	friendlyarm,nanopi-r2s-plus|\
 	friendlyarm,nanopi-r3s|\
 	friendlyarm,nanopi-r4s|\
 	friendlyarm,nanopi-r4s-enterprise|\
@@ -85,6 +86,7 @@ rockchip_setup_macs()
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		;;
 	friendlyarm,nanopi-r2c-plus|\
+	friendlyarm,nanopi-r2s-plus|\
 	friendlyarm,nanopi-r4s|\
 	friendlyarm,nanopi-r5s|\
 	sinovoip,rk3568-bpi-r2pro)

--- a/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
+++ b/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
@@ -42,6 +42,7 @@ sinovoip,rk3568-bpi-r2pro)
 friendlyarm,nanopi-r2c|\
 friendlyarm,nanopi-r2c-plus|\
 friendlyarm,nanopi-r2s|\
+friendlyarm,nanopi-r2s-plus|\
 radxa,cm3-io|\
 xunlong,orangepi-r1-plus|\
 xunlong,orangepi-r1-plus-lts)

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -112,6 +112,14 @@ define Device/friendlyarm_nanopi-r2s
 endef
 TARGET_DEVICES += friendlyarm_nanopi-r2s
 
+define Device/friendlyarm_nanopi-r2s-plus
+  $(Device/rk3328)
+  DEVICE_VENDOR := FriendlyARM
+  DEVICE_MODEL := NanoPi R2S Plus
+  DEVICE_PACKAGES := kmod-usb-net-rtl8152
+endef
+TARGET_DEVICES += friendlyarm_nanopi-r2s-plus
+
 define Device/friendlyarm_nanopi-r3s
   $(Device/rk3566)
   DEVICE_VENDOR := FriendlyARM


### PR DESCRIPTION
The NanoPi R2S Plus is a NanoPi R2S with on-board eMMC added. The device tree (rk3328-nanopi-r2s-plus.dts) is already present in kernel 6.12, and U-Boot support has been present since v2025.01, so neither a kernel DTS backport nor a U-Boot patch is required.

Hardware
--------
Rockchip RK3328 (4x Cortex-A53, up to 1.4 GHz)
1GB DDR4 RAM
32GB eMMC 5.1
microSD slot (up to 128GB)
1x 1000 Base-T (native, RTL8211F via GMAC) - WAN
1x 1000 Base-T (USB 3.0, RTL8153B) - LAN
Optional M.2 SDIO Wi-Fi
2x USB 2.0 Type-A host
1x USB-C (5V power input, USB device for Maskrom update) 1x USB-C (onboard USB-to-UART debug console, 1500000 bps) 1x serial debug header / UART0 (3.3V TTL, 3-pin 2.54mm) 2 Buttons (GPIO key, Maskrom)
3 LEDs (SYS red, WAN green, LAN green)
DC 5V/2A power
Operating temperature 0 to 70 C

The MAC addresses are derived from the eMMC CID, so they are stable regardless of whether the device boots from microSD or eMMC.

Installation
------------

On RK3328 the BootROM boots the eMMC before the microSD slot, so the Maskrom button must be held to boot from microSD while stock firmware is still on the eMMC.

How to boot from eMMC:

1. Write the uncompressed sysupgrade image to sdcard
2. Hold the "Mask" button while powering on the device
3. Wait until OpenWrt is fully booted
4. Copy the compressed .gz sysupgrade image to the machine's /tmp folder using scp
5. Run: gunzip -c /tmp/openwrt-...-friendlyarm_nanopi-r2s-plus-squashfs-sysupgrade.img.gz | dd of=/dev/mmcblk1 bs=4M conv=fsync
6. Power the device off, remove the sdcard and power it back on

Tested:
- microSD boot (via Maskrom button) and native eMMC boot
- Both Ethernet ports (RTL8211F WAN, RTL8153B LAN)
- eMMC-derived MAC addresses


Backport of: https://github.com/openwrt/openwrt/pull/23854
