### PR TITLE
realtek: pcs: rtl930x: another bunch of calibration cleanup

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -2320,8 +2320,7 @@ static void rtpcs_930x_sds_rxcal_tap_get(struct rtpcs_serdes *sds,
 	}
 }
 
-static void rtpcs_930x_sds_do_rx_calibration_1(struct rtpcs_serdes *sds,
-					       enum rtpcs_sds_mode hw_mode)
+static void rtpcs_930x_sds_rxcal_init(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode)
 {
 	/* From both rtl9300_rxCaliConf_serdes_myParam and rtl9300_rxCaliConf_phy_myParam */
 	int tap0_init_val = 0x1f; /* Initial Decision Fed Equalizer 0 tap */
@@ -2584,7 +2583,7 @@ static void rtpcs_930x_sds_do_rx_calibration(struct rtpcs_serdes *sds,
 {
 	u32 latch_sts;
 
-	rtpcs_930x_sds_do_rx_calibration_1(sds, hw_mode);
+	rtpcs_930x_sds_rxcal_init(sds, hw_mode);
 	rtpcs_930x_sds_rxcal_fgcal(sds);
 	rtpcs_930x_sds_rxcal_vth_tap0_adapt_lock(sds);
 

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -2339,17 +2339,16 @@ static int rtpcs_930x_sds_rxcal_tap_get(struct rtpcs_serdes *sds, unsigned int t
 
 static void rtpcs_930x_sds_rxcal_init(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode)
 {
-	/* From both rtl9300_rxCaliConf_serdes_myParam and rtl9300_rxCaliConf_phy_myParam */
-	int tap0_init_val = 0x1f; /* Initial Decision Fed Equalizer 0 tap */
+	int tap0_init_val = 0x1f; /* initial DFE TAP0 */
 	int vth_min = 0x1;
 
-	/* 1.1.1 --- */
-	rtpcs_sds_write(sds, PAGE_TGR_PRO_0, 0, 0); /* initial value */
+	/* Clear some seeds and bits */
+	rtpcs_sds_write(sds, PAGE_TGR_PRO_0, 0, 0);
 
 	/* FGCAL */
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x01, 14, 14, 0x00);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1c, 10,  5, 0x20);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x02,  0,  0, 0x01);
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1c, 10,  5, 0x20); /* offset_ini */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x02,  0,  0, 0x01); /* z0_ok */
 
 	/* DCVS */
 	for (int i = 0; i <= 5; i++) {
@@ -2357,12 +2356,12 @@ static void rtpcs_930x_sds_rxcal_init(struct rtpcs_serdes *sds, enum rtpcs_sds_m
 		rtpcs_930x_sds_rxcal_dcvs_set_adapt(sds, i, true);
 	}
 
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x00,  3,  0, 0x0f);
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x00,  3,  0, 0x0f); /* z0_ok_X */
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x04,  6,  6, 0x01);
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x04,  7,  7, 0x01);
 
-	/* LEQ (Long Term Equivalent signal level) */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x16, 14,  8, 0x00);
+	/* LEQ (Linear Equalization) */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x16, 14,  8, 0x00); /* FILTER_OUT */
 
 	/* DFE (Decision Feedback Equalizer) TAPs */
 	rtpcs_930x_sds_rxcal_tap_set_value(sds, 0, tap0_init_val, 0);
@@ -2375,45 +2374,36 @@ static void rtpcs_930x_sds_rxcal_init(struct rtpcs_serdes *sds, enum rtpcs_sds_m
 	rtpcs_930x_sds_rxcal_vth_set_value(sds, 0x07, 0x07);
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0b,  5,  3, vth_min);
 
-	/* --- 1.1.1 */
+	/* load DFE initial value */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0f, 13,  7, 0x7f); /* load_in_init */
 
-	/* 1.1.2 Load DFE initial value --- */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0f, 13,  7, 0x7f);
+	/* disable LEQ training, enable DFE clock */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x17,  7,  7, 0x00); /* EQHOLD */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x17,  6,  2, 0x00); /* EQOUT */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0c,  8,  8, 0x00); /* MAXHOLD_EN */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0b,  4,  4, 0x01); /* dfe_adapt_eqen */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x12, 14, 14, 0x00); /* start_timer_en */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x02, 15, 15, 0x00); /* hold_timer_en */
 
-	/* --- 1.1.2 */
+	/* offset cali setting */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0f, 15, 14, 0x03); /* cali_en */
 
-	/* 1.1.3 disable LEQ training, enable DFE clock --- */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x17,  7,  7, 0x00);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x17,  6,  2, 0x00);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0c,  8,  8, 0x00);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0b,  4,  4, 0x01);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x12, 14, 14, 0x00);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x02, 15, 15, 0x00);
-
-	/* --- 1.1.3 */
-
-	/* 1.1.4 offset cali setting --- */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0f, 15, 14, 0x03);
-	/* --- 1.1.4 */
-
-	/* 1.1.5 LEQ and DFE setting --- */
+	/* LEQ and DFE setting */
 
 	/* assume this is equivalent with (PHY_TYPE == SERDES && MEDIA == FIBER_10G) for now */
 	if (hw_mode == RTPCS_SDS_MODE_10GBASER) {
 		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x03, 13, 8, 0x1f);
 		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x00, 13, 13, 0x01);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x16, 14, 8, 0x00); /* REG0_FILTER_OUT */
+		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x16, 14, 8, 0x00); /* FILTER_OUT */
 	}
 
 	/* REG0_LEQ_DC_GAIN, 0x01 for short DACs */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x16,  3,  2, 0x02);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0f,  6,  0, 0x5f);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x05,  7,  2, 0x1f);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x19,  9,  5, 0x1f);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0b, 15,  9, 0x3c);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0b,  1,  0, 0x03);
-
-	/* --- 1.1.5 */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x16,  3,  2, 0x02); /* LEQ_DC_GAIN */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0f,  6,  0, 0x5f); /* dfe_adapt_en */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x05,  7,  2, 0x1f); /* dfe_adapt_en2 */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x19,  9,  5, 0x1f); /* leq_min */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0b, 15,  9, 0x3c); /* gray_en */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0b,  1,  0, 0x03); /* dfe_adapt_mode */
 }
 
 static void rtpcs_930x_sds_rxcal_fgcal(struct rtpcs_serdes *sds)

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -2232,110 +2232,109 @@ static int rtpcs_930x_sds_rxcal_vth_get(struct rtpcs_serdes *sds, unsigned int *
 	return 0;
 }
 
-static void rtpcs_930x_sds_rxcal_tap_manual(struct rtpcs_serdes *sds,
-					    int tap_id, bool manual, u32 tap_list[])
+static int rtpcs_930x_sds_rxcal_tap_set_adapt(struct rtpcs_serdes *sds, unsigned int tap_id,
+					      bool enable)
 {
 	if (tap_id > 4)
-		return;
+		return -EINVAL;
 
 	/* ##REG0_LOAD_IN_INIT[0], [11:7] = TAP0-TAP4 */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xf, tap_id + 7, tap_id + 7,
-			     manual ? 0x1 : 0x0);
+	return rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xf, tap_id + 7, tap_id + 7,
+				    enable ? 0x0 : 0x1);
+}
 
