### PR TITLE
ramips: mt76x8: add support for Teltonika RUT301

### DIFF
--- a/target/linux/ramips/dts/mt7628an_teltonika_rut301.dts
+++ b/target/linux/ramips/dts/mt7628an_teltonika_rut301.dts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include "mt7628an.dtsi"
+
+/ {
+	compatible = "teltonika,rut301", "mediatek,mt7628an-soc";
+	model = "Teltonika RUT301";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_din1 {
+			gpio-export,name = "digital_input1";
+			gpio-export,input = <0>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		gpio_dout1 {
+			gpio-export,name = "digital_output1";
+			gpio-export,output = <0>;
+			gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_din2 {
+			gpio-export,name = "digital_input2";
+			gpio-export,input = <0>;
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		gpio_dout2 {
+			gpio-export,name = "digital_output2";
+			gpio-export,output = <0>;
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+		};
+
+		lan1 {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <1>;
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <2>;
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <3>;
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+		};
+
+		lan4 {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <4>;
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "config";
+				reg = <0x020000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_config_0: macaddr@0 {
+						reg = <0x0 0x6>;
+						compatible = "mac-base";
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@30000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x030000 0xf40000>;
+			};
+
+			partition@f70000 {
+				label = "event-log";
+				reg = <0xf70000 0x90000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2s", "uart1", "p4led_an", "p3led_an", "p2led_an", "p1led_an", "p0led_an", "gpio", "wled_an", "perst", "spi cs1", "refclk";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_config_0 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x2f>;
+};
+

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -765,6 +765,20 @@ define Device/tama_w06
 endef
 TARGET_DEVICES += tama_w06
 
+define Device/teltonika_rut301
+  DEVICE_VENDOR := Teltonika
+  DEVICE_MODEL := RUT301
+  SUPPORTED_TELTONIKA_DEVICES := teltonika,rut301
+  IMAGE_SIZE := 15616k
+  BLOCKSIZE := 64k
+  DEVICE_PACKAGES += -kmod-mt7603 -wpad-basic-mbedtls kmod-usb2 kmod-usb-ohci
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs | check-size | append-teltonika-metadata
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-metadata
+endef
+TARGET_DEVICES += teltonika_rut301
+
 define Device/teltonika_rut9x1
   DEVICE_VENDOR := Teltonika
   DEVICE_MODEL := RUT951

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -106,6 +106,13 @@ teltonika,rut241)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x02"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x01"
 	;;
+teltonika,rut301)
+	ucidef_set_led_switch "lan1" "lan1" "green:lan-1" "switch0" "0x1"
+	ucidef_set_led_switch "lan2" "lan2" "green:lan-2" "switch0" "0x2"
+	ucidef_set_led_switch "lan3" "lan3" "green:lan-3" "switch0" "0x4"
+	ucidef_set_led_switch "lan4" "lan4" "green:lan-4" "switch0" "0x8"
+	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
+	;;
 teltonika,rut976|\
 teltonika,rut9x1|\
 teltonika,rut9x6)

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -176,7 +176,8 @@ ramips_setup_interfaces()
 		ucidef_set_interface_lan "eth0"
 		ucidef_set_interface "wan" device "/dev/cdc-wdm0" protocol "qmi"
 		;;
-	linksys,e5400)
+	linksys,e5400|\
+	teltonika,rut301)
 		ucidef_add_switch "switch0" \
 			"0:lan:1" "1:lan:2" "2:lan:3" "3:lan:4" "4:wan" "6@eth0"
 		;;

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/03_gpio_switches
@@ -22,6 +22,10 @@ teltonika,rut241)
 	ucidef_add_gpio_switch "modem_power" "Modem power" "modem_power" "1"
 	ucidef_add_gpio_switch "modem_reset" "Modem reset" "modem_reset" "0"
 	;;
+teltonika,rut301)
+	ucidef_add_gpio_switch "digital_output1" "Digital output 1" "digital_output1" "0"
+	ucidef_add_gpio_switch "digital_output2" "Digital output 2" "digital_output2" "0"
+	;;
 teltonika,rut9x1)
 	ucidef_add_gpio_switch "digital_output" "Digital output 1" "digital_output1" "0"
 	ucidef_add_gpio_switch "modem_power" "Modem power button" "modem_power" "1"


### PR DESCRIPTION
This commit adds support for the Teltonika RUT301 wifi-less power saving router with usb and external gpios.

Specification:
- MediaTek MT7628AN SoC
- 128 MB RAM
- 16MB SPI‌ NOR Flash
- 5x 10/100 Mbps Ethernet
- 2.0 USB type-A host port
- 2x digital input/output (24V open collector, exported as GPIO)
- 1x button (reset)
- 1x user LED (power)
- 5x Ethernet port LEDs (controllable)

Flashing via OEM WebUI:
1. Download the firmware image *-squashfs-factory.bin
2. Upload firmware image via OEM WebUI firmware update, don't keep settings

To revert back to OEM firmware:
https://wiki.teltonika-networks.com/view/Bootloader_menu

UART (not needed to flash):
Available on the PCB edge connector, 115200 8N1 3V3
Pins, counted from the slot: Top: 1=TxD, 3=GND,  Botton: 1=RxD
I sawed an old PCI socket to fit. Press a key to interrupt uboot.
But don't run saveenv, it bricked my board.

Flash layout:
mtd0:   128kB U-Boot, ubootenv at 0x1f800 without CRC
mtd1:    64kB config, MAC-Address in binary at the beginning
mtd2: 15616kB firmware, dynamically partitioned into:
mtd3: ~2000kB kernel
mtd4: ~2600kB rootfs (squashfs)
mtd5: leftover rootfs_data
mtd6:   576kB event-log from Teltonika, unknown format