### PR TITLE
elfutils: add $(FPIC) to LDFLAGS

### DIFF
--- a/package/libs/elfutils/Makefile
+++ b/package/libs/elfutils/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=elfutils
 PKG_VERSION:=0.195
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://sourceware.org/$(PKG_NAME)/ftp/$(PKG_VERSION) \
@@ -87,6 +87,8 @@ TARGET_CFLAGS += \
 	-Wno-unused-result \
 	-Wno-format-nonliteral \
 	-Wno-error=use-after-free
+
+TARGET_LDFLAGS += $(FPIC)
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include


### PR DESCRIPTION
Ensure -fPIC is passed during the linking stage to fix LTO build failures (relocation errors) on MIPS and other architectures.

Fixes build error:
```
    ...
    <artificial>:(.text.nlist+0x250): relocation R_MIPS16_26 against `__tls_get_addr' cannot be used when making a shared object; recompile with -fPIC
    <artificial>:(.text.nlist+0x260): relocation R_MIPS16_26 against `__stack_chk_fail' cannot be used when making a shared object; recompile with -fPIC
    ./openwrt/staging_dir/toolchain-mips_24kc_gcc-15.3.0_musl/mips-openwrt-linux-musl/bin/ld.bfd: non-dynamic relocations refer to dynamic symbol tsearch
    ./openwrt/staging_dir/toolchain-mips_24kc_gcc-15.3.0_musl/mips-openwrt-linux-musl/bin/ld.bfd: failed to set dynamic section sizes: bad value
    collect2: error: ld returned 1 exit status
    make[6]: *** [Makefile:1801: libelf.so] Error 1
    make[5]: *** [Makefile:634: all-recursive] Error 1
    make[4]: *** [Makefile:549: all] Error 2
    make[4]: Leaving directory './openwrt/build_dir/target-mips_24kc_musl/elfutils-0.195'
    make[3]: *** [Makefile:122: ./openwrt/build_dir/target-mips_24kc_musl/elfutils-0.195/.built] Error 2
    make[3]: Leaving directory './openwrt/package/libs/elfutils'
    time: package/libs/elfutils/compile#2.68#0.12#1.60
	ERROR: package/libs/elfutils failed to build.
```

Build tested on: tplink_tl-wr842n-v3