-	if (!manual) {
-		mdelay(10);
-		return;
-	}
+static int rtpcs_930x_sds_rxcal_tap_set_value(struct rtpcs_serdes *sds, unsigned int tap_id,
+					      int tap_even, int tap_odd)
+{
+	int ret = 0;
+
+	if (tap_id > 4)
+		return -EINVAL;
 
 	switch (tap_id) {
 	case 0:
-		/* ##REG0_TAP0_INIT[5:0]=Tap0_Value */
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x03, 5, 5, tap_list[0]);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x03, 4, 0, tap_list[1]);
+		ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x03, 5, 0,
+					   rtpcs_sign_mag_encode(tap_even, 5));
 		break;
 	case 1:
-		rtpcs_sds_write_bits(sds, PAGE_ANA_COM, 0x07, 6, 6, tap_list[0]);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x09, 11, 6, tap_list[1]);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_COM, 0x07, 5, 5, tap_list[2]);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x12, 5, 0, tap_list[3]);
+		ret = rtpcs_sds_write_bits(sds, PAGE_ANA_COM, 0x07, 6, 5,
+					   (tap_even < 0) << 1 | (tap_odd < 0));
+		if (!ret)
+			ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x09, 11, 6,
+						   abs(tap_even) & GENMASK(4, 0));
+		if (!ret)
+			ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x12, 5, 0,
+						   abs(tap_odd) & GENMASK(4, 0));
 		break;
 	case 2:
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x09, 5, 5, tap_list[0]);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x09, 4, 0, tap_list[1]);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0a, 11, 11, tap_list[2]);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0a, 10, 6, tap_list[3]);
+		ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x09, 5, 0,
+					   rtpcs_sign_mag_encode(tap_even, 5));
+		if (!ret)
+			ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0a, 11, 6,
+						   rtpcs_sign_mag_encode(tap_odd, 5));
 		break;
 	case 3:
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0a, 5, 5, tap_list[0]);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0a, 4, 0, tap_list[1]);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x06, 5, 5, tap_list[2]);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x06, 4, 0, tap_list[3]);
+		ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0a, 5, 0,
+					   rtpcs_sign_mag_encode(tap_even, 5));
+		if (!ret)
+			ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x06, 5, 0,
+						   rtpcs_sign_mag_encode(tap_odd, 5));
 		break;
 	case 4:
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x01, 5, 5, tap_list[0]);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x01, 4, 0, tap_list[1]);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x06, 11, 11, tap_list[2]);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x06, 10, 6, tap_list[3]);
+		ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x01, 5, 0,
+					   rtpcs_sign_mag_encode(tap_even, 5));
+		if (!ret)
+			ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x06, 11, 6,
+						   rtpcs_sign_mag_encode(tap_odd, 5));
 		break;
 	default:
 		break;
 	}
+
+	return ret;
 }
 
-static void rtpcs_930x_sds_rxcal_tap_get(struct rtpcs_serdes *sds,
-					 u32 tap_id, u32 tap_list[])
+static int rtpcs_930x_sds_rxcal_tap_get(struct rtpcs_serdes *sds, unsigned int tap_id,
+					int *tap_even, int *tap_odd)
 {
-	u32 tap0_sign_out;
-	u32 tap0_coef_bin;
-	u32 tap_sign_out_even;
-	u32 tap_coef_bin_even;
-	u32 tap_sign_out_odd;
-	u32 tap_coef_bin_odd;
-	bool tap_manual;
+	int ret, val;
 
-	rtpcs_930x_sds_set_debug(sds, 0x20);
-	if (!tap_id) {
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, 0);	/* COEF_SEL */
-		/* ##Tap1 Even Read Out */
-		mdelay(1);
-		tap0_sign_out = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 5, 5);
-		tap0_coef_bin = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 4, 0);
+	ret = rtpcs_930x_sds_set_debug(sds, 0x20);
+	if (ret < 0)
+		return ret;
 
-		pr_info("tap0: coef_bin = %d, sign = %s\n", tap0_coef_bin,
-			tap0_sign_out ? "-" : "+");
+	ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, tap_id); /* COEF_SEL */
+	if (ret < 0)
+		return ret;
+	mdelay(1);
 
-		tap_list[0] = tap0_sign_out;
-		tap_list[1] = tap0_coef_bin;
+	val = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 5, 0);
+	if (val < 0)
+		return val;
 
-		tap_manual = !!rtpcs_sds_read_bits(sds, PAGE_ANA_10G, 0x0f, 7, 7);
-		pr_info("tap0: manual = %u\n", tap_manual);
-	} else {
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, tap_id); /* COEF_SEL */
-		mdelay(1);
-		/* ##Tap1 Even Read Out */
-		tap_sign_out_even = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 5, 5);
-		tap_coef_bin_even = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 4, 0);
+	*tap_even = rtpcs_sign_mag_decode(val, 5);
+	pr_debug("tap%d: even coefficient = %d\n", tap_id, *tap_even);
 
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, (tap_id + 5)); /* COEF_SEL */
-		/* ##Tap1 Odd Read Out */
-		tap_sign_out_odd = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 5, 5);
-		tap_coef_bin_odd = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 4, 0);
+	if (tap_id > 0) {
+		/* COEF_SEL */
+		ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, (tap_id + 5));
+		if (ret < 0)
+			return ret;
 
-		pr_info("tap%u: even coefficient = %u, sign = %s\n", tap_id, tap_coef_bin_even,
-			tap_sign_out_even ? "-" : "+");
+		val = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 5, 0);
+		if (val < 0)
+			return val;
 
-		pr_info("tap%u: odd coefficient = %u, sign = %s\n", tap_id, tap_coef_bin_odd,
-			tap_sign_out_odd ? "-" : "+");
-
-		tap_list[0] = tap_sign_out_even;
-		tap_list[1] = tap_coef_bin_even;
-		tap_list[2] = tap_sign_out_odd;
-		tap_list[3] = tap_coef_bin_odd;
-
-		tap_manual = rtpcs_sds_read_bits(sds, PAGE_ANA_10G, 0x0f, tap_id + 7,
-						 tap_id + 7);
-		pr_info("tap%u: manual = %d\n", tap_id, tap_manual);
+		*tap_odd = rtpcs_sign_mag_decode(val, 5);
+		pr_debug("tap%u: odd coefficient = %d\n", tap_id, *tap_odd);
 	}
+
+	val = rtpcs_sds_read_bits(sds, PAGE_ANA_10G, 0x0f, tap_id + 7, tap_id + 7);
+	if (val < 0)
+		return val;
+
+	pr_debug("tap%u: manual = %d\n", tap_id, val);
+	return 0;
 }
 
 static void rtpcs_930x_sds_rxcal_init(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode)
