### PR TITLE
mediatek: add device tree overlay for BPI-R4 I2C1

### DIFF
--- a/target/linux/mediatek/files-6.18/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4-i2c1.dtso
+++ b/target/linux/mediatek/files-6.18/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4-i2c1.dtso
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: (GPL-2.0-or-later OR MIT)
+/*
+ * Device tree overlay for the BananaPi BPI-R4.
+ * This overlay enables the I2C1 interface on pin 3 and 5 of CON2 "GPIO header".
+ * These pins are shared with GPIO 17 and 18, these GPIO pins cannot be used
+ * for other purposes anymore if enabled.
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "bananapi,bpi-r4", "mediatek,mt7988a";
+};
+
+&i2c1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c1_pins>;
+	status = "okay";
+};

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -674,7 +674,7 @@ define Device/bananapi_bpi-r4-common
   DEVICE_VENDOR := Bananapi
   DEVICE_DTS_DIR := $(DTS_DIR)/
   DEVICE_DTS_LOADADDR := 0x45f00000
-  DEVICE_DTS_OVERLAY:= mt7988a-bananapi-bpi-r4-emmc mt7988a-bananapi-bpi-r4-rtc mt7988a-bananapi-bpi-r4-sd mt7988a-bananapi-bpi-r4-wifi-be14
+  DEVICE_DTS_OVERLAY:= mt7988a-bananapi-bpi-r4-emmc mt7988a-bananapi-bpi-r4-rtc mt7988a-bananapi-bpi-r4-sd mt7988a-bananapi-bpi-r4-wifi-be14 mt7988a-bananapi-bpi-r4-i2c1
   DEVICE_DTC_FLAGS := --pad 4096
   DEVICE_PACKAGES := kmod-hwmon-pwmfan kmod-i2c-mux-pca954x kmod-eeprom-at24 kmod-mt7996-firmware kmod-mt7996-233-firmware \
 		     kmod-rtc-pcf8563 kmod-sfp kmod-phy-aquantia kmod-usb3 e2fsprogs f2fsck mkf2fs mt7988-wo-firmware

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -709,7 +709,9 @@ define Device/bananapi_bpi-r4-common
   DEVICE_VENDOR := Bananapi
   DEVICE_DTS_DIR := $(DTS_DIR)/
   DEVICE_DTS_LOADADDR := 0x45f00000
-  DEVICE_DTS_OVERLAY:= mt7988a-bananapi-bpi-r4-emmc mt7988a-bananapi-bpi-r4-rtc mt7988a-bananapi-bpi-r4-sd mt7988a-bananapi-bpi-r4-wifi-be14
+  DEVICE_DTS_OVERLAY:= mt7988a-bananapi-bpi-r4-emmc mt7988a-bananapi-bpi-r4-i2c1 \
+		       mt7988a-bananapi-bpi-r4-rtc mt7988a-bananapi-bpi-r4-sd \
+		       mt7988a-bananapi-bpi-r4-wifi-be14
   DEVICE_DTC_FLAGS := --pad 4096
   DEVICE_PACKAGES := kmod-hwmon-pwmfan kmod-i2c-mux-pca954x kmod-eeprom-at24 kmod-mt7996-firmware kmod-mt7996-233-firmware \
 		     kmod-rtc-pcf8563 kmod-sfp kmod-phy-aquantia kmod-usb3 e2fsprogs f2fsck mkf2fs mt7988-wo-firmware


### PR DESCRIPTION
Banana Pi BPI-R4 has an GPIO header with 2 I2C pins that are connected to I2C1 interface of the SOC.
This I2C interface is disabled by default, but can be enabled with this overlay.

Once enabled it can be used to add different I2C devices to the board, e.g. power sensors like INA219 or temperature sensors like SHT31. Many are already supported by current linux kernel and by OpenWrt, others need extra software.
(I tested with an INA219 module.)

To enable I2C1 overlay, add into u-boot bootconf_extra parameter: 'mt7988a-bananapi-bpi-r4-i2c1'.
You can use the following example script:

```sh
overlay="mt7988a-bananapi-bpi-r4-i2c1"
current="$(fw_printenv -n bootconf_extra 2>/dev/null)"
if [ -n "${current}" ]; then
    fw_setenv bootconf_extra "${current}#${overlay}"
else
    fw_setenv bootconf_extra "${overlay}"
fi
```
