### PR TITLE
wifi-scripts: ucode: disable options with interoperability problems 

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
@@ -963,9 +963,8 @@
 			"type": "boolean"
 		},
 		"sae_ext_key": {
-			"description": "Advertise the SAE-EXT-KEY AKM alongside plain SAE. Mandatory for EHT, enabled by default.",
-			"type": "boolean",
-			"default": true
+			"description": "Advertise the SAE-EXT-KEY AKM (SAE using a group-dependent hash) alongside plain SAE. Mandatory for EHT, recommended otherwise. Defaults off for sae and sae-mixed because some clients misbehave when SAE-EXT-KEY is offered, and on for sae-compat BSSes using an EHT htmode (where SAE-EXT-KEY is mandatory), carried in a separate RSN Override element that legacy clients ignore.",
+			"type": "boolean"
 		},
 		"sae_password_file": {
 			"description": "External file containing VLAN SAE MAC address triplets",

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
@@ -371,6 +371,10 @@
 		"gas_address3": {
 			"type": "string"
 		},
+		"gcmp256": {
+			"description": "Advertise the GCMP-256 pairwise cipher on HE/EHT BSSes (alongside CCMP for sae/sae-mixed, in the RSNE Override 2 element for sae-compat). Mandatory for EHT, recommended otherwise. Defaults off for sae and sae-mixed because some clients and chipsets misbehave when GCMP-256 is offered, and on for sae-compat BSSes using an EHT htmode (where GCMP-256 is mandatory), carried in a separate RSN Override element that legacy clients ignore. Only advertised when the driver supports the GCMP-256 cipher.",
+			"type": "boolean"
+		},
 		"hidden": {
 			"type": "alias",
 			"default": "ignore_broadcast_ssid"

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -551,7 +551,7 @@ export function generate(interface, data, config, vlans, stas, phy_features) {
 	config.start_disabled = data.ap_start_disabled;
 	iface_setup(config);
 
-	iface.parse_encryption(config, data.config);
+	iface.parse_encryption(config, data.config, phy_features);
 	if (data.config.band == '6g') {
 		if (config.auth_type == 'psk-sae')
 			config.auth_type = 'sae';

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -14,6 +14,8 @@ import * as fs from 'fs';
 const NL80211_EXT_FEATURE_ENABLE_FTM_RESPONDER = 33;
 const NL80211_EXT_FEATURE_RADAR_BACKGROUND = 61;
 
+const WLAN_CIPHER_SUITE_GCMP_256 = 0x000fac09;
+
 let phy_features = {};
 let phy_capabilities = {};
 
@@ -496,6 +498,7 @@ function device_capabilities(config) {
 
 	phy_features.ftm_responder = device_extended_features(phy.extended_features, NL80211_EXT_FEATURE_ENABLE_FTM_RESPONDER);
 	phy_features.radar_background = device_extended_features(phy.extended_features, NL80211_EXT_FEATURE_RADAR_BACKGROUND);
+	phy_features.cipher_gcmp256 = WLAN_CIPHER_SUITE_GCMP_256 in (phy.cipher_suites ?? []);
 }
 
 function generate(config) {

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
@@ -3,7 +3,7 @@
 import { append_value, log } from 'wifi.common';
 import * as fs from 'fs';
 
-export function parse_encryption(config, dev_config) {
+export function parse_encryption(config, dev_config, phy_features) {
 	if (!config.encryption)
 		return;
 
@@ -62,7 +62,7 @@ export function parse_encryption(config, dev_config) {
 		config.wpa_pairwise = 'CCMP';
 		if (dev_config.band != '6g')
 			config.rsn_override_pairwise = 'CCMP';
-		if (wildcard(dev_config.htmode ?? '', 'EHT*'))
+		if (phy_features?.cipher_gcmp256 && wildcard(dev_config.htmode ?? '', 'EHT*'))
 			config.rsn_override_pairwise_2 = 'GCMP-256';
 		break;
 
@@ -107,7 +107,7 @@ export function parse_encryption(config, dev_config) {
 		config.wpa_pairwise ??= null;
 	else if (config.hw_mode == 'ad')
 		config.wpa_pairwise ??= 'GCMP';
-	else if (wildcard(dev_config?.htmode, 'EHT*') || wildcard(dev_config?.htmode, 'HE*'))
+	else if (phy_features?.cipher_gcmp256)
 		config.wpa_pairwise ??= 'GCMP-256 CCMP';
 	else
 		config.wpa_pairwise ??= 'CCMP';

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
@@ -20,15 +20,16 @@ export function parse_encryption(config, dev_config, phy_features) {
 	config.auth_type = encryption[0] ?? 'none';
 
 	/*
-	 * The SAE-EXT-KEY (SAE-GDH) AKM is only mandatory for EHT/MLO and breaks
-	 * interoperability with some clients, so only default it on where it is
-	 * both required and safe to offer: on Compatibility mode (sae-compat)
-	 * BSSes that run an EHT htmode, which carry it in a separate RSN Override
-	 * element that legacy clients ignore. It stays off for WPA3-Personal (sae)
-	 * and Transition (sae-mixed) mode and on non-EHT BSSes. An explicit
-	 * sae_ext_key option overrides this per BSS.
+	 * GCMP-256 and the SAE-EXT-KEY (SAE-GDH) AKM are only mandatory for
+	 * EHT/MLO and break interoperability with many clients, so only default
+	 * them on where they are both required and safe to offer: on Compatibility
+	 * mode (sae-compat) BSSes that run an EHT htmode, which carry them in a
+	 * separate RSN Override element that legacy clients ignore. They stay off
+	 * for WPA3-Personal (sae) and Transition (sae-mixed) mode and on non-EHT
+	 * BSSes. Explicit gcmp256 and sae_ext_key options override this per BSS.
 	 */
 	let compat = (config.auth_type == 'sae-compat');
+	config.gcmp256 ??= compat && wildcard(dev_config?.htmode ?? '', 'EHT*');
 	config.sae_ext_key ??= compat && wildcard(dev_config?.htmode ?? '', 'EHT*');
 
 	switch(config.auth_type) {
@@ -74,7 +75,7 @@ export function parse_encryption(config, dev_config, phy_features) {
 		config.wpa_pairwise = 'CCMP';
 		if (dev_config.band != '6g')
 			config.rsn_override_pairwise = 'CCMP';
-		if (phy_features?.cipher_gcmp256 && wildcard(dev_config.htmode ?? '', 'EHT*'))
+		if (config.gcmp256 && phy_features?.cipher_gcmp256)
 			config.rsn_override_pairwise_2 = 'GCMP-256';
 		break;
 
@@ -119,7 +120,7 @@ export function parse_encryption(config, dev_config, phy_features) {
 		config.wpa_pairwise ??= null;
 	else if (config.hw_mode == 'ad')
 		config.wpa_pairwise ??= 'GCMP';
-	else if (phy_features?.cipher_gcmp256)
+	else if (config.gcmp256 && phy_features?.cipher_gcmp256)
 		config.wpa_pairwise ??= 'GCMP-256 CCMP';
 	else
 		config.wpa_pairwise ??= 'CCMP';

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
@@ -19,6 +19,18 @@ export function parse_encryption(config, dev_config, phy_features) {
 
 	config.auth_type = encryption[0] ?? 'none';
 
+	/*
+	 * The SAE-EXT-KEY (SAE-GDH) AKM is only mandatory for EHT/MLO and breaks
+	 * interoperability with some clients, so only default it on where it is
+	 * both required and safe to offer: on Compatibility mode (sae-compat)
+	 * BSSes that run an EHT htmode, which carry it in a separate RSN Override
+	 * element that legacy clients ignore. It stays off for WPA3-Personal (sae)
+	 * and Transition (sae-mixed) mode and on non-EHT BSSes. An explicit
+	 * sae_ext_key option overrides this per BSS.
+	 */
+	let compat = (config.auth_type == 'sae-compat');
+	config.sae_ext_key ??= compat && wildcard(dev_config?.htmode ?? '', 'EHT*');
+
 	switch(config.auth_type) {
 	case 'owe':
 		config.auth_type = 'owe';
@@ -189,7 +201,7 @@ export function wpa_key_mgmt(config, band) {
 			if (config.ieee80211r)
 				append_value(config, 'wpa_key_mgmt', 'FT-SAE');
 
-			if (config.sae_ext_key && config.rsn_override_pairwise_2) {
+			if (config.sae_ext_key) {
 				append_value(config, 'rsn_override_key_mgmt_2', 'SAE-EXT-KEY');
 				if (config.ieee80211r)
 					append_value(config, 'rsn_override_key_mgmt_2', 'FT-SAE-EXT-KEY');
@@ -205,7 +217,7 @@ export function wpa_key_mgmt(config, band) {
 			if (config.ieee80211r)
 				append_value(config, 'rsn_override_key_mgmt', 'FT-SAE');
 
-			if (config.sae_ext_key && config.rsn_override_pairwise_2) {
+			if (config.sae_ext_key) {
 				append_value(config, 'rsn_override_key_mgmt_2', 'SAE-EXT-KEY');
 				if (config.ieee80211r)
 					append_value(config, 'rsn_override_key_mgmt_2', 'FT-SAE-EXT-KEY');


### PR DESCRIPTION
 * wifi-scripts: ucode: only advertise GCMP-256 when the driver supports it
    
    The GCMP-256 pairwise cipher was advertised based only on the BSS htmode
    (HE/EHT), without checking whether the driver actually implements it. On
    phys that do not support GCMP-256 this makes hostapd reject the
    configuration and fail to start.
    
    Query the phy's NL80211 cipher suite list in device_capabilities() and
    expose a phy_features.cipher_gcmp256 flag, then only offer GCMP-256 when
    the driver advertises the GCMP-256 cipher suite (00-0F-AC:9, 0x000fac09),
    mirroring how the HT/VHT feature flags are already gated on the reported
    phy capabilities. This covers both the sae/sae-mixed "GCMP-256 CCMP"
    pairwise default and the GCMP-256 pairwise cipher in the sae-compat RSNE
    Override 2 element.
    
    The "GCMP-256 CCMP" default now keys off driver support alone instead of
    the htmode; a follow-up commit reintroduces the per-mode/EHT restriction
    via a gcmp256 option.
    
    Fixes: 1f86f4e471f8 ("wifi-scripts: ucode: simplify wpa_pairwise default selection")
    Fixes: 86b9eec8f02b ("wifi-scripts: ucode: add WPA3-Personal Compatibility Mode")

 * wifi-scripts: ucode: default the SAE-EXT-KEY AKM per WPA3 mode
    
    Commit a12cec9ea3c8 ("wifi-scripts: ucode: advertise SAE-EXT-KEY AKM
    alongside SAE") advertised the SAE-EXT-KEY AKM (00-0F-AC:24, SAE using a
    group-dependent hash, aka SAE-GDH) by default on every sae, sae-mixed and
    sae-compat BSS.
    
    WPA3 Specification v3.5 only makes this AKM mandatory when the BSS enables
    EHT or MLO (section 2.5, item 4); for HE and below it is merely
    recommended (sections 2.2 and 2.3). In practice the FT-SAE-EXT-KEY AKM
    (SAE-EXT-KEY combined with 802.11r), which gets added automatically once
    Fast Transition is enabled, keeps some clients from associating (a Samsung
    Galaxy Tab S10 FE) or makes them reboot shortly after connecting (a Poco
    X6). Plain SAE-EXT-KEY without FT was seen to work on the same tablet, but
    its interoperability is not well tested.
    
    Drop the fixed schema default and pick the default from the auth type in
    parse_encryption instead. Only default it on where it is both mandatory
    and safe to offer: on Compatibility mode (sae-compat) BSSes running an EHT
    htmode, which carry it in a separate RSN Override element that legacy
    clients ignore. Keep it off for WPA3-Personal (sae) and Transition
    (sae-mixed) mode, where it would sit in the main RSNE that a choking
    client cannot ignore, and off on non-EHT BSSes. An explicit
    'option sae_ext_key 0/1' still overrides this per BSS.
    
    The SAE-EXT-KEY AKM in the sae-compat RSN Override 2 element now keys off
    config.sae_ext_key alone; the extra config.rsn_override_pairwise_2 guard
    is dropped, decoupling the AKM from the GCMP-256 pairwise cipher so each
    follows its own option.
    
    Fixes: a12cec9ea3c8 ("wifi-scripts: ucode: advertise SAE-EXT-KEY AKM alongside SAE")

 * wifi-scripts: ucode: add gcmp256 option, default GCMP-256 per WPA3 mode
    
    Commit 1f86f4e471f8 ("wifi-scripts: ucode: simplify wpa_pairwise default
    selection") made HE and EHT BSSes default their pairwise cipher to
    "GCMP-256 CCMP", and commit 86b9eec8f02b ("wifi-scripts: ucode: add
    WPA3-Personal Compatibility Mode") always put GCMP-256 into the RSNE
    Override 2 element on EHT compatibility-mode BSSes.
    
    WPA3 Specification v3.5 only makes GCMP-256 mandatory when the BSS enables
    EHT or MLO (section 2.5, item 5); for HE and below the WPA3 and Wi-Fi
    Enhanced Open Deployment Guide v1.1 lists it as recommended, not required.
    Advertising it by default causes interoperability problems: several
    clients fail to associate when GCMP-256 is offered as a pairwise cipher
    and connect again with CCMP only (Nanoleaf devices, a Motorola/Unisoc
    phone, a Linux/iwd laptop).
    
    Add a gcmp256 UCI option and, like sae_ext_key, default it on only where
    GCMP-256 is both mandatory and safe: on Compatibility mode (sae-compat)
    BSSes running an EHT htmode, which carry it in a separate RSNE Override 2
    element that legacy clients ignore. It defaults off for WPA3-Personal
    (sae) and Transition (sae-mixed) mode and on non-EHT BSSes. An explicit
    'option gcmp256 0/1' overrides the default per BSS.
    
    Both GCMP-256 pairwise defaults now key off config.gcmp256 (and, from the
    earlier driver-support change, the phy actually implementing the cipher):
    the sae/sae-mixed "GCMP-256 CCMP" pairwise cipher and the sae-compat RSNE
    Override 2 element. The 'encryption sae+gcmp256' suffix and the wpa3-192
    mode still force GCMP-256 as before.
    
    Fixes: 1f86f4e471f8 ("wifi-scripts: ucode: simplify wpa_pairwise default selection")
    Fixes: 86b9eec8f02b ("wifi-scripts: ucode: add WPA3-Personal Compatibility Mode")