@@ -2542,11 +2541,11 @@ static void rtpcs_930x_sds_rxcal_leq_adapt_lock(struct rtpcs_serdes *sds)
 static void rtpcs_930x_sds_rxcal_vth_tap0_adapt_lock(struct rtpcs_serdes *sds)
 {
 	unsigned int vth_p, vth_n;
-	u32 tap0_list[4] = {0};
+	int tap0;
 
 	/* run VTH/TAP auto-adapt */
 	rtpcs_930x_sds_rxcal_vth_set_adapt(sds, true);
-	rtpcs_930x_sds_rxcal_tap_manual(sds, 0, false, tap0_list);
+	rtpcs_930x_sds_rxcal_tap_set_adapt(sds, 0, true);
 	mdelay(200);
 
 	/* manually set learned VTH */
@@ -2558,37 +2557,31 @@ static void rtpcs_930x_sds_rxcal_vth_tap0_adapt_lock(struct rtpcs_serdes *sds)
 	mdelay(100);
 
 	/* manually set learned TAP0 */
-	rtpcs_930x_sds_rxcal_tap_get(sds, 0, tap0_list);
-	rtpcs_930x_sds_rxcal_tap_manual(sds, 0, true, tap0_list);
+	if (rtpcs_930x_sds_rxcal_tap_get(sds, 0, &tap0, NULL) < 0)
+		return;
+	rtpcs_930x_sds_rxcal_tap_set_value(sds, 0, tap0, 0);
+	rtpcs_930x_sds_rxcal_tap_set_adapt(sds, 0, false);
 }
 
 static void rtpcs_930x_sds_rxcal_dfe_taps_adapt(struct rtpcs_serdes *sds)
 {
-	u32 tap1_list[4] = {0};
-	u32 tap2_list[4] = {0};
-	u32 tap3_list[4] = {0};
-	u32 tap4_list[4] = {0};
-
 	/* dfeTap1_4Enable true */
-	rtpcs_930x_sds_rxcal_tap_manual(sds, 1, false, tap1_list);
-	rtpcs_930x_sds_rxcal_tap_manual(sds, 2, false, tap2_list);
-	rtpcs_930x_sds_rxcal_tap_manual(sds, 3, false, tap3_list);
-	rtpcs_930x_sds_rxcal_tap_manual(sds, 4, false, tap4_list);
+	rtpcs_930x_sds_rxcal_tap_set_adapt(sds, 1, true);
+	rtpcs_930x_sds_rxcal_tap_set_adapt(sds, 2, true);
+	rtpcs_930x_sds_rxcal_tap_set_adapt(sds, 3, true);
+	rtpcs_930x_sds_rxcal_tap_set_adapt(sds, 4, true);
 
 	mdelay(30);
 }
 
 static void rtpcs_930x_sds_rxcal_dfe_disable(struct rtpcs_serdes *sds)
 {
-	u32 tap1_list[4] = {0};
-	u32 tap2_list[4] = {0};
-	u32 tap3_list[4] = {0};
-	u32 tap4_list[4] = {0};
+	int tap_even = 0, tap_odd = 0;
 
-	rtpcs_930x_sds_rxcal_tap_manual(sds, 1, true, tap1_list);
-	rtpcs_930x_sds_rxcal_tap_manual(sds, 2, true, tap2_list);
-	rtpcs_930x_sds_rxcal_tap_manual(sds, 3, true, tap3_list);
-	rtpcs_930x_sds_rxcal_tap_manual(sds, 4, true, tap4_list);
+	for (int i = 1; i <= 4; i++) {
+		rtpcs_930x_sds_rxcal_tap_set_value(sds, i, tap_even, tap_odd);
+		rtpcs_930x_sds_rxcal_tap_set_adapt(sds, i, false);
+	}
 
 	mdelay(10);
 }

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -357,14 +357,14 @@ static int rtpcs_sds_to_mmd(enum rtpcs_page sds_page, int sds_regnum)
 	return (sds_page << 8) + sds_regnum;
 }
 
-static inline int rtpcs_sign_mag_decode(unsigned int val, unsigned int sign_bit)
+static int rtpcs_sign_mag_decode(unsigned int val, unsigned int sign_bit)
 {
 	int mag = val & GENMASK(sign_bit - 1, 0);
 
 	return (val & BIT(sign_bit)) ? -mag : mag;
 }
 
-static inline unsigned int rtpcs_sign_mag_encode(int val, unsigned int sign_bit)
+static unsigned int rtpcs_sign_mag_encode(int val, unsigned int sign_bit)
 {
 	return (val < 0 ? BIT(sign_bit) : 0) | (abs(val) & GENMASK(sign_bit - 1, 0));
 }
@@ -2062,93 +2062,69 @@ static int rtpcs_930x_sds_set_debug(struct rtpcs_serdes *sds, unsigned int debug
 	return rtpcs_sds_write_bits(sds, PAGE_ANA_COM, 0x06, 11, 6, debug_sel); /* RX_DEBUG_SEL */
 }
 
-__always_unused
-static int rtpcs_930x_sds_rxcal_dcvs_manual(struct rtpcs_serdes *sds,
-					    u32 dcvs_id, bool manual, u32 dcvs_list[])
+__maybe_unused
+static int rtpcs_930x_sds_rxcal_dcvs_set_adapt(struct rtpcs_serdes *sds, unsigned int dcvs_id,
+					       bool enable)
 {
 	u8 reg[6] = { 0x1e, 0x1e, 0x1e, 0x1e, 0x01, 0x02 };
 	u8 bit[6] = { 14, 13, 12, 11, 15, 11 };
 
 	if (dcvs_id > 5)
-		return;
+		return -EINVAL;
 
-	/* set DCVS auto/manual */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, reg[dcvs_id], bit[dcvs_id], bit[dcvs_id],
-			     manual ? 0x1 : 0x0);
-
-	if (!manual) {
-		/* give auto mode some time */
-		mdelay(1);
-		return;
-	}
-
-	switch (dcvs_id) {
-	case 0:
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1c,  4,  4, dcvs_list[0]);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1c,  3,  0, dcvs_list[1]);
-		break;
-	case 1:
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1d, 15, 15, dcvs_list[0]);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1d, 14, 11, dcvs_list[1]);
-		break;
-	case 2:
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1d, 10, 10, dcvs_list[0]);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1d,  9,  6, dcvs_list[1]);
-		break;
-	case 3:
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1d,  5,  5, dcvs_list[0]);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1d,  4,  1, dcvs_list[1]);
-		break;
-	case 4:
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x02, 10, 10, dcvs_list[0]);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x02,  9,  6, dcvs_list[1]);
-		break;
-	case 5:
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x11,  4,  4, dcvs_list[0]);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x11,  3,  0, dcvs_list[1]);
-		break;
-	default:
-		break;
-	}
+	return rtpcs_sds_write_bits(sds, PAGE_ANA_10G, reg[dcvs_id], bit[dcvs_id],
+				    bit[dcvs_id], enable ? 0x0 : 0x1);
 }
 
-__always_unused
-static void rtpcs_930x_sds_rxcal_dcvs_get(struct rtpcs_serdes *sds,
-					  u32 dcvs_id, u32 dcvs_list[])
+__maybe_unused
+static int rtpcs_930x_sds_rxcal_dcvs_set_coef(struct rtpcs_serdes *sds, unsigned int dcvs_id,
+					      int dcvs_coef)
+{
+	u8 reg[6] = { 0x1c, 0x1d, 0x1d, 0x1d, 0x02, 0x11 };
+	u8 lbit[6] = { 0, 11, 6, 1, 6, 0 };
+	if (dcvs_id > 5)
+		return -EINVAL;
+
+	return rtpcs_sds_write_bits(sds, PAGE_ANA_10G, reg[dcvs_id], lbit[dcvs_id] + 4,
+				    lbit[dcvs_id], rtpcs_sign_mag_encode(dcvs_coef, 4));
+}
+
+__maybe_unused
+static int rtpcs_930x_sds_rxcal_dcvs_get_coef(struct rtpcs_serdes *sds,
+					      unsigned int dcvs_id, int *dcvs_coef)
 {
 	u8 manual_reg[6] = { 0x1e, 0x1e, 0x1e, 0x1e, 0x01, 0x02 };
 	u8 coeff_sel[6] = { 0x22, 0x23, 0x24, 0x25, 0x2c, 0x2d };
 	u8 manual_bit[6] = { 14, 13, 12, 11, 15, 11 };
-	u32 dcvs_sign_out = 0, dcvs_coef_bin = 0;
-	struct rtpcs_serdes *even_sds;
-	bool dcvs_manual;
+	int ret, val;
 
 	if (dcvs_id > 5)
-		return;
+		return -EINVAL;
 
-	even_sds = rtpcs_sds_get_even(sds);
-	if (sds == even_sds)
-		rtpcs_sds_write(sds, PAGE_WDIG, 0x2, 0x2f);
-	else
-		rtpcs_sds_write(even_sds, PAGE_WDIG, 0x2, 0x31);
+	ret = rtpcs_930x_sds_set_debug(sds, 0x20);
+	if (ret < 0)
+		return ret;
 
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x15, 9, 9, 0x1);	/* REG0_RX_EN_TEST */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_COM, 0x06, 11, 6, 0x20); /* REG0_RX_DEBUG_SEL */
-
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, coeff_sel[dcvs_id]);
+	ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, coeff_sel[dcvs_id]);
+	if (ret < 0)
+		return ret;
 	mdelay(1);
 
 	/* ## DCVSX Read Out */
