### PR TITLE
qualcommax: ipq807x: Add support for TP-Link Deco X60 v2 (EU)

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq807x
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq807x
@@ -49,6 +49,7 @@ netgear,wax218|\
 netgear,wax620|\
 netgear,wax630|\
 tplink,deco-x80-5g|\
+tplink,deco-x60-v2|\
 tplink,eap620hd-v1|\
 tplink,eap660hd-v1)
 	ubootenv_add_mtd "0:appsblenv" "0x0" "0x40000" "0x20000"

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -93,6 +93,7 @@ ALLWIFIBOARDS:= \
 	tplink_archer-c60-v1 \
 	tplink_archer-c60-v2 \
 	tplink_deco-x80-5g \
+	tplink_deco-x60-v2 \
 	tplink_eap225-wall-v2 \
 	tplink_eap610-outdoor \
 	tplink_eap620-hd-v3 \
@@ -290,6 +291,7 @@ $(eval $(call generate-ipq-wifi-package,tplink_archer-c6-v2,TP-Link Archer C6 V2
 $(eval $(call generate-ipq-wifi-package,tplink_archer-c60-v1,TP-Link Archer C60 V1))
 $(eval $(call generate-ipq-wifi-package,tplink_archer-c60-v2,TP-Link Archer C60 V2))
 $(eval $(call generate-ipq-wifi-package,tplink_deco-x80-5g,TP-Link Deco X80-5G))
+$(eval $(call generate-ipq-wifi-package,tplink_deco-x60-v2,TP-Link Deco X60 v2))
 $(eval $(call generate-ipq-wifi-package,tplink_eap225-wall-v2,TP-Link EAP225-Wall v2))
 $(eval $(call generate-ipq-wifi-package,tplink_eap610-outdoor,TPLink EAP610-Outdoor))
 $(eval $(call generate-ipq-wifi-package,tplink_eap620-hd-v3,TP-Link EAP620 HD v3))

--- a/target/linux/qualcommax/dts/ipq8071-deco-x60-v2.dts
+++ b/target/linux/qualcommax/dts/ipq8071-deco-x60-v2.dts
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "ipq8074-512m.dtsi"
+#include "ipq8074-ac-cpu.dtsi"
+#include "ipq8074-ess.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "TP-Link Deco X60 v2";
+	compatible = "tplink,deco-x60-v2", "qcom,ipq8074";
+
+	aliases {
+		serial0 = &blsp1_uart5;
+		led-boot = &led_red;
+		led-failsafe = &led_red;
+		led-running = &led_green;
+		led-upgrade = &led_blue;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-append = " root=/dev/ubiblock0_1 swiotlb=1 coherent_pool=2M";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins &button_wps_pins>;
+		pinctrl-names = "default";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&tlmm 26 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&tlmm 34 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+		status = "okay";
+
+		led_red: red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&tlmm 31 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		led_green: green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&tlmm 30 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		led_blue: blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&tlmm 32 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		wlan2g {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&tlmm 42 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1radio";
+		};
+
+		wlan5g {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&tlmm 43 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0radio";
+		};
+	};
+};
+
+&tlmm {
+	mdio_pins: mdio-pins {
+		mdc {
+			pins = "gpio68";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio {
+			pins = "gpio69";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	button_pins: button-pins {
+		mux {
+			pins = "gpio26";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	button_wps_pins: wps-button-pins {
+		mux {
+			pins = "gpio34";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	led_pins: led-pins {
+		mux_0 {
+			pins = "gpio31", "gpio32", "gpio30";  /* RGB LEDs */
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-down;
+		};
+		mux_1 {
+			pins = "gpio42", "gpio43";  /* WiFi activity LEDs */
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-down;
+		};
+	};
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "qcom,smem-part"; /* define SMEM partition table */
+		};
+	};
+};
+
+&blsp1_uart5 {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qusb_phy_0 {
+	status = "okay";
+};
+
+&ssphy_0 {
+	status = "okay";
+};
+
+&usb_0 {
+	status = "okay";
+};
+
+&edma {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
+
+	ethernet-phy-package@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "qcom,qca8075-package";
+		reg = <0>;
+
+		qca8075_3: ethernet-phy@3 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <3>;
+		};
+
+		qca8075_4: ethernet-phy@4 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <4>;
+		};
+	};
+};
+
+&switch {
+	status = "okay";
+
+	switch_lan_bmp = <ESS_PORT4>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT5>; /* wan port bitmap */
+	switch_mac_mode = <MAC_MODE_PSGMII>;
+
+	qcom,port_phyinfo {
+		port@4 {
+			port_id = <4>;
+			phy_address = <3>;
+		};
+
+		port@5 {
+			port_id = <5>;
+			phy_address = <4>;
+		};
+	};
+};
+
+&dp4 {
+	status = "okay";
+	phy-handle = <&qca8075_3>;
+	label = "lan";
+};
+
+&dp5 {
+	status = "okay";
+	phy-handle = <&qca8075_4>;
+	label = "wan";
+};
+
+&wifi {
+	status = "okay";
+	qcom,ath11k-fw-memory-mode = <1>;
+	qcom,ath11k-calibration-variant = "TPLink-Deco-X60-v2";
+};
+
+

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -635,3 +635,18 @@ define Device/zyxel_nwa210ax
 	ZYXEL_MODEL_ID := 5c e1
 endef
 TARGET_DEVICES += zyxel_nwa210ax
+
+define Device/tplink_deco-x60-v2
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := TP-Link
+	DEVICE_MODEL := Deco X60
+	DEVICE_VARIANT := v2
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	DEVICE_DTS_CONFIG := config@ac04
+	SOC := ipq8071
+	DEVICE_PACKAGES := ipq-wifi-tplink_deco-x60-v2
+endef
+TARGET_DEVICES += tplink_deco-x60-v2
+

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -15,6 +15,7 @@ ipq807x_setup_interfaces()
 	edgecore,eap102|\
 	tcl,linkhub-hh500v|\
 	tplink,deco-x80-5g|\
+	tplink,deco-x60-v2|\
 	yuncore,ax880|\
 	zte,mf269)
 		ucidef_set_interfaces_lan_wan "lan" "wan"
@@ -103,7 +104,8 @@ ipq807x_setup_macs()
 		wan_mac=$(mtd_get_mac_binary "0:ART" 0x5e290)
 		lan_mac=$(mtd_get_mac_binary "0:ART" 0x5e296)
 		;;
-	tplink,deco-x80-5g)
+	tplink,deco-x80-5g|\
+	tplink,deco-x60-v2)
 		label_mac=$(get_mac_binary /tmp/factory_data/default-mac 0)
 		lan_mac=$(macaddr_add $label_mac 1)
 		wan_mac=$label_mac

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -111,7 +111,8 @@ case "$FIRMWARE" in
 		ath11k_patch_mac $(mtd_get_mac_binary "0:ART" 0x5e2a2) 1
 		ath11k_set_macflag
 		;;
-	tplink,deco-x80-5g)
+	tplink,deco-x80-5g|\
+	tplink,deco-x60-v2)
 		caldata_extract "0:art" 0x1000 0x20000
 		label_mac=$(get_mac_binary /tmp/factory_data/default-mac 0)
 		ath11k_patch_mac $(macaddr_add $label_mac -1) 0

