### PR TITLE
github: add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Maintain GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "github"
+    labels:
+      - "GitHub/CI"


### PR DESCRIPTION
If any updates are found, Dependabot will automatically create a pull request with the 'GitHub/CI' label and the 'github:' commit message prefix.

Dependabot will run weekly.

Suggested: https://github.com/openwrt/openwrt/pull/22903#issuecomment-4233550054
Idea approved: https://github.com/openwrt/openwrt/pull/22903#issuecomment-4256194185