-	dcvs_sign_out = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14,  4,  4);
-	dcvs_coef_bin = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14,  3,  0);
-	dcvs_manual = !!rtpcs_sds_read_bits(sds, PAGE_ANA_10G, manual_reg[dcvs_id],
-					    manual_bit[dcvs_id], manual_bit[dcvs_id]);
+	val = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 4, 0);
+	if (val < 0)
+		return val;
 
-	pr_info("%s: DCVS %u sign = %s, manual = %u, even coefficient = %u\n", __func__,
-		dcvs_id, dcvs_sign_out ? "-" : "+", dcvs_manual, dcvs_coef_bin);
+	*dcvs_coef = rtpcs_sign_mag_decode(val, 4);
+	val = rtpcs_sds_read_bits(sds, PAGE_ANA_10G, manual_reg[dcvs_id], manual_bit[dcvs_id],
+				  manual_bit[dcvs_id]);
+	if (val < 0)
+		return val;
 
-	dcvs_list[0] = dcvs_sign_out;
-	dcvs_list[1] = dcvs_coef_bin;
+	pr_debug("%s: DCVS %u, manual = %u, coefficient = %d\n", __func__,
+		 dcvs_id, val, *dcvs_coef);
+
+	return 0;
 }
 
 static void rtpcs_930x_sds_rxcal_leq_manual(struct rtpcs_serdes *sds,

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <linux/delay.h>
 #include <linux/mdio.h>
 #include <linux/mfd/syscon.h>
 #include <linux/of.h>
@@ -1716,7 +1717,7 @@ static void rtpcs_930x_sds_rx_reset(struct rtpcs_serdes *sds,
 		page = PAGE_ANA_1G2;
 
 	rtpcs_sds_write_bits(sds, page, 0x15, 4, 4, 0x1);
-	mdelay(5);
+	usleep_range(5000, 6000);
 	rtpcs_sds_write_bits(sds, page, 0x15, 4, 4, 0x0);
 }
 
@@ -2106,7 +2107,7 @@ static int rtpcs_930x_sds_rxcal_dcvs_get_coef(struct rtpcs_serdes *sds,
 	ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, coeff_sel[dcvs_id]);
 	if (ret < 0)
 		return ret;
-	mdelay(1);
+	usleep_range(1000, 2000);
 
 	/* ## DCVSX Read Out */
 	val = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 4, 0);
@@ -2131,7 +2132,7 @@ static int rtpcs_930x_sds_rxcal_leq_set_adapt(struct rtpcs_serdes *sds, bool ena
 
 	ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x18, 15, 15, enable ? 0x0 : 0x1);
 	if (!ret && enable)
-		mdelay(100);
+		msleep(100);
 
 	return ret;
 }
@@ -2166,7 +2167,7 @@ static int rtpcs_930x_sds_rxcal_leq_get_coef(struct rtpcs_serdes *sds)
 	ret = rtpcs_930x_sds_set_debug(sds, 0x10);
 	if (ret < 0)
 		return ret;
-	mdelay(1);
+	usleep_range(1000, 2000);
 
 	/* ##LEQ Read Out */
 	gray = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 7, 3);
@@ -2216,7 +2217,7 @@ static int rtpcs_930x_sds_rxcal_vth_get(struct rtpcs_serdes *sds, unsigned int *
 	ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, 0xc); /* COEF_SEL */
 	if (ret < 0)
 		return ret;
-	mdelay(1);
+	usleep_range(1000, 2000);
 
 	/* ##VthP & VthN Read Out */
 	val = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 5, 0);
@@ -2306,7 +2307,7 @@ static int rtpcs_930x_sds_rxcal_tap_get(struct rtpcs_serdes *sds, unsigned int t
 	ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, tap_id); /* COEF_SEL */
 	if (ret < 0)
 		return ret;
-	mdelay(1);
+	usleep_range(1000, 2000);
 
 	val = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 5, 0);
 	if (val < 0)
@@ -2486,7 +2487,7 @@ static void rtpcs_930x_sds_rxcal_leq_adapt_lock(struct rtpcs_serdes *sds)
 			return;
 
 		sum10 += val;
-		mdelay(10);
+		usleep_range(10000, 11000);
 	}
 
 	/* rounded average of where auto-adapt settled */
@@ -2531,7 +2532,7 @@ static void rtpcs_930x_sds_rxcal_vth_tap0_adapt_lock(struct rtpcs_serdes *sds)
 	/* run VTH/TAP auto-adapt */
 	rtpcs_930x_sds_rxcal_vth_set_adapt(sds, true);
 	rtpcs_930x_sds_rxcal_tap_set_adapt(sds, 0, true);
-	mdelay(200);
+	msleep(200);
 
 	/* manually set learned VTH */
 	if (rtpcs_930x_sds_rxcal_vth_get(sds, &vth_p, &vth_n) < 0)
@@ -2539,7 +2540,7 @@ static void rtpcs_930x_sds_rxcal_vth_tap0_adapt_lock(struct rtpcs_serdes *sds)
 	rtpcs_930x_sds_rxcal_vth_set_value(sds, vth_p, vth_n);
 	rtpcs_930x_sds_rxcal_vth_set_adapt(sds, false);
 
-	mdelay(100);
+	msleep(100);
 
 	/* manually set learned TAP0 */
 	if (rtpcs_930x_sds_rxcal_tap_get(sds, 0, &tap0, NULL) < 0)
@@ -2556,7 +2557,7 @@ static void rtpcs_930x_sds_rxcal_dfe_taps_adapt(struct rtpcs_serdes *sds)
 	rtpcs_930x_sds_rxcal_tap_set_adapt(sds, 3, true);
 	rtpcs_930x_sds_rxcal_tap_set_adapt(sds, 4, true);
 
-	mdelay(30);
+	msleep(30);
 }
 
 static void rtpcs_930x_sds_rxcal_dfe_disable(struct rtpcs_serdes *sds)
@@ -2568,7 +2569,7 @@ static void rtpcs_930x_sds_rxcal_dfe_disable(struct rtpcs_serdes *sds)
 		rtpcs_930x_sds_rxcal_tap_set_adapt(sds, i, false);
 	}
 
