### PR TITLE
procd: remount the rootfs read-only at halt

### DIFF
--- a/package/base-files/files/etc/init.d/umount
+++ b/package/base-files/files/etc/init.d/umount
@@ -1,13 +1,119 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2006 OpenWrt.org
 
-STOP=90
+# after every other shutdown script has stopped writing, but before
+# mdadm (STOP=98) stops the arrays
+STOP=97
 
 restart() {
 	:
 }
 
+# syslog is usually gone by the time this script runs, so report straight
+# to the console
+console_print() {
+	echo "$@" > /dev/console 2> /dev/null || echo "$@"
+}
+
+# Succeeds when / does not sit on a block device (nothing to do) or when
+# it is already/successfully remounted read-only.
+root_remount_ro() {
+	set -- $(awk '$2 == "/" { dev = $1; opts = $4 } END { print dev, opts }' /proc/mounts)
+
+	case "$1" in
+	/dev/*) ;;
+	*) return 0 ;;
+	esac
+	case "$2" in
+	ro | ro,*) return 0 ;;
+	esac
+
+	mount -o remount,ro / 2> /dev/null
+}
+
+# List "pid comm path" for every process, pid 1 and ourselves included,
+# holding a file on the root superblock open for writing. Only such
+# descriptors make the read-only remount of / fail, leaving a dirty
+# journal for the next boot's fsck; writers on other filesystems cannot
+# block it. Membership is decided by the descriptor's mnt_id, not its
+# path, so files deleted while open are accounted for as well.
+disk_writers() {
+	local root_dev fd pid target flags mnt_id
+
+	root_dev="$(awk '$5 == "/" { dev = $3 } END { print dev }' \
+		/proc/self/mountinfo)"
+
+	for fd in /proc/[0-9]*/fd/*; do
+		pid="${fd#/proc/}"
+		pid="${pid%%/*}"
+
+		target="$(readlink "$fd" 2> /dev/null)"
+		case "$target" in
+		/*) ;;
+		*) continue ;;
+		esac
+
+		set -- $(awk '/^flags:/ { f = $2 } /^mnt_id:/ { m = $2 }
+			END { print f, m }' \
+			"/proc/$pid/fdinfo/${fd##*/}" 2> /dev/null)
+		flags="$1" mnt_id="$2"
+
+		# the last octal digit of the flags carries O_ACCMODE
+		case "${flags#"${flags%?}"}" in
+		1 | 2) ;;
+		*) continue ;;
+		esac
+
+		[ "$(awk -v id="$mnt_id" '$1 == id { print $3; exit }' \
+			/proc/self/mountinfo)" = "$root_dev" ] || continue
+
+		echo "$pid $(cat "/proc/$pid/comm" 2> /dev/null) $target"
+	done
+}
+
 stop() {
+	local sig writers pinned
+
 	sync
+
+	# an active swap file on / holds it open for writing from within
+	# the kernel, where no process listing can show it
+	swapoff -a 2> /dev/null
+
+	# The root filesystem can never be unmounted; when it sits on a
+	# block device it must be remounted read-only instead so the
+	# journal is cleanly closed, otherwise the next fsck will find a
+	# dirty journal and stale free block/inode counts. Processes still
+	# holding files open for writing block the remount, so report and
+	# remove them before retrying.
+	if ! root_remount_ro; then
+		for sig in TERM KILL; do
+			writers="$(disk_writers)"
+			[ -n "$writers" ] || break
+
+			# pid 1 and this script must survive, but their
+			# descriptors explain a remount failure just as well
+			pinned="$(echo "$writers" | awk -v self="$$" \
+				'$1 == 1 || $1 == self')"
+			if [ -n "$pinned" ]; then
+				console_print "shutdown: files on / open for writing by init or the shutdown script:"
+				console_print "$pinned"
+			fi
+
+			writers="$(echo "$writers" | awk -v self="$$" \
+				'$1 != 1 && $1 != self')"
+			[ -n "$writers" ] || break
+
+			console_print "shutdown: processes still writing to /, sending SIG$sig:"
+			console_print "$writers"
+			kill -$sig $(echo "$writers" | awk '{ print $1 }' | sort -u) 2> /dev/null
+			sleep 1
+			root_remount_ro && break
+		done
+
+		root_remount_ro || console_print \
+			"shutdown: unable to remount / read-only, next boot will recover the journal"
+	fi
+
 	/bin/umount -a -d -r
 }

