### PR TITLE
mvebu: disable packet steering on globalscale,mochabin

### DIFF
--- a/target/linux/mvebu/base-files/etc/uci-defaults/01_packet_steering
+++ b/target/linux/mvebu/base-files/etc/uci-defaults/01_packet_steering
@@ -1,0 +1,15 @@
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+globalscale,mochabin)
+	uci -q get network.globals.packet_steering > /dev/null || {
+		uci set network.globals='globals'
+		uci set network.globals.packet_steering=0
+		uci commit network
+	}
+	;;
+esac
+
+exit 0


### PR DESCRIPTION
Enabled:
```
Idle Latency:     8.96 ms   (jitter: 0.07ms, low: 8.91ms, high: 9.02ms)
    Download:  1511.15 Mbps (data used: 1.9 GB)
                  9.42 ms   (jitter: 12.74ms, low: 8.56ms, high: 233.14ms)
      Upload:   930.62 Mbps (data used: 823.1 MB)
                 15.51 ms   (jitter: 0.95ms, low: 9.24ms, high: 17.61ms)
```
Disabled:
```
Idle Latency:     8.95 ms   (jitter: 0.05ms, low: 8.89ms, high: 9.01ms)
    Download:  6758.30 Mbps (data used: 8.5 GB)
                 16.48 ms   (jitter: 0.69ms, low: 8.65ms, high: 20.35ms)
      Upload:   931.39 Mbps (data used: 812.4 MB)
                 16.61 ms   (jitter: 0.72ms, low: 9.24ms, high: 19.36ms))
```
All routing done over the SFP+ port, with flow offloading disabled (enabling it hurts performance by a factor of 100 in either case).

This might be worth a cherry-pick in the release branches, this was tested on 25.12.5