-	mdelay(10);
+	usleep_range(10000, 11000);
 }
 
 static void rtpcs_930x_sds_do_rx_calibration(struct rtpcs_serdes *sds,
@@ -2583,10 +2584,10 @@ static void rtpcs_930x_sds_do_rx_calibration(struct rtpcs_serdes *sds,
 	/* Do this only for 10GR mode */
 	if (hw_mode == RTPCS_SDS_MODE_10GBASER) {
 		rtpcs_930x_sds_rxcal_dfe_taps_adapt(sds);
-		mdelay(20);
+		msleep(20);
 
 		latch_sts = rtpcs_sds_read_bits(sds, PAGE_TGR_STD_0, 1, 2, 2);
-		mdelay(1);
+		usleep_range(1000, 2000);
 		latch_sts = rtpcs_sds_read_bits(sds, PAGE_TGR_STD_0, 1, 2, 2);
 		if (latch_sts) {
 			rtpcs_930x_sds_rxcal_dfe_disable(sds);
@@ -2686,7 +2687,7 @@ static int rtpcs_930x_sds_check_calibration(struct rtpcs_serdes *sds,
 
 	/* Count errors during 1ms */
 	errors1 = rtpcs_930x_sds_sym_err_get(sds, hw_mode);
-	mdelay(1);
+	usleep_range(1000, 2000);
 	errors2 = rtpcs_930x_sds_sym_err_get(sds, hw_mode);
 
 	switch (hw_mode) {
@@ -2987,7 +2988,7 @@ static int rtpcs_930x_sds_post_config(struct rtpcs_serdes *sds, enum rtpcs_sds_m
 	do {
 		rtpcs_930x_sds_do_rx_calibration(sds, hw_mode);
 		calib_tries++;
-		mdelay(50);
+		msleep(50);
 	} while (rtpcs_930x_sds_check_calibration(sds, hw_mode) && calib_tries < 3);
 	if (calib_tries >= 3)
 		pr_warn("%s: SerDes RX calibration failed\n", __func__);
@@ -3233,7 +3234,7 @@ static void rtpcs_931x_sds_rx_reset(struct rtpcs_serdes *sds)
 	rtpcs_sds_write(sds, PAGE_ANA_10G_EXT, 0x2, 0x6010);
 	rtpcs_sds_write(sds, PAGE_ANA_MISC, 0x0, 0xc30);
 
-	mdelay(50);
+	msleep(50);
 }
 
 static int rtpcs_931x_sds_cmu_page_get(enum rtpcs_sds_mode hw_mode)

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -2183,36 +2183,53 @@ static int rtpcs_930x_sds_rxcal_leq_get_coef(struct rtpcs_serdes *sds)
 	return bin;
 }
 
-static void rtpcs_930x_sds_rxcal_vth_manual(struct rtpcs_serdes *sds,
-					    bool manual, u32 vth_list[])
+static int rtpcs_930x_sds_rxcal_vth_set_adapt(struct rtpcs_serdes *sds, bool enable)
 {
-	/* REG0_LOAD_IN_INIT, [13:13] = VTH */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0f, 13, 13, manual ? 0x1 : 0x0);
-
-	if (manual) {
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x13,  5,  3, vth_list[0]);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x13,  2,  0, vth_list[1]);
-	} else
-		mdelay(10);
+	return rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0f, 13, 13, enable ? 0 : 1);
 }
 
-static void rtpcs_930x_sds_rxcal_vth_get(struct rtpcs_serdes *sds,
-					 u32 vth_list[])
+static int rtpcs_930x_sds_rxcal_vth_set_value(struct rtpcs_serdes *sds, unsigned int vth_p,
+					      unsigned int vth_n)
 {
-	int vth_manual;
+	int ret;
 
-	rtpcs_930x_sds_set_debug(sds, 0x20);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, 0xc); /* COEF_SEL */
+	ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x13,  5,  3, vth_p);
+	if (ret < 0)
+		return ret;
 
+	ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x13,  2,  0, vth_n);
+	if (ret < 0)
+		return ret;
+
+	return 0;
+}
+
+static int rtpcs_930x_sds_rxcal_vth_get(struct rtpcs_serdes *sds, unsigned int *vth_p,
+					unsigned int *vth_n)
+{
+	int manual, ret, val;
+
+	ret = rtpcs_930x_sds_set_debug(sds, 0x20);
+	if (ret < 0)
+		return ret;
+
+	ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, 0xc); /* COEF_SEL */
+	if (ret < 0)
+		return ret;
 	mdelay(1);
 
 	/* ##VthP & VthN Read Out */
-	vth_list[0] = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 2, 0); /* v_thp set bin */
-	vth_list[1] = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 5, 3); /* v_thn set bin */
-	vth_manual = rtpcs_sds_read_bits(sds, PAGE_ANA_10G, 0x0f, 13, 13);
+	val = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 5, 0);
+	if (val < 0)
+		return val;
 
-	pr_info("vthp_set_bin = %d, vthn_set_bin = %d, manual = %d\n", vth_list[0], vth_list[1],
-		vth_manual);
+	*vth_p = FIELD_GET(GENMASK(2, 0), val);
+	*vth_n = FIELD_GET(GENMASK(5, 3), val);
+	manual = rtpcs_sds_read_bits(sds, PAGE_ANA_10G, 0x0f, 13, 13);
+
+	pr_debug("vth_p = %d, vth_n = %d, manual = %d\n", *vth_p, *vth_n,
+		manual);
+	return 0;
 }
 
 static void rtpcs_930x_sds_rxcal_tap_manual(struct rtpcs_serdes *sds,
@@ -2524,17 +2541,19 @@ static void rtpcs_930x_sds_rxcal_leq_adapt_lock(struct rtpcs_serdes *sds)
 
 static void rtpcs_930x_sds_rxcal_vth_tap0_adapt_lock(struct rtpcs_serdes *sds)
 {
+	unsigned int vth_p, vth_n;
 	u32 tap0_list[4] = {0};
-	u32 vth_list[2] = {0};
 
 	/* run VTH/TAP auto-adapt */
-	rtpcs_930x_sds_rxcal_vth_manual(sds, false, vth_list);
+	rtpcs_930x_sds_rxcal_vth_set_adapt(sds, true);
 	rtpcs_930x_sds_rxcal_tap_manual(sds, 0, false, tap0_list);
 	mdelay(200);
 
 	/* manually set learned VTH */
-	rtpcs_930x_sds_rxcal_vth_get(sds, vth_list);
-	rtpcs_930x_sds_rxcal_vth_manual(sds, true, vth_list);
+	if (rtpcs_930x_sds_rxcal_vth_get(sds, &vth_p, &vth_n) < 0)
+		return;
+	rtpcs_930x_sds_rxcal_vth_set_value(sds, vth_p, vth_n);
+	rtpcs_930x_sds_rxcal_vth_set_adapt(sds, false);
 
 	mdelay(100);
 

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -2032,9 +2032,25 @@ static void rtpcs_930x_sds_tx_config(struct rtpcs_serdes *sds,
 	rtpcs_sds_write_bits(sds, page, 0x18, 15, 12, impedance);
 }
 
+static int rtpcs_930x_sds_set_debug(struct rtpcs_serdes *sds, unsigned int debug_sel)
+{
+	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
+	int ret;
+
+	ret = rtpcs_sds_write(even_sds, PAGE_WDIG, 0x2, (sds == even_sds) ? 0x2f : 0x31);
+	if (ret < 0)
+		return ret;
+
+	ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x15, 9, 9, 0x1);	/* RX_EN_TEST */
+	if (ret < 0)
+		return ret;
+
+	return rtpcs_sds_write_bits(sds, PAGE_ANA_COM, 0x06, 11, 6, debug_sel); /* RX_DEBUG_SEL */
+}
+
 __always_unused
-static void rtpcs_930x_sds_rxcal_dcvs_manual(struct rtpcs_serdes *sds,
-					     u32 dcvs_id, bool manual, u32 dcvs_list[])
+static int rtpcs_930x_sds_rxcal_dcvs_manual(struct rtpcs_serdes *sds,
+					    u32 dcvs_id, bool manual, u32 dcvs_list[])
 {
 	u8 reg[6] = { 0x1e, 0x1e, 0x1e, 0x1e, 0x01, 0x02 };
 	u8 bit[6] = { 14, 13, 12, 11, 15, 11 };
@@ -2157,13 +2173,10 @@ static u32 rtpcs_930x_sds_rxcal_gray_to_binary(u32 gray_code)
 
 static u32 rtpcs_930x_sds_rxcal_leq_read(struct rtpcs_serdes *sds)
 {
-	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
 	u32 leq_gray, leq_bin;
 	bool leq_manual;
 
-	rtpcs_sds_write(even_sds, PAGE_WDIG, 0x2, (sds == even_sds) ? 0x2f : 0x31); /* REG_DBGO_SEL */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x15, 9, 9, 0x1);	/* REG0_RX_EN_TEST */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_COM, 0x06, 11, 6, 0x10);	/* REG0_RX_DEBUG_SEL */
+	rtpcs_930x_sds_set_debug(sds, 0x10);
 	mdelay(1);
 
 	/* ##LEQ Read Out */
@@ -2191,13 +2204,10 @@ static void rtpcs_930x_sds_rxcal_vth_manual(struct rtpcs_serdes *sds,
 static void rtpcs_930x_sds_rxcal_vth_get(struct rtpcs_serdes *sds,
 					 u32 vth_list[])
 {
-	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
 	int vth_manual;
 
-	rtpcs_sds_write(even_sds, PAGE_WDIG, 0x2, (sds == even_sds) ? 0x2f : 0x31); /* REG_DBGO_SEL */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x15, 9, 9, 0x1);		/* REG0_RX_EN_TEST */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_COM, 0x06, 11, 6, 0x20);	/* REG0_RX_DEBUG_SEL */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, 0xc);	/* REG0_COEF_SEL */
+	rtpcs_930x_sds_set_debug(sds, 0x20);
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, 0xc); /* COEF_SEL */
 
 	mdelay(1);
 
