### PR TITLE
ath79: add support for Ubiquiti UniFi AP v2

### DIFF
--- a/target/linux/ath79/dts/ar9342_ubnt_unifi-ap-v2.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_unifi-ap-v2.dts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9342_ubnt_xw.dtsi"
+
+/ {
+	compatible = "ubnt,unifi-ap-v2", "ubnt,xw", "qca,ar9342";
+	model = "Ubiquiti UniFi AP v2";
+
+	aliases {
+		led-boot = &led_dome_green;
+		led-failsafe = &led_dome_orange;
+		led-running = &led_dome_green;
+		led-upgrade = &led_dome_green;
+		label-mac-device = &eth0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_dome_green: dome_green {
+			label = "green:dome";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led_dome_orange: dome_orange {
+			label = "orange:dome";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi {
+	flash@0 {
+		partitions {
+			/delete-node/ partition@40000;
+			/delete-node/ partition@50000;
+
+			partition@0 {
+				reg = <0x000000 0x060000>;
+			};
+
+			partition@60000 {
+				label = "u-boot-env";
+				reg = <0x060000 0x010000>;
+				read-only;
+			};
+
+			partition@70000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x070000 0x730000>;
+			};
+
+			partition@7a0000 {
+				label = "board_config";
+				reg = <0x7a0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy1: ethernet-phy@1 {
+		reg = <1>;
+		phy-mode = "mii";
+		reset-gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&phy1>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -14,6 +14,9 @@ case "$board" in
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0" "link"
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1" "link"
 	;;
+ubnt,unifi-ap-v2)
+	ucidef_set_led_netdev "lan" "LAN" "green:dome" "eth0" "link"
+	;;
 alcatel,hh40v)
 	ucidef_set_led_netdev "lan_data" "LAN Data" "green:lan" "eth1" "tx rx"
 	ucidef_set_led_netdev "lan_link" "LAN Link" "orange:lan" "eth1" "link"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -123,6 +123,7 @@ ath79_setup_interfaces()
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-lr|\
 	ubnt,unifiac-mesh|\
+	ubnt,unifi-ap-v2|\
 	ubnt,unifi|\
 	watchguard,ap100|\
 	watchguard,ap200|\

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -277,6 +277,22 @@ define Device/ubnt_unifi-ap
 endef
 TARGET_DEVICES += ubnt_unifi-ap
 
+define Device/ubnt_unifi-ap-v2
+  $(Device/ubnt)
+  SOC := ar9342
+  IMAGES := sysupgrade.bin
+  IMAGE_SIZE := 7360k
+  DEVICE_MODEL := UniFi AP
+  DEVICE_VARIANT := v2
+  UBNT_BOARD := XM
+  UBNT_CHIP := ar934x
+  UBNT_TYPE := BZ
+  UBNT_VERSION := 6.0.4
+  DEVICE_PACKAGES := -kmod-usb2
+  SUPPORTED_DEVICES += uap-v2 unifi-ap-v2
+endef
+TARGET_DEVICES += ubnt_unifi-ap-v2
+
 define Device/ubnt_unifi-ap-lr
   $(Device/ubnt-bz)
   DEVICE_MODEL := UniFi AP


### PR DESCRIPTION
Adds support for the late Ubiquiti UniFi AP non-AC v2 board with
AR9342 SoC and AR8032 Fast Ethernet PHY.

This is not the older AR7241-based UniFi AP already covered by
`ubnt_unifi-ap`. The tested units identify as UniFi AP/BZ stock firmware, but
the board follows the AR9342/XW hardware wiring and needs a separate DTS,
flash layout, Ethernet PHY definition, and LED mapping.

Hardware:

- SoC: Atheros AR9342
- RAM: 64 MB
- Flash: 8 MB SPI NOR
- Ethernet: 1x 10/100 Mbps, AR8032 external PHY at MDIO address 1, MII
- Power: 24 V passive PoE-in
- Wi-Fi: 2.4 GHz integrated WMAC
- LEDs: green/orange dome LEDs
- Button: reset
- UART: 115200 8N1

Flash layout used by OpenWrt:

```text
0x000000..0x060000  u-boot
0x060000..0x070000  u-boot-env
0x070000..0x7a0000  firmware
0x7a0000..0x7b0000  board_config
0x7b0000..0x7f0000  cfg
0x7f0000..0x800000  art
```

The stock bootloader reports one `kernel` partition from `0x070000` to
`0x7b0000`. On tested hardware the last 64 KiB are preserved as
`board_config`, matching the XW/BZ-style layout.

Installation notes:

- This target intentionally emits a sysupgrade image only.
- Stock BZ.v4.3.28 requires signed images for the normal Ubiquiti upgrade path.
- Initial installation was tested from stock firmware using the Ubiquiti flash
  unlock interface (`/proc/ubnthal/.uf`) and a stock-side MTD helper.
- Initial installation was also tested by external SPI programming.
- Both installation paths preserve U-Boot, cfg, and art/calibration data.
- U-Boot must be set to boot OpenWrt directly:

```text
bootcmd=bootm 0x9f070000
```

The direct boot command avoids `ubntappinit`; on tested units, that path
re-enabled SPI NOR protection before OpenWrt booted and prevented overlay
writes from persisting after reboot.

Tested on physical hardware:

- Boot from flash
- Ethernet link and traffic through AR8032
- 2.4 GHz AP mode
- VLAN tagged SSIDs on `eth0.3`, `eth0.4`, and `eth0.5`
- LuCI
- green dome LED as Ethernet link LED
- sysupgrade from the new profile
- JFFS2 overlay and configuration persistence after reboot

I can add detailed stock-to-OpenWrt installation instructions to the device wiki
once the target name and support approach are accepted.
