### PR TITLE
ath79: convert archer C7v1/2 to DSA

### DIFF
--- a/target/linux/ath79/dts/qca9558_tplink_archer-c.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-c.dtsi
@@ -110,68 +110,173 @@
 &mdio0 {
 	status = "okay";
 
-	switch@1f {
-		compatible = "qca,ar8327";
-		reg = <0x1f>;
+	ethernet-switch@0 {
+		compatible = "qca,qca8327";
+		#address-cells = <1>;
+		#size-cells = <0>;
 
-		qca,ar8327-initvals = <
-			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
-			0x0c 0x07600000 /* PORT6 PAD MODE CTRL */
-			0x50 0xc737c737 /* LED_CTRL0 */
-			0x54 0x00000000 /* LED_CTRL1 */
-			0x58 0x00000000 /* LED_CTRL2 */
-			0x5c 0x0030c300 /* LED_CTRL3 */
-			0x7c 0x0000007e /* PORT0_STATUS */
-			0x94 0x0000007e /* PORT6 STATUS */
-			>;
+		reg = <0>;
 
-		leds {
-			led@0 {
+		ethernet-ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			ethernet-port@0 {
 				reg = <0>;
-				color = <LED_COLOR_ID_GREEN>;
-				function = LED_FUNCTION_WAN;
-				qca,led-mode = <0>;
+				ethernet = <&eth1>;
+				phy-mode = "sgmii";
+				qca,sgmii-rxclk-falling-edge;
+
+				fixed-link {
+					speed = <1000>;
+					full-duplex;
+				};
 			};
 
-			led@3 {
+			ethernet-port@1 {
+				reg = <1>;
+				label = "wan";
+				phy-mode = "internal";
+				phy-handle = <&phy_port1>;
+
+				leds {
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					led@0 {
+						reg = <0>;
+						color = <LED_COLOR_ID_GREEN>;
+						function = LED_FUNCTION_WAN;
+						default-state = "keep";
+					};
+				};
+			};
+
+			ethernet-port@2 {
+				reg = <2>;
+				label = "lan1";
+				phy-mode = "internal";
+				phy-handle = <&phy_port2>;
+
+				leds {
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					led@0 {
+						reg = <0>;
+						color = <LED_COLOR_ID_GREEN>;
+						function = LED_FUNCTION_LAN;
+						default-state = "keep";
+					};
+				};
+			};
+
+			ethernet-port@3 {
 				reg = <3>;
-				color = <LED_COLOR_ID_GREEN>;
-				function = LED_FUNCTION_LAN;
-				function-enumerator = <1>;
-				qca,led-mode = <0>;
+				label = "lan2";
+				phy-mode = "internal";
+				phy-handle = <&phy_port3>;
+
+				leds {
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					led@0 {
+						reg = <0>;
+						color = <LED_COLOR_ID_GREEN>;
+						function = LED_FUNCTION_LAN;
+						default-state = "keep";
+					};
+				};
 			};
 
-			led@6 {
+			ethernet-port@4 {
+				reg = <4>;
+				label = "lan3";
+				phy-mode = "internal";
+				phy-handle = <&phy_port4>;
+
+				leds {
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					led@0 {
+						reg = <0>;
+						color = <LED_COLOR_ID_GREEN>;
+						function = LED_FUNCTION_LAN;
+						default-state = "keep";
+					};
+				};
+			};
+
+			ethernet-port@5 {
+				reg = <5>;
+				label = "lan4";
+				phy-mode = "internal";
+				phy-handle = <&phy_port5>;
+
+				leds {
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					led@0 {
+						reg = <0>;
+						color = <LED_COLOR_ID_GREEN>;
+						function = LED_FUNCTION_LAN;
+						default-state = "keep";
+					};
+				};
+			};
+
+			ethernet-port@6 {
 				reg = <6>;
-				color = <LED_COLOR_ID_GREEN>;
-				function = LED_FUNCTION_LAN;
-				function-enumerator = <2>;
-				qca,led-mode = <0>;
+				ethernet = <&eth0>;
+				phy-mode = "rgmii-id";
+
+				fixed-link {
+					speed = <1000>;
+					full-duplex;
+				};
+			};
+		};
+
+		mdio {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			phy_port1: phy@0 {
+				reg = <0>;
 			};
 
-			led@9 {
-				reg = <9>;
-				color = <LED_COLOR_ID_GREEN>;
-				function = LED_FUNCTION_LAN;
-				function-enumerator = <3>;
-				qca,led-mode = <0>;
+			phy_port2: phy@1 {
+				reg = <1>;
 			};
 
-			led@12 {
-				reg = <12>;
-				color = <LED_COLOR_ID_GREEN>;
-				function = LED_FUNCTION_LAN;
-				function-enumerator = <4>;
-				qca,led-mode = <0>;
+			phy_port3: phy@2 {
+				reg = <2>;
+			};
+
+			phy_port4: phy@3 {
+				reg = <3>;
+			};
+
+			phy_port5: phy@4 {
+				reg = <4>;
 			};
 		};
 	};
+};
+
+&mdio1 {
+	status = "okay";
 };
 
 &eth0 {
 	status = "okay";
 
 	pll-data = <0x56000000 0x00000101 0x00001616>;
+
+	phy-mode = "rgmii";
 
 	fixed-link {
 		speed = <1000>;
@@ -188,6 +293,8 @@
 	status = "okay";
 
 	pll-data = <0x03000101 0x00000101 0x00001616>;
+
+	phy-mode = "sgmii";
 
 	fixed-link {
 		speed = <1000>;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -195,11 +195,7 @@ ath79_setup_interfaces()
 	nec,wg1800hp|\
 	nec,wg1800hp2|\
 	nec,wg2200hp|\
-	tplink,archer-c5-v1|\
-	tplink,archer-c7-v1|\
-	tplink,archer-c7-v2|\
-	tplink,tl-wdr4900-v2|\
-	tplink,tl-wdr7500-v3)
+	tplink,tl-wdr4900-v2)
 		ucidef_add_switch "switch0" \
 			"0u@eth1" "2:lan" "3:lan" "4:lan" "5:lan" "6u@eth0" "1:wan"
 		;;
@@ -519,6 +515,17 @@ ath79_setup_interfaces()
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:3" "3:lan:2" "4:lan:1"
+		;;
+	tplink,archer-c5-v1|\
+	tplink,archer-c7-v1|\
+	tplink,archer-c7-v2|\
+	tplink,tl-wdr7500-v3)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
+		ucidef_set_network_device_conduit "lan1" "eth1"
+		ucidef_set_network_device_conduit "lan2" "eth1"
+		ucidef_set_network_device_conduit "lan3" "eth1"
+		ucidef_set_network_device_conduit "lan4" "eth1"
+		ucidef_set_network_device_conduit "wan" "eth0"
 		;;
 	tplink,archer-d50-v1)
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/generic/base-files/etc/board.d/05_compat-version
+++ b/target/linux/ath79/generic/base-files/etc/board.d/05_compat-version
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+. /lib/functions.sh
+. /lib/functions/uci-defaults.sh
+
+board_config_update
+
+case "$(board_name)" in
+	tplink,archer-c5-v1|\
+	tplink,archer-c7-v1|\
+	tplink,archer-c7-v2|\
+	tplink,tl-wdr7500-v3)
+		ucidef_set_compat_version "1.1"
+		;;
+esac
+
+board_config_flush
+
+exit 0

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -53,9 +53,11 @@ define Device/tplink_archer-c5-v1
   DEVICE_MODEL := Archer C5
   DEVICE_VARIANT := v1
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k-ct \
-	ath10k-firmware-qca988x-ct
+	ath10k-firmware-qca988x-ct kmod-dsa-qca8k kmod-phy-qca83xx -swconfig
   TPLINK_HWID := 0xc5000001
   SUPPORTED_DEVICES += archer-c5
+  DEVICE_COMPAT_VERSION := 1.1
+  DEVICE_COMPAT_MESSAGE := Config cannot be migrated from swconfig to DSA
 endef
 TARGET_DEVICES += tplink_archer-c5-v1
 
@@ -162,9 +164,12 @@ define Device/tplink_archer-c7-v1
   SOC := qca9558
   DEVICE_MODEL := Archer C7
   DEVICE_VARIANT := v1
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport \
+	kmod-dsa-qca8k kmod-phy-qca83xx -swconfig
   TPLINK_HWID := 0x75000001
   SUPPORTED_DEVICES += archer-c7
+  DEVICE_COMPAT_VERSION := 1.1
+  DEVICE_COMPAT_MESSAGE := Config cannot be migrated from swconfig to DSA
 endef
 TARGET_DEVICES += tplink_archer-c7-v1
 
@@ -174,9 +179,11 @@ define Device/tplink_archer-c7-v2
   DEVICE_MODEL := Archer C7
   DEVICE_VARIANT := v2
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k-ct \
-	ath10k-firmware-qca988x-ct
+	ath10k-firmware-qca988x-ct kmod-dsa-qca8k kmod-phy-qca83xx -swconfig
   TPLINK_HWID := 0xc7000002
   SUPPORTED_DEVICES += archer-c7
+  DEVICE_COMPAT_VERSION := 1.1
+  DEVICE_COMPAT_MESSAGE := Config cannot be migrated from swconfig to DSA
   IMAGES += factory-us.bin factory-eu.bin
   IMAGE/factory-us.bin := tplink-v1-image factory -C US
   IMAGE/factory-eu.bin := tplink-v1-image factory -C EU
@@ -672,9 +679,11 @@ define Device/tplink_tl-wdr7500-v3
   DEVICE_MODEL := TL-WDR7500
   DEVICE_VARIANT := v3
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k-ct \
-	ath10k-firmware-qca988x-ct
+	ath10k-firmware-qca988x-ct kmod-dsa-qca8k kmod-phy-qca83xx -swconfig
   TPLINK_HWID := 0x75000003
   SUPPORTED_DEVICES += archer-c7
+  DEVICE_COMPAT_VERSION := 1.1
+  DEVICE_COMPAT_MESSAGE := Config cannot be migrated from swconfig to DSA
 endef
 TARGET_DEVICES += tplink_tl-wdr7500-v3
 

--- a/target/linux/ath79/patches-6.18/740-net-dsa-qca8k-keep-mdio-master-enabled-in-command-cl.patch
+++ b/target/linux/ath79/patches-6.18/740-net-dsa-qca8k-keep-mdio-master-enabled-in-command-cl.patch
@@ -1,0 +1,72 @@
+From 92a60f5aec2db208387a8dcd95e86024198760df Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Sat, 1 Aug 2026 13:09:54 -0700
+Subject: [PATCH] net: dsa: qca8k: keep mdio master enabled in command clear
+
+Writing 0 to QCA8K_MDIO_MASTER_CTRL after each management command also
+cleared QCA8K_MDIO_MASTER_EN, disabling the mdio master entirely. Keep
+QCA8K_MDIO_MASTER_EN set when clearing the command bits so the mdio
+master stays selected for subsequent accesses.
+
+Add qca8k_mdio_master_disable() and call it from qca8k_sw_remove() and
+qca8k_sw_shutdown() to explicitly disable the mdio master during teardown.
+
+Assisted-by: opencode:big-pickle
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ drivers/net/dsa/qca/qca8k-8xxx.c | 16 ++++++++++++++--
+ 1 file changed, 14 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/dsa/qca/qca8k-8xxx.c
++++ b/drivers/net/dsa/qca/qca8k-8xxx.c
+@@ -625,7 +625,7 @@ qca8k_phy_eth_command(struct qca8k_priv
+ {
+ 	struct sk_buff *write_skb, *clear_skb, *read_skb;
+ 	struct qca8k_mgmt_eth_data *mgmt_eth_data;
+-	u32 write_val, clear_val = 0, val;
++	u32 write_val, clear_val = QCA8K_MDIO_MASTER_EN, val;
+ 	struct net_device *mgmt_conduit;
+ 	int ret, ret1;
+ 	bool ack;
+@@ -679,7 +679,7 @@ qca8k_phy_eth_command(struct qca8k_priv
+ 	 * 1. Send mdio master packet
+ 	 * 2. Busy Wait for mdio master command
+ 	 * 3. Get the data if we are reading
+-	 * 4. Reset the mdio master (even with error)
++	 * 4. Clear the command bits while keeping the mdio master selected
+ 	 */
+ 	mutex_lock(&mgmt_eth_data->mutex);
+ 
+@@ -2227,6 +2227,16 @@ qca8k_sw_probe(struct mdio_device *mdiod
+ 	return dsa_register_switch(priv->ds);
+ }
+ 
++static void qca8k_mdio_master_disable(struct qca8k_priv *priv)
++{
++	int ret;
++
++	ret = regmap_clear_bits(priv->regmap, QCA8K_MDIO_MASTER_CTRL,
++				QCA8K_MDIO_MASTER_EN);
++	if (ret)
++		dev_warn(priv->dev, "failed to disable mdio master: %d\n", ret);
++}
++
+ static void
+ qca8k_sw_remove(struct mdio_device *mdiodev)
+ {
+@@ -2240,6 +2250,7 @@ qca8k_sw_remove(struct mdio_device *mdio
+ 		qca8k_port_set_status(priv, i, 0);
+ 
+ 	dsa_unregister_switch(priv->ds);
++	qca8k_mdio_master_disable(priv);
+ }
+ 
+ static void qca8k_sw_shutdown(struct mdio_device *mdiodev)
+@@ -2250,6 +2261,7 @@ static void qca8k_sw_shutdown(struct mdi
+ 		return;
+ 
+ 	dsa_switch_shutdown(priv->ds);
++	qca8k_mdio_master_disable(priv);
+ 
+ 	dev_set_drvdata(&mdiodev->dev, NULL);
+ }


### PR DESCRIPTION
Convert the TP-Link Archer C7 v1 and v2 from the legacy swconfig framework to DSA (Distributed Switch Architecture).

- Replace the deprecated qca,ar8327 switch binding with the modern qca,qca8327 DSA binding in the device tree, defining each port explicitly (cpu, wan, lan1-4) with appropriate PHY handles and fixed-link configurations.
- Move the board out of the shared swconfig switch setup in 02_network and add a DSA-specific network configuration.
- Add a compat-version bump (1.1) via 05_compat-version to trigger automatic config migration on upgrade.
- Update the image Makefile to drop swconfig from device packages and add the necessary DSA dependencies.

This enables native DSA features such as bridge offloading and simplifies the network stack by removing the swconfig abstraction layer.

These routers have enough space for DSA so no concern there.

ping @luizluca @olemmela