### PR TITLE
mediatek: filogic: add USB VBUS regulator for Globitel BT-R320

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-globitel-bt-r320.dts
+++ b/target/linux/mediatek/dts/mt7981b-globitel-bt-r320.dts
@@ -27,6 +27,16 @@
 		reg = <0 0x40000000 0 0x40000000>;
 	};
 
+	usb_vbus: regulator-usb-vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&pio 14 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-boot-on;
+	};
+
 	gpio-keys {
 		compatible = "gpio-keys";
 
@@ -221,5 +231,6 @@
 };
 
 &xhci {
+	vbus-supply = <&usb_vbus>;
 	status = "okay";
 };


### PR DESCRIPTION
Add the USB VBUS regulator for Globitel BT-R320.

GPIO14 controls VBUS and is active high.

Tested on BT-R320:
- "vbus-supply" is present in the live device tree
- no "dummy regulator" warning from xhci-mtk
- USB device enumerates