### PR TITLE
kernel: minimize kmod-sched-connmark dependencies

### DIFF
--- a/package/kernel/linux/modules/netsupport.mk
+++ b/package/kernel/linux/modules/netsupport.mk
@@ -825,7 +825,7 @@ $(eval $(call KernelPackage,sched-cake))
 define KernelPackage/sched-connmark
   SUBMENU:=$(NETWORK_SUPPORT_MENU)
   TITLE:=Traffic shaper conntrack mark support
-  DEPENDS:=+kmod-sched-core +kmod-ipt-core +kmod-ipt-conntrack-extra
+  DEPENDS:=+kmod-sched-core +kmod-nf-conntrack
   KCONFIG:=CONFIG_NET_ACT_CONNMARK
   FILES:=$(LINUX_DIR)/net/sched/act_connmark.ko
   AUTOLOAD:=$(call AutoLoad,71, act_connmark)


### PR DESCRIPTION
Remove iptables kmod dependency from kmod-sched-connmark. 
Both dependents
package/network/config/qos-scripts
../packages/net/trafficshaper
Already pull in ipt kmods via iptables-mod-conntrack-extra 

Permits "clean" nftables migration at
https://github.com/openwrt/packages/pull/29830