@@ -2263,7 +2273,6 @@ static void rtpcs_930x_sds_rxcal_tap_manual(struct rtpcs_serdes *sds,
 static void rtpcs_930x_sds_rxcal_tap_get(struct rtpcs_serdes *sds,
 					 u32 tap_id, u32 tap_list[])
 {
-	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
 	u32 tap0_sign_out;
 	u32 tap0_coef_bin;
 	u32 tap_sign_out_even;
@@ -2272,12 +2281,9 @@ static void rtpcs_930x_sds_rxcal_tap_get(struct rtpcs_serdes *sds,
 	u32 tap_coef_bin_odd;
 	bool tap_manual;
 
-	rtpcs_sds_write(even_sds, PAGE_WDIG, 0x2, (sds == even_sds) ? 0x2f : 0x31); /* REG_DBGO_SEL */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x15, 9, 9, 0x1);	/* REG0_RX_EN_TEST */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_COM, 0x06, 11, 6, 0x20);	/* REG0_RX_DEBUG_SEL */
-
+	rtpcs_930x_sds_set_debug(sds, 0x20);
 	if (!tap_id) {
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, 0);	/* REG0_COEF_SEL */
+		rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, 0);	/* COEF_SEL */
 		/* ##Tap1 Even Read Out */
 		mdelay(1);
 		tap0_sign_out = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 5, 5);
@@ -2292,13 +2298,13 @@ static void rtpcs_930x_sds_rxcal_tap_get(struct rtpcs_serdes *sds,
 		tap_manual = !!rtpcs_sds_read_bits(sds, PAGE_ANA_10G, 0x0f, 7, 7);
 		pr_info("tap0: manual = %u\n", tap_manual);
 	} else {
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, tap_id); /* REG0_COEF_SEL */
+		rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, tap_id); /* COEF_SEL */
 		mdelay(1);
 		/* ##Tap1 Even Read Out */
 		tap_sign_out_even = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 5, 5);
 		tap_coef_bin_even = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 4, 0);
 
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, (tap_id + 5)); /* REG0_COEF_SEL */
+		rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, (tap_id + 5)); /* COEF_SEL */
 		/* ##Tap1 Odd Read Out */
 		tap_sign_out_odd = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 5, 5);
 		tap_coef_bin_odd = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 4, 0);
@@ -2410,7 +2416,6 @@ static void rtpcs_930x_sds_rxcal_init(struct rtpcs_serdes *sds, enum rtpcs_sds_m
 
 static void rtpcs_930x_sds_rxcal_fgcal(struct rtpcs_serdes *sds)
 {
-	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
 	u32 fgcal_binary, fgcal_gray;
 	u32 offset_range;
 
@@ -2431,15 +2436,11 @@ static void rtpcs_930x_sds_rxcal_fgcal(struct rtpcs_serdes *sds)
 	/* Foreground Calibration --- */
 
 	for (int run = 0; run < 10; run++) {
-		/* REG_DBGO_SEL */
-		rtpcs_sds_write(even_sds, PAGE_WDIG, 0x2, (sds == even_sds) ? 0x2f : 0x31);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x15, 9, 9, 0x1);	/* REG0_RX_EN_TEST */
-		rtpcs_sds_write_bits(sds, PAGE_ANA_COM, 0x06, 11, 6, 0x20);	/* REG0_RX_DEBUG_SEL */
-
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, 0xf); /* REG0_COEF_SEL */
+		rtpcs_930x_sds_set_debug(sds, 0x20);
+		rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, 0xf); /* COEF_SEL */
 		/* ##FGCAL read gray */
 		fgcal_gray = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 5, 0);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, 0xe); /* REG0_COEF_SEL */
+		rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0c, 5, 0, 0xe); /* COEF_SEL */
 		/* ##FGCAL read binary */
 		fgcal_binary = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 5, 0);
 

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -2348,8 +2348,8 @@ static void rtpcs_930x_sds_rxcal_init(struct rtpcs_serdes *sds, enum rtpcs_sds_m
 
 	/* FGCAL */
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x01, 14, 14, 0x00);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1c, 10,  5, 0x20); /* offset_ini */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x02,  0,  0, 0x01); /* z0_ok */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1c, 10, 5, 0x20); /* offset_ini */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x02, 0, 0, 0x01); /* z0_ok */
 
 	/* DCVS */
 	for (int i = 0; i <= 5; i++) {
@@ -2357,12 +2357,11 @@ static void rtpcs_930x_sds_rxcal_init(struct rtpcs_serdes *sds, enum rtpcs_sds_m
 		rtpcs_930x_sds_rxcal_dcvs_set_adapt(sds, i, true);
 	}
 
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x00,  3,  0, 0x0f); /* z0_ok_X */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x04,  6,  6, 0x01);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x04,  7,  7, 0x01);
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x00, 3, 0, 0x0f); /* z0_ok_X */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x04, 7, 6, 0x03);
 
 	/* LEQ (Linear Equalization) */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x16, 14,  8, 0x00); /* FILTER_OUT */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x16, 14, 8, 0x00); /* FILTER_OUT */
 
 	/* DFE (Decision Feedback Equalizer) TAPs */
 	rtpcs_930x_sds_rxcal_tap_set_value(sds, 0, tap0_init_val, 0);
