### PR TITLE
qualcommbe: ipq9574: USXGMII fixes

### DIFF
--- a/target/linux/qualcommbe/patches-6.18/0356-arm64-dts-qcom-ipq9574-describe-remaining-uniphy-resets.patch
+++ b/target/linux/qualcommbe/patches-6.18/0356-arm64-dts-qcom-ipq9574-describe-remaining-uniphy-resets.patch
@@ -1,0 +1,58 @@
+From: Kenneth Kasilag <kenneth@kasilag.me>
+Date: Thu, 02 Jul 2026 00:00:00 +0000
+Subject: [PATCH] arm64: dts: qcom: ipq9574: describe remaining uniphy resets
+
+Each uniphy has, besides the XPCS reset, a system reset in the GCC and
+a soft reset in the NSSCC. The vendor driver pulses both on every
+interface mode change as part of the uniphy bring-up. Describe them,
+and name the resets while at it, so the PCS driver can pick them up.
+
+Signed-off-by: Kenneth Kasilag <kenneth@kasilag.me>
+---
+ arch/arm64/boot/dts/qcom/ipq9574.dtsi | 21 ++++++++++++++++---
+ 1 file changed, 18 insertions(+), 3 deletions(-)
+
+--- a/arch/arm64/boot/dts/qcom/ipq9574.dtsi
++++ b/arch/arm64/boot/dts/qcom/ipq9574.dtsi
+@@ -1493,7 +1493,12 @@
+ 				 <&gcc GCC_UNIPHY0_AHB_CLK>;
+ 			clock-names = "sys",
+ 				      "ahb";
+-			resets = <&gcc GCC_UNIPHY0_XPCS_RESET>;
++			resets = <&gcc GCC_UNIPHY0_XPCS_RESET>,
++				 <&gcc GCC_UNIPHY0_SYS_RESET>,
++				 <&nsscc UNIPHY0_SOFT_RESET>;
++			reset-names = "xpcs",
++				      "sys",
++				      "soft";
+ 			#clock-cells = <1>;
+ 
+ 			pcs0_ch0: pcs-mii@0 {
+@@ -1538,7 +1543,12 @@
+ 				 <&gcc GCC_UNIPHY1_AHB_CLK>;
+ 			clock-names = "sys",
+ 				      "ahb";
+-			resets = <&gcc GCC_UNIPHY1_XPCS_RESET>;
++			resets = <&gcc GCC_UNIPHY1_XPCS_RESET>,
++				 <&gcc GCC_UNIPHY1_SYS_RESET>,
++				 <&nsscc UNIPHY1_SOFT_RESET>;
++			reset-names = "xpcs",
++				      "sys",
++				      "soft";
+ 			#clock-cells = <1>;
+ 
+ 			pcs1_ch0: uniphy-ch@0 {
+@@ -1559,7 +1569,12 @@
+ 				 <&gcc GCC_UNIPHY2_AHB_CLK>;
+ 			clock-names = "sys",
+ 				      "ahb";
+-			resets = <&gcc GCC_UNIPHY2_XPCS_RESET>;
++			resets = <&gcc GCC_UNIPHY2_XPCS_RESET>,
++				 <&gcc GCC_UNIPHY2_SYS_RESET>,
++				 <&nsscc UNIPHY2_SOFT_RESET>;
++			reset-names = "xpcs",
++				      "sys",
++				      "soft";
+ 			#clock-cells = <1>;
+ 
+ 			pcs2_ch0: pcs-mii@0 {

--- a/target/linux/qualcommbe/patches-6.18/0357-net-pcs-qcom-ipq9574-complete-USXGMII-in-band-AN.patch
+++ b/target/linux/qualcommbe/patches-6.18/0357-net-pcs-qcom-ipq9574-complete-USXGMII-in-band-AN.patch
@@ -1,0 +1,87 @@
+From: Kenneth Kasilag <kenneth@kasilag.me>
+Date: Tue, 30 Jun 2026 00:00:00 +0000
+Subject: [PATCH] net: pcs: qcom-ipq9574: complete USXGMII in-band AN
+
+The XPCS signals USXGMII in-band autonegotiation completion through an
+interrupt that is never enabled, waited for or acknowledged, so rate
+adaptation never starts and the MAC receives nothing even though the
+SerDes achieves block lock. The advertised speed and duplex are also
+left at their reset values while autonegotiation runs.
+
+Follow the vendor SSDK sequence: enable the completion interrupt and
+advertise 10G/full duplex when configuring the PCS, and on link-up
+restart the in-band autonegotiation, wait for completion and
+acknowledge it before programming the negotiated speed. The wait is
+best-effort, as in the vendor driver.
+
+Signed-off-by: Kenneth Kasilag <kenneth@kasilag.me>
+---
+ drivers/net/pcs/pcs-qcom-ipq9574.c | 34 ++++++++++++++++++++++++++--
+ 1 file changed, 26 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/pcs/pcs-qcom-ipq9574.c
++++ b/drivers/net/pcs/pcs-qcom-ipq9574.c
+@@ -95,6 +95,7 @@
+ #define XPCS_MII_CTRL			0x1f0000
+ #define XPCS_MII1_CTRL(x)		(0x1a0000 + 0x10000 * ((x) - 1))
+ #define XPCS_MII_AN_EN			BIT(12)
++#define XPCS_MII_AN_RESTART		BIT(9)
+ #define XPCS_DUPLEX_FULL		BIT(8)
+ #define XPCS_SPEED_MASK			(BIT(13) | BIT(6) | BIT(5))
+ #define XPCS_SPEED_10000		(BIT(13) | BIT(6))
+@@ -107,10 +108,12 @@
+ #define XPCS_MII_AN_CTRL		0x1f8001
+ #define XPCS_MII1_AN_CTRL(x)		(0x1a8001 + 0x10000 * ((x) - 1))
+ #define XPCS_MII_AN_8BIT		BIT(8)
++#define XPCS_MII_AN_INTR_EN		BIT(0)
+ 
+ #define XPCS_MII_AN_INTR_STS		0x1f8002
+ #define XPCS_MII1_AN_INTR_STS(x)	(0x1a8002 + 0x10000 * ((x) - 1))
+ #define XPCS_USXG_AN_LINK_STS		BIT(14)
++#define XPCS_MII_AN_CL37_CMPLT		BIT(0)
+ #define XPCS_USXG_AN_SPEED_MASK		GENMASK(12, 10)
+ #define XPCS_USXG_AN_SPEED_10		0
+ #define XPCS_USXG_AN_SPEED_100		1
+@@ -472,12 +475,16 @@ static int ipq_pcs_config_usxgmii(struct
+ 	}
+ 
+ 	reg = (index == 0) ? XPCS_MII_AN_CTRL : XPCS_MII1_AN_CTRL(index);
+-	ret = regmap_set_bits(qpcs->regmap, reg, XPCS_MII_AN_8BIT);
++	ret = regmap_set_bits(qpcs->regmap, reg,
++			      XPCS_MII_AN_8BIT | XPCS_MII_AN_INTR_EN);
+ 	if (ret)
+ 		return ret;
+ 
+ 	reg = (index == 0) ? XPCS_MII_CTRL : XPCS_MII1_CTRL(index);
+-	return regmap_set_bits(qpcs->regmap, reg, XPCS_MII_AN_EN);
++	/* Advertise 10G/full while AN runs; link-up applies the result */
++	return regmap_update_bits(qpcs->regmap, reg,
++				  XPCS_MII_AN_EN | XPCS_SPEED_MASK | XPCS_DUPLEX_FULL,
++				  XPCS_MII_AN_EN | XPCS_SPEED_10000 | XPCS_DUPLEX_FULL);
+ }
+ 
+ static int ipq_pcs_config_10gbaser(struct ipq_pcs *qpcs)
+@@ -553,6 +560,23 @@ static int ipq_pcs_link_up_config_usxgmi
+ 	unsigned int reg, val;
+ 	int ret;
+ 
++	/* Rate adaptation is held off until the AN completion is acked:
++	 * restart in-band AN, wait for it and ack it.
++	 */
++	reg = (index == 0) ? XPCS_MII_CTRL : XPCS_MII1_CTRL(index);
++	ret = regmap_set_bits(qpcs->regmap, reg, XPCS_MII_AN_RESTART);
++	if (ret)
++		return ret;
++
++	reg = (index == 0) ? XPCS_MII_AN_INTR_STS : XPCS_MII1_AN_INTR_STS(index);
++	ret = regmap_read_poll_timeout(qpcs->regmap, reg, val,
++				       val & XPCS_MII_AN_CL37_CMPLT,
++				       1000, 100000);
++	if (ret)
++		dev_warn(qpcs->dev, "USXGMII in-band AN did not complete\n");
++	else
++		regmap_clear_bits(qpcs->regmap, reg, XPCS_MII_AN_CL37_CMPLT);
++
+ 	switch (speed) {
+ 	case SPEED_10000:
+ 		val = XPCS_SPEED_10000;

--- a/target/linux/qualcommbe/patches-6.18/0358-net-pcs-qcom-ipq9574-enable-uniphy-25MHz-clock-output.patch
+++ b/target/linux/qualcommbe/patches-6.18/0358-net-pcs-qcom-ipq9574-enable-uniphy-25MHz-clock-output.patch
@@ -1,0 +1,50 @@
+From: Kenneth Kasilag <kenneth@kasilag.me>
+Date: Wed, 01 Jul 2026 00:00:00 +0000
+Subject: [PATCH] net: pcs: qcom-ipq9574: enable uniphy 25MHz clock output
+
+Some board designs feed an external PHY its reference clock from the
+uniphy 25MHz clock output instead of a local crystal. Enable the
+output when the devicetree opts in with "qcom,uniphy-clkout-25mhz".
+
+The clock output register only becomes writable once the PLL reset
+and calibration have completed, so program it at the end of the mode
+configuration rather than at probe time.
+
+Signed-off-by: Kenneth Kasilag <kenneth@kasilag.me>
+---
+ drivers/net/pcs/pcs-qcom-ipq9574.c | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+--- a/drivers/net/pcs/pcs-qcom-ipq9574.c
++++ b/drivers/net/pcs/pcs-qcom-ipq9574.c
+@@ -23,6 +23,11 @@
+ #define PCS_CALIBRATION			0x1e0
+ #define PCS_CALIBRATION_DONE		BIT(7)
+ 
++/* 25MHz reference clock output to an external PHY */
++#define PCS_CLKOUT_50M_CTRL		0x610
++#define PCS_CLKOUT_50M_25M_EN		BIT(0)
++#define PCS_CLKOUT_50M_DIV2_SEL		BIT(5)
++
+ #define PCS_MISC2			0x218
+ #define PCS_MISC2_MODE_MASK		GENMASK(6, 5)
+ #define PCS_MISC2_MODE_SGMII		FIELD_PREP(PCS_MISC2_MODE_MASK, 0x1)
+@@ -377,6 +382,18 @@ static int ipq_pcs_config_mode(struct ip
+ 
+ 	qpcs->interface = interface;
+ 
++	/* The clock output register is only writable after PLL reset
++	 * and calibration, so this cannot be done at probe.
++	 */
++	if (of_property_read_bool(qpcs->dev->of_node,
++				  "qcom,uniphy-clkout-25mhz")) {
++		ret = regmap_set_bits(qpcs->regmap, PCS_CLKOUT_50M_CTRL,
++				      PCS_CLKOUT_50M_25M_EN |
++				      PCS_CLKOUT_50M_DIV2_SEL);
++		if (ret)
++			return ret;
++	}
++
+ 	/* Configure the RX and TX clock to NSSCC as 125M or 312.5M based
+ 	 * on current interface mode.
+ 	 */

--- a/target/linux/qualcommbe/patches-6.18/0359-net-pcs-qcom-ipq9574-pulse-uniphy-sys-reset.patch
+++ b/target/linux/qualcommbe/patches-6.18/0359-net-pcs-qcom-ipq9574-pulse-uniphy-sys-reset.patch
@@ -1,0 +1,66 @@
+From: Kenneth Kasilag <kenneth@kasilag.me>
+Date: Wed, 01 Jul 2026 00:00:00 +0000
+Subject: [PATCH] net: pcs: qcom-ipq9574: pulse uniphy sys/soft resets during config
+
+The uniphy never receives a software reset pulse during interface mode
+configuration. The vendor SSDK asserts the GCC system reset and the
+NSSCC soft reset together for 100ms on every uniphy mode change;
+without the pulse, parts of the uniphy analog block can remain in
+their power-on state.
+
+Pulse both resets, when the devicetree provides them, after the mode
+is programmed. Both resets are optional so existing devicetrees keep
+working.
+
+Signed-off-by: Kenneth Kasilag <kenneth@kasilag.me>
+---
+ drivers/net/pcs/pcs-qcom-ipq9574.c | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+--- a/drivers/net/pcs/pcs-qcom-ipq9574.c
++++ b/drivers/net/pcs/pcs-qcom-ipq9574.c
+@@ -157,6 +157,8 @@ struct ipq_pcs {
+ 
+ 	struct ipq_pcs_mii *qpcs_mii[PCS_MAX_MII_NRS];
+ 	struct reset_control *xpcs_rstc;
++	struct reset_control *sys_rstc;
++	struct reset_control *soft_rstc;
+ };
+ 
+ #define phylink_pcs_to_qpcs_mii(_pcs)	\
+@@ -361,6 +363,18 @@ static int ipq_pcs_config_mode(struct ip
+ 			return ret;
+ 	}
+ 
++	/* Pulse the resets as the vendor SSDK does: both held for
++	 * 100ms, then another 100ms to settle after release.
++	 */
++	if (qpcs->sys_rstc || qpcs->soft_rstc) {
++		reset_control_assert(qpcs->sys_rstc);
++		reset_control_assert(qpcs->soft_rstc);
++		msleep(100);
++		reset_control_deassert(qpcs->sys_rstc);
++		reset_control_deassert(qpcs->soft_rstc);
++		msleep(100);
++	}
++
+ 	/* PCS PLL reset */
+ 	ret = regmap_clear_bits(qpcs->regmap, PCS_PLL_RESET, PCS_ANA_SW_RESET);
+ 	if (ret)
+@@ -1075,6 +1089,16 @@ static int ipq9574_pcs_probe(struct plat
+ 		return dev_err_probe(dev, PTR_ERR(qpcs->xpcs_rstc),
+ 				     "Failed to get XPCS reset\n");
+ 
++	qpcs->sys_rstc = devm_reset_control_get_optional_exclusive(dev, "sys");
++	if (IS_ERR(qpcs->sys_rstc))
++		return dev_err_probe(dev, PTR_ERR(qpcs->sys_rstc),
++				     "Failed to get uniphy sys reset\n");
++
++	qpcs->soft_rstc = devm_reset_control_get_optional_exclusive(dev, "soft");
++	if (IS_ERR(qpcs->soft_rstc))
++		return dev_err_probe(dev, PTR_ERR(qpcs->soft_rstc),
++				     "Failed to get uniphy soft reset\n");
++
+ 	ret = ipq_pcs_clk_register(qpcs);
+ 	if (ret)
+ 		return ret;

--- a/target/linux/qualcommbe/patches-6.18/0360-net-pcs-qcom-ipq9574-set-MISC2-phy-mode-for-USXGMII.patch
+++ b/target/linux/qualcommbe/patches-6.18/0360-net-pcs-qcom-ipq9574-set-MISC2-phy-mode-for-USXGMII.patch
@@ -1,0 +1,52 @@
+From: Kenneth Kasilag <kenneth@kasilag.me>
+Date: Thu, 02 Jul 2026 00:00:00 +0000
+Subject: [PATCH] net: pcs: qcom-ipq9574: fix MISC2 phy mode field and cover USXGMII
+
+The MISC2 phy mode field is modelled as two bits at the wrong offset:
+the hardware field is three bits wide and starts one bit lower. The
+SGMII and 2500BASE-X values only come out right because the power-on
+default happens to keep the missed bit set, and USXGMII is not
+programmed at all, leaving the uniphy in its power-on SGMII
+personality.
+
+Model the field at its documented position, add the USXGMII mode
+value and write the rate field explicitly instead of relying on its
+power-on default, matching the values the vendor SSDK programs.
+
+Signed-off-by: Kenneth Kasilag <kenneth@kasilag.me>
+---
+ drivers/net/pcs/pcs-qcom-ipq9574.c | 14 +++++++++-----
+ 1 file changed, 10 insertions(+), 4 deletions(-)
+
+--- a/drivers/net/pcs/pcs-qcom-ipq9574.c
++++ b/drivers/net/pcs/pcs-qcom-ipq9574.c
+@@ -29,9 +29,11 @@
+ #define PCS_CLKOUT_50M_DIV2_SEL		BIT(5)
+ 
+ #define PCS_MISC2			0x218
+-#define PCS_MISC2_MODE_MASK		GENMASK(6, 5)
+-#define PCS_MISC2_MODE_SGMII		FIELD_PREP(PCS_MISC2_MODE_MASK, 0x1)
+-#define PCS_MISC2_MODE_SGMII_PLUS	FIELD_PREP(PCS_MISC2_MODE_MASK, 0x2)
++#define PCS_MISC2_RATE_MASK		GENMASK(1, 0)
++#define PCS_MISC2_MODE_MASK		GENMASK(6, 4)
++#define PCS_MISC2_MODE_SGMII		FIELD_PREP(PCS_MISC2_MODE_MASK, 0x3)
++#define PCS_MISC2_MODE_SGMII_PLUS	FIELD_PREP(PCS_MISC2_MODE_MASK, 0x5)
++#define PCS_MISC2_MODE_USXGMII		FIELD_PREP(PCS_MISC2_MODE_MASK, 0x7)
+ 
+ #define PCS_MODE_CTRL			0x46c
+ #define PCS_MODE_SEL_MASK		GENMASK(12, 8)
+@@ -356,9 +358,13 @@ static int ipq_pcs_config_mode(struct ip
+ 			return ret;
+ 	}
+ 
++	if (interface == PHY_INTERFACE_MODE_USXGMII)
++		misc2 = PCS_MISC2_MODE_USXGMII;
++
+ 	if (misc2) {
+ 		ret = regmap_update_bits(qpcs->regmap, PCS_MISC2,
+-					 PCS_MISC2_MODE_MASK, misc2);
++					 PCS_MISC2_MODE_MASK |
++					 PCS_MISC2_RATE_MASK, misc2);
+ 		if (ret)
+ 			return ret;
+ 	}

--- a/target/linux/qualcommbe/patches-6.18/0361-net-pcs-qcom-ipq9574-align-USXGMII-bring-up-with-SSDK.patch
+++ b/target/linux/qualcommbe/patches-6.18/0361-net-pcs-qcom-ipq9574-align-USXGMII-bring-up-with-SSDK.patch
@@ -1,0 +1,218 @@
+From: Kenneth Kasilag <kenneth@kasilag.me>
+Date: Thu, 02 Jul 2026 00:00:00 +0000
+Subject: [PATCH] net: pcs: qcom-ipq9574: align USXGMII bring-up with vendor SSDK
+
+Align the USXGMII configuration sequence with the SSDK:
+
+- Reset the PCS PLL by programming the whole reset register with the
+  documented assert and release values and 100ms holds, instead of
+  toggling a single bit for 1ms and relying on the power-on state of
+  the remaining analog enables.
+
+- Keep the uniphy port clocks disabled across the reconfiguration and
+  re-enable them after calibration, before releasing the XPCS reset.
+  Restore them on failure as well, so the enable count stays balanced
+  against the pcs_enable/pcs_disable callbacks.
+
+- Select in-band link detection explicitly rather than the SFP
+  loss-of-signal input, which does not exist on non-SFP ports.
+
+- Wait for the 10GBASE-R receiver to link before enabling the USXGMII
+  adaptation layer. Best-effort, since the PHY SerDes may only come
+  up later.
+
+Other interface modes keep the previous behaviour.
+
+Signed-off-by: Kenneth Kasilag <kenneth@kasilag.me>
+---
+ drivers/net/pcs/pcs-qcom-ipq9574.c | 104 ++++++++++++++++++++++++-----
+ 1 file changed, 91 insertions(+), 13 deletions(-)
+
+--- a/drivers/net/pcs/pcs-qcom-ipq9574.c
++++ b/drivers/net/pcs/pcs-qcom-ipq9574.c
+@@ -71,6 +71,12 @@
+ 
+ #define PCS_PLL_RESET			0x780
+ #define PCS_ANA_SW_RESET		BIT(6)
++#define PCS_PLL_RESET_ASSERT		0x2bf
++#define PCS_PLL_RESET_RELEASE		0x2ff
++
++/* LOS-from-SFP select; 0x7 on SFP ports, 0 otherwise */
++#define PCS_LINK_DETECT			0x570
++#define PCS_DETECT_LOS_FROM_SFP		GENMASK(8, 6)
+ 
+ #define XPCS_INDIRECT_ADDR		0x8000
+ #define XPCS_INDIRECT_AHB_ADDR		0x83fc
+@@ -299,6 +305,22 @@ static void ipq_pcs_get_state_10gbaser(s
+ 	state->pause |= MLO_PAUSE_TXRX_MASK;
+ }
+ 
++/* Re-enable the port clocks held off across a USXGMII reconfiguration */
++static int ipq_pcs_restore_port_clks(struct ipq_pcs *qpcs,
++				     phy_interface_t interface)
++{
++	int ret;
++
++	if (interface != PHY_INTERFACE_MODE_USXGMII || !qpcs->qpcs_mii[0])
++		return 0;
++
++	ret = clk_prepare_enable(qpcs->qpcs_mii[0]->rx_clk);
++	if (ret)
++		return ret;
++
++	return clk_prepare_enable(qpcs->qpcs_mii[0]->tx_clk);
++}
++
+ static int ipq_pcs_config_mode(struct ipq_pcs *qpcs,
+ 			       phy_interface_t interface)
+ {
+@@ -307,6 +329,12 @@ static int ipq_pcs_config_mode(struct ip
+ 	bool xpcs_mode = false;
+ 	int ret;
+ 
++	/* The port clocks must be held off across the reconfiguration */
++	if (interface == PHY_INTERFACE_MODE_USXGMII && qpcs->qpcs_mii[0]) {
++		clk_disable_unprepare(qpcs->qpcs_mii[0]->rx_clk);
++		clk_disable_unprepare(qpcs->qpcs_mii[0]->tx_clk);
++	}
++
+ 	/* Assert XPCS reset */
+ 	reset_control_assert(qpcs->xpcs_rstc);
+ 
+@@ -344,18 +372,19 @@ static int ipq_pcs_config_mode(struct ip
+ 		xpcs_mode = true;
+ 		break;
+ 	default:
+-		return -EOPNOTSUPP;
++		ret = -EOPNOTSUPP;
++		goto err_clk;
+ 	}
+ 
+ 	ret = regmap_update_bits(qpcs->regmap, PCS_MODE_CTRL, mask, val);
+ 	if (ret)
+-		return ret;
++		goto err_clk;
+ 
+ 	if (interface == PHY_INTERFACE_MODE_10G_QXGMII) {
+ 		ret = regmap_set_bits(qpcs->regmap, PCS_QP_USXG_OPTION,
+ 				      PCS_QP_USXG_GMII_SRC_XPCS);
+ 		if (ret)
+-			return ret;
++			goto err_clk;
+ 	}
+ 
+ 	if (interface == PHY_INTERFACE_MODE_USXGMII)
+@@ -366,7 +395,15 @@ static int ipq_pcs_config_mode(struct ip
+ 					 PCS_MISC2_MODE_MASK |
+ 					 PCS_MISC2_RATE_MASK, misc2);
+ 		if (ret)
+-			return ret;
++			goto err_clk;
++	}
++
++	/* Link detection is in-band; there is no SFP LOS input here */
++	if (interface == PHY_INTERFACE_MODE_USXGMII) {
++		ret = regmap_update_bits(qpcs->regmap, PCS_LINK_DETECT,
++					 PCS_DETECT_LOS_FROM_SFP, 0);
++		if (ret)
++			goto err_clk;
+ 	}
+ 
+ 	/* Pulse the resets as the vendor SSDK does: both held for
+@@ -382,14 +419,34 @@ static int ipq_pcs_config_mode(struct ip
+ 	}
+ 
+ 	/* PCS PLL reset */
+-	ret = regmap_clear_bits(qpcs->regmap, PCS_PLL_RESET, PCS_ANA_SW_RESET);
+-	if (ret)
+-		return ret;
++	if (interface == PHY_INTERFACE_MODE_USXGMII) {
++		/* Program the whole register: the analog enables must not
++		 * be left at their power-on state.
++		 */
++		ret = regmap_write(qpcs->regmap, PCS_PLL_RESET,
++				   PCS_PLL_RESET_ASSERT);
++		if (ret)
++			goto err_clk;
+ 
+-	fsleep(20000);
+-	ret = regmap_set_bits(qpcs->regmap, PCS_PLL_RESET, PCS_ANA_SW_RESET);
+-	if (ret)
+-		return ret;
++		msleep(100);
++		ret = regmap_write(qpcs->regmap, PCS_PLL_RESET,
++				   PCS_PLL_RESET_RELEASE);
++		if (ret)
++			goto err_clk;
++
++		msleep(100);
++	} else {
++		ret = regmap_clear_bits(qpcs->regmap, PCS_PLL_RESET,
++					PCS_ANA_SW_RESET);
++		if (ret)
++			goto err_clk;
++
++		fsleep(20000);
++		ret = regmap_set_bits(qpcs->regmap, PCS_PLL_RESET,
++				      PCS_ANA_SW_RESET);
++		if (ret)
++			goto err_clk;
++	}
+ 
+ 	/* Wait for calibration completion */
+ 	ret = regmap_read_poll_timeout(qpcs->regmap, PCS_CALIBRATION,
+@@ -397,9 +454,14 @@ static int ipq_pcs_config_mode(struct ip
+ 				       1000, 100000);
+ 	if (ret) {
+ 		dev_err(qpcs->dev, "PCS calibration timed-out\n");
+-		return ret;
++		goto err_clk;
+ 	}
+ 
++	/* Re-enable the port clocks disabled at entry */
++	ret = ipq_pcs_restore_port_clks(qpcs, interface);
++	if (ret)
++		return ret;
++
+ 	qpcs->interface = interface;
+ 
+ 	/* The clock output register is only writable after PLL reset
+@@ -434,6 +496,12 @@ static int ipq_pcs_config_mode(struct ip
+ 		reset_control_deassert(qpcs->xpcs_rstc);
+ 
+ 	return 0;
++
++err_clk:
++	/* Best-effort restore of the clocks disabled at entry */
++	ipq_pcs_restore_port_clks(qpcs, interface);
++
++	return ret;
+ }
+ 
+ static int ipq_pcs_config_sgmii(struct ipq_pcs *qpcs,
+@@ -472,7 +540,7 @@ static int ipq_pcs_config_usxgmii(struct
+ 				  int index,
+ 				  phy_interface_t interface)
+ {
+-	unsigned int reg;
++	unsigned int reg, val;
+ 	int ret;
+ 
+ 	/* Configure the XPCS for USXGMII mode if required */
+@@ -481,6 +549,16 @@ static int ipq_pcs_config_usxgmii(struct
+ 		if (ret)
+ 			return ret;
+ 
++		/* Best-effort wait for the receiver to link before enabling
++		 * adaptation; the PHY SerDes may only come up later.
++		 */
++		ret = regmap_read_poll_timeout(qpcs->regmap, XPCS_KR_STS,
++					       val, val & XPCS_KR_LINK_STS,
++					       1000, 100000);
++		if (ret)
++			dev_warn(qpcs->dev,
++				 "10GBASE-R link not up before USXG_EN\n");
++
+ 		ret = regmap_set_bits(qpcs->regmap, XPCS_DIG_CTRL, XPCS_USXG_EN);
+ 		if (ret)
+ 			return ret;


### PR DESCRIPTION
During testing for the Askey SBE1V1K, flaky behavior for
the 10G port was observed between different hardware
revisions.

On hardware version 4.0, there seemed to be no issues
with the PHY - it simply worked as expected out of the
box.

However, on hardware version 4.1, the PHY could not
seem to achieve lock-on with the IPQ9574 UNIPHY PCS.

Investigation revealed incomplete clock and reset
bringup from the upstream code when compared to the
SSDK code.

This patch series exposes the clocks, resets, and
sequencing used in the SSDK to the IPQ9574 PCS
driver, which results in consistent functionality of
the 10G PHY on both hardware revisions.

Signed-off-by: Kenneth Kasilag <kenneth@kasilag.me>