### PR TITLE
netifd: dhcp: allow suppressing the DHCPv4 client ID

### DIFF
--- a/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
+++ b/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
@@ -15,6 +15,7 @@ proto_dhcp_init_config() {
 	proto_config_add_string 'ipaddr:ipaddr'
 	proto_config_add_string 'hostname:hostname'
 	proto_config_add_string clientid
+	proto_config_add_boolean sendclientid
 	proto_config_add_string vendorid
 	proto_config_add_boolean 'broadcast:bool'
 	proto_config_add_boolean 'norelease:bool'
@@ -58,8 +59,8 @@ proto_dhcp_setup() {
 	local config="$1"
 	local iface="$2"
 
-	local ipaddr hostname clientid vendorid broadcast norelease reqopts defaultreqopts iface6rd sendopts delegate zone6rd zone mtu6rd customroutes classlessroute timeout retry tryagain
-	json_get_vars ipaddr hostname clientid vendorid broadcast norelease reqopts defaultreqopts iface6rd delegate zone6rd zone mtu6rd customroutes classlessroute timeout retry tryagain
+	local ipaddr hostname clientid sendclientid vendorid broadcast norelease reqopts defaultreqopts iface6rd sendopts delegate zone6rd zone mtu6rd customroutes classlessroute timeout retry tryagain
+	json_get_vars ipaddr hostname clientid sendclientid vendorid broadcast norelease reqopts defaultreqopts iface6rd delegate zone6rd zone mtu6rd customroutes classlessroute timeout retry tryagain
 
 	local opt dhcpopts
 	for opt in $reqopts; do
@@ -79,7 +80,11 @@ proto_dhcp_setup() {
 		[ -z "$clientid" ] && logger -p warn -t dhcp "$iface: ignoring invalid clientid value"
 	}
 	[ -z "$clientid" ] && clientid="$(proto_dhcp_get_default_clientid "$iface")"
-	[ -n "$clientid" ] && clientid="-x 0x3d:$clientid"
+	if [ "$sendclientid" = 0 ]; then
+		clientid="-C"
+	elif [ -n "$clientid" ]; then
+		clientid="-x 0x3d:$clientid"
+	fi
 	[ -n "$vendorid" ] && append dhcpopts "-x 0x3c:$(echo -n "$vendorid" | hexdump -ve '1/1 "%02x"')"
 	[ -n "$iface6rd" ] && proto_export "IFACE6RD=$iface6rd"
 	[ "$iface6rd" != 0 -a -f /lib/netifd/proto/6rd.sh ] && append dhcpopts "-O 212"


### PR DESCRIPTION
Since commit 387b49d89aa5 ("netifd dhcp: send DHCP client ID by default") an empty clientid no longer starts udhcpc with -C, so DHCP option 61 (client identifier) is always sent: either derived from the global DHCP DUID (see 9151c7015ed2 "netifd: use the global DHCP DUID for DHCPv4") or, failing that, from udhcpc's own MAC-based default. Some ISPs (e.g. Turksat KabloNet) reject requests carrying option 61, which regressed WAN connectivity compared to 24.10.

Add a per-interface boolean "sendclientid" so users can opt out again. When set to 0, udhcpc is invoked with -C and no client identifier is sent, restoring the pre-387b49d89aa5 behaviour. The option is unset by default, so the current send-by-default behaviour is preserved.

This only covers DHCPv4; the DHCPv6 DUID stays mandatory per RFC 8415.

Reported-at: https://github.com/openwrt/openwrt/issues/24065
Fixes: 387b49d89aa5 ("netifd dhcp: send DHCP client ID by default")
Assisted-by: Claude:claude-opus-4-8