### PR TITLE
ath79: fix Ethernet auto-negotiation on Ruckus ZoneFlex 7025

### DIFF
--- a/target/linux/ath79/dts/ar7240_ruckus_zf7025.dts
+++ b/target/linux/ath79/dts/ar7240_ruckus_zf7025.dts
@@ -186,6 +186,16 @@
 	nvmem-cell-names = "mac-address";
 };
 
+/*
+ * eth0 is connected to PHY 4 of the AR7240 built-in switch, which is
+ * 10/100 Mbps only, but the PHY erroneously advertises gigabit. This
+ * makes phylib attempt 1000BASE-T master/slave resolution that never
+ * completes, breaking auto-negotiation. Cap the PHY at 100 Mbps.
+ */
+&swphy4 {
+	max-speed = <100>;
+};
+
 &eth1 {
 	status = "okay";
 	nvmem-cells = <&macaddr_board_data_6c>;


### PR DESCRIPTION
On the ZoneFlex 7025 the uplink port (eth0) is connected to PHY 4 of the
AR7240 built-in switch. This PHY erroneously advertises 1000baseT/Full
capability, even though the AR7240 built-in switch only supports 10/100 Mbps.

Because of the bogus gigabit capability, phylib performs 1000BASE-T
master/slave resolution against the PHY's non-functional gigabit registers,
which never completes. Auto-negotiation then fails: the link flaps between
speeds or never comes up at all, while a manually forced fixed speed works fine.

Cap the PHY at 100 Mbps so the gigabit capability is removed and the
master/slave resolution path is skipped. eth0 then auto-negotiates reliably
to 100 Mbps full-duplex.

Tested on real hardware (Ruckus ZoneFlex 7025, ath79 / OpenWrt 23.05):
before this change eth0 flapped or failed to link under auto-negotiation;
after it, `ethtool` no longer lists 1000baseT/Full under "Supported link
modes" and eth0 auto-negotiates reliably to 100 Mbps full-duplex, obtaining
a DHCP lease on the uplink.
