### PR TITLE
realtek: generate lan_list from device tree to avoid startup race

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -249,9 +249,21 @@ realtek_setup_poe()
 	esac
 }
 
+realtek_lan_list()
+{
+	local labels
+
+	labels="$(find /sys/firmware/devicetree/base -path '*/ethernet-ports/port@*/label' 2>/dev/null | \
+		xargs cat 2>/dev/null | tr '\0' '\n' | grep '^lan' | sort -V | uniq | xargs)"
+
+	[ -n "$labels" ] || labels="$(ls -1 -v -d /sys/class/net/lan* 2>/dev/null | xargs -n1 basename | xargs)"
+
+	echo "$labels"
+}
+
 board=$(board_name)
 board_config_update
-lan_list=$(ls -1 -v -d /sys/class/net/lan* | xargs -n1 basename | xargs)
+lan_list=$(realtek_lan_list)
 realtek_setup_interfaces "$board" "$lan_list"
 realtek_setup_macs "$board" "$lan_list"
 realtek_setup_poe "$board" "$lan_list"


### PR DESCRIPTION
Taking over from #23839 and applying requested change, since this blocks two device support PRs and author hasn't updated.

@carlosz1986 Could you give this a quick test again? My Unifi device is now in productive use, so I cannot check anymore.