@@ -2373,14 +2372,13 @@ static void rtpcs_930x_sds_rxcal_init(struct rtpcs_serdes *sds, enum rtpcs_sds_m
 
 	/* VTH (Voltage Threshold) */
 	rtpcs_930x_sds_rxcal_vth_set_value(sds, 0x07, 0x07);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0b,  5,  3, vth_min);
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0b, 5, 3, vth_min);
 
 	/* load DFE initial value */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0f, 13,  7, 0x7f); /* load_in_init */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0f, 13, 7, 0x7f); /* load_in_init */
 
 	/* disable LEQ training, enable DFE clock */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x17,  7,  7, 0x00); /* EQHOLD */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x17,  6,  2, 0x00); /* EQOUT */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x17,  7,  2, 0x00); /* [7] = EQHOLD, [6:2] = EQOUT */
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0c,  8,  8, 0x00); /* MAXHOLD_EN */
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0b,  4,  4, 0x01); /* dfe_adapt_eqen */
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x12, 14, 14, 0x00); /* start_timer_en */
@@ -2399,12 +2397,12 @@ static void rtpcs_930x_sds_rxcal_init(struct rtpcs_serdes *sds, enum rtpcs_sds_m
 	}
 
 	/* REG0_LEQ_DC_GAIN, 0x01 for short DACs */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x16,  3,  2, 0x02); /* LEQ_DC_GAIN */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0f,  6,  0, 0x5f); /* dfe_adapt_en */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x05,  7,  2, 0x1f); /* dfe_adapt_en2 */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x19,  9,  5, 0x1f); /* leq_min */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0b, 15,  9, 0x3c); /* gray_en */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0b,  1,  0, 0x03); /* dfe_adapt_mode */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x16, 3, 2, 0x02); /* LEQ_DC_GAIN */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0f, 6, 0, 0x5f); /* dfe_adapt_en */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x05, 7, 2, 0x1f); /* dfe_adapt_en2 */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x19, 9, 5, 0x1f); /* leq_min */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0b, 15, 9, 0x3c); /* gray_en */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0b, 1, 0, 0x03); /* dfe_adapt_mode */
 }
 
 static void rtpcs_930x_sds_rxcal_fgcal(struct rtpcs_serdes *sds)

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -350,9 +350,23 @@ struct rtpcs_sds_tx_config {
 	u8 post_amp;
 };
 
+/* Calculation helpers */
+
 static int rtpcs_sds_to_mmd(enum rtpcs_page sds_page, int sds_regnum)
 {
 	return (sds_page << 8) + sds_regnum;
+}
+
+static inline int rtpcs_sign_mag_decode(unsigned int val, unsigned int sign_bit)
+{
+	int mag = val & GENMASK(sign_bit - 1, 0);
+
+	return (val & BIT(sign_bit)) ? -mag : mag;
+}
+
+static inline unsigned int rtpcs_sign_mag_encode(int val, unsigned int sign_bit)
+{
+	return (val < 0 ? BIT(sign_bit) : 0) | (abs(val) & GENMASK(sign_bit - 1, 0));
 }
 
 /*
@@ -2070,8 +2084,8 @@ static int rtpcs_930x_sds_rxcal_dcvs_manual(struct rtpcs_serdes *sds,
 
 	switch (dcvs_id) {
 	case 0:
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x03,  5,  5, dcvs_list[0]);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x03,  4,  0, dcvs_list[1]);
+		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1c,  4,  4, dcvs_list[0]);
+		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1c,  3,  0, dcvs_list[1]);
 		break;
 	case 1:
 		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1d, 15, 15, dcvs_list[0]);
@@ -2086,8 +2100,8 @@ static int rtpcs_930x_sds_rxcal_dcvs_manual(struct rtpcs_serdes *sds,
 		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1d,  4,  1, dcvs_list[1]);
 		break;
 	case 4:
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x11, 10, 10, dcvs_list[0]);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x11,  9,  6, dcvs_list[1]);
+		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x02, 10, 10, dcvs_list[0]);
+		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x02,  9,  6, dcvs_list[1]);
 		break;
 	case 5:
 		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x11,  4,  4, dcvs_list[0]);

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -2062,7 +2062,6 @@ static int rtpcs_930x_sds_set_debug(struct rtpcs_serdes *sds, unsigned int debug
 	return rtpcs_sds_write_bits(sds, PAGE_ANA_COM, 0x06, 11, 6, debug_sel); /* RX_DEBUG_SEL */
 }
 
-__maybe_unused
 static int rtpcs_930x_sds_rxcal_dcvs_set_adapt(struct rtpcs_serdes *sds, unsigned int dcvs_id,
 					       bool enable)
 {
@@ -2076,7 +2075,6 @@ static int rtpcs_930x_sds_rxcal_dcvs_set_adapt(struct rtpcs_serdes *sds, unsigne
 				    bit[dcvs_id], enable ? 0x0 : 0x1);
 }
 
-__maybe_unused
 static int rtpcs_930x_sds_rxcal_dcvs_set_coef(struct rtpcs_serdes *sds, unsigned int dcvs_id,
 					      int dcvs_coef)
 {
@@ -2331,15 +2329,11 @@ static void rtpcs_930x_sds_rxcal_init(struct rtpcs_serdes *sds, enum rtpcs_sds_m
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x02,  0,  0, 0x01);
 
 	/* DCVS */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1e, 14, 11, 0x00);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x01, 15, 15, 0x00);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x02, 11, 11, 0x00);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1c,  4,  0, 0x00);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1d, 15, 11, 0x00);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1d, 10,  6, 0x00);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1d,  5,  1, 0x00);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x02, 10,  6, 0x00);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x11,  4,  0, 0x00);
+	for (int i = 0; i <= 5; i++) {
+		rtpcs_930x_sds_rxcal_dcvs_set_coef(sds, i, 0);
+		rtpcs_930x_sds_rxcal_dcvs_set_adapt(sds, i, true);
+	}
+
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x00,  3,  0, 0x0f);
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x04,  6,  6, 0x01);
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x04,  7,  7, 0x01);

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -4155,8 +4155,8 @@ static int rtpcs_probe(struct platform_device *pdev)
 			return ret;
 	}
 
-	for_each_child_of_node_scoped(dev->of_node, child) {
-		ret = of_property_read_u32(child, "reg", &sds_id);
+	device_for_each_child_node_scoped(dev, child) {
+		ret = fwnode_property_read_u32(child, "reg", &sds_id);
 		if (ret)
 			return ret;
 
@@ -4164,7 +4164,7 @@ static int rtpcs_probe(struct platform_device *pdev)
 			return -EINVAL;
 
 		sds = &ctrl->serdes[sds_id];
-		sds->fwnode = fwnode_handle_get(of_fwnode_handle(child));
+		sds->fwnode = fwnode_handle_get(child);
 		ret = devm_add_action_or_reset(dev, rtpcs_sds_put_fwnode, sds);
 		if (ret)
 			return ret;

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -2125,27 +2125,27 @@ static int rtpcs_930x_sds_rxcal_dcvs_get_coef(struct rtpcs_serdes *sds,
 	return 0;
 }
 
-static void rtpcs_930x_sds_rxcal_leq_manual(struct rtpcs_serdes *sds,
-					    bool manual, u32 leq_gray)
+static int rtpcs_930x_sds_rxcal_leq_set_adapt(struct rtpcs_serdes *sds, bool enable)
 {
-	if (manual) {
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x18, 15, 15, 0x1);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x16, 14, 10, leq_gray);
-	} else {
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x18, 15, 15, 0x0);
+	int ret;
+
+	ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x18, 15, 15, enable ? 0x0 : 0x1);
+	if (!ret && enable)
 		mdelay(100);
