### PR TITLE
intel-microcode: fix build error on rebuild

### DIFF
--- a/package/firmware/intel-microcode/Makefile
+++ b/package/firmware/intel-microcode/Makefile
@@ -39,6 +39,7 @@ endef
 
 define Build/Compile
 	IUCODE_TOOL=$(STAGING_DIR)/../host/bin/iucode_tool $(MAKE) -C $(PKG_BUILD_DIR)
+	rm -rf $(PKG_BUILD_DIR)/intel-ucode-ipkg
 	mkdir -p $(PKG_BUILD_DIR)/intel-ucode-ipkg
 	$(STAGING_DIR)/../host/bin/iucode_tool -q \
 		--write-firmware=$(PKG_BUILD_DIR)/intel-ucode-ipkg $(PKG_BUILD_DIR)/$(MICROCODE).bin


### PR DESCRIPTION
When rebuilding the package, iucode_tool fails with a "File exists" error if the directory already contained firmware from the previous build (incl. in the successful build case).

Fix this by removing the directory before invoking iucode_tool.

Fixes the following build error:

```
iucode_tool: 06-0f-02: cannot write to, or create file: File exists
make[2]: *** [Makefile:57: .../.built] Error 2
```