### PR TITLE
mediatek: filogic: fix Globitel BT-R320 recovery image name

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1837,7 +1837,7 @@ define Device/globitel_bt-r320
   KERNEL := kernel-bin | lzma
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  KERNEL_INITRAMFS_SUFFIX := -initramfs-recovery.itb
+  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
   IMAGES := sysupgrade.itb
   IMAGE_SIZE := $$(shell expr 64 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
   IMAGE/sysupgrade.itb := append-kernel | \


### PR DESCRIPTION
Fix duplicated "initramfs" in the Globitel BT-R320 recovery image name.

Before:
"openwrt-mediatek-filogic-globitel_bt-r320-initramfs-initramfs-recovery.itb"

After:
"openwrt-mediatek-filogic-globitel_bt-r320-initramfs-recovery.itb"