### PR TITLE
kernel: modules: mux-mmio: add missing regmap-mmio dependency

### DIFF
--- a/package/kernel/linux/modules/multiplexer.mk
+++ b/package/kernel/linux/modules/multiplexer.mk
@@ -36,7 +36,7 @@ $(eval $(call KernelPackage,mux-gpio))
 define KernelPackage/mux-mmio
   SUBMENU:=$(OTHER_MENU)
   TITLE:=MMIO/Regmap register bitfield-controlled Multiplexer controller
-  DEPENDS:=+kmod-mux-core
+  DEPENDS:=+kmod-mux-core +kmod-regmap-mmio
   KCONFIG:=CONFIG_MUX_MMIO
   FILES:=$(LINUX_DIR)/drivers/mux/mux-mmio.ko
   AUTOLOAD:=$(call AutoProbe,mux-mmio)


### PR DESCRIPTION
mux-mmio.ko depends on regmap-mmio.ko at runtime, but the kmod package was missing the dependency, causing build failures when the module is included.

Fixes: ac3901689881 ("kernel: modules: package MMIO mux driver")

ping @Leo-PL @robimarko 