--- a/target/linux/qualcommax/ipq807x/base-files/lib/preinit/09_mount_factory_data
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/preinit/09_mount_factory_data
@@ -18,7 +18,8 @@ preinit_mount_factory_data() {
 preinit_mount_factory_partitions() {
 
 	case $(board_name) in
-	tplink,deco-x80-5g)
+	tplink,deco-x80-5g|\
+	tplink,deco-x60-v2)
 		preinit_mount_factory_data "factory_data"
 		preinit_mount_factory_data "runtime_data"
 		;;

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -271,6 +271,7 @@ platform_do_upgrade() {
 		nand_do_upgrade "$1"
 		;;
 	tplink,deco-x80-5g|\
+	tplink,deco-x60-v2|\
 	tplink,eap620hd-v1|\
 	tplink,eap660hd-v1)
 		tplink_do_upgrade "$1"


### PR DESCRIPTION
Add TP-Link Deco X60 v2. Needs firmware from [github.com/openwrt/firmware_qca-wireless/pull/142](https://github.com/openwrt/firmware_qca-wireless/pull/142) and minor tweaks to commit message/hw info. 


TP-Link Deco X60 is a dual-band AX3000 Mesh WiFi 6 router. Version 2 (European variant) runs on Qualcomm IPQ8071 SoC with QCN5024/QCN5054 wireless chips.

Hardware Specifications
-----------------------
CPU:       Qualcomm IPQ8071A
RAM:       512 MiB
Flash:     128 MiB Winbond W29N01HZ
WiFi 2.4G: QCN5024 (2×2:2 MU-MIMO, 802.11ax/a/b/g/n)
WiFi 5G:   QCN5054 (2×4:4 MU-MIMO, 802.11ax/a/b/g/n/ac)
Eth Switch: QCA8075 (2× 1GbE ports)

Installation Notes
------------------
Initial access via hardware UART (pads on board, 115200 8n1):
  TP8 = VCC (1.8V)
  TP7 = GND
  TP6 = RX (connect to TX on adapter)
  TP5 = TX (connect to RX on adapter)

Boot process from stock firmware:
1. Enter uboot with 'tpl'
2. Set server IP and use tftpboot command
    - setenv ipaddr 192.168.1.1
    - setenv serverip 192.168.1.2
3. Load initramfs image: 
    - tftpboot 0x44000000 192.168.1.2:openwrt-qualcommax-ipq807x-tplink_deco-x60-v2-initramfs-uImage.itb
4. Boot kernel: `bootm`

Device Tree Changes
-------------------
Added complete devicetree overlay with:
* LED definitions (RGB status, per-radio activity indicators)
* Button configuration (reset, WPS)
* Ethernet switch binding (LAN/WAN port assignment)
* WLAN ath11k driver integration

Notes
-------------------
Wifi firmware missing from OpenWRT. Pull request waiting in firmware_qca-wireless https://github.com/openwrt/firmware_qca-wireless/pull/142

Tested On
---------
Deco X60 v2 EU (hardware version printed on bottom label) Firmware: OpenWrt HEAD built on 3.7.2026

Edit: My device is labeled as Deco X60(EU) but also has an fcc id TE7X60V2 on the bottom, so these are very likely the same. The stock firmware contains a bunch of different wifi firmware images, however (including bdwlan_US and bdwlan_DE) 