-	}
+
+	return ret;
 }
 
-static void rtpcs_930x_sds_rxcal_leq_offset_manual(struct rtpcs_serdes *sds,
-						   bool manual, u32 offset)
+static int rtpcs_930x_sds_rxcal_leq_set_coef(struct rtpcs_serdes *sds, unsigned int leq_gray,
+					     unsigned int offset)
 {
-	if (manual) {
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x17, 6, 2, offset);
-	} else {
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x17, 6, 2, offset);
-		mdelay(1);
-	}
+	int ret;
+
+	ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x17, 6, 2, offset);
+	if (ret < 0)
+		return ret;
+
+	return rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x16, 14, 10, leq_gray);
 }
 
 static u32 rtpcs_930x_sds_rxcal_gray_to_binary(u32 gray_code)
@@ -2159,21 +2159,28 @@ static u32 rtpcs_930x_sds_rxcal_gray_to_binary(u32 gray_code)
 	return binary;
 }
 
-static u32 rtpcs_930x_sds_rxcal_leq_read(struct rtpcs_serdes *sds)
+static int rtpcs_930x_sds_rxcal_leq_get_coef(struct rtpcs_serdes *sds)
 {
-	u32 leq_gray, leq_bin;
-	bool leq_manual;
+	int bin, gray, manual, ret;
 
-	rtpcs_930x_sds_set_debug(sds, 0x10);
+	ret = rtpcs_930x_sds_set_debug(sds, 0x10);
+	if (ret < 0)
+		return ret;
 	mdelay(1);
 
 	/* ##LEQ Read Out */
-	leq_gray = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 7, 3);
-	leq_manual = !!rtpcs_sds_read_bits(sds, PAGE_ANA_10G, 0x18, 15, 15);
-	leq_bin = rtpcs_930x_sds_rxcal_gray_to_binary(leq_gray);
+	gray = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 7, 3);
+	if (gray < 0)
+		return gray;
 
-	pr_info("LEQ gray: %u, LEQ bin: %u, LEQ manual: %u\n", leq_gray, leq_bin, leq_manual);
-	return leq_bin;
+	bin = rtpcs_930x_sds_rxcal_gray_to_binary(gray);
+
+	manual = rtpcs_sds_read_bits(sds, PAGE_ANA_10G, 0x18, 15, 15);
+	if (manual < 0)
+		return manual;
+
+	pr_debug("LEQ gray: %d, LEQ bin: %d, LEQ manual: %u\n", gray, bin, manual);
+	return bin;
 }
 
 static void rtpcs_930x_sds_rxcal_vth_manual(struct rtpcs_serdes *sds,
@@ -2463,17 +2470,21 @@ static void rtpcs_930x_sds_rxcal_leq_adapt_lock(struct rtpcs_serdes *sds)
 			     sds->media == RTPCS_SDS_MEDIA_DAC_SHORT ||
 			     sds->media == RTPCS_SDS_MEDIA_DAC_LONG;
 	u32 sum10 = 0, avg10;
-	int i;
+	int i, val;
 
 	/* 1.3.1: release LEQ auto-adapt, let it settle from zero */
 	if (!direct_serdes)
 		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xc, 8, 8, 0x0);
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x17, 7, 7, 0x0);
-	rtpcs_930x_sds_rxcal_leq_manual(sds, false, 0);
+	rtpcs_930x_sds_rxcal_leq_set_adapt(sds, true);
 
 	/* 1.3.2: sample the auto-adapted LEQ value 10 times over ~100ms */
 	for (i = 0; i < 10; i++) {
-		sum10 += rtpcs_930x_sds_rxcal_leq_read(sds);
+		val = rtpcs_930x_sds_rxcal_leq_get_coef(sds);
+		if (val < 0)
+			return;
+
+		sum10 += val;
 		mdelay(10);
 	}
 
@@ -2503,12 +2514,12 @@ static void rtpcs_930x_sds_rxcal_leq_adapt_lock(struct rtpcs_serdes *sds)
 
 	/* lock LEQ at corrected value for direct SerDes; PHY-attached stays in auto-adapt */
 	if (direct_serdes) {
-		rtpcs_930x_sds_rxcal_leq_offset_manual(sds, 1, 0);
 		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x17, 7, 7, 0x1);
-		rtpcs_930x_sds_rxcal_leq_manual(sds, true, avg10);
+		rtpcs_930x_sds_rxcal_leq_set_adapt(sds, false);
+		rtpcs_930x_sds_rxcal_leq_set_coef(sds, avg10, 0);
 	}
 
-	pr_info("SDS %u LEQ = %u", sds->id, rtpcs_930x_sds_rxcal_leq_read(sds));
+	pr_info("SDS %u LEQ = %u", sds->id, rtpcs_930x_sds_rxcal_leq_get_coef(sds));
 }
 
 static void rtpcs_930x_sds_rxcal_vth_tap0_adapt_lock(struct rtpcs_serdes *sds)

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -2364,20 +2364,15 @@ static void rtpcs_930x_sds_rxcal_init(struct rtpcs_serdes *sds, enum rtpcs_sds_m
 	/* LEQ (Long Term Equivalent signal level) */
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x16, 14,  8, 0x00);
 
-	/* DFE (Decision Fed Equalizer) */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x03,  5,  0, tap0_init_val);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x09, 11,  6, 0x00);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x09,  5,  0, 0x00);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0a,  5,  0, 0x00);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x01,  5,  0, 0x00);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x12,  5,  0, 0x00);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0a, 11,  6, 0x00);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x06,  5,  0, 0x00);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x01,  5,  0, 0x00);
+	/* DFE (Decision Feedback Equalizer) TAPs */
+	rtpcs_930x_sds_rxcal_tap_set_value(sds, 0, tap0_init_val, 0);
+	rtpcs_930x_sds_rxcal_tap_set_value(sds, 1, 0, 0);
+	rtpcs_930x_sds_rxcal_tap_set_value(sds, 2, 0, 0);
+	rtpcs_930x_sds_rxcal_tap_set_value(sds, 3, 0, 0);
+	rtpcs_930x_sds_rxcal_tap_set_value(sds, 4, 0, 0);
 
-	/* Vth */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x13,  5,  3, 0x07);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x13,  2,  0, 0x07);
+	/* VTH (Voltage Threshold) */
+	rtpcs_930x_sds_rxcal_vth_set_value(sds, 0x07, 0x07);
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0b,  5,  3, vth_min);
 
 	/* --- 1.1.1 */


### PR DESCRIPTION
This series brings another batch of cleanup and improvements to the RTL930x calibration code, making it cleaner, better understandable and more consistent in itself. Several bad patterns still existing from SDK are replaced which makes the code even more concise. All that also demystifies quite a lot of that code, getting a better understanding of the calibration pipeline now.

Plus a general PCS commit taken over from #24094 