### PR TITLE
treewide: various fwnode conversions

### DIFF
--- a/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
+++ b/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
@@ -441,7 +441,7 @@ static int gpio_keys_button_probe(struct platform_device *pdev,
 	struct gpio_keys_platform_data *pdata = dev_get_platdata(dev);
 	struct gpio_keys_button_dev *bdev;
 	struct gpio_keys_button *buttons;
-	struct device_node *prev = NULL;
+	struct fwnode_handle *prev = NULL;
 	int error = 0;
 	int i;
 
@@ -522,11 +522,11 @@ static int gpio_keys_button_probe(struct platform_device *pdev,
 			}
 		} else {
 			/* Device-tree */
-			struct device_node *child =
-				of_get_next_child(dev->of_node, prev);
+			struct fwnode_handle *child =
+				device_get_next_child_node(dev, prev);
 
 			bdata->gpiod = devm_fwnode_gpiod_get(dev,
-				of_fwnode_handle(child), NULL, GPIOD_IN,
+				child, NULL, GPIOD_IN,
 				desc);
 
 			prev = child;
@@ -579,7 +579,7 @@ static int gpio_keys_button_probe(struct platform_device *pdev,
 	error = 0;
 
 out:
-	of_node_put(prev);
+	fwnode_handle_put(prev);
 	return error;
 }
 

--- a/package/kernel/ubnt-ledbar/src/leds-ubnt-ledbar.c
+++ b/package/kernel/ubnt-ledbar/src/leds-ubnt-ledbar.c
@@ -144,15 +144,15 @@ UBNT_LEDBAR_CONTROL_RGBS(green);
 UBNT_LEDBAR_CONTROL_RGBS(blue);
 
 
-static int ubnt_ledbar_init_led(struct device_node *np, struct ubnt_ledbar *ledbar,
+static int ubnt_ledbar_init_led(struct fwnode_handle *fw, struct ubnt_ledbar *ledbar,
 				struct led_classdev *led_cdev)
 {
 	struct led_init_data init_data = {};
 
-	if (!np)
+	if (!fw)
 		return 0;
 
-	init_data.fwnode = of_fwnode_handle(np);
+	init_data.fwnode = fw;
 
 	led_cdev->max_brightness = UBNT_LEDBAR_MAX_BRIGHTNESS;
 
@@ -161,26 +161,24 @@ static int ubnt_ledbar_init_led(struct device_node *np, struct ubnt_ledbar *ledb
 
 static int ubnt_ledbar_probe(struct i2c_client *client)
 {
-	struct device_node *np = client->dev.of_node;
+	struct device *dev = &client->dev;
 	struct ubnt_ledbar *ledbar;
 	int err;
 
-	ledbar = devm_kzalloc(&client->dev, sizeof(*ledbar), GFP_KERNEL);
+	ledbar = devm_kzalloc(dev, sizeof(*ledbar), GFP_KERNEL);
 	if (!ledbar)
 		return -ENOMEM;
 
-	ledbar->enable_gpio = devm_gpiod_get(&client->dev, "enable", GPIOD_OUT_LOW);
-
+	ledbar->enable_gpio = devm_gpiod_get(dev, "enable", GPIOD_OUT_LOW);
 	if (IS_ERR(ledbar->enable_gpio))
-		return dev_err_probe(&client->dev, PTR_ERR(ledbar->enable_gpio), "Failed to get enable gpio");
+		return dev_err_probe(dev, PTR_ERR(ledbar->enable_gpio), "Failed to get enable gpio");
 
-	ledbar->reset_gpio = devm_gpiod_get_optional(&client->dev, "reset", GPIOD_OUT_LOW);
-
+	ledbar->reset_gpio = devm_gpiod_get_optional(dev, "reset", GPIOD_OUT_LOW);
 	if (IS_ERR(ledbar->reset_gpio))
-		return dev_err_probe(&client->dev, PTR_ERR(ledbar->reset_gpio), "Failed to get reset gpio");
+		return dev_err_probe(dev, PTR_ERR(ledbar->reset_gpio), "Failed to get reset gpio");
 
 	ledbar->led_count = 1;
-	of_property_read_u32(np, "led-count", &ledbar->led_count);
+	device_property_read_u32(dev, "led-count", &ledbar->led_count);
 
 	ledbar->client = client;
 
@@ -194,13 +192,13 @@ static int ubnt_ledbar_probe(struct i2c_client *client)
 	ubnt_ledbar_reset(ledbar);
 
 	ledbar->led_red.brightness_set_blocking = ubnt_ledbar_set_red_brightness;
-	ubnt_ledbar_init_led(of_get_child_by_name(np, "red"), ledbar, &ledbar->led_red);
+	ubnt_ledbar_init_led(device_get_named_child_node(dev, "red"), ledbar, &ledbar->led_red);
 
 	ledbar->led_green.brightness_set_blocking = ubnt_ledbar_set_green_brightness;
-	ubnt_ledbar_init_led(of_get_child_by_name(np, "green"), ledbar, &ledbar->led_green);
+	ubnt_ledbar_init_led(device_get_named_child_node(dev, "green"), ledbar, &ledbar->led_green);
 
 	ledbar->led_blue.brightness_set_blocking = ubnt_ledbar_set_blue_brightness;
-	ubnt_ledbar_init_led(of_get_child_by_name(np, "blue"), ledbar, &ledbar->led_blue);
+	ubnt_ledbar_init_led(device_get_named_child_node(dev, "blue"), ledbar, &ledbar->led_blue);
 
 	return ubnt_ledbar_apply_state(ledbar);
 }

--- a/target/linux/bmips/files/drivers/leds/leds-sercomm-msp430.c
+++ b/target/linux/bmips/files/drivers/leds/leds-sercomm-msp430.c
@@ -256,7 +256,7 @@ static int msp430_pattern_set(struct led_classdev *led_cdev,
 	return 0;
 }
 
-static int msp430_led_probe(struct spi_device *spi, struct device_node *nc, u8 id)
+static int msp430_led_probe(struct spi_device *spi, struct fwnode_handle *fw, u8 id)
 {
 	struct device *dev = &spi->dev;
 	struct led_init_data init_data = {};
@@ -271,9 +271,9 @@ static int msp430_led_probe(struct spi_device *spi, struct device_node *nc, u8 i
 	led->id = id;
 	led->spi = spi;
 
-	init_data.fwnode = of_fwnode_handle(nc);
+	init_data.fwnode = fw;
 
-	state = led_init_default_state_get(init_data.fwnode);
+	state = led_init_default_state_get(fw);
 	switch (state) {
 	case LEDS_DEFSTATE_ON:
 		led->cdev.brightness = MSP430_LED_BRIGHTNESS_MAX;
@@ -326,17 +326,18 @@ static inline int msp430_check_workmode(struct spi_device *spi)
 static int msp430_leds_probe(struct spi_device *spi)
 {
 	struct device *dev = &spi->dev;
-	struct device_node *np = dev_of_node(dev);
+	struct fwnode_handle *fw = dev_fwnode(dev);
+	struct fwnode_handle *child;
 	int rc;
 
 	rc = msp430_check_workmode(spi);
 	if (rc)
 		return rc;
 
-	for_each_available_child_of_node_scoped(np, child) {
+	fwnode_for_each_available_child_node(fw, child) {
 		u32 reg;
 
-		if (of_property_read_u32(child, "reg", &reg))
+		if (fwnode_property_read_u32(child, "reg", &reg))
 			continue;
 
 		if (reg < MSP430_LED_MIN_ID || reg > MSP430_LED_MAX_ID) {
@@ -346,8 +347,10 @@ static int msp430_leds_probe(struct spi_device *spi)
 		}
 
 		rc = msp430_led_probe(spi, child, reg);
-		if (rc < 0)
+		if (rc < 0) {
+			fwnode_handle_put(child);
 			return rc;
+		}
 	}
 
 	return 0;

--- a/target/linux/generic/files/drivers/net/phy/ar8327.c
+++ b/target/linux/generic/files/drivers/net/phy/ar8327.c
@@ -37,12 +37,9 @@ ar8327_phy_rgmii_set(struct ar8xxx_priv *priv, struct phy_device *phydev)
 {
 	u16 phy_val = 0;
 	int phyaddr = phydev->mdio.addr;
-	struct device_node *np = phydev->mdio.dev.of_node;
+	struct device *dev = &phydev->mdio.dev;
 
-	if (!np)
-		return;
-
-	if (!of_property_read_bool(np, "qca,phy-rgmii-en")) {
+	if (!device_property_present(dev, "qca,phy-rgmii-en")) {
 		pr_err("ar8327: qca,phy-rgmii-en is not specified\n");
 		return;
 	}
@@ -53,7 +50,7 @@ ar8327_phy_rgmii_set(struct ar8xxx_priv *priv, struct phy_device *phydev)
 				AR8327_PHY_MODE_SEL, phy_val);
 
 	/* set rgmii tx clock delay if needed */
-	if (!of_property_read_bool(np, "qca,txclk-delay-en")) {
+	if (!device_property_present(dev, "qca,txclk-delay-en")) {
 		pr_err("ar8327: qca,txclk-delay-en is not specified\n");
 		return;
 	}
@@ -64,7 +61,7 @@ ar8327_phy_rgmii_set(struct ar8xxx_priv *priv, struct phy_device *phydev)
 				AR8327_PHY_SYS_CTRL, phy_val);
 
 	/* set rgmii rx clock delay if needed */
-	if (!of_property_read_bool(np, "qca,rxclk-delay-en")) {
+	if (!device_property_present(dev, "qca,rxclk-delay-en")) {
 		pr_err("ar8327: qca,rxclk-delay-en is not specified\n");
 		return;
 	}
@@ -364,31 +361,36 @@ ar8327_led_destroy(struct ar8327_led *aled)
 }
 
 static void
-ar8327_leds_init(struct ar8xxx_priv *priv, struct device_node *leds)
+ar8327_leds_init(struct ar8xxx_priv *priv, struct fwnode_handle *leds)
 {
 	struct ar8327_data *data = priv->chip_data;
+	struct fwnode_handle *child;
 	unsigned i;
 
 	if (!IS_ENABLED(CONFIG_AR8216_PHY_LEDS))
 		return;
 
-	for_each_available_child_of_node_scoped(leds, child) {
+	fwnode_for_each_available_child_node(leds, child) {
 		u32 reg = 0, mode = 0;
 		struct ar8327_led_info info;
+		const char *name;
 		int ret;
 
-		ret = of_property_read_u32(child, "reg", &reg);
+		ret = fwnode_property_read_u32(child, "reg", &reg);
 		if (ret) {
-			pr_err("ar8327: LED %s is missing reg node\n", child->name);
+			pr_err("ar8327: LED %s is missing reg node\n", fwnode_get_name(child));
 			continue;
 		}
 
-		of_property_read_u32(child, "qca,led-mode", &mode);
+		fwnode_property_read_u32(child, "qca,led-mode", &mode);
+
+		if (fwnode_property_read_string(child, "label", &name))
+			name = fwnode_get_name(child);
 
 		info = (struct ar8327_led_info) {
-			.name = of_get_property(child, "label", NULL) ? : child->name,
-			.fwnode = of_fwnode_handle(child),
-			.active_low = of_property_read_bool(child, "active-low"),
+			.name = name,
+			.fwnode = child,
+			.active_low = fwnode_property_present(child, "active-low"),
 			.led_num = (enum ar8327_led_num) reg,
 		        .mode = (enum ar8327_led_mode) mode
 		};
@@ -428,25 +430,29 @@ ar8327_leds_cleanup(struct ar8xxx_priv *priv)
 }
 
 static int
-ar8327_hw_config_of(struct ar8xxx_priv *priv, struct device_node *np)
+ar8327_hw_config_of(struct ar8xxx_priv *priv, struct device *dev)
 {
 	struct ar8327_data *data = priv->chip_data;
-	const __be32 *paddr;
-	int len;
-	int i;
+	int len, i;
+	u32 *vals;
 
-	paddr = of_get_property(np, "qca,ar8327-initvals", &len);
-	if (!paddr || len < (2 * sizeof(*paddr)))
+	len = device_property_count_u32(dev, "qca,ar8327-initvals");
+	if (len < 2 || (len & 1))
 		return -EINVAL;
 
-	len /= sizeof(*paddr);
+	vals = kmalloc_array(len, sizeof(*vals), GFP_KERNEL);
+	if (!vals)
+		return -ENOMEM;
 
-	for (i = 0; i < len - 1; i += 2) {
-		u32 reg;
-		u32 val;
+	if (device_property_read_u32_array(dev, "qca,ar8327-initvals",
+					vals, len)) {
+	        kfree(vals);
+	        return -EINVAL;
+	}
 
-		reg = be32_to_cpup(paddr + i);
-		val = be32_to_cpup(paddr + i + 1);
+	for (i = 0; i < len; i += 2) {
+		u32 reg = vals[i];
+		u32 val = vals[i + 1];
 
 		switch (reg) {
 		case AR8327_REG_PORT_STATUS(0):
@@ -460,38 +466,43 @@ ar8327_hw_config_of(struct ar8xxx_priv *priv, struct device_node *np)
 			break;
 		}
 	}
+
+	kfree(vals);
 	return 0;
 }
 
 static int
 ar8327_hw_init(struct ar8xxx_priv *priv)
 {
-	struct device_node *np = priv->pdev->of_node;
-	struct device_node *leds;
+	struct device *dev = priv->pdev;
+	struct fwnode_handle *child;
+	struct fwnode_handle *leds;
 	struct ar8327_data *data;
-	size_t count;
+	size_t count = 0;
 	int ret;
 
-	leds = of_get_child_by_name(np, "leds");
-	count = leds ? of_get_child_count(leds) : 0;
+	leds = device_get_named_child_node(dev, "leds");
+	if (leds)
+		fwnode_for_each_child_node(leds, child)
+			count++;
 	data = kzalloc(struct_size(data, leds, count), GFP_KERNEL);
 	if (!data) {
-		of_node_put(leds);
+		fwnode_handle_put(leds);
 		return -ENOMEM;
 	}
 
 	priv->chip_data = data;
 
-	ret = ar8327_hw_config_of(priv, np);
+	ret = ar8327_hw_config_of(priv, dev);
 	if (ret) {
-		of_node_put(leds);
+		fwnode_handle_put(leds);
 		return ret;
 	}
 
 	if (leds)
 		ar8327_leds_init(priv, leds);
 
-	of_node_put(leds);
+	fwnode_handle_put(leds);
 
 	ar8xxx_phy_init(priv);
 

--- a/target/linux/mediatek/files/drivers/leds/leds-smartrg-system.c
+++ b/target/linux/mediatek/files/drivers/leds/leds-smartrg-system.c
@@ -109,17 +109,18 @@ srg_led_set_brightness(struct led_classdev *led_cdev,
 }
 
 static int
-srg_led_init_led(struct srg_led_ctrl *sysled_ctrl, struct device_node *np)
+srg_led_init_led(struct srg_led_ctrl *sysled_ctrl, struct fwnode_handle *fw)
 {
 	struct led_init_data init_data = {};
 	struct led_classdev *led_cdev;
 	struct srg_led *sysled;
+	const char *name;
 	int index, ret;
 
-	if (!np)
+	if (!fw)
 		return -ENOENT;
 
-	ret = of_property_read_u32(np, "reg", &index);
+	ret = fwnode_property_read_u32(fw, "reg", &index);
 	if (ret) {
 		dev_err(&sysled_ctrl->client->dev,
 			"srg_led_init_led: no reg defined in np!\n");
@@ -135,9 +136,12 @@ srg_led_init_led(struct srg_led_ctrl *sysled_ctrl, struct device_node *np)
 	sysled->index = index;
 	sysled->ctrl = sysled_ctrl;
 
-	init_data.fwnode = of_fwnode_handle(np);
+	init_data.fwnode = fw;
 
-	led_cdev->name = of_get_property(np, "label", NULL) ? : np->name;
+	if (fwnode_property_read_string(fw, "label", &name))
+		name = fwnode_get_name(fw);
+
+	led_cdev->name = name;
 	led_cdev->brightness = LED_OFF;
 	led_cdev->max_brightness = LED_FULL;
 	led_cdev->brightness_set_blocking = srg_led_set_brightness;
@@ -161,23 +165,24 @@ static int
 
 srg_led_probe(struct i2c_client *client)
 {
-	struct device_node *np = client->dev.of_node;
+	struct device *dev = &client->dev;
+	struct fwnode_handle *fw = dev_fwnode(dev);
 	struct srg_led_ctrl *sysled_ctrl;
 	int err;
 
-	sysled_ctrl = devm_kzalloc(&client->dev, sizeof(*sysled_ctrl), GFP_KERNEL);
+	sysled_ctrl = devm_kzalloc(dev, sizeof(*sysled_ctrl), GFP_KERNEL);
 	if (!sysled_ctrl)
 		return -ENOMEM;
 
 	sysled_ctrl->client = client;
 
-	err = devm_mutex_init(&client->dev, &sysled_ctrl->lock);
+	err = devm_mutex_init(dev, &sysled_ctrl->lock);
 	if (err)
 		return err;
 
 	i2c_set_clientdata(client, sysled_ctrl);
 
-	for_each_available_child_of_node_scoped(np, child) {
+	fwnode_for_each_available_child_node_scoped(fw, child) {
 		if (srg_led_init_led(sysled_ctrl, child))
 			continue;
 

--- a/target/linux/ramips/patches-6.18/870-Input-sx951x-add-Semtech-SX9512-SX9513-driver.patch
+++ b/target/linux/ramips/patches-6.18/870-Input-sx951x-add-Semtech-SX9512-SX9513-driver.patch
@@ -57,7 +57,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
  obj-$(CONFIG_KEYBOARD_TM2_TOUCHKEY)	+= tm2-touchkey.o
 --- /dev/null
 +++ b/drivers/input/keyboard/sx951x.c
-@@ -0,0 +1,490 @@
+@@ -0,0 +1,494 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
 + * Input driver for Semtech SX9512/SX9513 capacitive touch sensors.
@@ -237,11 +237,12 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 +}
 +
 +static int sx951x_led_init(struct sx951x_priv *priv,
-+			   struct device_node *channel_node, u32 reg)
++			   struct fwnode_handle *channel_node, u32 reg)
 +{
-+	struct device_node *led_node;
++	struct fwnode_handle *led_node;
 +	struct sx951x_led *led = &priv->leds[reg];
 +	struct led_init_data init_data = {};
++	const char *name;
 +	int error;
 +
 +	if (led->registered) {
@@ -250,7 +251,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 +		return -EINVAL;
 +	}
 +
-+	led_node = of_get_child_by_name(channel_node, "led");
++	led_node = fwnode_get_named_child_node(channel_node, "led");
 +	if (!led_node) {
 +		/* No LED */
 +		return 0;
@@ -261,8 +262,11 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 +	led->cdev.max_brightness = 1;
 +	led->cdev.brightness = LED_OFF;
 +
-+	init_data.default_label = of_get_property(led_node, "label", NULL);
-+	init_data.fwnode = of_fwnode_handle(led_node);
++	if (fwnode_property_read_string(led_node, "label", &name))
++		name = fwnode_get_name(led_node);
++
++	init_data.default_label = name;
++	init_data.fwnode = led_node;
 +
 +	led->reg = reg;
 +	led->priv = priv;
@@ -298,7 +302,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 +	}
 +}
 +
-+static int sx951x_channel_init(struct sx951x_priv *priv, struct device_node *of_node,
++static int sx951x_channel_init(struct sx951x_priv *priv, struct fwnode_handle *fw,
 +			       u32 chan_idx)
 +{
 +	struct sx951x_key_data *key_data;
@@ -311,14 +315,14 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 +	key_data->cin_delta = SX951X_KEY_DEFAULT_CIN_DELTA;
 +	key_data->sense_threshold = SX951X_KEY_DEFAULT_SENSE_THRESHOLD;
 +
-+	error = of_property_read_u32(of_node, "linux,keycodes",
++	error = fwnode_property_read_u32(fw, "linux,keycodes",
 +				     &priv->keycodes[chan_idx]);
 +	if (error) {
 +		/* Not configured */
 +		return 0;
 +	}
 +
-+	error = of_property_read_u32(of_node, "semtech,cin-delta",
++	error = fwnode_property_read_u32(fw, "semtech,cin-delta",
 +				     &key_data->cin_delta);
 +	if (key_data->cin_delta > 0x03) {
 +		dev_err(dev, "Failed to read cin-delta for channel %d: %d\n",
@@ -326,7 +330,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 +		return error;
 +	}
 +
-+	error = of_property_read_u32(of_node, "semtech,sense-threshold",
++	error = fwnode_property_read_u32(fw, "semtech,sense-threshold",
 +				     &key_data->sense_threshold);
 +	if (key_data->sense_threshold > 0xff) {
 +		dev_err(dev, "Failed to read sense-threshold for channel %d: %d\n",
@@ -364,8 +368,8 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 +	int error;
 +	u32 reg;
 +
-+	for_each_child_of_node_scoped(dev->of_node, child) {
-+		error = of_property_read_u32(child, "reg", &reg);
++	device_for_each_child_node_scoped(dev, child) {
++		error = fwnode_property_read_u32(child, "reg", &reg);
 +		if (error != 0 || reg >= SX951X_NUM_CHANNELS) {
 +			dev_err(dev, "Invalid channel %d\n", reg);
 +			return -EINVAL;
@@ -479,7 +483,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 +		return PTR_ERR(priv->regmap);
 +
 +	/* Parse device configuration */
-+	if (of_property_read_u32(dev->of_node, "poll-interval",
++	if (device_property_read_u32(dev, "poll-interval",
 +				 &priv->poll_interval))
 +		priv->poll_interval = SX951X_POLL_INTERVAL;
 +


### PR DESCRIPTION
Avoid having to use of_fwnode_handle and use fwnode_handle directly.

Upstream prefers fwnode to of anyway.