### PR TITLE
kernel: Add SCSI target core and LIO backend kernel packages

### DIFF
--- a/package/kernel/linux/modules/block.mk
+++ b/package/kernel/linux/modules/block.mk
@@ -292,6 +292,101 @@ endef
 
 $(eval $(call KernelPackage,iscsi-initiator))
 
+define KernelPackage/target-core
+  SUBMENU:=$(BLOCK_MENU)
+  TITLE:=Linux SCSI target core
+  DEPENDS:=+kmod-scsi-core +kmod-fs-configfs +kmod-lib-crc-t10dif
+  KCONFIG:= \
+	CONFIG_TARGET_CORE \
+	CONFIG_TCM_PSCSI=n \
+	CONFIG_TCM_USER2=n \
+	CONFIG_LOOPBACK_TARGET=n \
+	CONFIG_TCM_FC=n \
+	CONFIG_SBP_TARGET=n \
+	CONFIG_REMOTE_TARGET=n \
+	CONFIG_TCM_QLA2XXX=n \
+	CONFIG_INFINIBAND_SRPT=n \
+	CONFIG_SCSI_EFCT=n \
+	CONFIG_SCSI_IBMVSCSIS=n \
+	CONFIG_USB_CONFIGFS_F_TCM=n \
+	CONFIG_USB_GADGET_TARGET=n \
+	CONFIG_VHOST_SCSI=n \
+	CONFIG_XEN_SCSI_BACKEND=n
+  FILES:= \
+	$(LINUX_DIR)/drivers/target/target_core_mod.ko
+  AUTOLOAD:=$(call AutoProbe,target_core_mod)
+endef
+
+define KernelPackage/target-core/description
+ Kernel support for the Linux SCSI target core used by LIO.
+ The target core provides the configfs infrastructure for exporting
+ local storage to SCSI initiators.
+endef
+
+$(eval $(call KernelPackage,target-core))
+
+
+define KernelPackage/tcm-iblock
+  SUBMENU:=$(BLOCK_MENU)
+  TITLE:=LIO iblock backend
+  DEPENDS:=+kmod-target-core
+  KCONFIG:= \
+	CONFIG_TCM_IBLOCK
+  FILES:= \
+	$(LINUX_DIR)/drivers/target/target_core_iblock.ko
+  AUTOLOAD:=$(call AutoProbe,target_core_iblock)
+endef
+
+define KernelPackage/tcm-iblock/description
+ Kernel support for the LIO iblock backend.
+ This backend exports existing block devices as SCSI target LUNs.
+endef
+
+$(eval $(call KernelPackage,tcm-iblock))
+
+
+define KernelPackage/tcm-fileio
+  SUBMENU:=$(BLOCK_MENU)
+  TITLE:=LIO fileio backend
+  DEPENDS:=+kmod-target-core
+  KCONFIG:= \
+	CONFIG_TCM_FILEIO
+  FILES:= \
+	$(LINUX_DIR)/drivers/target/target_core_file.ko
+  AUTOLOAD:=$(call AutoProbe,target_core_file)
+endef
+
+define KernelPackage/tcm-fileio/description
+ Kernel support for the LIO fileio backend.
+ This backend exports regular files as SCSI target LUNs.
+endef
+
+$(eval $(call KernelPackage,tcm-fileio))
+
+
+define KernelPackage/iscsi-target
+  SUBMENU:=$(BLOCK_MENU)
+  TITLE:=LIO iSCSI target
+  DEPENDS:=+kmod-target-core +kmod-crypto-hash +kmod-crypto-md5 \
+	+LINUX_6_12:kmod-crypto-crc32c
+  KCONFIG:= \
+	CONFIG_INET \
+	CONFIG_ISCSI_TARGET \
+	CONFIG_ISCSI_TARGET_CXGB4=n \
+	CONFIG_INFINIBAND_ISERT=n
+  FILES:= \
+	$(LINUX_DIR)/drivers/target/iscsi/iscsi_target_mod.ko
+  AUTOLOAD:=$(call AutoProbe,iscsi_target_mod)
+endef
+
+define KernelPackage/iscsi-target/description
+ Kernel support for the LIO iSCSI target fabric.
+ This allows OpenWrt to export local block or file-backed storage
+ to iSCSI initiators.
+endef
+
+$(eval $(call KernelPackage,iscsi-target))
+
 
 define KernelPackage/md-mod
   SUBMENU:=$(BLOCK_MENU)

--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -165,6 +165,19 @@ endef
 $(eval $(call KernelPackage,crypto-crc32c))
 
 
+define KernelPackage/crypto-crct10dif
+  TITLE:=CRC-T10DIF CRC module
+  DEPENDS:=@LINUX_6_12 +kmod-crypto-hash
+  KCONFIG:=CONFIG_CRYPTO_CRCT10DIF
+  FILES:=$(LINUX_DIR)/crypto/crct10dif_common.ko \
+	$(LINUX_DIR)/crypto/crct10dif_generic.ko
+  AUTOLOAD:=$(call AutoLoad,04,crct10dif_common crct10dif_generic,1)
+  $(call AddDepends/crypto)
+endef
+
+$(eval $(call KernelPackage,crypto-crct10dif))
+
+
 define KernelPackage/crypto-ctr
   TITLE:=Counter Mode CryptoAPI module
   DEPENDS:=+kmod-crypto-manager +kmod-crypto-seqiv

--- a/package/kernel/linux/modules/lib.mk
+++ b/package/kernel/linux/modules/lib.mk
@@ -39,6 +39,23 @@ endef
 $(eval $(call KernelPackage,lib-crc-itu-t))
 
 
+define KernelPackage/lib-crc-t10dif
+  SUBMENU:=$(LIB_MENU)
+  TITLE:=CRC-T10DIF support
+  KCONFIG:=CONFIG_CRC_T10DIF
+  DEPENDS:=+LINUX_6_12:kmod-crypto-crct10dif
+  FILES:=$(LINUX_DIR)/lib/crc-t10dif.ko@lt6.18 \
+	$(LINUX_DIR)/lib/crc/crc-t10dif.ko@ge6.18
+  AUTOLOAD:=$(call AutoProbe,crc-t10dif)
+endef
+
+define KernelPackage/lib-crc-t10dif/description
+ Kernel module for CRC-T10DIF support
+endef
+
+$(eval $(call KernelPackage,lib-crc-t10dif))
+
+
 define KernelPackage/lib-crc7
   SUBMENU:=$(LIB_MENU)
   TITLE:=CRC7 support


### PR DESCRIPTION
Added kernel packages for SCSI target core, LIO backends, and iSCSI target support.