### PR TITLE
treewide: remove factory:

### DIFF
--- a/target/linux/ipq806x/dts/qcom-ipq8062-wg2600hp3.dts
+++ b/target/linux/ipq806x/dts/qcom-ipq8062-wg2600hp3.dts
@@ -322,7 +322,7 @@
 					read-only;
 				};
 
-				factory: partition@2b0000 {
+				partition@2b0000 {
 					label = "PRODUCTDATA";
 					reg = <0x02b0000 0x0030000>;
 					read-only;

--- a/target/linux/mediatek/dts/mt7981b-alwaylink-m01k43.dts
+++ b/target/linux/mediatek/dts/mt7981b-alwaylink-m01k43.dts
@@ -308,7 +308,7 @@
 				reg = <0x040000 0x010000>;
 			};
 
-			factory: partition@50000 {
+			partition@50000 {
 				label = "factory";
 				reg = <0x050000 0x0b0000>;
 				read-only;

--- a/target/linux/mediatek/dts/mt7981b-comfast-cf-xr186.dts
+++ b/target/linux/mediatek/dts/mt7981b-comfast-cf-xr186.dts
@@ -147,7 +147,7 @@
 				read-only;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x0200000>;
 				read-only;

--- a/target/linux/mediatek/dts/mt7981b-livinet-li320.dts
+++ b/target/linux/mediatek/dts/mt7981b-livinet-li320.dts
@@ -186,7 +186,7 @@
 				reg = <0x100000 0x80000>;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x200000>;
 				read-only;

--- a/target/linux/mediatek/dts/mt7981b-netis-eap930-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-netis-eap930-v1.dts
@@ -120,10 +120,26 @@
 				read-only;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x200000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_1fef20: macaddr@1fef20 {
+						compatible = "mac-base";
+						reg = <0x1fef20 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
 			};
 
 			partition@380000 {
@@ -151,24 +167,6 @@
 					};
 				};
 			};
-		};
-	};
-};
-
-&factory {
-	nvmem-layout {
-		compatible = "fixed-layout";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		eeprom_factory_0: eeprom@0 {
-			reg = <0x0 0x1000>;
-		};
-
-		macaddr_factory_1fef20: macaddr@1fef20 {
-			compatible = "mac-base";
-			reg = <0x1fef20 0x6>;
-			#nvmem-cell-cells = <1>;
 		};
 	};
 };

--- a/target/linux/mediatek/dts/mt7986a-jiorouter-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-jiorouter-common.dtsi
@@ -204,7 +204,7 @@
 				read-only;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x200000>;
 				read-only;

--- a/target/linux/mediatek/dts/mt7988a-zbtlink-zbt-z8803be.dts
+++ b/target/linux/mediatek/dts/mt7988a-zbtlink-zbt-z8803be.dts
@@ -370,9 +370,10 @@
 			reg = <0x100000 0x80000>;
 		};
 
-		factory: partition@180000 {
+		partition@180000 {
 			label = "Factory";
 			reg = <0x180000 0x400000>;
+
 			nvmem-layout {
 				compatible = "fixed-layout";
 				#address-cells = <1>;

--- a/target/linux/ramips/dts/mt7620a_wavlink_wl-wn531g3-a2.dts
+++ b/target/linux/ramips/dts/mt7620a_wavlink_wl-wn531g3-a2.dts
@@ -94,7 +94,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_wavlink_wl-wn531g3.dts
+++ b/target/linux/ramips/dts/mt7620a_wavlink_wl-wn531g3.dts
@@ -94,7 +94,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_comfast_cf-ew72-v2.dts
+++ b/target/linux/ramips/dts/mt7621_comfast_cf-ew72-v2.dts
@@ -164,8 +164,6 @@
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
-		// Wi-Fi device reads it's MAC address from EEPROM (&factory + 4)
-		// adding anything related to mac-address here will cause use random MAC
 	};
 };
 
@@ -175,8 +173,6 @@
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";
-		// Wi-Fi device reads it's MAC address from EEPROM, (&factory + 0x8000 + 4)
-		// adding anything related to mac-address here will cause use random MAC.
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_dlink_dir-1360-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-1360-a1.dts
@@ -110,7 +110,7 @@
 			read-only;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "factory";
 			reg = <0x100000 0x40000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_elecom_wmc-c2533gst.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wmc-c2533gst.dts
@@ -49,18 +49,12 @@
 	nvmem-cell-names = "mac-address";
 };
 