--- a/package/system/procd/Makefile
+++ b/package/system/procd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=procd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/procd.git

--- a/package/system/procd/patches/0001-state-remount-the-root-filesystem-read-only-before-halting.patch
+++ b/package/system/procd/patches/0001-state-remount-the-root-filesystem-read-only-before-halting.patch
@@ -1,0 +1,72 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: John Audia <therealgraysky@proton.me>
+Date: Sat, 12 Sep 2026 14:22:40 +0000
+Subject: [PATCH] state: remount the root filesystem read-only before halting
+
+sync() writes dirty data back, but it does not leave the root
+filesystem clean: a journalling filesystem only commits its superblock
+on remount or unmount. On ext4 this means every boot replays the
+journal and e2fsck finds the free block and inode counts stale, even
+after an orderly reboot.
+
+The shutdown scripts cannot fix this. "umount -a -r" does attempt the
+read-only remount, but it runs while procd and everything it
+supervises are still alive, and the remount fails with EBUSY as long
+as any process holds a file open for writing. The only point at which
+the root is idle is after the final SIGKILL, so remount it read-only
+there, right before the kernel is asked to reboot.
+
+A remount of an overlay root only syncs its upper filesystem, and a
+swap file on the root filesystem still keeps it busy; both are left
+as they are. The root of a container belongs to the host and is
+skipped.
+
+logd is stopped long before this point, so anything logged from
+STATE_HALT went to a syslog socket nobody reads. Switch to the console
+that set_console() already prepared, so that a failed remount can be
+seen.
+
+Signed-off-by: John Audia <therealgraysky@proton.me>
+---
+ state.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/state.c b/state.c
+index 8464ba9..24465e6 100644
+--- a/state.c
++++ b/state.c
+@@ -14,6 +14,7 @@
+ 
+ #include <fcntl.h>
+ #include <pwd.h>
++#include <sys/mount.h>
+ #include <sys/reboot.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+@@ -184,6 +185,8 @@ static void state_enter(void)
+ 		break;
+ 
+ 	case STATE_HALT:
++		/* logd is gone by now, log to the console instead */
++		ulog_open(ULOG_STDIO, LOG_DAEMON, "procd");
+ 		// To prevent killed processes from interrupting the sleep
+ 		signal(SIGCHLD, SIG_IGN);
+ 		LOG("- SIGTERM processes -\n");
+@@ -195,6 +198,17 @@ static void state_enter(void)
+ 		sync();
+ 		sleep(1);
+ #ifndef DISABLE_INIT
++		/*
++		 * sync() writes the data back, but does not leave the root
++		 * filesystem clean: a journalling filesystem only commits its
++		 * superblock on remount or unmount, and the remount is only
++		 * possible now that no process is left to hold a file on it
++		 * open for writing. The root of a container is the host's.
++		 */
++		if (!is_container() &&
++		    mount(NULL, "/", NULL, MS_REMOUNT | MS_RDONLY, NULL))
++			ERROR("failed to remount / read-only: %m\n");
++
+ 		perform_halt();
+ #else
+ 		exit(EXIT_SUCCESS);


### PR DESCRIPTION
An ext4 rootfs reports a dirty journal and stale free block/inode counts on every boot, even after an orderly reboot:

      % e2fsck -fvy /dev/nvme0n1p2
      rootfs: recovering journal
      Free blocks count wrong (136398, counted=124525).
      Fix? yes
      Free inodes count wrong (41703, counted=41667).
      Fix? yes
 
`sync()` is not enough, as a journalling filesystem only commits its superblock on remount or unmount. The "umount -a -r" in the umount init script does try a read-only remount, but it runs while procd and the daemons it supervises are still alive, so it fails with EBUSY as long as any of them holds a file open for writing.

The only point in the shutdown where the root is idle is after procd's final SIGKILL, so have procd remount it read-only there, right before it asks the kernel to reboot.

While there, switch procd's log channel to the console on the way into STATE_HALT. logd is long gone by then, so a failed remount would otherwise go unseen.