### PR TITLE
mac80211: ath9k: call reset on init

### DIFF
--- a/package/kernel/mac80211/patches/ath9k/550-ath9k-of.patch
+++ b/package/kernel/mac80211/patches/ath9k/550-ath9k-of.patch
@@ -102,7 +102,7 @@
  	int ret;
  
  	if (!of_device_is_available(np))
-@@ -633,6 +714,43 @@ static int ath9k_of_init(struct ath_soft
+@@ -633,6 +714,46 @@ static int ath9k_of_init(struct ath_soft
  
  	ath_dbg(common, CONFIG, "parsing configuration from OF node\n");
  
@@ -115,11 +115,13 @@
 +#ifdef CONFIG_ATH79
 +	if (ah->hw_version.devid == AR5416_AR9100_DEVID) {
 +		ah->external_reset = ar913x_wmac_reset;
++		ah->external_reset();
 +	} else if (ah->hw_version.devid == AR9300_DEVID_AR9330) {
 +		ah->get_mac_revision = ar9330_get_soc_revision;
 +		u32 t = ath79_reset_rr(AR933X_RESET_REG_BOOTSTRAP);
 +		ah->is_clk_25mhz = !(t & AR933X_BOOTSTRAP_REF_CLK_40);
 +		ah->external_reset = ar933x_wmac_reset;
++		ah->external_reset();
 +	} else if (ah->hw_version.devid == AR9300_DEVID_AR9340) {
 +		ah->get_mac_revision = ath79_get_soc_revision;
 +		u32 t = ath79_reset_rr(AR934X_RESET_REG_BOOTSTRAP);
@@ -136,6 +138,7 @@
 +		u32 t = ath79_reset_rr(QCA955X_RESET_REG_BOOTSTRAP);
 +		ah->is_clk_25mhz = !(t & QCA955X_BOOTSTRAP_REF_CLK_40);
 +		ah->external_reset = qca955x_wmac_reset;
++		ah->external_reset();
 +	} else if (ah->hw_version.devid == AR9300_DEVID_QCA956X) {
 +		ah->get_mac_revision = ath79_get_soc_revision;
 +		u32 t = ath79_reset_rr(QCA956X_RESET_REG_BOOTSTRAP);
@@ -146,7 +149,7 @@
  	if (of_property_read_bool(np, "qca,no-eeprom")) {
  		/* ath9k-eeprom-<bus>-<id>.bin */
  		scnprintf(eeprom_name, sizeof(eeprom_name),
-@@ -651,6 +769,17 @@ static int ath9k_of_init(struct ath_soft
+@@ -651,6 +772,17 @@ static int ath9k_of_init(struct ath_soft
  	if (ret == -EPROBE_DEFER)
  		return ret;
  


### PR DESCRIPTION
Even though external_reset() is handled elsewhere, it seems some devices need it here.

Fixes: 0ccc336c56fc ("mac80211: ath9k: avoid a double reset")

Fixes: https://github.com/openwrt/openwrt/issues/23805

ping @dds90