-&factory {
-	nvmem-layout {
-		compatible = "fixed-layout";
-		#address-cells = <1>;
-		#size-cells = <1>;
+&nvmem {
+	macaddr_factory_fff4: macaddr@fff4 {
+		reg = <0xfff4 0x6>;
+	};
 
-		macaddr_factory_fff4: macaddr@fff4 {
-			reg = <0xfff4 0x6>;
-		};
-
-		macaddr_factory_fffa: macaddr@fffa {
-			reg = <0xfffa 0x6>;
-		};
+	macaddr_factory_fffa: macaddr@fffa {
+		reg = <0xfffa 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_elecom_wmc-m1267gst2.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wmc-m1267gst2.dts
@@ -54,24 +54,18 @@
 	nvmem-cell-names = "eeprom", "mac-address";
 };
 
-&factory {
-	nvmem-layout {
-		compatible = "fixed-layout";
-		#address-cells = <1>;
-		#size-cells = <1>;
+&nvmem {
+	macaddr_factory_4: macaddr@4 {
+		compatible = "mac-base";
+		reg = <0x4 0x6>;
+		#nvmem-cell-cells = <1>;
+	};
 
-		macaddr_factory_4: macaddr@4 {
-			compatible = "mac-base";
-			reg = <0x4 0x6>;
-			#nvmem-cell-cells = <1>;
-		};
+	macaddr_factory_fff4: macaddr@fff4 {
+		reg = <0xfff4 0x6>;
+	};
 
-		macaddr_factory_fff4: macaddr@fff4 {
-			reg = <0xfff4 0x6>;
-		};
-
-		macaddr_factory_fffa: macaddr@fffa {
-			reg = <0xfffa 0x6>;
-		};
+	macaddr_factory_fffa: macaddr@fffa {
+		reg = <0xfffa 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_elecom_wmc-s1267gs2.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wmc-s1267gs2.dts
@@ -63,20 +63,14 @@
 	nvmem-cell-names = "eeprom", "mac-address";
 };
 
-&factory {
-	nvmem-layout {
-		compatible = "fixed-layout";
-		#address-cells = <1>;
-		#size-cells = <1>;
+&nvmem {
+	macaddr_factory_4: macaddr@4 {
+		compatible = "mac-base";
+		reg = <0x4 0x6>;
+		#nvmem-cell-cells = <1>;
+	};
 
-		macaddr_factory_4: macaddr@4 {
-			compatible = "mac-base";
-			reg = <0x4 0x6>;
-			#nvmem-cell-cells = <1>;
-		};
-
-		macaddr_factory_fff4: macaddr@fff4 {
-			reg = <0xfff4 0x6>;
-		};
+	macaddr_factory_fff4: macaddr@fff4 {
+		reg = <0xfff4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-1167gs2-b.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-1167gs2-b.dts
@@ -54,24 +54,18 @@
 	nvmem-cell-names = "eeprom", "mac-address";
 };
 
-&factory {
-	nvmem-layout {
-		compatible = "fixed-layout";
-		#address-cells = <1>;
-		#size-cells = <1>;
+&nvmem {
+	macaddr_factory_4: macaddr@4 {
+		compatible = "mac-base";
+		reg = <0x4 0x6>;
+		#nvmem-cell-cells = <1>;
+	};
 
-		macaddr_factory_4: macaddr@4 {
-			compatible = "mac-base";
-			reg = <0x4 0x6>;
-			#nvmem-cell-cells = <1>;
-		};
+	macaddr_factory_fff4: macaddr@fff4 {
+		reg = <0xfff4 0x6>;
+	};
 
-		macaddr_factory_fff4: macaddr@fff4 {
-			reg = <0xfff4 0x6>;
-		};
-
-		macaddr_factory_fffa: macaddr@fffa {
-			reg = <0xfffa 0x6>;
-		};
+	macaddr_factory_fffa: macaddr@fffa {
+		reg = <0xfffa 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-1167gst2.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-1167gst2.dts
@@ -54,20 +54,14 @@
 	nvmem-cell-names = "eeprom", "mac-address";
 };
 
-&factory {
-	nvmem-layout {
-		compatible = "fixed-layout";
-		#address-cells = <1>;
-		#size-cells = <1>;
+&nvmem {
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
 
-		macaddr_factory_e000: macaddr@e000 {
-			reg = <0xe000 0x6>;
-		};
-
-		macaddr_factory_e006: macaddr@e006 {
-			compatible = "mac-base";
-			reg = <0xe006 0x6>;
-			#nvmem-cell-cells = <1>;
-		};
+	macaddr_factory_e006: macaddr@e006 {
+		compatible = "mac-base";
+		reg = <0xe006 0x6>;
+		#nvmem-cell-cells = <1>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-1750gs.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-1750gs.dts
@@ -49,18 +49,12 @@
 	nvmem-cell-names = "mac-address";
 };
 
-&factory {
-	nvmem-layout {
-		compatible = "fixed-layout";
-		#address-cells = <1>;
-		#size-cells = <1>;
+&nvmem {
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
 
-		macaddr_factory_e000: macaddr@e000 {
-			reg = <0xe000 0x6>;
-		};
-
-		macaddr_factory_e006: macaddr@e006 {
-			reg = <0xe006 0x6>;
-		};
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-1750gst2.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-1750gst2.dts
@@ -49,18 +49,12 @@
 	nvmem-cell-names = "mac-address";
 };
 
-&factory {
-	nvmem-layout {
-		compatible = "fixed-layout";
-		#address-cells = <1>;
-		#size-cells = <1>;
+&nvmem {
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
 
-		macaddr_factory_e000: macaddr@e000 {
-			reg = <0xe000 0x6>;
-		};
-
-		macaddr_factory_e006: macaddr@e006 {
-			reg = <0xe006 0x6>;
-		};
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-1750gsv.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-1750gsv.dts
@@ -49,18 +49,12 @@
 	nvmem-cell-names = "mac-address";
 };
 
-&factory {
-	nvmem-layout {
-		compatible = "fixed-layout";
-		#address-cells = <1>;
-		#size-cells = <1>;
+&nvmem {
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
 
-		macaddr_factory_e000: macaddr@e000 {
-			reg = <0xe000 0x6>;
-		};
-
-		macaddr_factory_e006: macaddr@e006 {
-			reg = <0xe006 0x6>;
-		};
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-1900gst.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-1900gst.dts
@@ -49,18 +49,12 @@
 	nvmem-cell-names = "mac-address";
 };
 
-&factory {
-	nvmem-layout {
-		compatible = "fixed-layout";
-		#address-cells = <1>;
-		#size-cells = <1>;
+&nvmem {
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
 
-		macaddr_factory_e000: macaddr@e000 {
-			reg = <0xe000 0x6>;
-		};
-
-		macaddr_factory_e006: macaddr@e006 {
-			reg = <0xe006 0x6>;
-		};
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-2533gs2.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-2533gs2.dts
@@ -49,18 +49,12 @@
 	nvmem-cell-names = "mac-address";
 };
 
-&factory {
-	nvmem-layout {
-		compatible = "fixed-layout";
-		#address-cells = <1>;
-		#size-cells = <1>;
+&nvmem {
+	macaddr_factory_fff4: macaddr@fff4 {
+		reg = <0xfff4 0x6>;
+	};
 
-		macaddr_factory_fff4: macaddr@fff4 {
-			reg = <0xfff4 0x6>;
-		};
-
-		macaddr_factory_fffa: macaddr@fffa {
-			reg = <0xfffa 0x6>;
-		};
+	macaddr_factory_fffa: macaddr@fffa {
+		reg = <0xfffa 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-2533gst.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-2533gst.dts
@@ -47,18 +47,12 @@
 	nvmem-cell-names = "mac-address";
 };
 
-&factory {
-	nvmem-layout {
-		compatible = "fixed-layout";
-		#address-cells = <1>;
-		#size-cells = <1>;
+&nvmem {
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
 
-		macaddr_factory_e000: macaddr@e000 {
-			reg = <0xe000 0x6>;
-		};
-
-		macaddr_factory_e006: macaddr@e006 {
-			reg = <0xe006 0x6>;
-		};
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-2533gst2.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-2533gst2.dts
@@ -49,18 +49,12 @@
 	nvmem-cell-names = "mac-address";
 };
 
-&factory {
-	nvmem-layout {
-		compatible = "fixed-layout";
-		#address-cells = <1>;
-		#size-cells = <1>;
+&nvmem {
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
 
-		macaddr_factory_e000: macaddr@e000 {
-			reg = <0xe000 0x6>;
-		};
-
-		macaddr_factory_e006: macaddr@e006 {
-			reg = <0xe006 0x6>;
-		};
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-gs.dtsi
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-gs.dtsi
@@ -147,12 +147,12 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;
 
-				nvmem-layout {
+				nvmem: nvmem-layout {
 					compatible = "fixed-layout";
 					#address-cells = <1>;
 					#size-cells = <1>;

--- a/target/linux/ramips/dts/mt7621_zyxel_lte7490-m904.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_lte7490-m904.dts
@@ -92,7 +92,7 @@
 			reg = <0x80000 0x80000>;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "Factory";
 			reg = <0x100000 0x40000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7628an_creality_wb-01.dts
+++ b/target/linux/ramips/dts/mt7628an_creality_wb-01.dts
@@ -83,7 +83,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_tplink_16m.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_16m.dtsi
@@ -46,12 +46,12 @@
 				read-only;
 			};
 
-			factory: partition@fd0000 {
+			partition@fd0000 {
 				label = "factory";
 				reg = <0xfd0000 0x30000>;
 				read-only;
 
-				nvmem-layout {
+				nvmem: nvmem-layout {
 					compatible = "fixed-layout";
 					#address-cells = <1>;
 					#size-cells = <1>;

--- a/target/linux/ramips/dts/mt7628an_tplink_8m.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_8m.dtsi
@@ -44,12 +44,12 @@
 				read-only;
 			};
 
-			factory: partition@7d0000 {
+			partition@7d0000 {
 				label = "factory";
 				reg = <0x7d0000 0x30000>;
 				read-only;
 
-				nvmem-layout {
+				nvmem: nvmem-layout {
 					compatible = "fixed-layout";
 					#address-cells = <1>;
 					#size-cells = <1>;

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-mr6400-v4.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-mr6400-v4.dts
@@ -100,16 +100,10 @@
 	nvmem-cell-names = "mac-address";
 };
 
-&factory {
-	nvmem-layout {
-		compatible = "fixed-layout";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		macaddr_factory_1f100: macaddr@1f100 {
-			compatible = "mac-base";
-			reg = <0x1f100 0x6>;
-			#nvmem-cell-cells = <1>;
-		};
+&nvmem {
+	macaddr_factory_1f100: macaddr@1f100 {
+		compatible = "mac-base";
+		reg = <0x1f100 0x6>;
+		#nvmem-cell-cells = <1>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-mr6400-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-mr6400-v5.dts
@@ -100,16 +100,10 @@
 	nvmem-cell-names = "mac-address";
 };
 
-&factory {
-	nvmem-layout {
-		compatible = "fixed-layout";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		macaddr_factory_1f100: macaddr@1f100 {
-			compatible = "mac-base";
-			reg = <0x1f100 0x6>;
-			#nvmem-cell-cells = <1>;
-		};
+&nvmem {
+	macaddr_factory_1f100: macaddr@1f100 {
+		compatible = "mac-base";
+		reg = <0x1f100 0x6>;
+		#nvmem-cell-cells = <1>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-mr6400-v7.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-mr6400-v7.dts
@@ -100,16 +100,10 @@
 	nvmem-cell-names = "mac-address";
 };
 
-&factory {
-	nvmem-layout {
-		compatible = "fixed-layout";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		macaddr_factory_1f100: macaddr@1f100 {
-			compatible = "mac-base";
-			reg = <0x1f100 0x6>;
-			#nvmem-cell-cells = <1>;
-		};
+&nvmem {
+	macaddr_factory_1f100: macaddr@1f100 {
+		compatible = "mac-base";
+		reg = <0x1f100 0x6>;
+		#nvmem-cell-cells = <1>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_zbtlink_zbt-we2426-b.dts
+++ b/target/linux/ramips/dts/mt7628an_zbtlink_zbt-we2426-b.dts
@@ -100,7 +100,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/siflower/dts/sf21h8898_bananapi_bpi-rv2-nand.dts
+++ b/target/linux/siflower/dts/sf21h8898_bananapi_bpi-rv2-nand.dts
@@ -34,7 +34,7 @@
 				compatible = "linux,ubi";
 
 				volumes {
-					factory: ubi-volume-factory {
+					ubi-volume-factory {
 						volname = "factory";
 
 						nvmem-layout {

--- a/target/linux/siflower/dts/sf21h8898_bananapi_bpi-rv2-nor.dts
+++ b/target/linux/siflower/dts/sf21h8898_bananapi_bpi-rv2-nor.dts
@@ -29,7 +29,7 @@
 				read-only;
 			};
 
-			factory: partition@90000 {
+			partition@90000 {
 				label = "factory";
 				reg = <0x90000 0x10000>;
 


### PR DESCRIPTION
For the most part, factory: remains as a hold over from nvmem-layout conversion and no longer serves any purpose.

In the case of &factory sections, reduce identation slightly by referencing the nvmem-layout node instead.
