### PR TITLE
qualcommax: Linksys MR7500 DTS and PHY enumeration fix

### DIFF
--- a/package/kernel/qca-ssdk/patches/fix_ssdk_aquantia_phy_mr7500_gated_bring_up.patch
+++ b/package/kernel/qca-ssdk/patches/fix_ssdk_aquantia_phy_mr7500_gated_bring_up.patch
@@ -1,0 +1,82 @@
+--- a/src/hsl/phy/aquantia_phy.c
++++ b/src/hsl/phy/aquantia_phy.c
+@@ -23,6 +23,7 @@
+ #include "hsl_phy.h"
+ #include "qcaphy_c45_common.h"
+ #include "ssdk_plat.h"
++#include <linux/of.h>
+ 
+ sw_error_t
+ aquantia_phy_get_speed(a_uint32_t dev_id, a_uint32_t phy_addr,
+@@ -1329,6 +1330,54 @@
+ * aquantia_phy_hw_register init to avoid packet loss
+ *
+ */
++
++#define MR7500_AQR_MDIO_ADDR              8
++#define MR7500_AQR_MMD_VEND1              0x1e
++#define MR7500_AQR_GSYSCFG_1G_REG         0x31c
++#define MR7500_AQR_HWINIT_POLL_MS         100
++#define MR7500_AQR_HWINIT_POLL_MAX        300
++
++static a_bool_t
++mr7500_wait_aqr_ready_for_hwinit(a_uint32_t dev_id, a_uint32_t phy_addr)
++{
++	a_uint16_t gsyscfg = 0xffff;
++	int poll;
++
++	if (!of_machine_is_compatible("linksys,mr7500"))
++		return A_TRUE;
++
++	if (phy_addr != MR7500_AQR_MDIO_ADDR)
++		return A_TRUE;
++
++	for (poll = 0; poll < MR7500_AQR_HWINIT_POLL_MAX; poll++) {
++		gsyscfg = hsl_phy_mmd_reg_read(dev_id, phy_addr, A_TRUE,
++						MR7500_AQR_MMD_VEND1,
++						MR7500_AQR_GSYSCFG_1G_REG);
++
++		if (gsyscfg == 0x0280 || gsyscfg == 0x0080) {
++			SSDK_INFO("MR7500-AQR-HWINIT-GATE: AQR ready after %d polls (%d ms) gsyscfg1=0x%04x\n",
++				  poll,
++				  poll * MR7500_AQR_HWINIT_POLL_MS,
++				  gsyscfg);
++			return A_TRUE;
++		}
++
++		aos_mdelay(MR7500_AQR_HWINIT_POLL_MS);
++	}
++
++	SSDK_INFO("MR7500-AQR-HWINIT-GATE: AQR not ready after %d ms, last gsyscfg1=0x%04x; skipping AQR hw_init writes\n",
++		  MR7500_AQR_HWINIT_POLL_MAX * MR7500_AQR_HWINIT_POLL_MS,
++		  gsyscfg);
++
++	return A_FALSE;
++}
++
++
+ sw_error_t
+ aquantia_phy_hw_init(a_uint32_t dev_id,  a_uint32_t port_bmp)
+ {
+@@ -1341,6 +1390,30 @@
+ 		if (port_bmp & (0x1 << port_id))
+ 		{
+ 			phy_addr = qca_ssdk_port_to_phy_addr(dev_id, port_id);
++
++			if (of_machine_is_compatible("linksys,mr7500") &&
++				phy_addr == MR7500_AQR_MDIO_ADDR) {
++				static a_bool_t initial_poll_done;
++
++				if (!initial_poll_done) {
++					if (!mr7500_wait_aqr_ready_for_hwinit(dev_id, phy_addr)) {
++						continue;
++					}
++
++					initial_poll_done = A_TRUE;
++				}
++
++			}
++
+ 			/*set auto neg of aq*/
+ 			rv = hsl_phy_modify_mmd(dev_id, phy_addr, A_TRUE,
+ 				AQUANTIA_MMD_PHY_XS_REGISTERS, AQUANTIA_PHY_XS_USX_TRANSMIT,

--- a/target/linux/qualcommax/dts/ipq6018-mr7500.dts
+++ b/target/linux/qualcommax/dts/ipq6018-mr7500.dts
@@ -322,9 +322,11 @@
 
 	aqr114c: ethernet-phy@8 {
 		reg = <8>;
-		reset-gpios = <&tlmm 77 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&tlmm 77 GPIO_ACTIVE_LOW>;
 		compatible = "ethernet-phy-ieee802.3-c45";
 		firmware-name = "marvell/AQR114C.cld";
+		nvmem-cells = <&aqr_fw>;
+		nvmem-cell-names = "firmware";
 
 		leds {
 			#address-cells = <1>;
@@ -462,21 +464,35 @@
 
 		partitions {
 			compatible = "qcom,smem-part";
-			#address-cells = <1>;
-			#size-cells = <1>;
 
 			partition-0-devinfo {
 				label = "devinfo";
 				read-only;
-				#address-cells = <1>;
-				#size-cells = <1>;
 
 				nvmem-layout {
 					compatible = "ascii-eq-delim-env";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
 					hw_mac_addr: hw_mac_addr {
 						compatible = "mac-base";
 						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition-0-ethphyfw {
+				label = "0:ethphyfw";
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					aqr_fw: firmware@0 {
+						/* Skip the QCOM MBN Header of 40 bytes */
+						reg = <0x28 0x60002>;
 					};
 				};
 			};

--- a/target/linux/qualcommax/patches-6.12/0913-mdio-fix_detect_c45_phy.patch
+++ b/target/linux/qualcommax/patches-6.12/0913-mdio-fix_detect_c45_phy.patch
@@ -1,0 +1,79 @@
+--- a/drivers/net/mdio/fwnode_mdio.c
++++ b/drivers/net/mdio/fwnode_mdio.c
+@@ -7,6 +7,7 @@
+  */
+ 
+ #include <linux/acpi.h>
++#include <linux/delay.h>
+ #include <linux/dev_printk.h>
+ #include <linux/fwnode_mdio.h>
+ #include <linux/of.h>
+@@ -125,19 +126,52 @@ int fwnode_mdiobus_register_phy(struct m
+ 	struct mii_timestamper *mii_ts = NULL;
+ 	struct pse_control *psec = NULL;
+ 	struct phy_device *phy;
++	struct phy_c45_device_ids c45_ids;
+ 	bool is_c45;
+ 	u32 phy_id;
+-	int rc;
++	int rc, retries = 0;
+ 
+ 	mii_ts = fwnode_find_mii_timestamper(child);
+ 	if (IS_ERR(mii_ts))
+ 		return PTR_ERR(mii_ts);
+ 
+ 	is_c45 = fwnode_device_is_compatible(child, "ethernet-phy-ieee802.3-c45");
+-	if (is_c45 || fwnode_get_phy_id(child, &phy_id))
++
++	memset(&c45_ids, 0xff, sizeof(c45_ids));
++	c45_ids.devices_in_package = BIT(MDIO_MMD_PMAPMD);
++	c45_ids.mmds_present = BIT(MDIO_MMD_PMAPMD);
++
++	if (!fwnode_get_phy_id(child, &phy_id)) {
++		if (is_c45) {
++			/*
++			 * DT supplied a Clause 45 PHY ID in the form
++			 * "ethernet-phy-idXXXX.XXXX". Populate synthetic
++			 * c45_ids so normal C45 driver matching and module
++			 * autoload work.
++			 */
++			c45_ids.device_ids[MDIO_MMD_PMAPMD] = phy_id;
++			phy = phy_device_create(bus, addr, 0, true, &c45_ids);
++		} else {
++			phy = phy_device_create(bus, addr, phy_id, false, NULL);
++		}
++	} else {
+ 		phy = get_phy_device(bus, addr, is_c45);
+-	else
+-		phy = phy_device_create(bus, addr, phy_id, 0, NULL);
++
++		if (IS_ERR(phy) && is_c45 && PTR_ERR(phy) == -ENODEV) {
++			/*
++			 * Some DT-declared Clause 45 PHYs can take time after
++			 * power-on/reset before they answer ID reads.
++			 * Retry for up to 5 seconds before giving up.
++			 */
++			for (retries = 1; retries <= 50; retries++) {
++				msleep(100);
++				phy = get_phy_device(bus, addr, true);
++				if (!IS_ERR(phy) || PTR_ERR(phy) != -ENODEV)
++					break;
++			}
++		}
++	}
++
+ 	if (IS_ERR(phy)) {
+ 		rc = PTR_ERR(phy);
+ 		goto clean_mii_ts;
+@@ -179,6 +213,11 @@ int fwnode_mdiobus_register_phy(struct m
+ 	if (mii_ts)
+ 		phy->mii_ts = mii_ts;
+ 
++	if (retries)
++		dev_info(&bus->dev,
++			 "C45 PHY at address %u became ready after %d ms\n",
++			 addr, retries * 100);
++
+ 	return 0;
+ 
+ unregister_phy:

--- a/target/linux/qualcommax/patches-6.12/0914-phy_device-fix-detect_c45.patch
+++ b/target/linux/qualcommax/patches-6.12/0914-phy_device-fix-detect_c45.patch
@@ -1,0 +1,37 @@
+--- a/drivers/net/phy/phy_device.c
++++ b/drivers/net/phy/phy_device.c
+@@ -1583,7 +1583,34 @@ int phy_attach_direct(struct net_device
+ 
+ 	/* Assume that if there is no driver, that it doesn't
+ 	 * exist, and we should use the genphy driver.
++	 *
++	 * For Clause 45 PHYs, try one late module request using
++	 * populated c45_ids before falling back to Generic Clause 45.
++	 * This helps on systems where the earlier request in
++	 * phy_device_create() ran before userspace/modprobe was ready.
+ 	 */
++
++	if (of_machine_is_compatible("linksys,mr7500") && !d->driver && phydev->is_c45) {
++		int i;
++		bool have_specific_c45_id = false;
++
++		for (i = 1; i < ARRAY_SIZE(phydev->c45_ids.device_ids); i++) {
++			u32 id = phydev->c45_ids.device_ids[i];
++
++			if (id == 0 || id == 0xffffffff)
++				continue;
++
++			have_specific_c45_id = true;
++			phy_request_driver_module(phydev, id);
++			break;
++		}
++
++		if (!d->driver && have_specific_c45_id) {
++			err = -EPROBE_DEFER;
++			goto error_put_device;
++		}
++	}
++
+ 	if (!d->driver) {
+ 		if (phydev->is_c45)
+ 			d->driver = &genphy_c45_driver.mdiodrv.driver;


### PR DESCRIPTION
This PR includes several fixes for the Linksys MR7500, targeting WAN PHY NVRAM mapping, PHY enumeration, and firmware loading for the Aquantia AQR114C 5G WAN PHY.

Commits:
- qualcommax: fix NVRAM map for MR7500 - Corrects the NVRAM partition mapping in the MR7500 DTS so nvmem-cells properly references the WAN PHY firmware blob, and fixes the reset GPIO polarity for the AQR114C PHY (active-low, was active-high).
- kernel: net: phy: fix C45 PHY enumeration - Fixes MDIO/PHY core detection of Clause 45 PHYs, needed for the AQR114C to be found correctly on the MDIO bus.
- kernel: net: phy: aquantia: gate fw init via DT - Adds a device-tree-gated path for firmware initialization on the Aquantia PHY.

Closes #21835 - (Additional documentation is needed on the wiki as the WAN PHY needs to be reflashed on stock devices, as the factory firmware is corrupted. See issue comments for details.).


