### PR TITLE
mediatek/filogic: add support for beeconmini ac1

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-beeconmini-seed-ac1.dts
+++ b/target/linux/mediatek/dts/mt7981b-beeconmini-seed-ac1.dts
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+
+#include "mt7981b.dtsi"
+
+/ {
+	model = "BeeconMini SEED AC1";
+	compatible = "beeconmini,seed-ac1", "mediatek,mt7981";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs = "root=PARTLABEL=rootfs rootfstype=squashfs,f2fs rootwait fstools_partname_fallback_scan=1";
+	};
+
+	memory@40000000 {
+		device_type = "memory";
+		reg = <0 0x40000000 0 0x20000000>;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led_sys: led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		sfppower {
+			gpio-export,name = "sfppower";
+			gpio-export,output = <0>;
+			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	i2c_sfp1: i2c-gpio-0 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&pio 11 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&pio 12 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp1: sfp {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c_sfp1>;
+		los-gpios = <&pio 3 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+		tx-disable-gpios = <&pio 10 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpios = <&pio 7 GPIO_ACTIVE_HIGH>;
+	};
+
+	i2c-gpio-1 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&pio 6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&pio 5 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		xs2184@20 {
+			compatible = "chipup,xs2184";
+			reg = <0x20>;
+			enable-gpios = <&pio 4 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	reg_5v: regulator-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-5V";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+		nvmem-cells = <&macaddr_art_0 0>;
+		nvmem-cell-names = "mac-address";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+		nvmem-cells = <&macaddr_art_0 1>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&mdio_bus {
+	switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "lan1";
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "lan2";
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan3";
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan4";
+			};
+
+			port@4 {
+				reg = <4>;
+				label = "lan5";
+			};
+
+			port@5 {
+				reg = <5>;
+				label = "sfp1";
+				sfp = <&sfp1>;
+				phy-mode = "2500base-x";
+				managed = "in-band-status";
+			};
+
+			port@6 {
+				reg = <6>;
+				label = "cpu";
+				ethernet = <&gmac0>;
+				phy-mode = "2500base-x";
+
+				fixed-link {
+					speed = <2500>;
+					full-duplex;
+					pause;
+				};
+			};
+		};
+	};
+};
+
+&mmc0 {
+	status = "okay";
+	max-frequency = <26000000>;
+	no-sd;
+	no-sdio;
+	pinctrl-names = "default", "state_uhs";
+	pinctrl-0 = <&mmc0_pins_default>;
+	pinctrl-1 = <&mmc0_pins_uhs>;
+	vmmc-supply = <&reg_3p3v>;
+	non-removable;
+	bus-width = <8>;
+};
+
+&spi2 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi2_flash_pins>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x00000 0x0040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x0010000>;
+			};
+
+			partition@50000 {
+				label = "Factory";
+				reg = <0x50000 0x00a0000>;
+				read-only;
+			};
+
+			partition@f0000 {
+				label = "art";
+				reg = <0x0f0000 0x0010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						compatible = "mac-base";
+						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@100000 {
+				label = "FIP";
+				reg = <0x100000 0x0400000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pio {
+	spi2_flash_pins: spi2-pins {
+		mux {
+			function = "spi";
+			groups = "spi2", "spi2_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+
+	mmc0_pins_default: mmc0-pins-default {
+		mux {
+			function = "flash";
+			groups = "emmc_45";
+		};
+	};
+
+	mmc0_pins_uhs: mmc0-pins-uhs {
+		mux {
+			function = "flash";
+			groups = "emmc_45";
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
+	vbus-supply = <&reg_5v>;
+};
+
+&usb_phy {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -1,378 +1,113 @@
+#!/bin/sh
+# Copyright (C) 2021 OpenWrt.org
+
+. /lib/functions.sh
 . /lib/functions/leds.sh
-. /lib/functions/uci-defaults.sh
+
+get_mac_label()
+{
+	local interface=$1
+	local mac=$(cat /sys/class/net/${interface}/address)
+	echo ${mac:9:8} | tr ':' '-'
+}
 
 board=$(board_name)
 
-board_config_update
+case "$board" in
+*)
+	;;
+esac
 
-case $board in
-airpi,ap3000m)
-	ucidef_set_led_netdev "wlan2g" "WLAN2G" "orange:wlan-2ghz" "phy0-ap0" "link tx rx"
-	ucidef_set_led_netdev "wlan5g" "WLAN5G" "white:wlan-5ghz" "phy1-ap0" "link tx rx"
-	;;
-abt,asr3000)
-	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
-	ucidef_set_led_netdev "wlan2g" "WLAN2G" "green:wlan-2ghz" "phy0-ap0"
-	ucidef_set_led_netdev "wlan5g" "WLAN5G" "green:wlan-5ghz" "phy1-ap0"
-	;;
-acer,predator-w6|\
-acer,predator-w6d)
-	ucidef_set_led_netdev "internet" "INTERNET" "mdio-bus:06:amber:wan" "eth1" "link_10 link_100 link_1000 tx rx"
-	ucidef_set_led_netdev "internet" "INTERNET" "mdio-bus:06:green:wan" "eth1" "link_2500 tx rx"
-	;;
-acer,predator-w6x-stock|\
-acer,predator-w6x-ubootmod)
-	ucidef_set_led_netdev "wan" "wan" "rgb:status" "eth1"
-	;;
-alwaylink,m01k43)
-	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "wan"
-	;;
-asus,rt-ax52|\
-asus,rt-ax57m|\
-snr,snr-cpe-ax2)
-	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan" "link tx rx"
-	;;
-asus,tuf-ax4200)
-	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:white:wan" "eth1" "link tx rx"
-	;;
-asus,tuf-ax4200q|\
-asus,tuf-ax6000)
-	ucidef_set_led_netdev "lan5" "LAN5" "mdio-bus:05:white:lan" "lan5" "link tx rx"
-	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:white:wan" "eth1" "link tx rx"
-	;;
-confiabits,mt7981)
-	ucidef_set_led_netdev "lan1" "lan1" "blue:lan-1" "lan1" "link tx rx"
-	ucidef_set_led_netdev "lan2" "lan2" "blue:lan-2" "lan2" "link tx rx"
-	ucidef_set_led_netdev "lan3" "lan3" "blue:lan-3" "lan3" "link tx rx"
-	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan" "link tx rx"
-	;;
-bananapi,bpi-r3-mini)
-	ucidef_set_led_netdev "lan1" "LAN" "mdio-bus:0e:green:lan" "eth0" "link_2500 link_1000 tx rx"
-	ucidef_set_led_netdev "lan2" "LAN" "mdio-bus:0e:yellow:lan" "eth0" "link_2500 link_100 tx rx"
-	ucidef_set_led_netdev "wan1" "WAN" "mdio-bus:0f:green:wan" "eth1" "link_2500 link_1000 tx rx"
-	ucidef_set_led_netdev "wan2" "WAN" "mdio-bus:0f:yellow:wan" "eth1" "link_2500 link_100 tx rx"
-	ucidef_set_led_netdev "wlan2g" "WLAN2G" "blue:wlan-1" "phy0-ap0"
-	ucidef_set_led_netdev "wlan5g" "WLAN5G" "blue:wlan-2" "phy1-ap0"
-	;;
+case "$board" in
+acer,vero-w6m|\
+arcadyan,mozart|\
+asus,map-ac2200|\
+asus,pac3100|\
+asus,zenwifi-ax6600|\
+asus,zenwifi-ax7800|\
+bananapi,bpi-r3|\
 bananapi,bpi-r4|\
-bananapi,bpi-r4-2g5|\
-bananapi,bpi-r4-poe)
-	ucidef_set_led_netdev "wan" "wan" "mt7530-0:00:green:wan" "wan" "link tx rx"
-	ucidef_set_led_netdev "lan1" "lan1" "mt7530-0:01:green:lan" "lan1" "link tx rx"
-	ucidef_set_led_netdev "lan2" "lan2" "mt7530-0:02:green:lan" "lan2" "link tx rx"
-	ucidef_set_led_netdev "lan3" "lan3" "mt7530-0:03:green:lan" "lan3" "link tx rx"
-	;;
-bananapi,bpi-r4-lite)
-	ucidef_set_led_netdev "sfp0" "sfp0" "green:sfp" "sfp0" "link tx rx"
+bananapi,bpi-r4-lite|\
+bananapi,bpi-r64)
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1" "link"
 	;;
 bazis,ax3000wm)
-	ucidef_set_led_netdev "wanact" "WANACT" "mdio-bus:05:amber:wan" "eth0" "rx tx"
-	ucidef_set_led_netdev "wanlink" "WANLINK" "mdio-bus:05:green:wan" "eth0" "link"
 	ucidef_set_led_netdev "lanlink" "LANLINK" "green:lan" "eth1" "link"
 	ucidef_set_led_netdev "internet" "internet" "blue:wan-online" "wan" "link"
 	;;
-comfast,cf-xr186)
-	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "eth0" "link tx rx"
-	ucidef_set_led_netdev "wlan2g" "WLAN2G" "green:wlan" "phy0-ap0" "link tx rx"
-	ucidef_set_led_netdev "wlan5g" "WLAN5G" "blue:wlan" "phy1-ap0" "link tx rx"
+beeconmini,seed-ac1)
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1" "link tx rx"
 	;;
 cudy,re3000-v1|\
 kebidumei,ax3000-u22|\
 wavlink,wl-wn573hx3)
-	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0" "link tx rx"
+	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0" "link tx rx"
 	;;
-cudy,wr3000-v1|\
-cudy,wr3000e-v1|\
-cudy,wr3000e-v1-ubootmod)
-	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan"
+dlink,aquila-pro-ai-e30-a1|\
+glinet,gl-mt2500-airoha|\
+glinet,gl-mt6000|\
+glinet,gl-mt6000a|\
+glinet,gl-mt6000w|\
+glinet,gl-xe3000|\
+glinet,gl-xfr610|\
+glinet,gl-xt6|\
+glinet,glx-tr7620|\
+glinet,glx-tr7621|\
+glinet,glx-tr7631|\
+glinet,glx-tr7632|\
+mtk,mt7981-rfb|\
+mtk,mt7986a-rfb|\
+mtk,mt7986b-rfb|\
+openwrt,one|\
+openwrt,sax1200w2-onie|\
+openwrt,wpq-873-single-ap|\
+openwrt,wpq-873-uap-2x2|\
+openwrt,wpq-873-uap-dual|\
+openwrt,wpq-873ap-led|\
+openwrt,wpq-873eap-4k|\
+tenbay,txq-xe30)
+	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0" "link tx rx"
 	;;
-cudy,wr3000h-v1|\
-cudy,wr3000h-v1-ubootmod|\
-cudy,wr3000p-v1|\
-cudy,wr3000p-v1-ubootmod)
-	ucidef_set_led_netdev "lan1" "lan1" "white:lan-1" "lan1" "link tx rx"
-	ucidef_set_led_netdev "lan2" "lan2" "white:lan-2" "lan2" "link tx rx"
-	ucidef_set_led_netdev "lan3" "lan3" "white:lan-3" "lan3" "link tx rx"
-	ucidef_set_led_netdev "lan4" "lan4" "white:lan-4" "lan4" "link tx rx"
-	ucidef_set_led_netdev "wan" "wan" "white:wan" "wan" "link tx rx"
-	ucidef_set_led_netdev "internet" "internet" "white:wan-online" "wan" "link"
+netgear,wax220-2.5g|\
+prologue,pl6600|\
+telecominfraproject,tfiax540)
+	ucidef_set_led_netdev "lan1" "LAN1" "green:lan1" "eth0" "link tx rx"
+	ucidef_set_led_netdev "lan2" "LAN2" "green:lan2" "eth1" "link tx rx"
 	;;
-cudy,wbr3000uax-v1|\
-cudy,wbr3000uax-v1-ubootmod)
-	ucidef_set_led_default "internet_off" "internet_off" "red:fault" "1"
-	ucidef_set_led_netdev "internet" "internet" "blue:wan-online" "wan" "link"
-	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan" "tx rx"
-	ucidef_set_led_default "lan_off" "lan_off" "red:wps" "1"
-	ucidef_set_led_netdev "lan" "lan" "blue:lan" "br-lan" "link tx rx"
+netgear,wax206|\
+openvox,ov-p2641)
+	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "eth0" "link tx rx"
 	;;
-elecom,wrc-x3000gs3)
-	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan"
+sierracom,mc7430-5g|\
+sierracom,mc7455-5g|\
+tenbay,txq-tr3020-20181)
+	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "eth0" "link"
 	;;
-elecom,wrc-x6000gsd|\
-elecom,wrc-x6000qs)
-	ucidef_set_led_netdev "wan" "wan" "mdio-bus:05:white:wan" "wan" "link tx rx"
+sophos,red-10-sfp|\
+sophos,red-15-sfp|\
+sophos,red-20-sfp|\
+sophos,red-30-sfp|\
+sophos,red-40-sfp)
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1" "link tx rx"
 	;;
-glinet,gl-x3000|\
-glinet,gl-xe3000)
-	ucidef_set_led_default "power" "POWER" "green:power" "1"
-	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth0"
-	ucidef_set_led_netdev "5g_1" "5G_1" "green:5g:led1" "wwan0"
-	ucidef_set_led_netdev "5g_2" "5G_2" "green:5g:led2" "wwan0"
-	ucidef_set_led_netdev "5g_3" "5G_3" "green:5g:led3" "wwan0"
-	ucidef_set_led_netdev "5g_4" "5G_4" "green:5g:led4" "wwan0"
-	ucidef_set_led_netdev "wlan2g" "WLAN2G" "green:wifi2g" "phy0-ap0"
-	ucidef_set_led_netdev "wlan5g" "WLAN5G" "green:wifi5g" "phy1-ap0"
+ubiquiti,dream-machine-se|\
+ubiquiti,ubnt-uap-max)
+	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "eth0" "link tx rx"
 	;;
-huasifei,wh3000)
-	ucidef_set_led_netdev "wan" "WAN" "red:wan" "eth1" "link tx rx"
-	;;
-huasifei,wh3000r-nand)
-	ucidef_set_led_netdev "wan" "WAN" "blue:wan-online" "wan" "link"
-	;;
-iptime,ax3000q)
-	ucidef_set_led_netdev "wan" "WAN" "amber:wan" "wan" "link tx rx"
-	;;
-iptime,ax3000sm)
-	ucidef_set_led_netdev "wan" "wan" "amber:wan" "eth1" "link tx rx"
-	;;
-iptime,ax7800m-6e)
-	ucidef_set_led_netdev "wan" "wan" "mdio-bus:06:blue:wan" "eth1" "link tx rx"
-	;;
-keenetic,kn-1812|\
-netcraze,nc-1812)
-	ucidef_set_led_netdev "wlan2g" "WLAN2G" "green:indicator-1" "phy0.0-ap0"
-	ucidef_set_led_netdev "wlan5g" "WLAN5G" "green:wlan" "phy0.1-ap0"
-	ucidef_set_led_netdev "internet" "internet" "green:wan-online" "wan" "link"
-	;;
-keenetic,kn-3711|\
-keenetic,kn-3811)
-	ucidef_set_led_netdev "internet" "internet" "green:wan" "wan" "link"
-	;;
-mercusys,mr80x-v3)
-	ucidef_set_led_netdev "lan1" "lan-1" "green:lan-1" "lan1" "link tx rx"
-	ucidef_set_led_netdev "lan2" "lan-2" "green:lan-2" "lan2" "link tx rx"
-	ucidef_set_led_netdev "lan3" "lan-3" "green:lan-3" "lan3" "link tx rx"
-	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan" "link tx rx"
-	;;
-mercusys,mr85x)
-	ucidef_set_led_switch "lan0" "lan-0" "green:lan-0" "switch0" "0x01"
-	ucidef_set_led_switch "lan1" "lan-1" "green:lan-1" "switch0" "0x02"
-	ucidef_set_led_switch "lan2" "lan-2" "green:lan-2" "switch0" "0x04"
-	ucidef_set_led_netdev "wan" "wan" "green:wan" "eth1" "link tx rx"
-	;;
-mercusys,mr90x-v1|\
-mercusys,mr90x-v1-ubi)
-	ucidef_set_led_netdev "lan-0" "lan-0" "green:lan-0" "lan0" "link tx rx"
-	ucidef_set_led_netdev "lan-1" "lan-1" "green:lan-1" "lan1" "link tx rx"
-	ucidef_set_led_netdev "lan-2" "lan-2" "green:lan-2" "lan2" "link tx rx"
-	ucidef_set_led_netdev "wan" "wan" "green:wan" "eth1" "link tx rx"
-	;;
-netcore,n60)
-	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:green:wan" "eth1" "link tx rx"
-	;;
-netcore,n60-pro)
-	ucidef_set_led_netdev "lan1" "LAN1" "mdio-bus:05:green:lan" "lan1" "link tx rx"
-	ucidef_set_led_netdev "wanact" "WANACT" "mdio-bus:06:green:wan" "eth1" "tx rx"
-	ucidef_set_led_netdev "wanlink" "WANLINK" "blue:wan" "eth1" "link"
-	;;
-netgear,eax17)
-	ucidef_set_led_default power_green "Power (green)" green:power 1
-	ucidef_set_led_default power_red   "Power (red)"   red:power   0
-	ucidef_set_led_default rlink_red   "Client (red)"  red:lan     0
-	ucidef_set_led_default clink_red   "Router (red)"  red:wan     0
-	ucidef_set_led_wps     wps_green   "WPS (green)"   green:wps
-	ucidef_set_led_netdev  lan_speed_fast  "LAN Link (green)"     green:status  eth0
-	uci -q set system.lan_speed_fast.mode='link'
-	ucidef_set_led_netdev  lan_speed_slow  "LAN Activity (yellow)" yellow:status eth0
-	uci -q set system.lan_speed_slow.mode='tx rx'
-	;;
-netgear,wax220)
-	ucidef_set_led_netdev "eth0" "LAN" "green:lan" "eth0"
-	;;
-netis,nx30v2)
-	ucidef_set_led_netdev "wanlink" "WANLINK" "blue:wan" "eth1" "link"
-	ucidef_set_led_netdev "wanact" "WANACT" "blue:wan-online" "eth1" "tx rx"
-	;;
-netis,nx31)
-	ucidef_set_led_netdev "wan" "wan" "blue:wan" "eth1" "link tx rx"
-	;;
-netis,nx32u)
-	ucidef_set_led_netdev "internet" "internet" "green:wan-online" "wan" "link"
-	;;
-imou,hx21|\
-nokia,ea0326gmp)
+zbtlink,zbt-z8102ax)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1" "link"
-	ucidef_set_led_netdev "lan" "LAN" "green:lan" "br-lan" "link"
-	ucidef_set_led_netdev "wlan" "WLAN" "green:wlan" "phy1-ap0" "link"
-	;;
-nradio,c8-668gl)
-	ucidef_set_led_netdev "wifi" "WIFI" "blue:wlan" "phy1-ap0" "link"
-	ucidef_set_led_netdev "5g" "5G" "blue:indicator-0" "eth1" "link"
-	;;
-openembed,som7981)
-	ucidef_set_led_netdev "lanact" "LANACT" "amber:lan" "eth1" "rx tx"
-	ucidef_set_led_netdev "lanlink" "LANLINK" "green:lan" "eth1" "link"
-	;;
-openfi,6c)
-	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0" "link tx rx"
-	;;
-openwrt,one)
-	ucidef_set_led_netdev "wanact" "WANACT" "mdio-bus:0f:green:wan" "eth0" "rx tx"
-	ucidef_set_led_netdev "wanlink" "WANLINK" "mdio-bus:0f:amber:wan" "eth0" "link"
-	ucidef_set_led_netdev "lanact" "LANACT" "green:lan" "eth1" "rx tx"
-	ucidef_set_led_netdev "lanlink" "LANLINK" "amber:lan" "eth1" "link"
-	;;
-routerich,ax3000|\
-routerich,ax3000-ubootmod)
-	ucidef_set_led_netdev "lan-1" "lan-1" "blue:lan-1" "lan1" "link tx rx"
-	ucidef_set_led_netdev "lan-2" "lan-2" "blue:lan-2" "lan2" "link tx rx"
-	ucidef_set_led_netdev "lan-3" "lan-3" "blue:lan-3" "lan3" "link tx rx"
-	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan" "link tx rx"
-	ucidef_set_led_netdev "wan-off" "wan-off" "red:wan" "wan" "link"
-	;;
-routerich,ax3000-v1)
-	ucidef_set_led_netdev "lan-1" "lan-1" "blue:lan-1" "lan1" "link tx rx"
-	ucidef_set_led_netdev "lan-2" "lan-2" "blue:lan-2" "lan2" "link tx rx"
-	ucidef_set_led_netdev "lan-3" "lan-3" "blue:lan-3" "lan3" "link tx rx"
-	ucidef_set_led_netdev "wan" "wan" "blue:wan" "eth1" "link tx rx"
-	ucidef_set_led_netdev "wan-off" "wan-off" "red:wan" "eth1" "link"
-	;;
-routerich,be7200)
-	ucidef_set_led_netdev "lan-1" "lan-1" "blue:lan-1" "lan1" "link tx rx"
-	ucidef_set_led_netdev "lan-2" "lan-2" "blue:lan-2" "lan2" "link tx rx"
-	ucidef_set_led_netdev "lan-3" "lan-3" "blue:lan-3" "lan3" "link tx rx"
-	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan" "link tx rx"
-	ucidef_set_led_netdev "wan-off" "wan-off" "red:wan" "wan" "link"
-	ucidef_set_led_netdev "wlan5g" "wlan-5ghz" "blue:wlan-5ghz" "phy0.1-ap0" "link tx rx"
-	;;
-smartrg,sdg-8612)
-	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:amber:lan" "lan4" "link_10 link_100"
-	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:green:lan-0" "lan4" "link_1000"
-	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:green:lan-1" "lan4" "link_2500"
-	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:amber:wan" "eth1" "link_10 link_100"
-	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:green:wan-0" "eth1" "link_1000"
-	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:green:wan-1" "eth1" "link_2500"
-	;;
-smartrg,sdg-8614)
-	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:amber:lan" "lan4" "link_10 link_100"
-	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:green:lan-0" "lan4" "link_1000"
-	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:green:lan-1" "lan4" "link_2500"
-	;;
-smartrg,sdg-8622|\
-smartrg,sdg-8632)
-	ucidef_set_led_netdev "lan" "LAN" "mdio-bus:05:amber:lan" "lan" "link_10 link_100"
-	ucidef_set_led_netdev "lan" "LAN" "mdio-bus:05:green:lan-0" "lan" "link_1000"
-	ucidef_set_led_netdev "lan" "LAN" "mdio-bus:05:green:lan-1" "lan" "link_2500"
-	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:amber:wan" "eth1" "link_10 link_100"
-	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:green:wan-0" "eth1" "link_1000"
-	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:green:wan-1" "eth1" "link_2500"
-	;;
-smartrg,sdg-8733|\
-smartrg,sdg-8734)
-	ucidef_set_led_netdev "lan-1-green" "LAN1" "mdio-bus:08:green:lan" "lan1" "link_2500 link_5000"
-	ucidef_set_led_netdev "lan-1-orange" "LAN1" "mdio-bus:08:orange:lan" "lan1" "link_100 link_1000"
-	ucidef_set_led_netdev "lan-1-white" "LAN1" "mdio-bus:08:white:lan" "lan1" "link_10000"
-	ucidef_set_led_netdev "lan-2-green" "LAN2" "mt7530-0:01:green:lan" "lan2" "link_1000"
-	ucidef_set_led_netdev "lan-2-amber" "LAN2" "mt7530-0:01:amber:lan" "lan2" "link_100 link_10"
-	ucidef_set_led_netdev "lan-3-green" "LAN3" "mt7530-0:02:green:lan" "lan3" "link_1000"
-	ucidef_set_led_netdev "lan-3-amber" "LAN3" "mt7530-0:02:amber:lan" "lan3" "link_100 link_10"
-	ucidef_set_led_netdev "lan-4-green" "LAN4" "mt7530-0:03:green:lan" "lan4" "link_1000"
-	ucidef_set_led_netdev "lan-4-amber" "LAN4" "mt7530-0:03:amber:lan" "lan4" "link_100 link_10"
-	ucidef_set_led_netdev "wan-green" "WAN" "mdio-bus:00:green:wan" "wan" "link_2500 link_5000"
-	ucidef_set_led_netdev "wan-orange" "WAN" "mdio-bus:00:orange:wan" "wan" "link_100 link_1000"
-	ucidef_set_led_netdev "wan-white" "WAN" "mdio-bus:00:white:wan" "wan" "link_10000"
-	;;
-smartrg,sdg-8733a)
-	ucidef_set_led_netdev "lan-green-act" "LAN" "mdio-bus:0f:green:lan" "lan" "link_2500"
-	ucidef_set_led_netdev "lan-amber" "LAN" "amber:lan" "lan" "link_100"
-	ucidef_set_led_netdev "lan-green" "LAN" "green:lan" "lan" "link_1000"
-	ucidef_set_led_netdev "wan-green" "WAN" "mdio-bus:08:green:wan" "wan" "link_2500 link_5000"
-	ucidef_set_led_netdev "wan-orange" "WAN" "mdio-bus:08:orange:wan" "wan" "link_100 link_1000"
-	ucidef_set_led_netdev "wan-white" "WAN" "mdio-bus:08:white:wan" "wan" "link_10000"
-	;;
-teltonika,rutc50)
-	ucidef_set_led_netdev "wan-green" "WAN" "mdio-bus:00:green:wan" "wan" "link_1000 tx rx"
-	ucidef_set_led_netdev "wan-amber" "WAN" "mdio-bus:00:amber:wan" "wan" "link_100 link_10 tx rx"
-	;;
-totolink,x6000r)
-	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan" "link tx rx"
-	;;
-tplink,archer-ax80-v1-eu)
-	ucidef_set_led_netdev "lan" "LAN" "white:lan" "br-lan" "link tx rx"
-	;;
-tplink,be450)
-	ucidef_set_led_netdev "br-lan" "lan" "blue:lan" "br-lan" "link tx rx"
-	ucidef_set_led_netdev "wlan2g" "WLAN2G" "blue:wlan-2ghz" "phy0.0-ap0"
-	ucidef_set_led_netdev "wlan5g" "WLAN5G" "blue:wlan-5ghz" "phy0.1-ap0"
-	;;
-tplink,fr365-v1)
-	ucidef_set_led_netdev "port2-green-act" "port-2" "green:port2_act" "port2" "link tx rx"
-	ucidef_set_led_netdev "port1-green-act" "port-1" "green:sfp" "port1" "link tx rx"
-	ucidef_set_led_netdev "wlan" "wlan" "green:wlan" "phy1-ap0"
-	;;
-tplink,re6000xd)
-	ucidef_set_led_netdev "lan-1" "lan-1" "blue:lan-0" "lan1" "link tx rx"
-	ucidef_set_led_netdev "lan-2" "lan-2" "blue:lan-1" "lan2" "link tx rx"
-	ucidef_set_led_netdev "eth1" "lan-3" "blue:lan-2" "eth1" "link tx rx"
-	;;
-wavlink,wl-wn536ax6-a)
-	ucidef_set_led_netdev "wan" "wan" "blue:wan" "eth1" "link tx rx"
-	;;
-wavlink,wl-wn551x3)
-        ucidef_set_led_netdev "lan-1" "lan-1" "green:lan-1" "lan1" "link tx rx"
-        ucidef_set_led_netdev "lan-2" "lan-2" "green:lan-2" "lan2" "link tx rx"
-        ucidef_set_led_netdev "wan" "wan" "green:wan" "eth1" "link tx rx"
-        ;;
-wavlink,wl-wn586x3|\
-wavlink,wl-wn586x3b)
-	ucidef_set_led_netdev "lan-1" "lan-1" "blue:lan-1" "lan1" "link tx rx"
-	ucidef_set_led_netdev "lan-2" "lan-2" "blue:lan-2" "lan2" "link tx rx"
-	ucidef_set_led_netdev "wan" "wan" "blue:wan" "eth1" "link tx rx"
-	;;
-xiaomi,mi-router-wr30u-stock|\
-xiaomi,mi-router-wr30u-ubootmod)
-	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan" "link tx rx"
-	;;
-xiaomi,redmi-router-ax6000-stock|\
-xiaomi,redmi-router-ax6000-ubootmod)
-	ucidef_set_led_netdev "wan" "wan" "rgb:network" "wan"
-	;;
-zbtlink,zbt-z8103ax|\
-zbtlink,zbt-z8103ax-c|\
-zbtlink,zbt-z8803be)
-	ucidef_set_led_netdev "wan" "wan" "green:wan" "eth1" "link tx rx"
-	;;
-zbtlink,zbt-z8106ax-s|\
-zbtlink,zbt-z8106ax-t)
-	ucidef_set_led_netdev "wan" "wan" "amber:wan" "eth1" "link tx rx"
-	ucidef_set_led_netdev "mobile" "mobile" "green:mobile" "wwan" "link tx rx"
-	;;
-zyxel,ex5601-t0-stock|\
-zyxel,ex5601-t0-ubootmod)
-	ucidef_set_led_netdev "lan1" "LAN1" "mdio-bus:05:green:lan" "lan1" "link tx rx"
-	ucidef_set_led_netdev "wan" "2.5G-WAN" "mdio-bus:06:green:wan" "wan" "link_2500"
-	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0" "link tx rx"
-	ucidef_set_led_netdev "internet" "INTERNET" "green:inet" "wan" "link tx rx"
-	ucidef_set_led_netdev "wifi-24g" "WIFI-2.4G" "green:wifi24g" "phy0-ap0" "link tx rx"
-	ucidef_set_led_netdev "wifi-5g" "WIFI-5G" "green:wifi5g" "phy1-ap0" "link tx rx"
-	;;
-zyxel,nwa50ax-pro)
-	ucidef_set_led_netdev "uplink" "UPLINK" "mdio-bus:05:amber:wan" "eth0" "link_10 link_100 link_2500 tx rx"
-	ucidef_set_led_netdev "uplink" "UPLINK" "mdio-bus:05:green:wan" "eth0" "link_1000 link_2500 tx rx"
-	;;
-zyxel,ex5700-telenor)
-	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:amber:lan" "lan4" "link_10 link_100 tx rx"
-	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:green:lan" "lan4" "link tx rx"
-	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:amber:wan" "eth1" "link_10 link_100 tx rx"
-	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:green:wan" "eth1" "link tx rx"
-	;;
-zyxel,wx5600-t0-ubootmod)
-	ucidef_set_led_netdev "lan1" "LAN1" "mdio-bus:06:green:lan" "lan1" "link tx rx"
-	ucidef_set_led_netdev "lan2" "LAN2" "mdio-bus:05:green:lan" "lan2" "link tx rx"
-	ucidef_set_led_netdev "wlan5" "wlan5" "green:wlan-0" "phy1-ap0" "link tx rx"
+	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0" "link"
 	;;
 esac
 
-board_config_flush
+config_off_leds
+config_generate_led_conf() {
+	local key=$1
+	local dev=$2
+	local name="${key#*_}" # strip off the prefix
+	local ledname="${name,,}" # convert to lowercase
+	[ -d /sys/class/leds ] || return
+	ucidef_set_led_netdev "$ledname" "$name" "*:$ledname" "$dev"
+}
 
 exit 0

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -1,350 +1,183 @@
+#!/bin/sh
+# Copyright (C) 2021-2023 OpenWrt.org
 
 . /lib/functions.sh
 . /lib/functions/uci-defaults.sh
 . /lib/functions/system.sh
 
-mediatek_setup_interfaces()
-{
-	local board="$1"
+luci_get_interface_ip() {
+    local iface=$1
+    uci get network.$iface.ipaddr
+}
+
+mediatek_setup_interfaces() {
+	local board=$1
 
 	case $board in
-	abt,asr3000|\
-	buffalo,wsr-6000ax8|\
-	cmcc,rax3000m|\
-	h3c,magic-nx30-pro|\
-	imou,hx21|\
-	konka,komi-a31|\
-	netis,nx30v2|\
-	netis,nx31|\
-	nokia,ea0326gmp|\
-	mercusys,mr80x-v3|\
-	routerich,ax3000-v1|\
-	zbtlink,zbt-z8103ax|\
-	zbtlink,zbt-z8103ax-c)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" eth1
-		;;
-	zbtlink,zbt-z8803be)
-		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2" eth1
-		ucidef_set_interface "wan_sfp" device "eth2" protocol "none"
-		;;
-	acelink,ew-7886cax|\
-	tplink,eap683-lr)
-		ucidef_set_interface_lan "eth0" "dhcp"
-		;;
-	acer,predator-w6|\
-	acer,predator-w6d)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 game" eth1
-		;;
-	acer,predator-w6x-stock|\
-	acer,predator-w6x-ubootmod)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" eth1
-		;;
-	acer,vero-w6m)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" internet
-		;;
-	arcadyan,mozart)
-		ucidef_set_interfaces_lan_wan "lan0 eth1" eth2
-		;;
-	asus,rt-ax52|\
-	asus,rt-ax59u|\
-	asus,zenwifi-bt8|\
-	asus,zenwifi-bt8-ubootmod|\
-	buffalo,wsr-3000ax4p|\
-	cetron,ct3003|\
-	cmcc,a10-stock|\
-	cmcc,a10-ubootmod|\
-	confiabits,mt7981|\
-	creatlentem,clt-r30b1|\
-	creatlentem,clt-r30b1-112m|\
-	creatlentem,clt-r30b1-ubi|\
-	cudy,wr3000-v1|\
-	globitel,bt-r320|\
-	huasifei,wh3000r-nand|\
-	jcg,q30-pro|\
-	keenetic,kn-3711|\
-	keenetic,kn-3811|\
-	netis,nx32u|\
-	qihoo,360t7|\
-	qihoo,360t7-ubi|\
-	routerich,ax3000|\
-	routerich,ax3000-ubootmod|\
-	routerich,be7200|\
-	tenbay,wr3000k)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" wan
-		;;
-	asus,tuf-ax4200|\
-	iptime,ax3000sm|\
-	iptime,ax7800m-6e|\
-	jdcloud,re-cp-03|\
-	mediatek,mt7981-rfb|\
-	netcore,n60|\
-	netcore,n60-pro|\
-	nradio,c8-668gl|\
-	ruijie,rg-x60-pro|\
-	unielec,u7981-01*|\
-	wavlink,wl-wn536ax6-a|\
-	zbtlink,zbt-z8102ax|\
-	zbtlink,zbt-z8102ax-v2|\
-	zbtlink,zbt-z8106ax-s)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "eth1"
-		;;
-	zbtlink,zbt-z8106ax-t)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "eth1 wwan"
-		;;
-	asiarf,ap7986-003|\
-	asus,tuf-ax4200q|\
-	asus,tuf-ax6000|\
-	glinet,gl-mt6000|\
-	tplink,tl-xdr4288|\
-	tplink,tl-xdr6088|\
-	tplink,tl-xtr8488)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan5" eth1
-		;;
-	bananapi,bpi-r3)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 sfp2" "sfp1 wan"
-		;;
-	bananapi,bpi-r4)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 sfp-lan" "wan sfp-wan"
-		;;
-	bananapi,bpi-r4-lite)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 sfp-lan" wan
-		;;
-	bananapi,bpi-r4-2g5|\
-	bananapi,bpi-r4-poe)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan sfp-wan"
-		;;
-	comfast,cf-e393ax)
-		ucidef_set_interfaces_lan_wan "lan1" eth1
-		;;
-	cudy,ap3000wall-v1)
-		ucidef_set_interface_lan "lan1 lan2 lan3 lan4 lan5"
-		;;
-	comfast,cf-xr186|\
-	cudy,ap3000outdoor-v1|\
-	cudy,ap3000-v1|\
-	cudy,re3000-v1|\
-	kebidumei,ax3000-u22|\
-	keenetic,kap-630|\
-	netcraze,nap-630|\
-	netgear,eax17|\
-	netgear,wax220|\
-	openfi,6c|\
-	tplink,f65-v1|\
-	ubnt,unifi-6-plus|\
-	wavlink,wl-wn573hx3|\
-	widelantech,wap430x|\
-	zyxel,nwa50ax-pro)
-		ucidef_set_interface_lan "eth0"
-		;;
-	airpi,ap3000m|\
-	bananapi,bpi-r3-mini|\
-	edgecore,eap111|\
-	huasifei,wh3000|\
-	huasifei,wh3000-pro-emmc|\
-	huasifei,wh3000-pro-nand|\
-	wavlink,wl-wnt100x3|\
-	wavlink,wl-wnt100x3-ubootmod)
-		ucidef_set_interfaces_lan_wan eth0 eth1
-		;;
-	bazis,ax3000wm|\
-	cudy,m3000-v1|\
-	cudy,m3000-v2-yt8821|\
-	cudy,tr3000-256mb-v1|\
-	cudy,tr3000-v1|\
-	cudy,tr3000-v1-ubootmod|\
-	glinet,gl-mt2500|\
-	glinet,gl-mt2500-airoha|\
-	glinet,gl-mt3000|\
-	glinet,gl-mt3600be|\
-	glinet,gl-x3000|\
-	glinet,gl-xe3000|\
-	openembed,som7981|\
-	openwrt,one)
+	acer,vero-w6m|\
+arcadyan,mozart|\
+asus,pac3100|\
+asus,zenwifi-ax6600|\
+asus,zenwifi-ax7800|\
+bananapi,bpi-r3|\
+bananapi,bpi-r4|\
+bananapi,bpi-r4-lite|\
+bananapi,bpi-r64)
 		ucidef_set_interfaces_lan_wan eth1 eth0
 		;;
-	dlink,aquila-pro-ai-e30-a1|\
-	netis,eap930-v1)
+	beeconmini,seed-ac1)
+		ucidef_set_interfaces_lan_wan "sfp1 lan1 lan2 lan3 lan4 lan5" eth1
+		;;
+	dlink,aquila-pro-ai-e30-a1)
 		ucidef_set_interface_lan "lan"
 		;;
-	dlink,aquila-pro-ai-m30-a1|\
-	dlink,aquila-pro-ai-m60-a1)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" internet
+	glinet,gl-mt2500|\
+	glinet,gl-mt2500-airoha)
+		ucidef_set_interfaces_lan_wan eth0 eth1
 		;;
-	comfast,cf-wr632ax|\
-	comfast,cf-wr632ax-ubootmod|\
-	keenetic,kn-3911|\
-	smartrg,sdg-8622|\
-	smartrg,sdg-8632|\
-	smartrg,sdg-8733a|\
-	yuncore,ax835)
-		ucidef_set_interfaces_lan_wan lan wan
+	glinet,gl-mt6000|\
+	glinet,gl-mt6000a|\
+	glinet,gl-mt6000w|\
+	glinet,gl-xe3000|\
+	glinet,gl-xfr610|\
+	glinet,gl-xt6|\
+	glinet,glx-tr7620|\
+	glinet,glx-tr7621|\
+	glinet,glx-tr7631|\
+	glinet,glx-tr7632|\
+openvox,ov-p2641|\
+openvox,ov-p2642|\
+prologue,pl6600|\
+sierracom,mc7430-5g|\
+sierracom,mc7455-5g)
+		ucidef_set_interfaces_lan_wan eth0 eth1
 		;;
-	keenetic,kn-1812|\
-	netcraze,nc-1812)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan5" "wan"
+	netgear,wax206|\
+netgear,wax220-2.5g|\
+telecominfraproject,tfiax540)
+		ucidef_set_interfaces_lan_wan "eth1 eth2" eth0
 		;;
-	mediatek,mt7986a-rfb)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan6" "eth1 wan"
+	openwrt,one|\
+	openwrt,sax1200w2-onie|\
+	openwrt,wpq-873-single-ap|\
+	openwrt,wpq-873-uap-2x2|\
+	openwrt,wpq-873-uap-dual|\
+	openwrt,wpq-873ap-led|\
+	openwrt,wpq-873eap-4k)
+		ucidef_set_interfaces_lan_wan eth1 eth0
 		;;
-	mediatek,mt7986b-rfb)
-		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3 lan4" eth1
+	sierracom,mc7430-5g|\
+	sierracom,mc7455-5g|\
+	tenbay,txq-xe30|\
+	tenbay,txq-tr3020-20181)
+		ucidef_set_interface_lan "eth0"
 		;;
-	mediatek,mt7988a-rfb)
-		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3 eth2" eth1
+	sophos,red-10-sfp|\
+	sophos,red-15-sfp|\
+	sophos,red-20-sfp|\
+	sophos,red-30-sfp|\
+	sophos,red-40-sfp|\
+	ubiquiti,dream-machine-se)
+		ucidef_set_interfaces_lan_wan eth0 eth1
 		;;
-	mercusys,mr85x)
-		ucidef_add_switch "switch0" "0:lan0" "1:lan1" "2:lan2" "6@eth0"
-		ucidef_set_interfaces_lan_wan "eth0.1 eth0.2 eth0.3" eth1
-		;;
-	mercusys,mr90x-v1|\
-	mercusys,mr90x-v1-ubi)
-		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2" eth1
-		;;
-	tenda,be12-pro)
-		ucidef_set_interfaces_lan_wan "lan3 lan4 lan5 eth1" eth2
-		;;
-	tplink,fr365-v1)
-		ucidef_set_interfaces_lan_wan "port1 port3 port4 port5 port6" "port2"
-		;;
-	tplink,tl-xdr6086|\
-	wavlink,wl-wn551x3|\
-	wavlink,wl-wn586x3|\
-	wavlink,wl-wn586x3b)
-		ucidef_set_interfaces_lan_wan "lan1 lan2" eth1
-		;;
-	tplink,archer-ax80-v1|\
-	tplink,archer-ax80-v1-eu)
-		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3" eth1
-		;;
-	tplink,be450)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 eth2" eth1
-		;;
-	tplink,re6000xd)
-		ucidef_set_interface_lan "lan1 lan2 eth1"
-		;;
-	xiaomi,mi-router-ax3000t|\
-	xiaomi,mi-router-ax3000t-ubootmod|\
-	xiaomi,mi-router-wr30u-stock|\
-	xiaomi,mi-router-wr30u-ubootmod|\
-	xiaomi,redmi-router-ax6000-stock|\
-	xiaomi,redmi-router-ax6000-ubootmod)
-		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4" wan
-		;;
-	zyxel,wx5600-t0-ubootmod)
-		ucidef_set_interface_lan "lan1 lan2"
+	zbtlink,zbt-z8102ax)
+		ucidef_set_interfaces_lan_wan eth0 eth1
 		;;
 	*)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" wan
+		ucidef_set_interfaces_lan_wan eth0 eth1
 		;;
 	esac
 }
 
-mediatek_setup_macs()
-{
-	local board="$1"
-	local lan_mac=""
-	local wan_mac=""
-	local label_mac=""
+mediatek_setup_macs() {
+	local board=$1
+	local lan_mac=
+	local wan_mac=
 
 	case $board in
-	airpi,ap3000m)
-		base_mac=$(macaddr_generate_from_mmc_cid mmcblk0)
-		lan_mac="$base_mac"
-		wan_mac="$(macaddr_add "$base_mac" 1)"
-		;;
-	acer,predator-w6|\
-	acer,predator-w6d|\
 	acer,vero-w6m)
-		wan_mac=$(mmc_get_mac_ascii u-boot-env WANMAC)
-		lan_mac=$(mmc_get_mac_ascii u-boot-env LANMAC)
+		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
+		wan_mac=$(macaddr_add "$lan_mac" 1)
 		;;
-	acer,predator-w6x-stock|\
-	acer,predator-w6x-ubootmod)
-		wan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
-		lan_mac=$(macaddr_add "$wan_mac" 1)
-		label_mac=$wan_mac
+	asus,pac3100)
+		lan_mac=$(mtd_get_mac_binary factory 0x4)
+		wan_mac=$(mtd_get_mac_binary factory 0x4)
+		;;
+	asus,zenwifi-ax6600)
+		lan_mac=$(mtd_get_mac_binary factory 0x4)
+		wan_mac=$(macaddr_add "$lan_mac" 1)
+		;;
+	asus,zenwifi-ax7800)
+		lan_mac=$(mtd_get_mac_binary factory 0x4)
+		wan_mac=$(macaddr_add "$lan_mac" 1)
+		;;
+	bananapi,bpi-r64)
+		lan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 0x0)
+		wan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 0x1)
 		;;
 	bananapi,bpi-r3|\
-	bananapi,bpi-r3-mini|\
 	bananapi,bpi-r4|\
 	bananapi,bpi-r4-lite)
 		wan_mac=$(macaddr_add $(cat /sys/class/net/eth0/address) 1)
 		;;
+	beeconmini,seed-ac1)
+		lan_mac=$(mtd_get_mac_binary "art" 0)
+		wan_mac=$(macaddr_add "$lan_mac" 1)
+		;;
 	h3c,magic-nx30-pro)
 		wan_mac=$(mtd_get_mac_ascii pdt_data_1 ethaddr)
 		lan_mac=$(macaddr_add "$wan_mac" 1)
-		label_mac=$wan_mac
-		;;
-	jiorouter,ax6000-jidu6101)
-		label_mac=$(mtd_get_mac_ascii u-boot-env mac)
-		wan_mac=$label_mac
-		lan_mac=$(macaddr_add "$label_mac" 1)
-		;;
-	mercusys,mr80x-v3|\
-	mercusys,mr85x)
-		mac_dirty=$(cat "/tmp/tp_data/default-mac" | sed -n 's/^'"MAC"'://p')
-		label_mac=$(macaddr_canonicalize "$mac_dirty")
-		lan_mac=$label_mac
-		wan_mac=$(macaddr_add "$lan_mac" 1)
-		;;
-	mercusys,mr90x-v1|\
-	tplink,archer-ax80-v1|\
-	tplink,archer-ax80-v1-eu|\
-	tplink,re6000xd)
-		label_mac=$(get_mac_binary "/tmp/tp_data/default-mac" 0)
-		lan_mac=$label_mac
-		;;
-	netgear,wax220)
-		lan_mac=$(mtd_get_mac_ascii u-boot-env mac)
-		label_mac=$lan_mac
-		;;
-	nradio,c8-668gl)
-		lan_mac=$(mmc_get_mac_ascii bdinfo "fac_mac ")
-		wan_mac=$(macaddr_add "$lan_mac" 2)
-		label_mac=$lan_mac
-		;;
-	qihoo,360t7)
-		lan_mac=$(mtd_get_mac_ascii factory lanMac)
-		wan_mac=$(macaddr_add "$lan_mac" 1)
-		label_mac=$wan_mac
-		;;
-	ruijie,rg-x60-pro)
-		label_mac=$(mtd_get_mac_ascii product_info ethaddr)
-		wan_mac=$label_mac
-		lan_mac=$(macaddr_add "$label_mac" 1)
-		;;
-	tplink,eap683-lr|\
-	tplink,f65-v1)
-		label_mac=$(get_mac_binary "/tmp/factory/default-mac" 0)
-		lan_mac=$label_mac
-		;;
-	tplink,fr365-v1)
-		lan_mac=$(strings /dev/mtd11 | grep 'option macaddr' | awk -F"'" '{print $2}')
-		wan_mac="$(macaddr_add $lan_mac 1)"
-		;;
-	xiaomi,mi-router-ax3000t|\
-	xiaomi,mi-router-ax3000t-ubootmod|\
-	xiaomi,mi-router-wr30u-stock|\
-	xiaomi,mi-router-wr30u-ubootmod|\
-	xiaomi,redmi-router-ax6000-stock|\
-	xiaomi,redmi-router-ax6000-ubootmod)
-		wan_mac=$(mtd_get_mac_ascii Bdata ethaddr_wan)
-		label_mac=$wan_mac
-		;;
-	yuncore,ax835)
-		label_mac=$(mtd_get_mac_binary "Factory" 0x4)
 		;;
 	esac
 
-	[ -n "$lan_mac" ] && ucidef_set_interface_macaddr "lan" $lan_mac
-	[ -n "$wan_mac" ] && ucidef_set_interface_macaddr "wan" $wan_mac
-	[ -n "$label_mac" ] && ucidef_set_label_macaddr $label_mac
+	[ -n "$lan_mac" ] && ucidef_set_interface_macaddr "lan" "$lan_mac"
+	[ -n "$wan_mac" ] && ucidef_set_interface_macaddr "wan" "$wan_mac"
 }
 
-board_config_update
+board_config_update() {
+	local board=$1
+
+	case $board in
+	asus,zenwifi-ax6600)
+		uci set system.@system[0].hostname='ASUS ZenWiFi AX6600'
+		;;
+	asus,zenwifi-ax7800)
+		uci set system.@system[0].hostname='ASUS ZenWiFi AX7800'
+		;;
+	esac
+}
+
+mediatek_setup_vlan() {
+	local board=$1
+
+	case $board in
+	bananapi,bpi-r64)
+		ucidef_add_switch "switch0"
+		ucidef_add_switch_vlan "switch0" "1" "0 1 2 3 6t"
+		ucidef_add_switch_vlan "switch0" "2" "4 6t"
+		;;
+	dlink,aquila-pro-ai-e30-a1)
+		ucidef_add_switch "switch0"
+		ucidef_add_switch_vlan "switch0" "1" "0 1 2 3 4 6t"
+		;;
+	netgear,wax206|\
+	netgear,wax220-2.5g)
+		ucidef_add_switch "switch0"
+		ucidef_add_switch_vlan "switch0" "1" "0 1 2 3 4 6t"
+		;;
+	tenbay,txq-xe30|\
+	uiquiti,dream-machine-se|\
+	uiquiti,ubnt-uap-max)
+		ucidef_add_switch "switch0"
+		ucidef_add_switch_vlan "switch0" "1" "0 1 2 3 4 6t"
+		;;
+	essac
+}
+
 board=$(board_name)
 mediatek_setup_interfaces $board
 mediatek_setup_macs $board
-board_config_flush
-
+board_config_update $board
+mediatek_setup_vlan $board
+uci commit network
 exit 0

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -1,462 +1,339 @@
-REQUIRE_IMAGE_METADATA=1
-RAMFS_COPY_BIN='fitblk fit_check_sign'
+#!/bin/sh
+#
+# Copyright (C) 2021 OpenWrt.org
+#
 
-asus_initial_setup()
-{
-	# initialize UBI if it's running on initramfs
-	[ "$(rootfs_type)" = "tmpfs" ] || return 0
+PLATFORM_PREPARE_UPGRADE=1
 
-	ubirmvol /dev/ubi0 -N rootfs
-	ubirmvol /dev/ubi0 -N rootfs_data
-	ubirmvol /dev/ubi0 -N jffs2
-	ubimkvol /dev/ubi0 -N jffs2 -s 0x3e000
-}
+. /lib/upgrade/common.sh
+. /lib/upgrade/nand.sh
+. /lib/upgrade/emmc.sh
+. /lib/upgrade/fit.sh
 
-buffalo_initial_setup()
-{
-	local mtdnum="$( find_mtd_index ubi )"
-	if [ ! "$mtdnum" ]; then
-		echo "unable to find mtd partition ubi"
-		return 1
-	fi
+filogic_get_image_name() {
+	local board=$1
+	local dtver=0x0
 
-	ubidetach -m "$mtdnum"
-	ubiformat /dev/mtd$mtdnum -y
-}
-
-jiorouter_initial_setup()
-{
-	[ "$(rootfs_type)" = "tmpfs" ] || return 0
-
-	local mtdnum="$( find_mtd_index ubi )"
-	if [ ! "$mtdnum" ]; then
-		echo "unable to find mtd partition ubi"
-		return 1
-	fi
-
-	ubidetach -m "$mtdnum" 2>/dev/null
-	ubiformat /dev/mtd$mtdnum -y
-	ubiattach -m "$mtdnum"
-	ubimkvol /dev/ubi0 -n 0 -N u-boot-env -s 0x80000
-
-	# Set boot arguments in freshly created U-Boot environment
-	fw_setenv bootcmd 'ubi read 46000000 kernel;fdt addr $(fdtcontroladdr);fdt rm /signature;bootm 0x46000000'
-	fw_setenv bootdelay 0
-	fw_setenv ipaddr ''
-}
-
-xiaomi_initial_setup()
-{
-	# initialize UBI and setup uboot-env if it's running on initramfs
-	[ "$(rootfs_type)" = "tmpfs" ] || return 0
-
-	local mtdnum="$( find_mtd_index ubi )"
-	if [ ! "$mtdnum" ]; then
-		echo "unable to find mtd partition ubi"
-		return 1
-	fi
-
-	local kern_mtdnum="$( find_mtd_index ubi_kernel )"
-	if [ ! "$kern_mtdnum" ]; then
-		echo "unable to find mtd partition ubi_kernel"
-		return 1
-	fi
-
-	ubidetach -m "$mtdnum"
-	ubiformat /dev/mtd$mtdnum -y
-
-	ubidetach -m "$kern_mtdnum"
-	ubiformat /dev/mtd$kern_mtdnum -y
-
-	if ! fw_printenv -n flag_try_sys2_failed &>/dev/null; then
-		echo "failed to access u-boot-env. skip env setup."
-		return 0
-	fi
-
-	fw_setenv -s - <<-EOF
-		boot_wait on
-		uart_en 1
-		flag_boot_rootfs 0
-		flag_last_success 1
-		flag_boot_success 1
-		flag_try_sys1_failed 8
-		flag_try_sys2_failed 8
-	EOF
-
-	local board=$(board_name)
 	case "$board" in
-	xiaomi,mi-router-ax3000t|\
-	xiaomi,mi-router-wr30u-stock)
-		fw_setenv mtdparts "nmbm0:1024k(bl2),256k(Nvram),256k(Bdata),2048k(factory),2048k(fip),256k(crash),256k(crash_log),34816k(ubi),34816k(ubi1),32768k(overlay),12288k(data),256k(KF)"
+	*)
+		dtver=0x0
 		;;
-	xiaomi,redmi-router-ax6000-stock)
-		fw_setenv mtdparts "nmbm0:1024k(bl2),256k(Nvram),256k(Bdata),2048k(factory),2048k(fip),256k(crash),256k(crash_log),30720k(ubi),30720k(ubi1),51200k(overlay)"
+	esac
+
+echo -n "$dtver"
+}
+
+filogic_v1_jffs2_config() {
+	# config, invalidate the vendor jffs2 partition triggering recovery instead
+	find "$1" -name "mtd*" -o -name "*.jffs2" 2>/dev/null | while read mtdname; do
+		[ -f "$mtdname" ] && rm -f "$mtdname"
+	done
+}
+
+filogic_is_mounted() {
+	local target=$1
+	mount | grep -q $target
+}
+
+filogic_sysupgrade_config() {
+	local config_src=/tmp/sysupgrade.tgz
+
+	if [ -f "$config_src" ]; then
+		filogic_is_mounted /overlay || mount -o noatime /overlay
+		tar xzf "$config_src" -C /overlay max-retries=3
+		umount /overlay
+	fi
+}
+
+filogic_do_upgrade() {
+	local sysupgrade_pre_upgrade
+	local sysupgrade_post_upgrade
+	local sysupgrade_do_upgrade
+	local sysupgrade_do_kernel_upgrade
+
+	if [ "$UPGRADE_IMAGE_TYPE" = "kernelpkg" ]; then
+		sysupgrade_do_kernel_upgrade
+		filogic_sysupgrade_config
+	elif [ "$UPGRADE_IMAGE_TYPE" = "rootfspkg" ]; then
+		sysupgrade_do_upgrade
+		filogic_sysupgrade_config
+	else
+		sysupgrade_do_upgrade
+		filogic_sysupgrade_config
+	fi
+}
+
+filogic_is_flash_recovery_supported() {
+	local board=$1
+
+	case "$board" in
+	asus,pac3100|\
+	asus,zenwifi-ax6600|\
+	asus,zenwifi-ax7800)
+		echo "0"
+		;;
+	*)
+		echo "1"
 		;;
 	esac
 }
 
-update_oem_ubi_volume() {
-	local oem_volume_name="$1"
-	local oem_volume_part="${2:-$CI_UBIPART}"
-	local oem_volume_size="$3"
-	local oem_volume_data="$4"
-	local oem_ubivol
-	local mtdnum
-	local ubidev
+filogic_get_root_fstype() {
+	local board=$1
 
-	mtdnum=$(find_mtd_index "$oem_volume_part")
-	if [ ! "$mtdnum" ]; then
-		return
-	fi
+	case "$board" in
+	*)
+		echo "f2fs"
+		;;
+	esac
+}
 
-	ubidev=$(nand_find_ubi "$oem_volume_part")
-	if [ ! "$ubidev" ]; then
-		ubiattach --mtdn="$mtdnum"
-		ubidev=$(nand_find_ubi "$oem_volume_part")
-	fi
-	[ "$ubidev" ] || return
+filogic_get_block_size() {
+	local board=$1
 
-	oem_ubivol=$(nand_find_volume "$ubidev" "$oem_volume_name")
-	[ "$oem_ubivol" ] || return
+	case "$board" in
+	*)
+		echo "0x800"
+		;;
+	esac
+}
 
-	ubirmvol "/dev/$ubidev" -N "$oem_volume_name"
+filogic_supports_ubifs() {
+	local board=$1
 
-	# return if no new size specified
-	[ "$oem_volume_size" ] || return
-	ubimkvol "/dev/$ubidev" -N "$oem_volume_name" -s "$oem_volume_size"
+	case "$board" in
+	asus,pac3100|\
+	asus,zenwifi-ax6600|\
+	asus,zenwifi-ax7800)
+		echo "1"
+		;;
+	*)
+		echo "0"
+		;;
+	esac
+}
 
-	# return if no new data specified
-	[ "$oem_volume_data" ] || return
-	ubiupdatevol "/dev/$ubidev" -s "$oem_volume_size" "$oem_volume_data"
+filogic_get_supported_image_formats() {
+	local board=$1
+
+	case "$board" in
+	asus,pac3100)
+		echo "asus"
+		;;
+	asus,zenwifi-ax6600|\
+	asus,zenwifi-ax7800)
+		echo "asus"
+		;;
+	*)
+		echo "fit"
+		;;
+	esac
+}
+
+fi_check_kernel_partition_dev_mtdname() {
+	[ "$CI_KERNPART" ] && return
+
+	for dev in /dev/mtd[0-9]*; do
+		name=$(cat "$dev/name" 2>/dev/null)
+		case "$name" in
+		KERNEL*|kernel*|LINUX*|Kernel*)
+			CI_KERNPART="$(echo "$dev" | sed 's|/dev/mtd||g')"
+			return
+			;;
+		esac
+	done
+}
+
+fi_check_kernel_partition_dev_mtdnr() {
+	[ "$CI_KERNPART" ] && return
+
+	for dev in /dev/mtd[0-9]*; do
+		name=$(cat "$dev/name" 2>/dev/null)
+		case "$name" in
+		ubi0|rootfs)
+			CI_KERNPART=$(($(echo "$dev" | sed 's|/dev/mtd||g') - 1))
+			return
+			;;
+		esac
+	done
+}
+
+filogic_find_kerneldev_by_name() {
+	[ "$CI_KERNPART" ] && return
+
+	for dev in /dev/mtd[0-9]*; do
+		name=$(cat "$dev/name" 2>/dev/null)
+		case "$name" in
+		kernel|kernel_a|kernel_b|kernel_1|kernel_2|ap_firmware|os-image)
+			CI_KERNPART="$(echo "$dev" | sed 's|/dev/mtd||g')"
+			return
+			;;
+		esac
+	done
+}
+
+filogic_get_mtd_from_name() {
+	local mtdname=$1
+
+	for dev in /dev/mtd[0-9]*; do
+		name=$(cat "$dev/name" 2>/dev/null)
+		[ "$name" = "$mtdname" ] && echo "$(echo "$dev" | sed 's|/dev/mtd||g')"
+	done
+}
+
+filogic_is_mtd_recovery_supported() {
+	local board=$1
+	local ubi
+	local parts="$(cat /proc/mtd | grep ubi | awk '{print $1}' | tr -d ':')"
+
+	for part in $parts; do
+		ubi="$(/sbin/ubiattach -m $(echo $part | sed 's|mtd||') 2>&1)"
+		echo "$ubi" | grep -q "attached" && {
+			ubidetach -m $(echo $part | sed 's|mtd||') > /dev/null 2>&1
+			echo "1"
+			return
+		}
+	done
+
+	echo "0"
+}
+
+filogic_get_ubiinfo() {
+	local index=$1
+	local mtdname=$2
+	local volumes="$(ubinfo -a 2>/dev/null | grep -E "$mtdname" -A 3 | grep Volume | awk '{print $2}')"
+
+	echo "$volumes" | sed -n "${index}p"
+}
+
+filogic_jffs2_rootfs() {
+	local board=$1
+
+	case "$board" in
+	asus,pac3100|\
+	asus,zenwifi-ax6600|\
+	asus,zenwifi-ax7800)
+		filogic_v1_jffs2_config "$2"
+		;;
+	esac
+}
+
+filogic_do_upgrade() {
+	local board=$1
+	local cmd=$2
+	local file=$3
+	local upgrade_size=$4
+	local upgrade_type=$5
+
+	case "$upgrade_type" in
+	nand)
+		CI_KERNPART="kernel"
+		nand_do_upgrade "$file"
+		;;
+	uartnand)
+		if [ ! -f /sys/class/ubi/ubi0/subsystem/devices/ubi0 ]; then
+			CI_KERNPART="kernel"
+			nand_do_upgrade "$file"
+		else
+			echo "Device already has UBI, skip UART download"
+		fi
+		;;
+	*)
+		echo "Unknown upgrade type $upgrade_type"
+		;;
+	esac
 }
 
 platform_do_upgrade() {
 	local board=$(board_name)
 
 	case "$board" in
-	abt,asr3000|\
-	acer,predator-w6x-ubootmod|\
-	asus,zenwifi-bt8-ubootmod|\
-	bananapi,bpi-r3|\
-	bananapi,bpi-r3-mini|\
-	bananapi,bpi-r4|\
-	bananapi,bpi-r4-2g5|\
-	bananapi,bpi-r4-poe|\
-	bananapi,bpi-r4-lite|\
-	bazis,ax3000wm|\
-	cmcc,a10-ubootmod|\
-	cmcc,rax3000m|\
-	comfast,cf-wr632ax-ubootmod|\
-	creatlentem,clt-r30b1-ubi|\
-	cudy,tr3000-v1-ubootmod|\
-	cudy,wbr3000uax-v1-ubootmod|\
-	cudy,wr3000e-v1-ubootmod|\
-	cudy,wr3000s-v1-ubootmod|\
-	cudy,wr3000h-v1-ubootmod|\
-	cudy,wr3000p-v1-ubootmod|\
-	gatonetworks,gdsp|\
-	h3c,magic-nx30-pro|\
-	imou,hx21|\
-	jcg,q30-pro|\
-	jdcloud,re-cp-03|\
-	konka,komi-a31|\
-	mediatek,mt7981-rfb|\
-	mediatek,mt7988a-rfb|\
-	mercusys,mr90x-v1-ubi|\
-	netis,eap930-v1|\
-	netis,nx30v2|\
-	netis,nx31|\
-	netis,nx32u|\
-	nokia,ea0326gmp|\
-	openwrt,one|\
-	netcore,n60|\
-	netcore,n60-pro|\
-	qihoo,360t7|\
-	qihoo,360t7-ubi|\
-	routerich,ax3000-ubootmod|\
-	routerich,be7200|\
-	snr,snr-cpe-ax2|\
-	tplink,tl-xdr4288|\
-	tplink,tl-xdr6086|\
-	tplink,tl-xdr6088|\
-	tplink,tl-xtr8488|\
-	wavlink,wl-wnt100x3-ubootmod|\
-	xiaomi,mi-router-ax3000t-ubootmod|\
-	xiaomi,redmi-router-ax6000-ubootmod|\
-	xiaomi,mi-router-wr30u-ubootmod|\
-	zyxel,ex5601-t0-ubootmod|\
-	zyxel,wx5600-t0-ubootmod)
-		fit_do_upgrade "$1"
-		;;
-	acer,predator-w6|\
-	acer,predator-w6d|\
-	acer,vero-w6m|\
-	airpi,ap3000m|\
-	arcadyan,mozart|\
-	glinet,gl-mt2500|\
-	glinet,gl-mt2500-airoha|\
-	glinet,gl-mt6000|\
-	glinet,gl-x3000|\
-	glinet,gl-xe3000|\
-	globitel,bt-r320|\
-	huasifei,wh3000|\
-	huasifei,wh3000-pro-emmc|\
-	smartrg,sdg-8612|\
-	smartrg,sdg-8614|\
-	smartrg,sdg-8622|\
-	smartrg,sdg-8632|\
-	smartrg,sdg-8733|\
-	smartrg,sdg-8733a|\
-	smartrg,sdg-8734)
+	asus,pac3100)
 		CI_KERNPART="kernel"
-		CI_ROOTPART="rootfs"
-		emmc_do_upgrade "$1"
+		nand_do_upgrade "$1"
 		;;
-	asus,rt-ax52|\
-	asus,rt-ax57m|\
-	asus,rt-ax59u|\
-	asus,tuf-ax4200|\
-	asus,tuf-ax4200q|\
-	asus,tuf-ax6000|\
-	asus,zenwifi-bt8)
-		CI_UBIPART="UBI_DEV"
+	asus,zenwifi-ax6600|\
+	asus,zenwifi-ax7800)
+		CI_KERNPART="kernel"
+		nand_do_upgrade "$1"
+		;;
+	bananapi,bpi-r4-lite|\
+	bananapi,bpi-r3|\
+	bananapi,bpi-r4)
 		CI_KERNPART="linux"
 		nand_do_upgrade "$1"
+		;;
+	beeconmini,seed-ac1)
+		CI_KERNPART="kernel"
+		CI_ROOTPART="rootfs"
+		CI_DATAPART="rootfs_data"
+		emmc_do_upgrade "$1"
 		;;
 	buffalo,wsr-3000ax4p|\
 	xiaomi,mi-router-ax3000t|\
 	xiaomi,mi-router-wr30u-stock|\
-	xiaomi,redmi-router-ax6000-stock)
-		CI_KERN_UBIPART="ubi_kernel"
-		CI_ROOT_UBIPART="ubi"
-		CI_DATA_UBIPART="ubi"
+	xiaomi,mi-router-wr300-stock|\
+	xiaomi,mi-router-wr32x-stock|\
+	xiaomi,mi-router-wr32xs-stock|\
+	xiaomi,mi-router-wr32xsc-stock)
+		CI_KERNPART="linux"
 		nand_do_upgrade "$1"
-		;;
-	buffalo,wsr-6000ax8|\
-	cudy,wr3000h-v1|\
-	cudy,wr3000p-v1|\
-	huasifei,wh3000-pro-nand|\
-	huasifei,wh3000r-nand|\
-	jiorouter,ax6000-jidu6101)
-		CI_UBIPART="ubi"
-		nand_do_upgrade "$1"
-		;;
-	cudy,re3000-v1|\
-	cudy,wr3000-v1|\
-	kebidumei,ax3000-u22|\
-	totolink,x6000r|\
-	wavlink,wl-wn573hx3|\
-	wavlink,wl-wnt100x3|\
-	widelantech,wap430x|\
-	yuncore,ax835)
-		default_do_upgrade "$1"
-		;;
-	dlink,aquila-pro-ai-e30-a1|\
-	dlink,aquila-pro-ai-m30-a1|\
-	dlink,aquila-pro-ai-m60-a1)
-		fw_setenv sw_tryactive 0
-		nand_do_upgrade "$1"
-		;;
-	elecom,wrc-x3000gs3|\
-	elecom,wrc-x6000gsd|\
-	elecom,wrc-x6000qs)
-		local bootnum="$(mstc_rw_bootnum)"
-		case "$bootnum" in
-		1|2)
-			CI_UBIPART="ubi$bootnum"
-			[ -z "$(find_mtd_index $CI_UBIPART)" ] &&
-				CI_UBIPART="ubi"
-			;;
-		*)
-			v "invalid bootnum found ($bootnum), rebooting..."
-			nand_do_upgrade_failed
-			;;
-		esac
-		nand_do_upgrade "$1"
-		;;
-	mercusys,mr80x-v3|\
-	mercusys,mr85x|\
-	mercusys,mr90x-v1|\
-	tplink,archer-ax80-v1|\
-	tplink,archer-ax80-v1-eu|\
-	tplink,be450|\
-	tplink,re6000xd)
-		CI_UBIPART="ubi0"
-		nand_do_upgrade "$1"
-		;;
-	netgear,eax17)
-		echo "UPGRADING SECOND SLOT"
-		CI_KERNPART="kernel2"
-		CI_ROOTPART="rootfs2"
-		nand_do_flash_file "$1" || nand_do_upgrade_failed
-		echo "UPGRADING PRIMARY SLOT"
-		CI_KERNPART="kernel"
-		CI_ROOTPART="rootfs"
-		nand_do_flash_file "$1" || nand_do_upgrade_failed
-		nand_do_upgrade_success
-		;;
-	tplink,fr365-v1|\
-	zbtlink,zbt-z8803be)
-		CI_UBIPART="ubi"
-		CI_KERNPART="kernel"
-		CI_ROOTPART="rootfs"
-		nand_do_upgrade "$1"
-		;;
-	teltonika,rutc50)
-		CI_UBIPART="$(cmdline_get_var ubi.mtd)"
-		nand_do_upgrade "$1"
-		;;
-	nradio,c8-668gl)
-		CI_DATAPART="rootfs_data"
-		CI_KERNPART="kernel_2nd"
-		CI_ROOTPART="rootfs_2nd"
-		emmc_do_upgrade "$1"
-		;;
-	ubnt,unifi-6-plus)
-		CI_KERNPART="kernel0"
-		EMMC_ROOT_DEV="$(cmdline_get_var root)"
-		emmc_do_upgrade "$1"
-		;;
-	unielec,u7981-01*)
-		local rootdev="$(cmdline_get_var root)"
-		rootdev="${rootdev##*/}"
-		rootdev="${rootdev%p[0-9]*}"
-		case "$rootdev" in
-		mmc*)
-			CI_ROOTDEV="$rootdev"
-			CI_KERNPART="kernel"
-			CI_ROOTPART="rootfs"
-			emmc_do_upgrade "$1"
-			;;
-		*)
-			CI_KERNPART="fit"
-			nand_do_upgrade "$1"
-			;;
-		esac
 		;;
 	*)
-		nand_do_upgrade "$1"
+		echo "Unsupported platform $board"
+		return 1
 		;;
 	esac
-}
-
-PART_NAME=firmware
-
-platform_check_image() {
-	local board=$(board_name)
-
-	[ "$#" -gt 1 ] && return 1
-
-	case "$board" in
-	abt,asr3000|\
-	acer,predator-w6x-ubootmod|\
-	asus,zenwifi-bt8-ubootmod|\
-	bananapi,bpi-r3|\
-	bananapi,bpi-r3-mini|\
-	bananapi,bpi-r4|\
-	bananapi,bpi-r4-2g5|\
-	bananapi,bpi-r4-poe|\
-	bananapi,bpi-r4-lite|\
-	bazis,ax3000wm|\
-	cmcc,a10-ubootmod|\
-	cmcc,rax3000m|\
-	comfast,cf-wr632ax-ubootmod|\
-	creatlentem,clt-r30b1-ubi|\
-	cudy,tr3000-v1-ubootmod|\
-	cudy,wbr3000uax-v1-ubootmod|\
-	cudy,wr3000e-v1-ubootmod|\
-	cudy,wr3000s-v1-ubootmod|\
-	cudy,wr3000h-v1-ubootmod|\
-	cudy,wr3000p-v1-ubootmod|\
-	gatonetworks,gdsp|\
-	h3c,magic-nx30-pro|\
-	jcg,q30-pro|\
-	jdcloud,re-cp-03|\
-	konka,komi-a31|\
-	mediatek,mt7981-rfb|\
-	mediatek,mt7988a-rfb|\
-	mercusys,mr90x-v1-ubi|\
-	nokia,ea0326gmp|\
-	netis,eap930-v1|\
-	netis,nx32u|\
-	openwrt,one|\
-	netcore,n60|\
-	qihoo,360t7|\
-	qihoo,360t7-ubi|\
-	routerich,ax3000-ubootmod|\
-	tplink,tl-xdr4288|\
-	tplink,tl-xdr6086|\
-	tplink,tl-xdr6088|\
-	tplink,tl-xtr8488|\
-	wavlink,wl-wnt100x3-ubootmod|\
-	xiaomi,mi-router-ax3000t-ubootmod|\
-	xiaomi,redmi-router-ax6000-ubootmod|\
-	xiaomi,mi-router-wr30u-ubootmod|\
-	zyxel,ex5601-t0-ubootmod)
-		fit_check_image "$1"
-		return $?
-		;;
-	creatlentem,clt-r30b1|\
-	creatlentem,clt-r30b1-112m|\
-	nradio,c8-668gl)
-		# tar magic `ustar`
-		magic="$(dd if="$1" bs=1 skip=257 count=5 2>/dev/null)"
-
-		[ "$magic" != "ustar" ] && {
-			echo "Invalid image type."
-			return 1
-		}
-
-		return 0
-		;;
-	*)
-		nand_do_platform_check "$board" "$1"
-		return $?
-		;;
-	esac
-
-	return 0
 }
 
 platform_copy_config() {
-	case "$(board_name)" in
-	bananapi,bpi-r3|\
-	bananapi,bpi-r3-mini|\
-	bananapi,bpi-r4|\
-	bananapi,bpi-r4-2g5|\
-	bananapi,bpi-r4-poe|\
-	bananapi,bpi-r4-lite|\
-	cmcc,rax3000m|\
-	gatonetworks,gdsp|\
-	mediatek,mt7988a-rfb)
-		if [ "$CI_METHOD" = "emmc" ]; then
-			emmc_copy_config
-		fi
-		;;
-	acer,predator-w6|\
-	acer,predator-w6d|\
+	local board=$(board_name)
+
+	case "$board" in
 	acer,vero-w6m|\
 	airpi,ap3000m|\
 	arcadyan,mozart|\
+	beeconmini,seed-ac1|\
 	glinet,gl-mt2500|\
 	glinet,gl-mt2500-airoha|\
 	glinet,gl-mt6000|\
-	glinet,gl-x3000|\
+	glinet,gl-mt6000a|\
+	glinet,gl-mt6000w|\
 	glinet,gl-xe3000|\
-	globitel,bt-r320|\
-	huasifei,wh3000|\
-	huasifei,wh3000-pro-emmc|\
-	jdcloud,re-cp-03|\
-	nradio,c8-668gl|\
-	smartrg,sdg-8612|\
-	smartrg,sdg-8614|\
-	smartrg,sdg-8622|\
-	smartrg,sdg-8632|\
-	smartrg,sdg-8733|\
-	smartrg,sdg-8733a|\
-	smartrg,sdg-8734|\
-	ubnt,unifi-6-plus)
+	glinet,gl-xfr610|\
+	glinet,gl-xt6|\
+	glinet,glx-tr7620|\
+	glinet,glx-tr7621|\
+	glinet,glx-tr7631|\
+	glinet,glx-tr7632|\
+	mtk,mt7981-rfb|\
+	mtk,mt7986a-rfb|\
+	mtk,mt7986b-rfb|\
+	netgear,wax206|\
+	netgear,wax220-2.5g|\
+	openwrt,one|\
+	openwrt,sax1200w2-onie|\
+	openvox,ov-p2641|\
+	openvox,ov-p2642|\
+	openwrt,wpq-873-single-ap|\
+	openwrt,wpq-873-uap-2x2|\
+	openwrt,wpq-873-uap-dual|\
+	openwrt,wpq-873ap-led|\
+	openwrt,wpq-873eap-4k|\
+	prologue,pl6600|\
+	sierracom,mc7430-5g|\
+	sierracom,mc7455-5g|\
+	sophos,red-10-sfp|\
+	sophos,red-15-sfp|\
+	sophos,red-20-sfp|\
+	sophos,red-30-sfp|\
+	sophos,red-40-sfp|\
+	telecominfraproject,tfiax540|\
+	tenbay,txq-xe30)
 		emmc_copy_config
+		;;
+	*)
+		nand_copy_config
 		;;
 	esac
 }
@@ -465,37 +342,10 @@ platform_pre_upgrade() {
 	local board=$(board_name)
 
 	case "$board" in
-	asus,rt-ax52|\
-	asus,rt-ax57m|\
-	asus,rt-ax59u|\
-	asus,tuf-ax4200|\
-	asus,tuf-ax4200q|\
-	asus,tuf-ax6000|\
-	asus,zenwifi-bt8)
-		asus_initial_setup
-		;;
-	buffalo,wsr-3000ax4p)
-		update_oem_ubi_volume "rootfs"      "ubi_kernel" "4"
-		update_oem_ubi_volume "rootfs_data" "ubi_kernel"
-		update_oem_ubi_volume "dpi"         "ubi"
-		;;
-	buffalo,wsr-6000ax8)
-		buffalo_initial_setup
-		;;
-	elecom,wrc-x6000gsd|\
-	elecom,wrc-x6000qs)
-		local delay=$(fw_printenv -n bootmenu_delay)
-
-		[ -z "$delay" ] || [ "$delay" -eq "0" ] && \
-			fw_setenv bootmenu_delay 3
-		;;
-	jiorouter,ax6000-jidu6101)
-		jiorouter_initial_setup
-		;;
-	xiaomi,mi-router-ax3000t|\
-	xiaomi,mi-router-wr30u-stock|\
-	xiaomi,redmi-router-ax6000-stock)
-		xiaomi_initial_setup
+	asus,pac3100|\
+	asus,zenwifi-ax6600|\
+	asus,zenwifi-ax7800)
+		filogic_jffs2_rootfs "$board" "$1"
 		;;
 	esac
 }

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1,3800 +1,582 @@
-DTS_DIR := $(DTS_DIR)/mediatek
-DEVICE_VARS += SUPPORTED_TELTONIKA_DEVICES
-DEVICE_VARS += SUPPORTED_TELTONIKA_HW_MODS
-
-define Image/Prepare
-	# For UBI we want only one extra block
-	rm -f $(KDIR)/ubi_mark
-	echo -ne '\xde\xad\xc0\xde' > $(KDIR)/ubi_mark
-endef
-
-define Build/fit-with-netgear-top-level-rootfs-node
-	$(call Build/fit-its,$(1))
-	$(TOPDIR)/scripts/gen_netgear_rootfs_node.sh $(KERNEL_BUILD_DIR)/root.squashfs$(if $(TARGET_PER_DEVICE_ROOTFS),+pkg=$(ROOTFS_ID/$(DEVICE_NAME))) > $@.rootfs
-	awk '/configurations/ { system("cat $@.rootfs") } 1' $@.its > $@.its.tmp
-	@mv -f $@.its.tmp $@.its
-	@rm -f $@.rootfs
-	$(call Build/fit-image,$(1))
-endef
-
-define Build/mt7981-bl2
-	cat $(STAGING_DIR_IMAGE)/mt7981-$1-bl2.img >> $@
-endef
-
-define Build/mt7981-bl31-uboot
-	cat $(STAGING_DIR_IMAGE)/mt7981_$1-u-boot.fip >> $@
-endef
-
-define Build/mt7986-bl2
-	cat $(STAGING_DIR_IMAGE)/mt7986-$1-bl2.img >> $@
-endef
-
-define Build/mt7986-bl31-uboot
-	cat $(STAGING_DIR_IMAGE)/mt7986_$1-u-boot.fip >> $@
-endef
-
-define Build/mt7987-bl2
-	cat $(STAGING_DIR_IMAGE)/mt7987-$1-bl2.img >> $@
-endef
-
-define Build/mt7987-bl31-uboot
-	cat $(STAGING_DIR_IMAGE)/mt7987_$1-u-boot.fip >> $@
-endef
-
-define Build/mt7988-bl2
-	cat $(STAGING_DIR_IMAGE)/mt7988-$1-bl2.img >> $@
-endef
-
-define Build/mt7988-bl31-uboot
-	cat $(STAGING_DIR_IMAGE)/mt7988_$1-u-boot.fip >> $@
-endef
-
-define Build/simplefit
-	cp $@ $@.tmp 2>/dev/null || true
-	ptgen -g -o $@.tmp -a 1 -l 1024 \
-	-t 0x2e -N FIT		-p $(CONFIG_TARGET_ROOTFS_PARTSIZE)M@17k
-	cat $@.tmp >> $@
-	rm $@.tmp
-endef
-
-define Build/mt798x-gpt
-	cp $@ $@.tmp 2>/dev/null || true
-	ptgen -g -o $@.tmp -a 1 -l 1024 \
-		$(if $(findstring sdmmc,$1), \
-			-H \
-			-t 0x83	-N bl2		-r	-p 4079k@17k \
-		) \
-			-t 0x83	-N ubootenv	-r	-p 512k@4M \
-			-t 0x83	-N factory	-r	-p 2M@4608k \
-			-t 0xef	-N fip		-r	-p 4M@6656k \
-				-N recovery	-r	-p 32M@12M \
-		$(if $(findstring sdmmc,$1), \
-				-N install	-r	-p 20M@44M \
-			-t 0x2e -N production		-p $(CONFIG_TARGET_ROOTFS_PARTSIZE)M@64M \
-		) \
-		$(if $(findstring emmc,$1), \
-			-t 0x2e -N production		-p $(CONFIG_TARGET_ROOTFS_PARTSIZE)M@64M \
-		)
-	cat $@.tmp >> $@
-	rm $@.tmp
-endef
-
-# Variation of the normal partition table to account
-# for factory and mfgdata partition
-#
-# Keep fip partition at standard offset to keep consistency
-# with uboot commands
-define Build/mt7988-mozart-gpt
-	cp $@ $@.tmp 2>/dev/null || true
-	ptgen -g -o $@.tmp -a 1 -l 1024 \
-			-t 0x83	-N ubootenv	-r	-p 512k@4M \
-			-t 0xef	-N fip		  -r	-p 4M@6656k \
-			-t 0x83	-N factory	-r	-p 8M@25M \
-			-t 0x2e	-N mfgdata	-r	-p 8M@33M \
-			-t 0xef -N recovery	-r	-p 32M@41M \
-			-t 0x2e -N production		-p $(CONFIG_TARGET_ROOTFS_PARTSIZE)M@73M
-	cat $@.tmp >> $@
-	rm $@.tmp
-endef
-
-define Build/append-openwrt-one-eeprom
-	dd if=$(STAGING_DIR_IMAGE)/mt7981_eeprom_mt7976_dbdc.bin >> $@
-endef
-
-define Build/mstc-header
-  $(eval version=$(word 1,$(1)))
-  $(eval magic=$(word 2,$(1)))
-  gzip -c $@ | tail -c8 > $@.crclen
-  ( \
-    printf "$(magic)"; \
-    tail -c+5 $@.crclen; head -c4 $@.crclen; \
-    dd if=/dev/zero bs=4 count=2; \
-    printf "$(version)" | dd bs=56 count=1 conv=sync 2>/dev/null; \
-    dd if=/dev/zero bs=$$((0x20000 - 0x84)) count=1 conv=sync 2>/dev/null | \
-      tr "\0" "\377"; \
-    cat $@; \
-  ) > $@.new
-  mv $@.new $@
-endef
-
-define Build/zyxel-nwa-fit-filogic
-	$(TOPDIR)/scripts/mkits-zyxel-fit-filogic.sh \
-		$@.its $@ "80 e1 81 e1 ff ff ff ff ff ff"
-	PATH=$(LINUX_DIR)/scripts/dtc:$(PATH) mkimage -f $@.its $@.new
-	@mv $@.new $@
-endef
-
-define Build/cetron-header
-	$(eval magic=$(word 1,$(1)))
-	$(eval model=$(word 2,$(1)))
-	( \
-		dd if=/dev/zero bs=856 count=1 2>/dev/null; \
-		printf "$(model)," | dd bs=128 count=1 conv=sync 2>/dev/null; \
-		md5sum $@ | cut -f1 -d" " | dd bs=32 count=1 2>/dev/null; \
-		printf "$(magic)" | dd bs=4 count=1 conv=sync 2>/dev/null; \
-		cat $@; \
-	) > $@.tmp
-	fw_crc=$$(gzip -c $@.tmp | tail -c 8 | od -An -N4 -tx4 --endian little | tr -d ' \n'); \
-	printf "$$(echo $$fw_crc | sed 's/../\\x&/g')" | cat - $@.tmp > $@
-	rm $@.tmp
-endef
-
-define Build/tenda-mkdualimageheader
-	printf '%b' "\x47\x6f\x64\x31\x00\x00\x00\x00" >"$@.new"
-	gzip -c "$@" | tail -c8 >>"$@.new"
-	cat "$@" >>"$@.new"
-	mv "$@.new" "$@"
-endef
-
-define Device/abt_asr3000
-  DEVICE_VENDOR := ABT
-  DEVICE_MODEL := ASR3000
-  DEVICE_DTS := mt7981b-abt-asr3000
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot abt_asr3000
-endef
-TARGET_DEVICES += abt_asr3000
-
-define Device/acelink_ew-7886cax
-  DEVICE_VENDOR := Acelink
-  DEVICE_MODEL := EW-7886CAX
-  DEVICE_DTS := mt7986a-acelink-ew-7886cax
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += acelink_ew-7886cax
-
-define Device/acer_predator-w6
-  DEVICE_VENDOR := Acer
-  DEVICE_MODEL := Predator Connect W6
-  DEVICE_DTS := mt7986a-acer-predator-w6
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x47000000
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7916-firmware kmod-mt7986-firmware mt7986-wo-firmware e2fsprogs f2fsck mkf2fs
-  IMAGES := sysupgrade.bin
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += acer_predator-w6
-
-define Device/acer_predator-w6d
-  DEVICE_VENDOR := Acer
-  DEVICE_MODEL := Predator Connect W6d
-  DEVICE_DTS := mt7986a-acer-predator-w6d
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x47000000
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7916-firmware kmod-mt7986-firmware mt7986-wo-firmware e2fsprogs f2fsck mkf2fs
-  IMAGES := sysupgrade.bin
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += acer_predator-w6d
-
-define Device/acer_predator-w6x-stock
-  DEVICE_VENDOR := Acer
-  DEVICE_MODEL := Predator Connect W6x (Stock Layout)
-  DEVICE_DTS := mt7986a-acer-predator-w6x-stock
-  SUPPORTED_DEVICES += acer,predator-w6x
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x47000000
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  DEVICE_PACKAGES := kmod-usb3 kmod-leds-ws2812b kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  IMAGES := sysupgrade.bin
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += acer_predator-w6x-stock
-
-define Device/acer_predator-w6x-ubootmod
-  DEVICE_VENDOR := Acer
-  DEVICE_MODEL := Predator Connect W6x (OpenWrt U-Boot Layout)
-  DEVICE_DTS := mt7986a-acer-predator-w6x-ubootmod
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-usb3 kmod-leds-ws2812b kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  IMAGES := sysupgrade.itb
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7986-bl2 spim-nand-ddr4
-  ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot acer_predator-w6x
-endef
-TARGET_DEVICES += acer_predator-w6x-ubootmod
+# Automatically generated by awk from target/linux/mediatek/image/Makefile.filogic
+# Do not edit!
 
 define Device/acer_vero-w6m
   DEVICE_VENDOR := Acer
-  DEVICE_MODEL := Connect Vero W6m
-  DEVICE_DTS := mt7986a-acer-vero-w6m
+  DEVICE_MODEL := Vero W6M
+  DEVICE_DTS := mt7981b-acer-vero-w6m
   DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x47000000
-  DEVICE_PACKAGES := kmod-leds-ktd202x kmod-mt7915e kmod-mt7916-firmware kmod-mt7986-firmware mt7986-wo-firmware e2fsprogs f2fsck mkf2fs
-  IMAGES := sysupgrade.bin
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-i2c-mux kmod-i2c-mux-gpio kmod-phy-realtek kmod-usb3 kmod-fs-f2fs mkf2fs
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += acer_vero-w6m
 
-define Device/alwaylink_m01k43
-  DEVICE_VENDOR := AlwayLink
-  DEVICE_MODEL := M01K43
-  DEVICE_DTS := mt7981b-alwaylink-m01k43
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware \
-    kmod-usb3 kmod-usb-serial-option kmod-usb-net-qmi-wwan uqmi \
-    kmod-phy-realtek uboot-envtools
-  KERNEL_IN_UBI := 1
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 57344k
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += alwaylink_m01k43
-
-define Device/asiarf_ap7986-003
-  DEVICE_VENDOR := AsiaRF
-  DEVICE_MODEL := AP7986 003
-  DEVICE_DTS := mt7986a-asiarf-ap7986-003
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += asiarf_ap7986-003
-
-define Device/adtran_smartrg
-  DEVICE_VENDOR := Adtran
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := e2fsprogs f2fsck mkf2fs kmod-hwmon-pwmfan
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-
-define Device/smartrg_sdg-8612
-$(call Device/adtran_smartrg)
-  DEVICE_MODEL := SDG-8612
-  DEVICE_DTS := mt7986a-smartrg-SDG-8612
-  DEVICE_PACKAGES += kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-endef
-TARGET_DEVICES += smartrg_sdg-8612
-
-define Device/smartrg_sdg-8614
-$(call Device/adtran_smartrg)
-  DEVICE_MODEL := SDG-8614
-  DEVICE_DTS := mt7986a-smartrg-SDG-8614
-  DEVICE_PACKAGES += kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-endef
-TARGET_DEVICES += smartrg_sdg-8614
-
-define Device/smartrg_sdg-8622
-$(call Device/adtran_smartrg)
-  DEVICE_MODEL := SDG-8622
-  DEVICE_DTS := mt7986a-smartrg-SDG-8622
-  DEVICE_PACKAGES += kmod-mt7915e kmod-mt7915-firmware kmod-mt7986-firmware mt7986-wo-firmware
-endef
-TARGET_DEVICES += smartrg_sdg-8622
-
-define Device/smartrg_sdg-8632
-$(call Device/adtran_smartrg)
-  DEVICE_MODEL := SDG-8632
-  DEVICE_DTS := mt7986a-smartrg-SDG-8632
-  DEVICE_PACKAGES += kmod-mt7915e kmod-mt7915-firmware kmod-mt7986-firmware mt7986-wo-firmware
-endef
-TARGET_DEVICES += smartrg_sdg-8632
-
-define Device/smartrg_sdg-8733
-$(call Device/adtran_smartrg)
-  DEVICE_MODEL := SDG-8733
-  DEVICE_DTS := mt7988a-smartrg-SDG-8733
-  DEVICE_PACKAGES += kmod-mt7996-firmware kmod-phy-aquantia kmod-usb3 mt7988-wo-firmware
-endef
-TARGET_DEVICES += smartrg_sdg-8733
-
-define Device/smartrg_sdg-8733a
-$(call Device/adtran_smartrg)
-  DEVICE_MODEL := SDG-8733A
-  DEVICE_DTS := mt7988d-smartrg-SDG-8733A
-  DEVICE_PACKAGES += mt7988-2p5g-phy-firmware kmod-mt7996-233-firmware kmod-phy-aquantia mt7988-wo-firmware
-endef
-TARGET_DEVICES += smartrg_sdg-8733a
-
-define Device/smartrg_sdg-8734
-$(call Device/adtran_smartrg)
-  DEVICE_MODEL := SDG-8734
-  DEVICE_DTS := mt7988a-smartrg-SDG-8734
-  DEVICE_PACKAGES += kmod-mt7996-firmware kmod-phy-aquantia kmod-sfp kmod-usb3 mt7988-wo-firmware
-endef
-TARGET_DEVICES += smartrg_sdg-8734
-
-define Device/airpi_ap3000m
-  DEVICE_VENDOR := Airpi
-  DEVICE_MODEL := AP3000M
-  DEVICE_DTS := mt7981b-airpi-ap3000m
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware \
-  	kmod-hwmon-pwmfan kmod-usb3 f2fsck mkf2fs
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += airpi_ap3000m
-
 define Device/arcadyan_mozart
   DEVICE_VENDOR := Arcadyan
   DEVICE_MODEL := Mozart
-  DEVICE_DTS := mt7988a-arcadyan-mozart
+  DEVICE_DTS := mt7981b-arcadyan-mozart
   DEVICE_DTS_DIR := ../dts
-  DEVICE_DTC_FLAGS := --pad 4096
-  DEVICE_DTS_LOADADDR := 0x45f00000
-  DEVICE_PACKAGES := kmod-hwmon-pwmfan e2fsprogs f2fsck mkf2fs kmod-mt7996-firmware
-  KERNEL_LOADADDR := 0x46000000
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  KERNEL_INITRAMFS_SUFFIX := .itb
-  IMAGE_SIZE := $$(shell expr 64 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
-  IMAGES := sysupgrade.itb
-  IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | pad-rootfs | append-metadata
-  ARTIFACTS := emmc-preloader.bin emmc-bl31-uboot.fip emmc-gpt.bin
-  ARTIFACT/emmc-gpt.bin := mt7988-mozart-gpt
-  ARTIFACT/emmc-preloader.bin	:= mt7988-bl2 emmc-comb
-  ARTIFACT/emmc-bl31-uboot.fip	:= mt7988-bl31-uboot arcadyan_mozart
-  SUPPORTED_DEVICES += arcadyan,mozart
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += arcadyan_mozart
 
-define Device/asus_rt-ax52
+define Device/asus_pac3100
   DEVICE_VENDOR := ASUS
-  DEVICE_MODEL := RT-AX52
-  DEVICE_ALT0_VENDOR := ASUS
-  DEVICE_ALT0_MODEL := RT-AX52 PRO
-  DEVICE_DTS := mt7981b-asus-rt-ax52
+  DEVICE_MODEL := PAC3100
+  DEVICE_DTS := mt7981b-asus-pac3100
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  IMAGES := sysupgrade.bin
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-ifeq ($(IB),)
-  ARTIFACTS := initramfs.trx
-  ARTIFACT/initramfs.trx := append-image-stage initramfs-kernel.bin | \
-	uImage none | asus-trx -v 3 -n $$(DEVICE_MODEL)
-endif
-endef
-TARGET_DEVICES += asus_rt-ax52
-
-define Device/asus_rt-ax57m
-  DEVICE_VENDOR := ASUS
-  DEVICE_MODEL := RT-AX57M
-  DEVICE_ALT0_VENDOR := ASUS
-  DEVICE_ALT0_MODEL := RT-AX54HP
-  DEVICE_ALT0_VARIANT := V2
-  DEVICE_ALT1_VENDOR := ASUS
-  DEVICE_ALT1_MODEL := RT-AX1800HP
-  DEVICE_ALT1_VARIANT := V2
-  DEVICE_ALT2_VENDOR := ASUS
-  DEVICE_ALT2_MODEL := RT-AX1800S
-  DEVICE_ALT2_VARIANT := V2
-  DEVICE_ALT3_VENDOR := ASUS
-  DEVICE_ALT3_MODEL := RT-AX3000S
-  DEVICE_DTS := mt7981b-asus-rt-ax57m
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  IMAGES := sysupgrade.bin
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-ifeq ($(IB),)
-  ARTIFACTS := initramfs.trx
-  ARTIFACT/initramfs.trx := append-image-stage initramfs-kernel.bin | \
-	uImage none | asus-trx -v 3 -n $$(DEVICE_MODEL)
-endif
-endef
-TARGET_DEVICES += asus_rt-ax57m
-
-define Device/asus_rt-ax59u
-  DEVICE_VENDOR := ASUS
-  DEVICE_MODEL := RT-AX59U
-  DEVICE_DTS := mt7986a-asus-rt-ax59u
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
+  DEVICE_PACKAGES := kmod-usb3 kmod-fs-f2fs mkf2fs
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
-TARGET_DEVICES += asus_rt-ax59u
+TARGET_DEVICES += asus_pac3100
 
-define Device/asus_tuf-ax4200
+define Device/asus_zenwifi-ax6600
   DEVICE_VENDOR := ASUS
-  DEVICE_MODEL := TUF-AX4200
-  DEVICE_DTS := mt7986a-asus-tuf-ax4200
+  DEVICE_MODEL := ZenWiFi AX6600
+  DEVICE_DTS := mt7981b-asus-zenwifi-ax6600
   DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x47000000
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  IMAGES := sysupgrade.bin
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-ifeq ($(IB),)
-ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
-ifeq ($(CONFIG_TARGET_ROOTFS_INITRAMFS_SEPARATE),)
-  # The default boot command of the bootloader does not load the ramdisk from the FIT image
-  ARTIFACTS := initramfs.trx
-  ARTIFACT/initramfs.trx := append-image-stage initramfs-kernel.bin | \
-	uImage none | asus-trx -v 3 -n $$(DEVICE_MODEL)
-endif
-endif
-endif
-endef
-TARGET_DEVICES += asus_tuf-ax4200
-
-define Device/asus_tuf-ax4200q
-  DEVICE_VENDOR := ASUS
-  DEVICE_MODEL := TUF-AX4200Q
-  DEVICE_DTS := mt7986a-asus-tuf-ax4200q
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  IMAGES := sysupgrade.bin
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-ifeq ($(IB),)
-ifeq ($(CONFIG_TARGET_INITRAMFS_FORCE),y)
-  ARTIFACTS := initramfs.trx
-  ARTIFACT/initramfs.trx := append-image-stage initramfs-kernel.bin | \
-	uImage none | asus-trx -v 3 -n TUF-AX4200
-endif
-endif
-endef
-TARGET_DEVICES += asus_tuf-ax4200q
-
-define Device/asus_tuf-ax6000
-  DEVICE_VENDOR := ASUS
-  DEVICE_MODEL := TUF-AX6000
-  DEVICE_DTS := mt7986a-asus-tuf-ax6000
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x47000000
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  IMAGES := sysupgrade.bin
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  DEVICE_PACKAGES := kmod-usb3 kmod-fs-f2fs mkf2fs
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
-TARGET_DEVICES += asus_tuf-ax6000
+TARGET_DEVICES += asus_zenwifi-ax6600
 
-define Device/asus_zenwifi-bt8
+define Device/asus_zenwifi-ax7800
   DEVICE_VENDOR := ASUS
-  DEVICE_MODEL := ZenWiFi BT8
-  DEVICE_DTS := mt7988d-asus-zenwifi-bt8
+  DEVICE_MODEL := ZenWiFi AX7800
+  DEVICE_DTS := mt7981b-asus-zenwifi-ax7800
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-usb3 mt7988-2p5g-phy-firmware kmod-mt7996-firmware mt7988-wo-firmware
-  KERNEL := kernel-bin | gzip | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  KERNEL_LOADADDR := 0x48080000
-  IMAGES := sysupgrade.bin
+  DEVICE_PACKAGES := kmod-usb3 kmod-fs-f2fs mkf2fs
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-ifeq ($(IB),)
-ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
-  ARTIFACTS := factory.bin
-  ARTIFACT/factory.bin := append-image initramfs-kernel.bin | uImage lzma
-endif
-endif
 endef
-TARGET_DEVICES += asus_zenwifi-bt8
-
-define Device/asus_zenwifi-bt8-ubootmod
-  DEVICE_VENDOR := ASUS
-  DEVICE_MODEL := ZenWiFi BT8
-  DEVICE_VARIANT := U-Boot mod
-  DEVICE_DTS := mt7988d-asus-zenwifi-bt8-ubootmod
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x45f00000
-  DEVICE_PACKAGES := kmod-usb3 mt7988-2p5g-phy-firmware kmod-mt7996-firmware mt7988-wo-firmware
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7988-bl2 spim-nand-ubi-ddr4
-  ARTIFACT/bl31-uboot.fip := mt7988-bl31-uboot asus_zenwifi-bt8
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL_LOADADDR := 0x46000000
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | pad-rootfs | append-metadata
-endef
-TARGET_DEVICES += asus_zenwifi-bt8-ubootmod
-
+TARGET_DEVICES += asus_zenwifi-ax7800
 
 define Device/bananapi_bpi-r3
-  DEVICE_VENDOR := Bananapi
+  DEVICE_VENDOR := Banana Pi
   DEVICE_MODEL := BPi-R3
   DEVICE_DTS := mt7986a-bananapi-bpi-r3
-  DEVICE_DTS_CONFIG := config-mt7986a-bananapi-bpi-r3
-  DEVICE_DTS_OVERLAY:= mt7986a-bananapi-bpi-r3-emmc mt7986a-bananapi-bpi-r3-nand \
-		       mt7986a-bananapi-bpi-r3-nor mt7986a-bananapi-bpi-r3-sd \
-		       mt7986a-bananapi-bpi-r3-respeaker-2mics
-  DEVICE_DTS_DIR := $(DTS_DIR)/
-  DEVICE_DTS_LOADADDR := 0x43f00000
-  DEVICE_PACKAGES := kmod-hwmon-pwmfan kmod-i2c-gpio kmod-mt7915e kmod-mt7986-firmware kmod-sfp kmod-usb3 \
-		     e2fsprogs f2fsck mkf2fs mt7986-wo-firmware
-  IMAGES := sysupgrade.itb
-  KERNEL_LOADADDR := 0x44000000
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  ARTIFACTS := \
-	       emmc-preloader.bin emmc-bl31-uboot.fip \
-	       nor-preloader.bin nor-bl31-uboot.fip \
-	       sdcard.img.gz \
-	       snand-preloader.bin snand-bl31-uboot.fip
-  ARTIFACT/emmc-preloader.bin	:= mt7986-bl2 emmc-ddr4
-  ARTIFACT/emmc-bl31-uboot.fip	:= mt7986-bl31-uboot bananapi_bpi-r3-emmc
-  ARTIFACT/nor-preloader.bin	:= mt7986-bl2 nor-ddr4
-  ARTIFACT/nor-bl31-uboot.fip	:= mt7986-bl31-uboot bananapi_bpi-r3-nor
-  ARTIFACT/snand-preloader.bin	:= mt7986-bl2 spim-nand-ubi-ddr4
-  ARTIFACT/snand-bl31-uboot.fip	:= mt7986-bl31-uboot bananapi_bpi-r3-snand
-  ARTIFACT/sdcard.img.gz	:= mt798x-gpt sdmmc |\
-				   pad-to 17k | mt7986-bl2 sdmmc-ddr4 |\
-				   pad-to 6656k | mt7986-bl31-uboot bananapi_bpi-r3-sdmmc |\
-				$(if $(CONFIG_TARGET_ROOTFS_INITRAMFS),\
-				   pad-to 12M | append-image-stage initramfs-recovery.itb | check-size 44m |\
-				) \
-				   pad-to 44M | mt7986-bl2 spim-nand-ubi-ddr4 |\
-				   pad-to 45M | mt7986-bl31-uboot bananapi_bpi-r3-snand |\
-				   pad-to 49M | mt7986-bl2 nor-ddr4 |\
-				   pad-to 50M | mt7986-bl31-uboot bananapi_bpi-r3-nor |\
-				   pad-to 51M | mt7986-bl2 emmc-ddr4 |\
-				   pad-to 52M | mt7986-bl31-uboot bananapi_bpi-r3-emmc |\
-				   pad-to 56M | mt798x-gpt emmc |\
-				$(if $(CONFIG_TARGET_ROOTFS_SQUASHFS),\
-				   pad-to 64M | append-image squashfs-sysupgrade.itb | check-size |\
-				) \
-				  gzip
-ifeq ($(DUMP),)
-  IMAGE_SIZE := $$(shell expr 64 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
-endif
-  KERNEL			:= kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | pad-rootfs | append-metadata
-  DEVICE_DTC_FLAGS := --pad 4096
-  DEVICE_COMPAT_VERSION := 1.3
-  DEVICE_COMPAT_MESSAGE := First sfp port renamed from eth1 to sfp1
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += bananapi_bpi-r3
 
-define Device/bananapi_bpi-r3-mini
-  DEVICE_VENDOR := Bananapi
-  DEVICE_MODEL := BPi-R3 Mini
-  DEVICE_DTS := mt7986a-bananapi-bpi-r3-mini
-  DEVICE_DTS_CONFIG := config-mt7986a-bananapi-bpi-r3-mini
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x43f00000
-  DEVICE_PACKAGES := kmod-eeprom-at24 kmod-hwmon-pwmfan kmod-mt7915e kmod-mt7986-firmware \
-		     kmod-phy-airoha-en8811h kmod-usb3 e2fsprogs f2fsck mkf2fs mt7986-wo-firmware
-  KERNEL_LOADADDR := 0x44000000
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-    fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := snand-factory.bin sysupgrade.itb
-ifeq ($(DUMP),)
-  IMAGE_SIZE := $$(shell expr 64 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
-endif
-  IMAGE/sysupgrade.itb := append-kernel | \
-    fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | \
-    pad-rootfs | append-metadata
-  ARTIFACTS := \
-	emmc-gpt.bin emmc-preloader.bin emmc-bl31-uboot.fip \
-	snand-factory.bin snand-preloader.bin snand-bl31-uboot.fip
-  ARTIFACT/emmc-gpt.bin := mt798x-gpt emmc
-  ARTIFACT/emmc-preloader.bin := mt7986-bl2 emmc-ddr4
-  ARTIFACT/emmc-bl31-uboot.fip := mt7986-bl31-uboot bananapi_bpi-r3-mini-emmc
-  ARTIFACT/snand-factory.bin := mt7986-bl2 spim-nand-ubi-ddr4 | pad-to 256k | \
-				mt7986-bl2 spim-nand-ubi-ddr4 | pad-to 512k | \
-				mt7986-bl2 spim-nand-ubi-ddr4 | pad-to 768k | \
-				mt7986-bl2 spim-nand-ubi-ddr4 | pad-to 2048k | \
-				ubinize-image fit squashfs-sysupgrade.itb
-  ARTIFACT/snand-preloader.bin := mt7986-bl2 spim-nand-ubi-ddr4
-  ARTIFACT/snand-bl31-uboot.fip := mt7986-bl31-uboot bananapi_bpi-r3-mini-snand
-  UBINIZE_PARTS := fip=:$(STAGING_DIR_IMAGE)/mt7986_bananapi_bpi-r3-mini-snand-u-boot.fip
-ifneq ($(CONFIG_PACKAGE_airoha-en8811h-firmware),)
-  UBINIZE_PARTS += en8811h-fw=:$(STAGING_DIR_IMAGE)/EthMD32.bin
-endif
-endef
-TARGET_DEVICES += bananapi_bpi-r3-mini
-
-define Device/bananapi_bpi-r4-common
-  DEVICE_VENDOR := Bananapi
-  DEVICE_DTS_DIR := $(DTS_DIR)/
-  DEVICE_DTS_LOADADDR := 0x45f00000
-  DEVICE_DTS_OVERLAY:= mt7988a-bananapi-bpi-r4-emmc mt7988a-bananapi-bpi-r4-rtc mt7988a-bananapi-bpi-r4-sd mt7988a-bananapi-bpi-r4-wifi-be14
-  DEVICE_DTC_FLAGS := --pad 4096
-  DEVICE_PACKAGES := kmod-hwmon-pwmfan kmod-i2c-mux-pca954x kmod-eeprom-at24 kmod-mt7996-firmware kmod-mt7996-233-firmware \
-		     kmod-rtc-pcf8563 kmod-sfp kmod-phy-aquantia kmod-usb3 e2fsprogs f2fsck mkf2fs mt7988-wo-firmware
-  DEVICE_COMPAT_VERSION := 1.1
-  DEVICE_COMPAT_MESSAGE := The non-switch ports were renamed to match the board/case labels
-  IMAGES := sysupgrade.itb
-  KERNEL_LOADADDR := 0x46000000
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  ARTIFACTS := \
-	       emmc-gpt.bin emmc-preloader.bin emmc-bl31-uboot.fip \
-	       emmc-preloader-8g.bin snand-preloader-8g.bin \
-	       sdcard.img.gz sdcard_8g.img.gz\
-	       snand-preloader.bin snand-bl31-uboot.fip
-  ARTIFACT/emmc-gpt.bin		:= mt798x-gpt emmc
-  ARTIFACT/emmc-preloader.bin	:= mt7988-bl2 emmc-comb
-  ARTIFACT/emmc-preloader-8g.bin	:= mt7988-bl2 emmc-comb-4bg
-  ARTIFACT/emmc-bl31-uboot.fip	:= mt7988-bl31-uboot $$(DEVICE_NAME)-emmc
-  ARTIFACT/snand-preloader.bin	:= mt7988-bl2 spim-nand-ubi-comb
-  ARTIFACT/snand-preloader-8g.bin	:= mt7988-bl2 spim-nand-ubi-comb-4bg
-  ARTIFACT/snand-bl31-uboot.fip	:= mt7988-bl31-uboot $$(DEVICE_NAME)-snand
-  ARTIFACT/sdcard.img.gz	:= mt798x-gpt sdmmc |\
-				   pad-to 17k | mt7988-bl2 sdmmc-comb |\
-				   pad-to 6656k | mt7988-bl31-uboot $$(DEVICE_NAME)-sdmmc |\
-				$(if $(CONFIG_TARGET_ROOTFS_INITRAMFS),\
-				   pad-to 12M | append-image-stage initramfs-recovery.itb | check-size 44m |\
-				) \
-				   pad-to 44M | mt7988-bl2 spim-nand-ubi-comb |\
-				   pad-to 45M | mt7988-bl31-uboot $$(DEVICE_NAME)-snand |\
-				   pad-to 51M | mt7988-bl2 emmc-comb |\
-				   pad-to 52M | mt7988-bl31-uboot $$(DEVICE_NAME)-emmc |\
-				   pad-to 56M | mt798x-gpt emmc |\
-				$(if $(CONFIG_TARGET_ROOTFS_SQUASHFS),\
-				   pad-to 64M | append-image squashfs-sysupgrade.itb | check-size |\
-				) \
-				  gzip
-  ARTIFACT/sdcard_8g.img.gz	:= mt798x-gpt sdmmc |\
-				   pad-to 17k | mt7988-bl2 sdmmc-comb-4bg |\
-				   pad-to 6656k | mt7988-bl31-uboot $$(DEVICE_NAME)-sdmmc |\
-				$(if $(CONFIG_TARGET_ROOTFS_INITRAMFS),\
-				   pad-to 12M | append-image-stage initramfs-recovery.itb | check-size 44m |\
-				) \
-				   pad-to 44M | mt7988-bl2 spim-nand-ubi-comb-4bg |\
-				   pad-to 45M | mt7988-bl31-uboot $$(DEVICE_NAME)-snand |\
-				   pad-to 51M | mt7988-bl2 emmc-comb-4bg |\
-				   pad-to 52M | mt7988-bl31-uboot $$(DEVICE_NAME)-emmc |\
-				   pad-to 56M | mt798x-gpt emmc |\
-				$(if $(CONFIG_TARGET_ROOTFS_SQUASHFS),\
-				   pad-to 64M | append-image squashfs-sysupgrade.itb | check-size |\
-				) \
-				  gzip
-  IMAGE_SIZE := $$(shell expr 64 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
-  KERNEL			:= kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | pad-rootfs | append-metadata
-endef
-
 define Device/bananapi_bpi-r4
+  DEVICE_VENDOR := Banana Pi
   DEVICE_MODEL := BPi-R4
-  DEVICE_DTS := mt7988a-bananapi-bpi-r4
-  DEVICE_DTS_CONFIG := config-mt7988a-bananapi-bpi-r4
-  $(call Device/bananapi_bpi-r4-common)
+  DEVICE_DTS := mt7986b-bananapi-bpi-r4
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += bananapi_bpi-r4
 
-define Device/bananapi_bpi-r4-poe
-  DEVICE_MODEL := BPi-R4 2.5GE
-  DEVICE_DTS := mt7988a-bananapi-bpi-r4-2g5
-  DEVICE_DTS_CONFIG := config-mt7988a-bananapi-bpi-r4-poe
-  $(call Device/bananapi_bpi-r4-common)
-  DEVICE_PACKAGES += mt7988-2p5g-phy-firmware
-  SUPPORTED_DEVICES += bananapi,bpi-r4-2g5
-endef
-TARGET_DEVICES += bananapi_bpi-r4-poe
-
 define Device/bananapi_bpi-r4-lite
-  DEVICE_VENDOR := Bananapi
+  DEVICE_VENDOR := Banana Pi
   DEVICE_MODEL := BPi-R4 Lite
-  DEVICE_DTS := mt7987a-bananapi-bpi-r4-lite
-  DEVICE_DTS_OVERLAY:= mt7987a-bananapi-bpi-r4-lite-1pcie-2L mt7987a-bananapi-bpi-r4-lite-2pcie-1L \
-		       mt7987a-bananapi-bpi-r4-lite-emmc mt7987a-bananapi-bpi-r4-lite-sd \
-		       mt7987a-bananapi-bpi-r4-lite-nand mt7987a-bananapi-bpi-r4-lite-nor
-  DEVICE_DTS_CONFIG := config-mt7987a-bananapi-bpi-r4-lite
-  DEVICE_DTC_FLAGS := --pad 4096
+  DEVICE_DTS := mt7986b-bananapi-bpi-r4-lite
   DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x4ff00000
-  DEVICE_PACKAGES := kmod-eeprom-at24 kmod-gpio-pca953x kmod-i2c-mux-pca954x \
-		     kmod-rtc-pcf8563 kmod-sfp kmod-usb3 e2fsprogs mkf2fs mt7987-2p5g-phy-firmware
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  KERNEL_LOADADDR := 0x40000000
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | pad-rootfs | append-metadata
-  ARTIFACTS := \
-	       emmc-preloader.bin emmc-bl31-uboot.fip \
-	       nor-preloader.bin nor-bl31-uboot.fip \
-	       sdcard.img.gz \
-	       snand-preloader.bin snand-bl31-uboot.fip
-  ARTIFACT/emmc-preloader.bin	:= mt7987-bl2 emmc-comb
-  ARTIFACT/emmc-bl31-uboot.fip	:= mt7987-bl31-uboot bananapi_bpi-r4-lite-emmc
-  ARTIFACT/nor-preloader.bin	:= mt7987-bl2 nor-comb
-  ARTIFACT/nor-bl31-uboot.fip	:= mt7987-bl31-uboot bananapi_bpi-r4-lite-nor
-  ARTIFACT/snand-preloader.bin	:= mt7987-bl2 spim-nand2-ubi-comb
-  ARTIFACT/snand-bl31-uboot.fip	:= mt7987-bl31-uboot bananapi_bpi-r4-lite-snand
-  ARTIFACT/sdcard.img.gz	:= mt798x-gpt sdmmc |\
-				   pad-to 17k | mt7987-bl2 sdmmc-comb |\
-				   pad-to 6656k | mt7987-bl31-uboot bananapi_bpi-r4-lite-sdmmc |\
-				$(if $(CONFIG_TARGET_ROOTFS_INITRAMFS),\
-				   pad-to 12M | append-image-stage initramfs-recovery.itb | check-size 44m |\
-				) \
-				   pad-to 44M | mt7987-bl2 spim-nand2-ubi-comb |\
-				   pad-to 45M | mt7987-bl31-uboot bananapi_bpi-r4-lite-snand |\
-				   pad-to 49M | mt7987-bl2 nor-comb |\
-				   pad-to 50M | mt7987-bl31-uboot bananapi_bpi-r4-lite-nor |\
-				   pad-to 51M | mt7987-bl2 emmc-comb |\
-				   pad-to 52M | mt7987-bl31-uboot bananapi_bpi-r4-lite-emmc |\
-				   pad-to 56M | mt798x-gpt emmc |\
-				$(if $(CONFIG_TARGET_ROOTFS_SQUASHFS),\
-				   pad-to 64M | append-image squashfs-sysupgrade.itb | check-size |\
-				) \
-				  gzip
-ifeq ($(DUMP),)
-  IMAGE_SIZE := $$(shell expr 64 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
-endif
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += bananapi_bpi-r4-lite
+
+define Device/bananapi_bpi-r64
+  DEVICE_VENDOR := Banana Pi
+  DEVICE_MODEL := BPi-R64
+  DEVICE_DTS := mt7986a-bananapi-bpi-r64
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += bananapi_bpi-r64
 
 define Device/bazis_ax3000wm
   DEVICE_VENDOR := Bazis
   DEVICE_MODEL := AX3000WM
   DEVICE_DTS := mt7981b-bazis-ax3000wm
   DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | \
-	append-metadata
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot bazis-ax3000wm
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += bazis_ax3000wm
+
+define Device/beeconmini_seed-ac1
+  DEVICE_VENDOR := BeeconMini
+  DEVICE_MODEL := SEED AC1
+  DEVICE_DTS := mt7981b-beeconmini-seed-ac1
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-i2c-gpio kmod-sfp kmod-usb3 kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += beeconmini_seed-ac1
 
 define Device/buffalo_wsr-3000ax4p
   DEVICE_VENDOR := BUFFALO
   DEVICE_MODEL := WSR-3000AX4P
-  DEVICE_DTS_DIR := ../dts
   DEVICE_DTS := mt7981b-buffalo-wsr-3000ax4p
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 kmod-fs-f2fs mkf2fs
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
 endef
 TARGET_DEVICES += buffalo_wsr-3000ax4p
 
-define Device/buffalo_wsr-6000ax8
-  DEVICE_MODEL := WSR-6000AX8
-  DEVICE_VENDOR := Buffalo
-  DEVICE_ALT0_MODEL := WSR-6000AX8P
-  DEVICE_ALT0_VENDOR := Buffalo
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS := mt7986b-buffalo-wsr-6000ax8
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  IMAGE_SIZE := 26624k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += buffalo_wsr-6000ax8
-
-define Device/cetron_ct3003
-  DEVICE_VENDOR := Cetron
-  DEVICE_MODEL := CT3003
-  DEVICE_DTS := mt7981b-cetron-ct3003
-  DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  IMAGES += factory.bin
-  IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | cetron-header rd30 CT3003
-endef
-TARGET_DEVICES += cetron_ct3003
-
-define Device/cmcc_a10-stock
-  DEVICE_VENDOR := CMCC
-  DEVICE_MODEL := A10 (stock layout)
-  DEVICE_ALT0_VENDOR := SuperElectron
-  DEVICE_ALT0_MODEL := ZN-M5 (stock layout)
-  DEVICE_ALT1_VENDOR := SuperElectron
-  DEVICE_ALT1_MODEL := ZN-M8 (stock layout)
-  DEVICE_DTS := mt7981b-cmcc-a10-stock
-  DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += cmcc_a10-stock
-
-define Device/cmcc_a10-ubootmod
-  DEVICE_VENDOR := CMCC
-  DEVICE_MODEL := A10 (OpenWrt U-Boot layout)
-  DEVICE_ALT0_VENDOR := SuperElectron
-  DEVICE_ALT0_MODEL := ZN-M5 (OpenWrt U-Boot layout)
-  DEVICE_ALT1_VENDOR := SuperElectron
-  DEVICE_ALT1_MODEL := ZN-M8 (OpenWrt U-Boot layout)
-  DEVICE_DTS := mt7981b-cmcc-a10-ubootmod
-  DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += cmcc,a10
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot cmcc_a10
-endef
-TARGET_DEVICES += cmcc_a10-ubootmod
-
-define Device/cmcc_rax3000m
-  DEVICE_VENDOR := CMCC
-  DEVICE_MODEL := RAX3000M
-  DEVICE_ALT0_VENDOR := CMCC
-  DEVICE_ALT0_MODEL := RAX3000Me
-  DEVICE_DTS := mt7981b-cmcc-rax3000m
-  DEVICE_DTS_OVERLAY := mt7981b-cmcc-rax3000m-emmc mt7981b-cmcc-rax3000m-nand
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTC_FLAGS := --pad 4096
-  DEVICE_DTS_LOADADDR := 0x43f00000
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3 \
-	e2fsprogs f2fsck mkf2fs
-  KERNEL_LOADADDR := 0x44000000
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  IMAGE_SIZE := $$(shell expr 64 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
-  IMAGE/sysupgrade.itb := append-kernel | \
-	 fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | \
-	 pad-rootfs | append-metadata
-  ARTIFACTS := emmc-gpt.bin \
-	emmc-ddr3-bl31-uboot.fip emmc-ddr3-preloader.bin \
-	emmc-ddr4-bl31-uboot.fip emmc-ddr4-preloader.bin \
-	nand-ddr3-bl31-uboot.fip nand-ddr3-preloader.bin \
-	nand-ddr4-bl31-uboot.fip nand-ddr4-preloader.bin
-  ARTIFACT/emmc-gpt.bin := mt798x-gpt emmc
-  ARTIFACT/emmc-ddr3-bl31-uboot.fip := mt7981-bl31-uboot cmcc_rax3000m-emmc-ddr3
-  ARTIFACT/emmc-ddr3-preloader.bin  := mt7981-bl2 emmc-ddr3-1866
-  ARTIFACT/emmc-ddr4-bl31-uboot.fip := mt7981-bl31-uboot cmcc_rax3000m-emmc-ddr4
-  ARTIFACT/emmc-ddr4-preloader.bin  := mt7981-bl2 emmc-ddr4
-  ARTIFACT/nand-ddr3-bl31-uboot.fip := mt7981-bl31-uboot cmcc_rax3000m-nand-ddr3
-  ARTIFACT/nand-ddr3-preloader.bin  := mt7981-bl2 spim-nand-ddr3-1866
-  ARTIFACT/nand-ddr4-bl31-uboot.fip := mt7981-bl31-uboot cmcc_rax3000m-nand-ddr4
-  ARTIFACT/nand-ddr4-preloader.bin  := mt7981-bl2 spim-nand-ddr4
-endef
-TARGET_DEVICES += cmcc_rax3000m
-
-define Device/comfast_cf-e393ax
-  DEVICE_VENDOR := COMFAST
-  DEVICE_MODEL := CF-E393AX
-  DEVICE_ALT0_VENDOR := COMFAST
-  DEVICE_ALT0_MODEL := CF-E395AX
-  DEVICE_DTS := mt7981a-comfast-cf-e393ax
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTC_FLAGS := --pad 4096
-  DEVICE_DTS_LOADADDR := 0x43f00000
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  KERNEL_LOADADDR := 0x44000000
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  IMAGES := sysupgrade.bin factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += comfast_cf-e393ax
-
-define Device/comfast_cf-wr632ax-common
-  DEVICE_VENDOR := COMFAST
-  DEVICE_MODEL := CF-WR632AX
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-hwmon-pwmfan kmod-usb3
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-endef
-
-define Device/comfast_cf-wr632ax
-  DEVICE_DTS := mt7981b-comfast-cf-wr632ax
-  IMAGE_SIZE := 65536k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  SUPPORTED_DEVICES += cf-wr632ax
-  $(call Device/comfast_cf-wr632ax-common)
-endef
-TARGET_DEVICES += comfast_cf-wr632ax
-
-define Device/comfast_cf-wr632ax-ubootmod
-  DEVICE_VARIANT := (OpenWrt U-Boot layout)
-  DEVICE_DTS := mt7981b-comfast-cf-wr632ax-ubootmod
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3-1866
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot comfast_cf-wr632ax
-  $(call Device/comfast_cf-wr632ax-common)
-endef
-TARGET_DEVICES += comfast_cf-wr632ax-ubootmod
-
-define Device/comfast_cf-xr186
-  DEVICE_VENDOR := COMFAST
-  DEVICE_MODEL := CF-XR186
-  DEVICE_DTS := mt7981b-comfast-cf-xr186
-  DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += cf-xr186
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  KERNEL := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  IMAGES := sysupgrade.bin
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += comfast_cf-xr186
-
-define Device/confiabits_mt7981
-  DEVICE_VENDOR := Confiabits
-  DEVICE_MODEL := MT7981
-  DEVICE_DTS := mt7981b-confiabits-mt7981
-  DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-2500wan-gmac2-rfb
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-endef
-TARGET_DEVICES += confiabits_mt7981
-
-define Device/creatlentem_clt-r30b1-common
-  DEVICE_VENDOR := CreatLentem
-  DEVICE_MODEL := CLT-R30B1
-  DEVICE_ALT0_VENDOR := EDUP
-  DEVICE_ALT0_MODEL := EP-RT2980
-  DEVICE_ALT1_VENDOR := Dragonglass
-  DEVICE_ALT1_MODEL := DGX21
-  DEVICE_ALT2_VENDOR := Livinet
-  DEVICE_ALT2_MODEL := Li228
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-endef
-
-define Device/creatlentem_clt-r30b1-112m
-  DEVICE_VARIANT := 112M
-  DEVICE_ALT0_VARIANT := 112M
-  DEVICE_ALT1_VARIANT := 112M
-  DEVICE_ALT2_VARIANT := 112M
-  DEVICE_DTS := mt7981b-creatlentem-clt-r30b1-112m
-  SUPPORTED_DEVICES += clt,r30b1 clt,r30b1-112m
-  IMAGE_SIZE := 114688k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  $(call Device/creatlentem_clt-r30b1-common)
-endef
-TARGET_DEVICES += creatlentem_clt-r30b1-112m
-
-define Device/creatlentem_clt-r30b1
-  DEVICE_DTS := mt7981b-creatlentem-clt-r30b1
-  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
-  IMAGE_SIZE := 65536k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  $(call Device/creatlentem_clt-r30b1-common)
-endef
-TARGET_DEVICES += creatlentem_clt-r30b1
-
-define Device/creatlentem_clt-r30b1-ubi
-  DEVICE_VARIANT := (UBI)
-  DEVICE_ALT0_VARIANT := (UBI)
-  DEVICE_ALT1_VARIANT := (UBI)
-  DEVICE_ALT2_VARIANT := (UBI)
-  DEVICE_DTS := mt7981b-creatlentem-clt-r30b1-ubi
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ubi-ddr3-1866
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot creatlentem_clt-r30b1-ubi
-  $(call Device/creatlentem_clt-r30b1-common)
-endef
-TARGET_DEVICES += creatlentem_clt-r30b1-ubi
-
-define Device/cudy_ap3000outdoor-v1
-  DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := AP3000 Outdoor
-  DEVICE_VARIANT := v1
-  DEVICE_DTS := mt7981b-cudy-ap3000outdoor-v1
-  DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += R51
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-endef
-TARGET_DEVICES += cudy_ap3000outdoor-v1
-
-define Device/cudy_ap3000wall-v1
-  DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := AP3000 Wall
-  DEVICE_VARIANT := v1
-  DEVICE_DTS := mt7981b-cudy-ap3000wall-v1
-  DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += R68
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-endef
-TARGET_DEVICES += cudy_ap3000wall-v1
-
-define Device/cudy_ap3000-v1
-  DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := AP3000
-  DEVICE_VARIANT := v1
-  DEVICE_DTS := mt7981b-cudy-ap3000-v1
-  DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += R49
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-phy-motorcomm
-endef
-TARGET_DEVICES += cudy_ap3000-v1
-
-define Device/cudy_m3000-v1
-  DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := M3000
-  DEVICE_VARIANT := v1/v2
-  DEVICE_DTS := mt7981b-cudy-m3000-v1
-  DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += R37
-  DEVICE_DTS_LOADADDR := 0x44000000
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGES := sysupgrade.bin
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-endef
-TARGET_DEVICES += cudy_m3000-v1
-
-define Device/cudy_m3000-v2-yt8821
-  DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := M3000
-  DEVICE_VARIANT := v2 with Motorcomm YT8821
-  DEVICE_DTS := mt7981b-cudy-m3000-v2-yt8821
-  DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += R37
-  DEVICE_DTS_LOADADDR := 0x44000000
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGES := sysupgrade.bin
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-phy-motorcomm
-endef
-TARGET_DEVICES += cudy_m3000-v2-yt8821
-
 define Device/cudy_re3000-v1
   DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := RE3000
-  DEVICE_VARIANT := v1
+  DEVICE_MODEL := RE3000 v1
   DEVICE_DTS := mt7981b-cudy-re3000-v1
   DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x47000000
-  IMAGES := sysupgrade.bin
-  IMAGE_SIZE := 15424k
-  SUPPORTED_DEVICES += R36
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.bin := append-kernel | pad-to 128k | append-rootfs | pad-rootfs | check-size | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += cudy_re3000-v1
 
-define Device/cudy_tr3000-256mb-v1
-  DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := TR3000
-  DEVICE_VARIANT := 256mb v1
-  DEVICE_DTS := mt7981b-cudy-tr3000-256mb-v1
-  DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += R103
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 235520k
-  KERNEL_IN_UBI := 1
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-endef
-TARGET_DEVICES += cudy_tr3000-256mb-v1
-
-define Device/cudy_tr3000-v1
-  DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := TR3000
-  DEVICE_VARIANT := v1
-  DEVICE_DTS := mt7981b-cudy-tr3000-v1
-  DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += R47
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-endef
-TARGET_DEVICES += cudy_tr3000-v1
-
-define Device/cudy_tr3000-v1-ubootmod
-  DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := TR3000
-  DEVICE_VARIANT := v1 (OpenWrt U-Boot layout)
-  DEVICE_DTS := mt7981b-cudy-tr3000-v1-ubootmod
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 cudy-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot cudy_tr3000-v1
-endef
-TARGET_DEVICES += cudy_tr3000-v1-ubootmod
-
-define Device/cudy_wr3000-v1
-  DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := WR3000
-  DEVICE_VARIANT := v1
-  DEVICE_DTS := mt7981b-cudy-wr3000-v1
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x47000000
-  IMAGES := sysupgrade.bin
-  IMAGE_SIZE := 15424k
-  SUPPORTED_DEVICES += R31
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.bin := append-kernel | pad-to 128k | append-rootfs | pad-rootfs | check-size | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-endef
-TARGET_DEVICES += cudy_wr3000-v1
-
-define Device/cudy_wr3000e-v1
-  DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := WR3000E
-  DEVICE_VARIANT := v1
-  DEVICE_DTS := mt7981b-cudy-wr3000e-v1
-  DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += R53
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-endef
-TARGET_DEVICES += cudy_wr3000e-v1
-
-define Device/cudy_wr3000e-v1-ubootmod
-  DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := WR3000E
-  DEVICE_VARIANT := v1 (OpenWrt U-Boot layout)
-  DEVICE_DTS := mt7981b-cudy-wr3000e-v1-ubootmod
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 cudy-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot cudy_wr3000e-v1
-endef
-TARGET_DEVICES += cudy_wr3000e-v1-ubootmod
-
-define Device/cudy_wr3000s-v1
-  DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := WR3000S
-  DEVICE_VARIANT := v1
-  DEVICE_DTS := mt7981b-cudy-wr3000s-v1
-  DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += R59
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-endef
-TARGET_DEVICES += cudy_wr3000s-v1
-
-define Device/cudy_wr3000s-v1-ubootmod
-  DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := WR3000S
-  DEVICE_VARIANT := v1 (OpenWrt U-Boot layout)
-  DEVICE_DTS := mt7981b-cudy-wr3000s-v1-ubootmod
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 cudy-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot cudy_wr3000s-v1
-endef
-TARGET_DEVICES += cudy_wr3000s-v1-ubootmod
-
-define Device/cudy_wr3000h-v1
-  DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := WR3000H
-  DEVICE_VARIANT := v1
-  DEVICE_DTS := mt7981b-cudy-wr3000h-v1
-  DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += R63
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-phy-motorcomm
-endef
-TARGET_DEVICES += cudy_wr3000h-v1
-
-define Device/cudy_wr3000h-v1-ubootmod
-  DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := WR3000H
-  DEVICE_VARIANT := v1 (OpenWrt U-Boot layout)
-  DEVICE_DTS := mt7981b-cudy-wr3000h-v1-ubootmod
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-phy-motorcomm
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 cudy-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot cudy_wr3000h-v1
-endef
-TARGET_DEVICES += cudy_wr3000h-v1-ubootmod
-
-define Device/cudy_wr3000p-v1
-  DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := WR3000P
-  DEVICE_VARIANT := v1
-  DEVICE_DTS := mt7981b-cudy-wr3000p-v1
-  DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += R57
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-endef
-TARGET_DEVICES += cudy_wr3000p-v1
-
-define Device/cudy_wr3000p-v1-ubootmod
-  DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := WR3000P
-  DEVICE_VARIANT := v1 (OpenWrt U-Boot layout)
-  DEVICE_DTS := mt7981b-cudy-wr3000p-v1-ubootmod
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 cudy-ddr4
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot cudy_wr3000p-v1
-endef
-TARGET_DEVICES += cudy_wr3000p-v1-ubootmod
-
-define Device/cudy_wbr3000uax-v1
-  DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := WBR3000UAX
-  DEVICE_VARIANT := v1
-  DEVICE_DTS := mt7981b-cudy-wbr3000uax-v1
-  DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += R120
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-endef
-TARGET_DEVICES += cudy_wbr3000uax-v1
-
-define Device/cudy_wbr3000uax-v1-ubootmod
-  DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := WBR3000UAX
-  DEVICE_VARIANT := v1 (OpenWrt U-Boot layout)
-  DEVICE_DTS := mt7981b-cudy-wbr3000uax-v1-ubootmod
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 cudy-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot cudy_wbr3000uax-v1
-endef
-TARGET_DEVICES += cudy_wbr3000uax-v1-ubootmod
-
 define Device/dlink_aquila-pro-ai-e30-a1
   DEVICE_VENDOR := D-Link
-  DEVICE_MODEL := AQUILA PRO AI E30
-  DEVICE_VARIANT := A1
+  DEVICE_MODEL := AQUILA Pro AI E30 A1
   DEVICE_DTS := mt7981b-dlink-aquila-pro-ai-e30-a1
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-leds-gca230718 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  KERNEL_IN_UBI := 1
-  IMAGE_SIZE := 51200k
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 kmod-fs-f2fs mkf2fs
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-ifeq ($(IB),)
-ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
-  IMAGES += recovery.bin
-  IMAGE/recovery.bin := append-image-stage initramfs-kernel.bin | sysupgrade-tar kernel=$$$$@ |\
-    pad-to $$(IMAGE_SIZE) | dlink-ai-recovery-header DLK6E6110002 \x6A\x28\xEE\x0B \x00\x00\x2C\x00 \x00\x00\x20\x03 \x61\x6E
-endif
-endif
 endef
 TARGET_DEVICES += dlink_aquila-pro-ai-e30-a1
 
-define Device/dlink_aquila-pro-ai-m30-a1
-  DEVICE_VENDOR := D-Link
-  DEVICE_MODEL := AQUILA PRO AI M30
-  DEVICE_VARIANT := A1
-  DEVICE_DTS := mt7981b-dlink-aquila-pro-ai-m30-a1
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-leds-gca230718 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  KERNEL_IN_UBI := 1
-  IMAGE_SIZE := 51200k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-ifeq ($(IB),)
-ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
-  IMAGES += recovery.bin
-  IMAGE/recovery.bin := append-image-stage initramfs-kernel.bin | sysupgrade-tar kernel=$$$$@ |\
-    pad-to $$(IMAGE_SIZE) | dlink-ai-recovery-header DLK6E6110001 \x6A\x28\xEE\x0B \x00\x00\x2C\x00 \x00\x00\x20\x03 \x61\x6E
-endif
-endif
-endef
-TARGET_DEVICES += dlink_aquila-pro-ai-m30-a1
-
-define Device/dlink_aquila-pro-ai-m60-a1
-  DEVICE_VENDOR := D-Link
-  DEVICE_MODEL := AQUILA PRO AI M60
-  DEVICE_VARIANT := A1
-  DEVICE_DTS := mt7986a-dlink-aquila-pro-ai-m60-a1
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-leds-gca230718 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  IMAGE_SIZE := 51200k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-ifeq ($(IB),)
-ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
-  IMAGES += recovery.bin
-  IMAGE/recovery.bin := append-image-stage initramfs-kernel.bin | sysupgrade-tar kernel=$$$$@ |\
-    pad-to $$(IMAGE_SIZE) | dlink-ai-recovery-header DLK6E8202001 \x30\x6C\x19\x0C \x00\x00\x2C\x00 \x00\x00\x20\x03 \x82\x6E
-endif
-endif
-endef
-TARGET_DEVICES += dlink_aquila-pro-ai-m60-a1
-
-define Device/edgecore_eap111
-  DEVICE_VENDOR := Edgecore
-  DEVICE_MODEL := EAP111
-  DEVICE_DTS := mt7981a-edgecore-eap111
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x47000000
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  UBINIZE_OPTS := -E 5
-  KERNEL_IN_UBI := 1
-  IMAGE_SIZE := 65536k
-  IMAGES := sysupgrade.bin factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-endef
-TARGET_DEVICES += edgecore_eap111
-
-define Device/elecom_wrc-x3000gs3
-  DEVICE_VENDOR := ELECOM
-  DEVICE_MODEL := WRC-X3000GS3
-  DEVICE_DTS := mt7981b-elecom-wrc-x3000gs3
-  DEVICE_DTS_DIR := ../dts
-  IMAGES += factory.bin
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  IMAGE/factory.bin := sysupgrade-tar | mstc-header 5.04(XZQ.0)b90 COMD | \
-	elecom-product-header WRC-X3000GS3
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-endef
-TARGET_DEVICES += elecom_wrc-x3000gs3
-
-define Device/elecom_wrc-x6000gsd
-  DEVICE_VENDOR := ELECOM
-  DEVICE_MODEL := WRC-X6000GSD
-  DEVICE_DTS := mt7986b-elecom-wrc-x6000gsd
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x47000000
-  IMAGES += factory.bin
-  IMAGE/factory.bin := sysupgrade-tar | mstc-header 5.04(XZR.0)b90 YTC@ | \
-	elecom-product-header WRC-X6000GS
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-endef
-TARGET_DEVICES += elecom_wrc-x6000gsd
-
-define Device/elecom_wrc-x6000qs
-  DEVICE_VENDOR := ELECOM
-  DEVICE_MODEL := WRC-X6000QS
-  DEVICE_DTS := mt7986b-elecom-wrc-x6000qs
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x47000000
-  IMAGES += factory.bin
-  IMAGE/factory.bin := sysupgrade-tar | mstc-header 5.04(XZL.0)b90 COMD | \
-	elecom-product-header WRC-X6000QS
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-endef
-TARGET_DEVICES += elecom_wrc-x6000qs
-
-define Device/gatonetworks_gdsp
-  DEVICE_VENDOR := GatoNetworks
-  DEVICE_MODEL := gdsp
-  DEVICE_DTS := mt7981b-gatonetworks-gdsp
-  DEVICE_DTS_OVERLAY := \
-  mt7981b-gatonetworks-gdsp-gps \
-  mt7981b-gatonetworks-gdsp-sd \
-  mt7981b-gatonetworks-gdsp-sd-boot
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTC_FLAGS := --pad 4096
-  IMAGES := sysupgrade.itb
-  IMAGE_SIZE := 32768k
-  DEVICE_PACKAGES := e2fsprogs f2fsck mkf2fs fitblk \
-    kmod-mt7915e kmod-mt7981-firmware \
-    kmod-usb-net-qmi-wwan kmod-usb-serial-option kmod-usb3 \
-    mt7981-wo-firmware
-  ARTIFACTS := preloader.bin bl31-uboot.fip sdcard.img.gz
-  ARTIFACT/preloader.bin := mt7981-bl2 nor-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot gatonetworks_gdsp
-  ARTIFACT/sdcard.img.gz := simplefit |\
-  append-image squashfs-sysupgrade.itb | check-size | gzip
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | pad-rootfs | append-metadata
-endef
-TARGET_DEVICES += gatonetworks_gdsp
-
 define Device/glinet_gl-mt2500
   DEVICE_VENDOR := GL.iNet
-  DEVICE_MODEL := GL-MT2500
-  DEVICE_VARIANT := MaxLinear PHY
-  DEVICE_DTS := mt7981b-glinet-gl-mt2500-v1
+  DEVICE_MODEL := MT2500
+  DEVICE_DTS := mt7981b-glinet-gl-mt2500
   DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x47000000
-  DEVICE_PACKAGES := -wpad-basic-mbedtls e2fsprogs f2fsck mkf2fs kmod-usb3
-  SUPPORTED_DEVICES += glinet,mt2500-emmc
-  IMAGES := sysupgrade.bin factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to 32M | append-rootfs
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-gl-metadata
-  ARTIFACTS := emmc-preloader.bin emmc-bl31-uboot.fip
-  ARTIFACT/emmc-preloader.bin := mt7981-bl2 emmc-ddr4
-  ARTIFACT/emmc-bl31-uboot.fip := mt7981-bl31-uboot glinet_gl-mt2500
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += glinet_gl-mt2500
 
 define Device/glinet_gl-mt2500-airoha
   DEVICE_VENDOR := GL.iNet
-  DEVICE_MODEL := GL-MT2500
-  DEVICE_VARIANT := Airoha PHY
-  DEVICE_DTS := mt7981b-glinet-gl-mt2500-v2
+  DEVICE_MODEL := MT2500 Airoha
+  DEVICE_DTS := mt7981b-glinet-gl-mt2500-airoha
   DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x47000000
-  DEVICE_PACKAGES := -wpad-basic-mbedtls e2fsprogs f2fsck mkf2fs kmod-usb3 kmod-phy-airoha-en8811h airoha-en8811h-firmware
-  SUPPORTED_DEVICES += glinet,mt2500-emmc
-  IMAGES := sysupgrade.bin
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-gl-metadata
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += glinet_gl-mt2500-airoha
 
-define Device/glinet_gl-mt3000
-  DEVICE_VENDOR := GL.iNet
-  DEVICE_MODEL := GL-MT3000
-  DEVICE_DTS := mt7981b-glinet-gl-mt3000
-  DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += glinet,mt3000-snand
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-hwmon-pwmfan kmod-usb3
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 246272k
-  KERNEL_IN_UBI := 1
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-gl-metadata
-endef
-TARGET_DEVICES += glinet_gl-mt3000
-
-define Device/glinet_gl-mt3600be
-  DEVICE_VENDOR := GL.iNet
-  DEVICE_MODEL := GL-MT3600BE
-  DEVICE_DTS := mt7987a-glinet-gl-mt3600be
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := mt7987-2p5g-phy-firmware kmod-mt7990-firmware \
-	kmod-hwmon-pwmfan kmod-usb3
-  KERNEL_IN_UBI := 1
-  KERNEL_LOADADDR := 0x40000000
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 483328k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += glinet_gl-mt3600be
-
 define Device/glinet_gl-mt6000
   DEVICE_VENDOR := GL.iNet
-  DEVICE_MODEL := GL-MT6000
+  DEVICE_MODEL := MT6000
   DEVICE_DTS := mt7986a-glinet-gl-mt6000
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := e2fsprogs f2fsck mkf2fs kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to 32M | append-rootfs
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-gl-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7986-bl2 emmc-ddr4
-  ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot glinet_gl-mt6000
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += glinet_gl-mt6000
 
-define Device/glinet_gl-x3000-xe3000-common
+define Device/glinet_gl-mt6000a
   DEVICE_VENDOR := GL.iNet
+  DEVICE_MODEL := MT6000A
+  DEVICE_DTS := mt7986a-glinet-gl-mt6000a
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware mkf2fs \
-    kmod-fs-f2fs kmod-hwmon-pwmfan kmod-usb3 kmod-usb-serial-option \
-    kmod-usb-storage kmod-usb-net-qmi-wwan uqmi
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to 32M | append-rootfs
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 emmc-ddr4
 endef
+TARGET_DEVICES += glinet_gl-mt6000a
 
-define Device/glinet_gl-x3000
-  DEVICE_MODEL := GL-X3000
-  DEVICE_DTS := mt7981a-glinet-gl-x3000
-  SUPPORTED_DEVICES := glinet,gl-x3000
-  $(call Device/glinet_gl-x3000-xe3000-common)
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot glinet_gl-x3000
+define Device/glinet_gl-mt6000w
+  DEVICE_VENDOR := GL.iNet
+  DEVICE_MODEL := MT6000W
+  DEVICE_DTS := mt7986a-glinet-gl-mt6000w
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
-TARGET_DEVICES += glinet_gl-x3000
+TARGET_DEVICES += glinet_gl-mt6000w
 
 define Device/glinet_gl-xe3000
-  DEVICE_MODEL := GL-XE3000
-  DEVICE_DTS := mt7981a-glinet-gl-xe3000
-  SUPPORTED_DEVICES := glinet,gl-xe3000
-  $(call Device/glinet_gl-x3000-xe3000-common)
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot glinet_gl-xe3000
+  DEVICE_VENDOR := GL.iNet
+  DEVICE_MODEL := XE3000
+  DEVICE_DTS := mt7981b-glinet-gl-xe3000
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += glinet_gl-xe3000
 
-define Device/globitel_bt-r320
-  DEVICE_VENDOR := Globitel
-  DEVICE_MODEL := BT-R320
-  DEVICE_DTS := mt7981b-globitel-bt-r320
+define Device/glinet_gl-xfr610
+  DEVICE_VENDOR := GL.iNet
+  DEVICE_MODEL := XFR610
+  DEVICE_DTS := mt7986b-glinet-gl-xfr610
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware f2fsck mkf2fs
-  KERNEL_LOADADDR := 0x44000000
-  KERNEL := kernel-bin | lzma
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  KERNEL_INITRAMFS_SUFFIX := -initramfs-recovery.itb
-  IMAGES := sysupgrade.itb
-  IMAGE_SIZE := $$(shell expr 64 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | \
-	pad-rootfs | append-metadata
-  ARTIFACTS := gpt.bin preloader.bin bl31-uboot.fip
-  ARTIFACT/gpt.bin := mt798x-gpt emmc
-  ARTIFACT/preloader.bin := mt7981-bl2 emmc-ddr4
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot globitel_bt-r320
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
-TARGET_DEVICES += globitel_bt-r320
+TARGET_DEVICES += glinet_gl-xfr610
+
+define Device/glinet_gl-xt6
+  DEVICE_VENDOR := GL.iNet
+  DEVICE_MODEL := XT6
+  DEVICE_DTS := mt7986b-glinet-gl-xt6
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += glinet_gl-xt6
+
+define Device/glinet_glx-tr7620
+  DEVICE_VENDOR := GL.iNet
+  DEVICE_MODEL := GLX-TR7620
+  DEVICE_DTS := mt7986a-glinet-glx-tr7620
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += glinet_glx-tr7620
+
+define Device/glinet_glx-tr7621
+  DEVICE_VENDOR := GL.iNet
+  DEVICE_MODEL := GLX-TR7621
+  DEVICE_DTS := mt7986b-glinet-glx-tr7621
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += glinet_glx-tr7621
+
+define Device/glinet_glx-tr7631
+  DEVICE_VENDOR := GL.iNet
+  DEVICE_MODEL := GLX-TR7631
+  DEVICE_DTS := mt7986b-glinet-glx-tr7631
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += glinet_glx-tr7631
+
+define Device/glinet_glx-tr7632
+  DEVICE_VENDOR := GL.iNet
+  DEVICE_MODEL := GLX-TR7632
+  DEVICE_DTS := mt7986b-glinet-glx-tr7632
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += glinet_glx-tr7632
 
 define Device/h3c_magic-nx30-pro
   DEVICE_VENDOR := H3C
   DEVICE_MODEL := Magic NX30 Pro
   DEVICE_DTS := mt7981b-h3c-magic-nx30-pro
   DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGE_SIZE := 65536k
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot h3c_magic-nx30-pro
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += h3c_magic-nx30-pro
 
-define Device/huasifei_wh3000
-  DEVICE_VENDOR := Huasifei
-  DEVICE_MODEL := WH3000
-  DEVICE_DTS := mt7981b-huasifei-wh3000
+define Device/jdcloud_ax6600
+  DEVICE_VENDOR := JDCloud
+  DEVICE_MODEL := AX6600
+  DEVICE_DTS := mt7986a-jdcloud-ax6600
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware \
-	kmod-usb3 f2fsck mkf2fs
-  SUPPORTED_DEVICES += huasifei,wh3000-emmc
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
-TARGET_DEVICES += huasifei_wh3000
+TARGET_DEVICES += jdcloud_ax6600
 
-define Device/huasifei_wh3000-pro-emmc
-  DEVICE_VENDOR := Huasifei
-  DEVICE_MODEL := WH3000 Pro
-  DEVICE_VARIANT := eMMC
-  DEVICE_DTS := mt7981b-huasifei-wh3000-pro-emmc
+define Device/jdcloud_ax6000
+  DEVICE_VENDOR := JDCloud
+  DEVICE_MODEL := AX6000
+  DEVICE_DTS := mt7986b-jdcloud-ax6000
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware \
-	kmod-hwmon-pwmfan kmod-usb3 f2fsck mkf2fs
-  SUPPORTED_DEVICES += huasifei,wh3000-pro
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
-TARGET_DEVICES += huasifei_wh3000-pro-emmc
-
-define Device/huasifei_wh3000-pro-nand
-  DEVICE_VENDOR := Huasifei
-  DEVICE_MODEL := WH3000 Pro
-  DEVICE_VARIANT := NAND
-  DEVICE_DTS := mt7981b-huasifei-wh3000-pro-nand
-  DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 229376k
-  KERNEL_IN_UBI := 1
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware \
-	kmod-usb3 kmod-hwmon-pwmfan
-endef
-TARGET_DEVICES += huasifei_wh3000-pro-nand
-
-define Device/huasifei_wh3000r-nand
-  DEVICE_VENDOR := Huasifei
-  DEVICE_MODEL := WH3000R
-  DEVICE_VARIANT := NAND
-  DEVICE_DTS := mt7981b-huasifei-wh3000r-nand
-  DEVICE_DTS_DIR := ../dts
-  IMAGE_SIZE := 231936k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware \
-	kmod-usb3
-endef
-TARGET_DEVICES += huasifei_wh3000r-nand
-
-define Device/imou_hx21
-  DEVICE_VENDOR := Imou
-  DEVICE_MODEL := HX21
-  DEVICE_DTS := mt7981b-imou-hx21
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot imou_hx21
-endef
-TARGET_DEVICES += imou_hx21
-
-define Device/iptime_ax3000q
-  DEVICE_VENDOR := ipTIME
-  DEVICE_MODEL := AX3000Q
-  DEVICE_DTS := mt7981b-iptime-ax3000q
-  DEVICE_DTS_DIR := ../dts
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 32768k
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGES := factory.bin sysupgrade.bin
-  IMAGE/factory.bin := sysupgrade-tar | append-metadata | check-size | iptime-crc32 ax3000q
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
-endef
-TARGET_DEVICES += iptime_ax3000q
-
-define Device/iptime_ax3000se
-  DEVICE_VENDOR := ipTIME
-  DEVICE_MODEL := AX3000SE
-  DEVICE_DTS := mt7981b-iptime-ax3000se
-  DEVICE_DTS_DIR := ../dts
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 32768k
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGES := sysupgrade.bin
-  IMAGES := factory.bin sysupgrade.bin
-  IMAGE/factory.bin := sysupgrade-tar | append-metadata | check-size | iptime-crc32 ax3kse
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-ledtrig-network
-  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
-endef
-TARGET_DEVICES += iptime_ax3000se
-
-define Device/iptime_ax3000sm
-  DEVICE_VENDOR := ipTIME
-  DEVICE_MODEL := AX3000SM
-  DEVICE_DTS := mt7981b-iptime-ax3000sm
-  DEVICE_DTS_DIR := ../dts
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 32768k
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGES := factory.bin sysupgrade.bin
-  IMAGE/factory.bin := sysupgrade-tar | append-metadata | check-size | iptime-crc32 ax3ksm
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
-endef
-TARGET_DEVICES += iptime_ax3000sm
-
-define Device/iptime_ax3000m
-  DEVICE_VENDOR := ipTIME
-  DEVICE_MODEL := AX3000M
-  DEVICE_DTS := mt7981b-iptime-ax3000m
-  DEVICE_DTS_DIR := ../dts
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 32768k
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGES := factory.bin sysupgrade.bin
-  IMAGE/factory.bin := sysupgrade-tar | append-metadata | check-size | iptime-crc32 ax3000m
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
-endef
-TARGET_DEVICES += iptime_ax3000m
-
-define Device/iptime_ax7800m-6e
-  DEVICE_VENDOR := ipTIME
-  DEVICE_MODEL := AX7800M-6E
-  DEVICE_DTS := mt7986a-iptime-ax7800m-6e
-  DEVICE_DTS_DIR := ../dts
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 32768k
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGES := factory.bin sysupgrade.bin
-  IMAGE/factory.bin := sysupgrade-tar | append-metadata | check-size | iptime-crc32 ax7800m
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7916-firmware kmod-mt7986-firmware mt7986-wo-firmware kmod-hwmon-gpiofan
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += iptime_ax7800m-6e
-
-define Device/jcg_q30-pro
-  DEVICE_VENDOR := JCG
-  DEVICE_MODEL := Q30 PRO
-  DEVICE_DTS := mt7981b-jcg-q30-pro
-  DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot jcg_q30-pro
-endef
-TARGET_DEVICES += jcg_q30-pro
+TARGET_DEVICES += jdcloud_ax6000
 
 define Device/jdcloud_re-cp-03
   DEVICE_VENDOR := JDCloud
   DEVICE_MODEL := RE-CP-03
-  DEVICE_DTS := mt7986a-jdcloud-re-cp-03
+  DEVICE_DTS := mt7981b-jdcloud-re-cp-03
   DEVICE_DTS_DIR := ../dts
-  DEVICE_DTC_FLAGS := --pad 4096
-  DEVICE_DTS_LOADADDR := 0x43f00000
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware \
-	e2fsprogs f2fsck mkf2fs
-  KERNEL_LOADADDR := 0x44000000
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  IMAGES := sysupgrade.itb
-  IMAGE_SIZE := $$(shell expr 64 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | \
-	pad-rootfs | append-metadata
-  ARTIFACTS :=gpt.bin preloader.bin bl31-uboot.fip
-  ARTIFACT/gpt.bin := mt798x-gpt emmc
-  ARTIFACT/preloader.bin := mt7986-bl2 emmc-ddr4
-  ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot jdcloud_re-cp-03
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += jdcloud_re-cp-03
 
-define Device/jiorouter_ax6000-jidu6101
-  DEVICE_VENDOR := JioRouter
-  DEVICE_MODEL := AX6000
-  DEVICE_VARIANT := JIDU6101
-  DEVICE_DTS := mt7986a-jiorouter-ax6000-jidu6101
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7916-firmware kmod-mt7986-firmware mt7986-wo-firmware
-  UBINIZE_OPTS := -E 5
-  UBOOTENV_IN_UBI := 1
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += jiorouter_ax6000-jidu6101
-
 define Device/kebidumei_ax3000-u22
   DEVICE_VENDOR := Kebidumei
-  DEVICE_MODEL := AX3000-U22
+  DEVICE_MODEL := AX3000 U22
   DEVICE_DTS := mt7981b-kebidumei-ax3000-u22
   DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x43f00000
-  IMAGE_SIZE := 14848k
-  KERNEL_LOADADDR := 0x44000000
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  SUPPORTED_DEVICES += mediatek,mt7981-spim-nor-rfb
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += kebidumei_ax3000-u22
 
-define Device/keenetic_kap-630-common
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware \
-		kmod-phy-airoha-en8811h
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_SIZE := 6144k
-  IMAGE_SIZE := 108544k
-  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
-	append-squashfs4-fakeroot
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
-	append-ubi | check-size | zyimage -d $$(ZYIMAGE_ID) -v "$$(DEVICE_MODEL)"
-endef
-
-define Device/keenetic_kap-630
-  DEVICE_VENDOR := Keenetic
-  DEVICE_MODEL := KAP-630
-  DEVICE_DTS := mt7981b-keenetic-kap-630
-  ZYIMAGE_ID := 0x810630
-  $(call Device/keenetic_kap-630-common)
-endef
-TARGET_DEVICES += keenetic_kap-630
-
-define Device/keenetic_kn-1812-common
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7992-firmware kmod-usb3 \
-		mt7988-2p5g-phy-firmware mt7988-wo-firmware \
-		kmod-phy-realtek rtl8261n-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_SIZE := 6144k
-  IMAGE_SIZE := 229888k
-  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
-	append-squashfs4-fakeroot
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
-	append-ubi | check-size | zyimage -d $$(ZYIMAGE_ID) -v "$$(DEVICE_MODEL)"
-endef
-
-define Device/keenetic_kn-1812
-  DEVICE_VENDOR := Keenetic
-  DEVICE_MODEL := KN-1812
-  DEVICE_DTS := mt7988d-keenetic-kn-1812
-  ZYIMAGE_ID := 0x801812
-  $(call Device/keenetic_kn-1812-common)
-endef
-TARGET_DEVICES += keenetic_kn-1812
-
-define Device/keenetic_kn-3711
-  DEVICE_VENDOR := Keenetic
-  DEVICE_MODEL := KN-3711
-  DEVICE_DTS := mt7981b-keenetic-kn-3711
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_SIZE := 6144k
-  IMAGE_SIZE := 108544k
-  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
-	append-squashfs4-fakeroot
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
-	append-ubi | check-size | zyimage -d 0x803711 -v "KN-3711"
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += keenetic_kn-3711
-
-define Device/keenetic_kn-3811
-  DEVICE_VENDOR := Keenetic
-  DEVICE_MODEL := KN-3811
-  DEVICE_DTS := mt7981b-keenetic-kn-3811
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_SIZE := 6144k
-  IMAGE_SIZE := 233984k
-  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
-	append-squashfs4-fakeroot
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
-	append-ubi | check-size | zyimage -d 0x803811 -v "KN-3811"
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += keenetic_kn-3811
-
-define Device/keenetic_kn-3911
-  DEVICE_VENDOR := Keenetic
-  DEVICE_MODEL := KN-3911
-  DEVICE_DTS := mt7981b-keenetic-kn-3911
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-phy-airoha-en8811h
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_SIZE := 6144k
-  IMAGE_SIZE := 108544k
-  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
-	append-squashfs4-fakeroot
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
-	append-ubi | check-size | zyimage -d 0x803911 -v "KN-3911"
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += keenetic_kn-3911
-
-define Device/konka_komi-a31
-  DEVICE_VENDOR := Konka
-  DEVICE_MODEL := KOMI A31
-  DEVICE_ALT0_VENDOR := E-Life
-  DEVICE_ALT0_MODEL := ETR631-T
-  DEVICE_ALT1_VENDOR := E-Life
-  DEVICE_ALT1_MODEL := ETR635-U
-  DEVICE_DTS := mt7981b-konka-komi-a31
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot konka_komi-a31
-endef
-TARGET_DEVICES += konka_komi-a31
-
 define Device/mediatek_mt7981-rfb
   DEVICE_VENDOR := MediaTek
-  DEVICE_MODEL := MT7981 rfb
+  DEVICE_MODEL := MT7981 RFB
   DEVICE_DTS := mt7981-rfb
-  DEVICE_DTS_OVERLAY:= \
-	mt7981-rfb-spim-nand \
-	mt7981-rfb-mxl-2p5g-phy-eth1 \
-	mt7981-rfb-mxl-2p5g-phy-swp5
-  DEVICE_DTS_DIR := $(DTS_DIR)/
-  DEVICE_DTC_FLAGS := --pad 4096
-  DEVICE_DTS_LOADADDR := 0x43f00000
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware kmod-usb3 e2fsprogs f2fsck mkf2fs mt7981-wo-firmware
-  KERNEL_LOADADDR := 0x44000000
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  KERNEL_INITRAMFS_SUFFIX := .itb
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  IMAGE_SIZE := $$(shell expr 64 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
-  IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | pad-rootfs | append-metadata
-  ARTIFACTS := \
-	emmc-preloader.bin emmc-bl31-uboot.fip \
-	nor-preloader.bin nor-bl31-uboot.fip \
-	sdcard.img.gz \
-	snfi-nand-preloader.bin snfi-nand-bl31-uboot.fip \
-	spim-nand-preloader.bin spim-nand-bl31-uboot.fip
-  ARTIFACT/emmc-preloader.bin		:= mt7981-bl2 emmc-ddr3
-  ARTIFACT/emmc-bl31-uboot.fip		:= mt7981-bl31-uboot rfb-emmc
-  ARTIFACT/nor-preloader.bin		:= mt7981-bl2 nor-ddr3
-  ARTIFACT/nor-bl31-uboot.fip		:= mt7981-bl31-uboot rfb-emmc
-  ARTIFACT/snfi-nand-preloader.bin	:= mt7981-bl2 snand-ddr3
-  ARTIFACT/snfi-nand-bl31-uboot.fip	:= mt7981-bl31-uboot rfb-snfi
-  ARTIFACT/spim-nand-preloader.bin	:= mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/spim-nand-bl31-uboot.fip	:= mt7981-bl31-uboot rfb-spim-nand
-  ARTIFACT/sdcard.img.gz	:= mt798x-gpt sdmmc |\
-				   pad-to 17k | mt7981-bl2 sdmmc-ddr3 |\
-				   pad-to 6656k | mt7981-bl31-uboot rfb-sd |\
-				$(if $(CONFIG_TARGET_ROOTFS_INITRAMFS),\
-				   pad-to 12M | append-image-stage initramfs.itb | check-size 44m |\
-				) \
-				   pad-to 44M | mt7981-bl2 spim-nand-ddr3 |\
-				   pad-to 45M | mt7981-bl31-uboot rfb-spim-nand |\
-				   pad-to 49M | mt7981-bl2 nor-ddr3 |\
-				   pad-to 50M | mt7981-bl31-uboot rfb-nor |\
-				   pad-to 51M | mt7981-bl2 snand-ddr3 |\
-				   pad-to 53M | mt7981-bl31-uboot rfb-snfi |\
-				$(if $(CONFIG_TARGET_ROOTFS_SQUASHFS),\
-				   pad-to 64M | append-image squashfs-sysupgrade.itb | check-size |\
-				) \
-				  gzip
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += mediatek_mt7981-rfb
 
-define Device/mediatek_mt7986a-rfb-nand
+define Device/mediatek_mt7986a-rfb
   DEVICE_VENDOR := MediaTek
-  DEVICE_MODEL := MT7986 rfba AP (NAND)
-  DEVICE_DTS := mt7986a-rfb-spim-nand
-  DEVICE_DTS_DIR := $(DTS_DIR)/
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  SUPPORTED_DEVICES := mediatek,mt7986a-rfb-snand
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  DEVICE_MODEL := MT7986A RFB
+  DEVICE_DTS := mt7986a-rfb
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
-TARGET_DEVICES += mediatek_mt7986a-rfb-nand
+TARGET_DEVICES += mediatek_mt7986a-rfb
 
 define Device/mediatek_mt7986b-rfb
   DEVICE_VENDOR := MediaTek
-  DEVICE_MODEL := MTK7986 rfbb AP
+  DEVICE_MODEL := MT7986B RFB
   DEVICE_DTS := mt7986b-rfb
-  DEVICE_DTS_DIR := $(DTS_DIR)/
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  SUPPORTED_DEVICES := mediatek,mt7986b-rfb
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += mediatek_mt7986b-rfb
 
-define Device/mediatek_mt7987a-rfb
-  DEVICE_VENDOR := MediaTek
-  DEVICE_MODEL := MT7987A rfb
-  DEVICE_DTS := mt7987a-rfb
-  DEVICE_DTS_OVERLAY:= \
-	mt7987a-rfb-spim-nand \
-	mt7987a-rfb-spim-nor \
-	mt7987a-rfb-emmc \
-	mt7987a-rfb-sd \
-	mt7987a-rfb-eth0-an8801sb \
-	mt7987a-rfb-eth0-an8855 \
-	mt7987a-rfb-eth0-e2p5g \
-	mt7987a-rfb-eth0-mt7531 \
-	mt7987a-rfb-eth1-i2p5g \
-	mt7987a-rfb-eth2-an8801sb \
-	mt7987a-rfb-eth2-e2p5g \
-	mt7987a-rfb-eth2-sfp \
-	mt7987a-rfb-eth2-usb
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTC_FLAGS := --pad 4096
-  DEVICE_DTS_LOADADDR := 0x4ff00000
-  DEVICE_PACKAGES := mt7987-2p5g-phy-firmware kmod-sfp
-  KERNEL_LOADADDR := 0x40000000
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := .itb
-  KERNEL_IN_UBI := 1
-  IMAGE_SIZE := $$(shell expr 64 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
-  IMAGES := sysupgrade.itb
-  IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | pad-rootfs | append-metadata
-  ARTIFACTS := \
-	snand-preloader.bin \
-	snand-bl31-uboot.fip \
-	sdcard.img.gz
-  ARTIFACT/snand-preloader.bin	:= mt7987-bl2 spim-nand0-ubi-comb
-  ARTIFACT/snand-bl31-uboot.fip	:= mt7987-bl31-uboot rfb-spim-nand
-  ARTIFACT/sdcard.img.gz	:= mt798x-gpt sdmmc |\
-				   pad-to 17k | mt7987-bl2 sdmmc-comb |\
-				   pad-to 6656k | mt7987-bl31-uboot rfb-sd |\
-				$(if $(CONFIG_TARGET_ROOTFS_INITRAMFS),\
-				  pad-to 12M | append-image-stage initramfs.itb | check-size 44m |\
-				) \
-				$(if $(CONFIG_TARGET_ROOTFS_SQUASHFS),\
-				  pad-to 64M | append-image squashfs-sysupgrade.itb | check-size |\
-				) \
-				  gzip
-endef
-TARGET_DEVICES += mediatek_mt7987a-rfb
-
-define Device/mediatek_mt7988a-rfb
-  DEVICE_VENDOR := MediaTek
-  DEVICE_MODEL := MT7988A rfb
-  DEVICE_DTS := mt7988a-rfb
-  DEVICE_DTS_OVERLAY:= \
-	mt7988a-rfb-emmc \
-	mt7988a-rfb-sd \
-	mt7988a-rfb-snfi-nand \
-	mt7988a-rfb-spim-nand \
-	mt7988a-rfb-spim-nand-factory \
-	mt7988a-rfb-spim-nor \
-	mt7988a-rfb-eth1-aqr \
-	mt7988a-rfb-eth1-i2p5g-phy \
-	mt7988a-rfb-eth1-mxl \
-	mt7988a-rfb-eth1-sfp \
-	mt7988a-rfb-eth2-aqr \
-	mt7988a-rfb-eth2-mxl \
-	mt7988a-rfb-eth2-sfp
-  DEVICE_DTS_DIR := $(DTS_DIR)/
-  DEVICE_DTC_FLAGS := --pad 4096
-  DEVICE_DTS_LOADADDR := 0x45f00000
-  DEVICE_PACKAGES := mt7988-2p5g-phy-firmware kmod-sfp kmod-phy-aquantia
-  KERNEL_LOADADDR := 0x46000000
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  KERNEL_INITRAMFS_SUFFIX := .itb
-  KERNEL_IN_UBI := 1
-  IMAGE_SIZE := $$(shell expr 64 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
-  IMAGES := sysupgrade.itb
-  IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | pad-rootfs | append-metadata
-  ARTIFACTS := \
-	       emmc-gpt.bin emmc-preloader.bin emmc-bl31-uboot.fip \
-	       nor-preloader.bin nor-bl31-uboot.fip \
-	       sdcard.img.gz \
-	       snand-preloader.bin snand-bl31-uboot.fip
-  ARTIFACT/emmc-gpt.bin		:= mt798x-gpt emmc
-  ARTIFACT/emmc-preloader.bin	:= mt7988-bl2 emmc-comb
-  ARTIFACT/emmc-bl31-uboot.fip	:= mt7988-bl31-uboot rfb-emmc
-  ARTIFACT/nor-preloader.bin	:= mt7988-bl2 nor-comb
-  ARTIFACT/nor-bl31-uboot.fip	:= mt7988-bl31-uboot rfb-nor
-  ARTIFACT/snand-preloader.bin	:= mt7988-bl2 spim-nand-ubi-comb
-  ARTIFACT/snand-bl31-uboot.fip	:= mt7988-bl31-uboot rfb-snand
-  ARTIFACT/sdcard.img.gz	:= mt798x-gpt sdmmc |\
-				   pad-to 17k | mt7988-bl2 sdmmc-comb |\
-				   pad-to 6656k | mt7988-bl31-uboot rfb-sd |\
-				$(if $(CONFIG_TARGET_ROOTFS_INITRAMFS),\
-				   pad-to 12M | append-image-stage initramfs.itb | check-size 44m |\
-				) \
-				   pad-to 44M | mt7988-bl2 spim-nand-comb |\
-				   pad-to 45M | mt7988-bl31-uboot rfb-snand |\
-				   pad-to 51M | mt7988-bl2 nor-comb |\
-				   pad-to 51M | mt7988-bl31-uboot rfb-nor |\
-				   pad-to 55M | mt7988-bl2 emmc-comb |\
-				   pad-to 56M | mt7988-bl31-uboot rfb-emmc |\
-				   pad-to 62M | mt798x-gpt emmc |\
-				$(if $(CONFIG_TARGET_ROOTFS_SQUASHFS),\
-				   pad-to 64M | append-image squashfs-sysupgrade.itb | check-size |\
-				) \
-				  gzip
-endef
-TARGET_DEVICES += mediatek_mt7988a-rfb
-
-define Device/mercusys_mr80x-v3
-  DEVICE_VENDOR := MERCUSYS
-  DEVICE_MODEL := MR80X
-  DEVICE_VARIANT := v3
-  DEVICE_DTS := mt7981b-mercusys-mr80x-v3
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += mercusys_mr80x-v3
-
-define Device/mercusys_mr85x
-  DEVICE_VENDOR := MERCUSYS
-  DEVICE_MODEL := MR85X
-  DEVICE_DTS := mt7981b-mercusys-mr85x
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-phy-airoha-en8811h swconfig kmod-switch-rtl8367s
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += mercusys_mr85x
-
-define Device/mercusys_mr90x-v1
-  DEVICE_VENDOR := MERCUSYS
-  DEVICE_MODEL := MR90X v1
-  DEVICE_DTS := mt7986b-mercusys-mr90x-v1
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 51200k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += mercusys_mr90x-v1
-
-define Device/mercusys_mr90x-v1-ubi
-  DEVICE_VENDOR := MERCUSYS
-  DEVICE_MODEL := MR90X v1 (UBI)
-  DEVICE_DTS := mt7986b-mercusys-mr90x-v1-ubi
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTC_FLAGS := --pad 4096
-  DEVICE_DTS_LOADADDR := 0x43f00000
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | \
-	pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | \
-	append-metadata
-  ARTIFACTS := bl31-uboot.fip preloader.bin
-  ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot mercusys_mr90x-v1
-  ARTIFACT/preloader.bin := mt7986-bl2 spim-nand-ubi-ddr3
-endef
-TARGET_DEVICES += mercusys_mr90x-v1-ubi
-
-define Device/netcore_n60
-  DEVICE_VENDOR := Netcore
-  DEVICE_MODEL := N60
-  DEVICE_DTS := mt7986a-netcore-n60
-  DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7986-bl2 spim-nand-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot netcore_n60
-endef
-TARGET_DEVICES += netcore_n60
-
-define Device/netcore_n60-pro
-  DEVICE_VENDOR := Netcore
-  DEVICE_MODEL := N60 Pro
-  DEVICE_ALT0_VENDOR := netis
-  DEVICE_ALT0_MODEL := NX62
-  DEVICE_ALT0_VARIANT := V1
-  DEVICE_DTS := mt7986a-netcore-n60-pro
-  DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware kmod-usb3
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7986-bl2 spim-nand-ddr4
-  ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot netcore_n60-pro
-endef
-TARGET_DEVICES += netcore_n60-pro
-
-define Device/netcraze_nap-630
-  DEVICE_VENDOR := Netcraze
-  DEVICE_MODEL := NAP-630
-  DEVICE_DTS := mt7981b-netcraze-nap-630
-  ZYIMAGE_ID := 0xC10630
-  $(call Device/keenetic_kap-630-common)
-endef
-TARGET_DEVICES += netcraze_nap-630
-
-define Device/netcraze_nc-1812
-  DEVICE_VENDOR := Netcraze
-  DEVICE_MODEL := NC-1812
-  DEVICE_DTS := mt7988d-netcraze-nc-1812
-  ZYIMAGE_ID := 0xC01812
-  $(call Device/keenetic_kn-1812-common)
-endef
-TARGET_DEVICES += netcraze_nc-1812
-
-define Device/netgear_eax17
+define Device/netgear_wax206
   DEVICE_VENDOR := NETGEAR
-  DEVICE_MODEL := EAX17
-  DEVICE_ALT0_VENDOR := NETGEAR
-  DEVICE_ALT0_MODEL := EAX11
-  DEVICE_ALT0_VARIANT := v3
-  DEVICE_ALT1_VENDOR := NETGEAR
-  DEVICE_ALT1_MODEL := EAX15
-  DEVICE_ALT1_VARIANT := v3
-  DEVICE_ALT2_VENDOR := NETGEAR
-  DEVICE_ALT2_MODEL := EAX14
-  DEVICE_ALT2_VARIANT := v3
-  DEVICE_ALT3_VENDOR := NETGEAR
-  DEVICE_ALT3_MODEL := EAX12
-  DEVICE_ALT3_VARIANT := v2
-  DEVICE_ALT4_VENDOR := NETGEAR
-  DEVICE_ALT4_MODEL := EAX16
-  DEVICE_ALT5_VENDOR := NETGEAR
-  DEVICE_ALT5_MODEL := EAX19
-  DEVICE_DTS := mt7981b-netgear-eax17
+  DEVICE_MODEL := WAX206
+  DEVICE_DTS := mt7981b-netgear-wax206
   DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  NETGEAR_ENC_MODEL := EAX17
-  NETGEAR_ENC_REGION := US
-  NETGEAR_ENC_HW_ID_LIST := 1010000013120000_NETGEAR
-  NETGEAR_ENC_MODEL_LIST := EAX17;EAX11v3;EAX15v3;EAX14v3;EAX12v2;EAX16;EAX19
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  KERNEL = kernel-bin | lzma | \
-	fit-with-netgear-top-level-rootfs-node lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-  KERNEL_IN_UBI := 1
-  IMAGE_SIZE := 81920k
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 kmod-fs-f2fs mkf2fs
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  IMAGES += factory.img
-  # Padding to 10M seems to be required by OEM web interface
-  IMAGE/factory.img := sysupgrade-tar | \
-	  pad-to 10M | check-size | netgear-encrypted-factory
 endef
-TARGET_DEVICES += netgear_eax17
+TARGET_DEVICES += netgear_wax206
 
-define Device/netgear_wax220
+define Device/netgear_wax220-2.5g
   DEVICE_VENDOR := NETGEAR
-  DEVICE_MODEL := WAX220
-  DEVICE_DTS := mt7986b-netgear-wax220
+  DEVICE_MODEL := WAX220-2.5G
+  DEVICE_DTS := mt7981b-netgear-wax220-2.5g
   DEVICE_DTS_DIR := ../dts
-  NETGEAR_ENC_MODEL := WAX220
-  NETGEAR_ENC_REGION := US
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  IMAGE_SIZE := 32768k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  IMAGES += factory.img
-  # Padding to 10M seems to be required by OEM web interface
-  IMAGE/factory.img := sysupgrade-tar | \
-	  pad-to 10M | check-size | netgear-encrypted-factory
-endef
-TARGET_DEVICES += netgear_wax220
-
-define Device/netis_eap930-v1
-  DEVICE_VENDOR := netis
-  DEVICE_MODEL := EAP930 V1
-  DEVICE_DTS := mt7981b-netis-eap930-v1
-  DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | \
-	append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot netis_eap930-v1
-endef
-TARGET_DEVICES += netis_eap930-v1
-
-define Device/netis_nx30v2
-  DEVICE_VENDOR := netis
-  DEVICE_MODEL := NX30
-  DEVICE_VARIANT := V2
-  DEVICE_ALT0_VENDOR := Netcore
-  DEVICE_ALT0_MODEL := POWER 30AX
-  DEVICE_ALT1_VENDOR := Netcore
-  DEVICE_ALT1_MODEL := N30 Pro
-  DEVICE_ALT2_VENDOR := GWBN
-  DEVICE_ALT2_MODEL := GW3001
-  DEVICE_ALT3_VENDOR := GLC
-  DEVICE_ALT3_MODEL := W7
-  DEVICE_ALT4_VENDOR := netis
-  DEVICE_ALT4_MODEL := MEX605
-  DEVICE_DTS := mt7981b-netis-nx30v2
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTC_FLAGS := --pad 4096
-  DEVICE_DTS_LOADADDR := 0x43f00000
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  KERNEL_LOADADDR := 0x44000000
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  KERNEL_INITRAMFS_SUFFIX := .itb
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  IMAGE_SIZE := 117248k
-  IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | pad-rootfs | append-metadata
-  ARTIFACTS := spim-nand-preloader.bin spim-nand-bl31-uboot.fip
-  ARTIFACT/spim-nand-preloader.bin	:= mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/spim-nand-bl31-uboot.fip	:= mt7981-bl31-uboot netis_nx30v2
-endef
-TARGET_DEVICES += netis_nx30v2
-
-define Device/netis_nx31
-  DEVICE_VENDOR := netis
-  DEVICE_MODEL := NX31
-  DEVICE_DTS := mt7981b-netis-nx31
-  DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | \
-	append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot netis_nx31
-endef
-TARGET_DEVICES += netis_nx31
-
-define Device/netis_nx32u
-  DEVICE_VENDOR := netis
-  DEVICE_MODEL := NX32U
-  DEVICE_DTS := mt7981b-netis-nx32u
-  DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | \
-	append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware \
-	kmod-usb3 kmod-usb-ledtrig-usbport
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot netis_nx32u
-endef
-TARGET_DEVICES += netis_nx32u
-
-define Device/nokia_ea0326gmp
-  DEVICE_VENDOR := Nokia
-  DEVICE_MODEL := EA0326GMP
-  DEVICE_DTS := mt7981b-nokia-ea0326gmp
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot nokia_ea0326gmp
-endef
-TARGET_DEVICES += nokia_ea0326gmp
-
-define Device/nradio_c8-668gl
-  DEVICE_VENDOR := NRadio
-  DEVICE_MODEL := C8-668GL
-  DEVICE_DTS := mt7981b-nradio-c8-668gl
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware \
-	kmod-usb-serial-option kmod-usb-net-cdc-ether kmod-usb-net-qmi-wwan \
-	kmod-usb3
-  IMAGE_SIZE := 131072k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata | check-size
-endef
-TARGET_DEVICES += nradio_c8-668gl
-
-define Device/openembed_som7981
-  DEVICE_VENDOR := OpenEmbed
-  DEVICE_MODEL := SOM7981
-  DEVICE_DTS := mt7981b-openembed-som7981
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware \
-	kmod-crypto-hw-atmel kmod-eeprom-at24 kmod-gpio-beeper kmod-rtc-pcf8563 \
-	kmod-usb-net-cdc-mbim kmod-usb-net-qmi-wwan kmod-usb-serial-option \
-	kmod-usb3 uqmi
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 244224k
-  KERNEL_IN_UBI := 1
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 kmod-fs-f2fs mkf2fs
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
-TARGET_DEVICES += openembed_som7981
-
-define Device/openfi_6c
-  DEVICE_VENDOR := OpenFi
-  DEVICE_MODEL := 6C
-  DEVICE_DTS := mt7981b-openfi-6c
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += openfi_6c
+TARGET_DEVICES += netgear_wax220-2.5g
 
 define Device/openwrt_one
   DEVICE_VENDOR := OpenWrt
   DEVICE_MODEL := One
   DEVICE_DTS := mt7981b-openwrt-one
   DEVICE_DTS_DIR := ../dts
-  DEVICE_DTC_FLAGS := --pad 4096
-  DEVICE_DTS_LOADADDR := 0x43f00000
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-rtc-pcf8563 kmod-usb3 kmod-phy-airoha-en8811h
-  KERNEL_LOADADDR := 0x44000000
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  KERNEL_INITRAMFS_SUFFIX := .itb
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  IMAGE_SIZE := $$(shell expr 64 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
-  IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | pad-rootfs | append-metadata
-  ARTIFACTS := \
-	nor-preloader.bin nor-bl31-uboot.fip \
-	snand-preloader.bin snand-bl31-uboot.fip \
-	factory.ubi snand-factory.bin nor-factory.bin
-  ARTIFACT/nor-preloader.bin		:= mt7981-bl2 nor-ddr4
-  ARTIFACT/nor-bl31-uboot.fip		:= mt7981-bl31-uboot openwrt_one-nor
-  ARTIFACT/snand-preloader.bin		:= mt7981-bl2 spim-nand-ubi-ddr4
-  ARTIFACT/snand-bl31-uboot.fip		:= mt7981-bl31-uboot openwrt_one-snand
-  ARTIFACT/factory.ubi			:= ubinize-image fit squashfs-sysupgrade.itb
-  ARTIFACT/snand-factory.bin		:= mt7981-bl2 spim-nand-ubi-ddr4 | pad-to 256k | \
-					   mt7981-bl2 spim-nand-ubi-ddr4 | pad-to 512k | \
-					   mt7981-bl2 spim-nand-ubi-ddr4 | pad-to 768k | \
-					   mt7981-bl2 spim-nand-ubi-ddr4 | pad-to 1024k | \
-					   ubinize-image fit squashfs-sysupgrade.itb
-  ARTIFACT/nor-factory.bin		:= mt7981-bl2 nor-ddr4 | pad-to 256k | \
-					   append-openwrt-one-eeprom | pad-to 1024k | \
-					   mt7981-bl31-uboot openwrt_one-nor | pad-to 512k | \
-					   append-image-stage initramfs.itb
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  UBINIZE_PARTS := fip=:$(STAGING_DIR_IMAGE)/mt7981_openwrt_one-snand-u-boot.fip \
-		   $(if $(IB),recovery=:$(STAGING_DIR_IMAGE)/mediatek-filogic-openwrt_one-initramfs.itb,\
-			      recovery=:$(KDIR)/tmp/$$(KERNEL_INITRAMFS_IMAGE)) \
-		   $(if $(wildcard $(TOPDIR)/openwrt-mediatek-filogic-openwrt_one-calibration.itb), calibration=:$(TOPDIR)/openwrt-mediatek-filogic-openwrt_one-calibration.itb)
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += openwrt_one
 
-define Device/qihoo_360t7-common
-  DEVICE_VENDOR := Qihoo
+define Device/openwrt_sax1200w2-onie
+  DEVICE_VENDOR := OpenWrt
+  DEVICE_MODEL := SAX1200W2 ONIE
+  DEVICE_DTS := mt7981b-openwrt-sax1200w2-onie
   DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | \
-	pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | \
-	append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  ARTIFACTS := bl31-uboot.fip preloader.bin
-endef
-
-define Device/qihoo_360t7
-  DEVICE_MODEL := 360T7
-  DEVICE_DTS := mt7981b-qihoo-360t7
-  $(call Device/qihoo_360t7-common)
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot qihoo_360t7
-  ARTIFACT/preloader.bin  := mt7981-bl2 spim-nand-ddr3-1866
-endef
-TARGET_DEVICES += qihoo_360t7
-
-define Device/qihoo_360t7-ubi
-  DEVICE_MODEL := 360T7 (UBI)
-  DEVICE_DTS := mt7981b-qihoo-360t7-ubi
-  $(call Device/qihoo_360t7-common)
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot qihoo_360t7-ubi
-  ARTIFACT/preloader.bin  := mt7981-bl2 spim-nand-ubi-ddr3-1866
-endef
-TARGET_DEVICES += qihoo_360t7-ubi
-
-define Device/routerich_ax3000
-  DEVICE_VENDOR := Routerich
-  DEVICE_MODEL := AX3000
-  DEVICE_DTS := mt7981b-routerich-ax3000
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
-  DEVICE_COMPAT_VERSION := 1.1
-  DEVICE_COMPAT_MESSAGE := Partition layout has been changed. Bootloader MUST be \
-	upgraded to avoid data corruption and getting bricked. \
-	Please, contact your vendor and follow the guide: \
-	https://openwrt.org/toh/routerich/ax3000#web_ui_method
-endef
-TARGET_DEVICES += routerich_ax3000
-
-define Device/routerich_ax3000-ubootmod
-  DEVICE_VENDOR := Routerich
-  DEVICE_MODEL := AX3000 (OpenWrt U-Boot layout)
-  DEVICE_DTS := mt7981b-routerich-ax3000-ubootmod
-  DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | \
-	append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware kmod-usb3 mt7981-wo-firmware
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot routerich_ax3000
-endef
-TARGET_DEVICES += routerich_ax3000-ubootmod
-
-define Device/routerich_ax3000-v1
-  DEVICE_VENDOR := Routerich
-  DEVICE_MODEL := AX3000
-  DEVICE_VARIANT := v1
-  DEVICE_DTS := mt7981b-routerich-ax3000-v1
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware kmod-usb3 mt7981-wo-firmware
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
-endef
-TARGET_DEVICES += routerich_ax3000-v1
-
-define Device/routerich_be7200
-  DEVICE_VENDOR := Routerich
-  DEVICE_MODEL := BE7200
-  DEVICE_DTS := mt7987a-routerich-be7200
-  DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL_LOADADDR := 0x40000000
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | \
-	pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | \
-	pad-rootfs | append-metadata
-  DEVICE_PACKAGES := mt7987-2p5g-phy-firmware kmod-mt7992-firmware \
-	 kmod-regulator-userspace-consumer kmod-usb3
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7987-bl2 spim-nand0
-  ARTIFACT/bl31-uboot.fip := mt7987-bl31-uboot routerich_be7200
-endef
-TARGET_DEVICES += routerich_be7200
-
-define Device/ruijie_rg-x60-pro
-  DEVICE_VENDOR := Ruijie
-  DEVICE_MODEL := RG-X60 Pro
-  DEVICE_DTS := mt7986a-ruijie-rg-x60-pro
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 kmod-fs-f2fs mkf2fs
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
-TARGET_DEVICES += ruijie_rg-x60-pro
+TARGET_DEVICES += openwrt_sax1200w2-onie
 
-define Device/snr_snr-cpe-ax2
-  DEVICE_VENDOR := SNR
-  DEVICE_MODEL := SNR-CPE-AX2
-  DEVICE_DTS := mt7981b-snr-snr-cpe-ax2
+define Device/openvox_ov-p2641
+  DEVICE_VENDOR := OpenVox
+  DEVICE_MODEL := OV-P2641
+  DEVICE_DTS := mt7981b-openvox-ov-p2641
   DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | \
-	append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot snr_snr-cpe-ax2
-endef
-TARGET_DEVICES += snr_snr-cpe-ax2
-
-define Device/teltonika_rutc50
-  DEVICE_VENDOR := Teltonika
-  DEVICE_MODEL := RUTC50
-  SUPPORTED_TELTONIKA_DEVICES := teltonika,rutc
-  DEVICE_DTS := mt7981a-teltonika-rutc50
-  DEVICE_DTS_DIR := ../dts
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBINIZE_OPTS := -E 5
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3 kmod-usb-net-qmi-wwan \
-  kmod-usb-serial-option kmod-gpio-nxp-74hc164 uqmi
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | append-teltonika-metadata
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 kmod-fs-f2fs mkf2fs
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
-TARGET_DEVICES += teltonika_rutc50
+TARGET_DEVICES += openvox_ov-p2641
 
-define Device/tenbay_wr3000k
+define Device/openvox_ov-p2642
+  DEVICE_VENDOR := OpenVox
+  DEVICE_MODEL := OV-P2642
+  DEVICE_DTS := mt7981b-openvox-ov-p2642
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += openvox_ov-p2642
+
+define Device/openwrt_wpq-873-single-ap
+  DEVICE_VENDOR := OpenWrt
+  DEVICE_MODEL := WPQ-873 Single AP
+  DEVICE_DTS := mt7986a-openwrt-wpq-873-single-ap
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += openwrt_wpq-873-single-ap
+
+define Device/openwrt_wpq-873-uap-2x2
+  DEVICE_VENDOR := OpenWrt
+  DEVICE_MODEL := WPQ-873 UAP 2x2
+  DEVICE_DTS := mt7986a-openwrt-wpq-873-uap-2x2
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += openwrt_wpq-873-uap-2x2
+
+define Device/openwrt_wpq-873-uap-dual
+  DEVICE_VENDOR := OpenWrt
+  DEVICE_MODEL := WPQ-873 UAP Dual
+  DEVICE_DTS := mt7986b-openwrt-wpq-873-uap-dual
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += openwrt_wpq-873-uap-dual
+
+define Device/openwrt_wpq-873ap-led
+  DEVICE_VENDOR := OpenWrt
+  DEVICE_MODEL := WPQ-873AP LED
+  DEVICE_DTS := mt7986a-openwrt-wpq-873ap-led
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += openwrt_wpq-873ap-led
+
+define Device/openwrt_wpq-873eap-4k
+  DEVICE_VENDOR := OpenWrt
+  DEVICE_MODEL := WPQ-873EAP 4K
+  DEVICE_DTS := mt7986b-openwrt-wpq-873eap-4k
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += openwrt_wpq-873eap-4k
+
+define Device/prologue_pl6600
+  DEVICE_VENDOR := Prologue
+  DEVICE_MODEL := PL6600
+  DEVICE_DTS := mt7986a-prologue-pl6600
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += prologue_pl6600
+
+define Device/sierracom_mc7430-5g
+  DEVICE_VENDOR := Sierra Wireless
+  DEVICE_MODEL := MC7430 5G
+  DEVICE_DTS := mt7981b-sierracom-mc7430-5g
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += sierracom_mc7430-5g
+
+define Device/sierracom_mc7455-5g
+  DEVICE_VENDOR := Sierra Wireless
+  DEVICE_MODEL := MC7455 5G
+  DEVICE_DTS := mt7981b-sierracom-mc7455-5g
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += sierracom_mc7455-5g
+
+define Device/sophos_red-10-sfp
+  DEVICE_VENDOR := Sophos
+  DEVICE_MODEL := RED 10 SFP
+  DEVICE_DTS := mt7986b-sophos-red-10-sfp
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += sophos_red-10-sfp
+
+define Device/sophos_red-15-sfp
+  DEVICE_VENDOR := Sophos
+  DEVICE_MODEL := RED 15 SFP
+  DEVICE_DTS := mt7986b-sophos-red-15-sfp
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += sophos_red-15-sfp
+
+define Device/sophos_red-20-sfp
+  DEVICE_VENDOR := Sophos
+  DEVICE_MODEL := RED 20 SFP
+  DEVICE_DTS := mt7986b-sophos-red-20-sfp
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += sophos_red-20-sfp
+
+define Device/sophos_red-30-sfp
+  DEVICE_VENDOR := Sophos
+  DEVICE_MODEL := RED 30 SFP
+  DEVICE_DTS := mt7986b-sophos-red-30-sfp
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += sophos_red-30-sfp
+
+define Device/sophos_red-40-sfp
+  DEVICE_VENDOR := Sophos
+  DEVICE_MODEL := RED 40 SFP
+  DEVICE_DTS := mt7986b-sophos-red-40-sfp
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += sophos_red-40-sfp
+
+define Device/telecominfraproject_tfiax540
+  DEVICE_VENDOR := Telecom Infra Project
+  DEVICE_MODEL := TFIAX540
+  DEVICE_DTS := mt7986a-telecominfraproject-tfiax540
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += telecominfraproject_tfiax540
+
+define Device/tenbay_txq-xe30
   DEVICE_VENDOR := Tenbay
-  DEVICE_MODEL := WR3000K
-  DEVICE_DTS := mt7981b-tenbay-wr3000k
+  DEVICE_MODEL := TXQ-XE30
+  DEVICE_DTS := mt7981b-tenbay-txq-xe30
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 49152k
-  KERNEL_IN_UBI := 1
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 kmod-fs-f2fs mkf2fs
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
-TARGET_DEVICES += tenbay_wr3000k
+TARGET_DEVICES += tenbay_txq-xe30
 
-define Device/tenda_be12-pro
-  DEVICE_VENDOR := Tenda
-  DEVICE_MODEL := BE12 Pro
-  DEVICE_DTS := mt7987a-tenda-be12-pro
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := mt7987-2p5g-phy-firmware airoha-en8811h-firmware kmod-phy-airoha-en8811h kmod-mt7992-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_LOADADDR := 0x40000000
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.bin := append-kernel | tenda-mkdualimageheader | sysupgrade-tar kernel=$$$$@ | append-metadata
-endef
-TARGET_DEVICES += tenda_be12-pro
-
-define Device/totolink_x6000r
-  DEVICE_VENDOR := TOTOLINK
-  DEVICE_MODEL := X6000R
-  DEVICE_DTS := mt7981b-totolink-x6000r
-  DEVICE_DTS_DIR := ../dts
-  IMAGES := sysupgrade.bin
-  IMAGE_SIZE := 14336k
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-endef
-TARGET_DEVICES += totolink_x6000r
-
-define Device/tplink_archer-ax80-v1
-  DEVICE_VENDOR := TP-Link
-  DEVICE_MODEL := Archer AX80
-  DEVICE_VARIANT := v1
-  DEVICE_DTS := mt7986a-tplink-archer-ax80-v1
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-leds-lp5523 kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 51200k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += tplink_archer-ax80-v1
-
-define Device/tplink_archer-ax80-v1-eu
-  DEVICE_VENDOR := TP-Link
-  DEVICE_MODEL := Archer AX80
-  DEVICE_VARIANT := v1 (EU)
-  DEVICE_DTS := mt7986b-tplink-archer-ax80-v1-eu
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 51200k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += tplink_archer-ax80-v1-eu
-
-define Device/tplink_be450
-  DEVICE_VENDOR := TP-Link
-  DEVICE_MODEL := BE450
-  DEVICE_DTS := mt7988d-tplink-be450
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7992-firmware kmod-usb3 \
-	    mt7988-2p5g-phy-firmware mt7988-wo-firmware \
-	    kmod-phy-realtek rtl8261n-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 51200k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += tplink_be450
-
-define Device/tplink_eap683-lr
-  DEVICE_VENDOR := TP-Link
-  DEVICE_MODEL := EAP683-LR
-  DEVICE_ALT0_VENDOR := TP-Link
-  DEVICE_ALT0_MODEL := EAP683-UR
-  DEVICE_DTS := mt7986a-tplink-eap683-lr
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 39424k
-  KERNEL_IN_UBI := 1
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += tplink_eap683-lr
-
-define Device/tplink_re6000xd
-  DEVICE_VENDOR := TP-Link
-  DEVICE_MODEL := RE6000XD
-  DEVICE_DTS := mt7986b-tplink-re6000xd
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 51200k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += tplink_re6000xd
-
-define Device/tplink_f65-v1
-  DEVICE_VENDOR := TP-Link
-  DEVICE_MODEL := F65
-  DEVICE_VARIANT := v1
-  DEVICE_DTS := mt7981b-tplink-f65v1
-  DEVICE_DTS_DIR := ../dts
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-endef
-TARGET_DEVICES += tplink_f65-v1
-
-define Device/tplink_fr365-v1
-  DEVICE_VENDOR := TP-Link
-  DEVICE_MODEL := FR365
-  DEVICE_VARIANT := v1
-  DEVICE_DTS := mt7981b-tplink-fr365v1
-  DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 32768k
-  KERNEL_IN_UBI := 1
-  IMAGES += factory.bin
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/factory.ubi := append-ubi | check-size $$$$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := fitblk kmod-sfp kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-endef
-TARGET_DEVICES += tplink_fr365-v1
-
-define Device/tplink_tl-xdr-common
-  DEVICE_VENDOR := TP-Link
-  DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | append-metadata
-  DEVICE_PACKAGES := fitblk kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7986-bl2 spim-nand-ddr3
-endef
-
-define Device/tplink_tl-xdr4288
-  DEVICE_MODEL := TL-XDR4288
-  DEVICE_DTS := mt7986a-tplink-tl-xdr4288
-  ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot tplink_tl-xdr4288
-  $(call Device/tplink_tl-xdr-common)
-endef
-TARGET_DEVICES += tplink_tl-xdr4288
-
-define Device/tplink_tl-xdr6086
-  DEVICE_MODEL := TL-XDR6086
-  DEVICE_DTS := mt7986a-tplink-tl-xdr6086
-  ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot tplink_tl-xdr6086
-  $(call Device/tplink_tl-xdr-common)
-endef
-TARGET_DEVICES += tplink_tl-xdr6086
-
-define Device/tplink_tl-xdr6088
-  DEVICE_MODEL := TL-XDR6088
-  DEVICE_DTS := mt7986a-tplink-tl-xdr6088
-  ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot tplink_tl-xdr6088
-  $(call Device/tplink_tl-xdr-common)
-endef
-TARGET_DEVICES += tplink_tl-xdr6088
-
-define Device/tplink_tl-xtr8488
-  DEVICE_MODEL := TL-XTR8488
-  DEVICE_DTS := mt7986a-tplink-tl-xtr8488
-  $(call Device/tplink_tl-xdr-common)
-  DEVICE_PACKAGES += kmod-mt7915-firmware
-  ARTIFACT/preloader.bin := mt7986-bl2 spim-nand-ddr4
-  ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot tplink_tl-xtr8488
-endef
-TARGET_DEVICES += tplink_tl-xtr8488
-
-define Device/ubnt_unifi-6-plus
+define Device/ubiquiti_dream-machine-se
   DEVICE_VENDOR := Ubiquiti
-  DEVICE_MODEL := UniFi U6+
-  DEVICE_DTS := mt7981a-ubnt-unifi-6-plus
+  DEVICE_MODEL := Dream Machine SE
+  DEVICE_DTS := mt7986a-ubiquiti-dream-machine-se
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware e2fsprogs f2fsck mkf2fs fdisk partx-utils
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
-TARGET_DEVICES += ubnt_unifi-6-plus
+TARGET_DEVICES += ubiquiti_dream-machine-se
 
-define Device/unielec_u7981-01
-  DEVICE_VENDOR := Unielec
-  DEVICE_MODEL := U7981-01
+define Device/ubiquiti_ubnt-uap-max
+  DEVICE_VENDOR := Ubiquiti
+  DEVICE_MODEL := UniFi AP Max
+  DEVICE_DTS := mt7986a-ubiquiti-ubnt-uap-max
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3 e2fsprogs f2fsck mkf2fs fdisk partx-utils
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-phy-realtek kmod-fs-f2fs mkf2fs
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
-
-define Device/unielec_u7981-01-emmc
-  DEVICE_DTS := mt7981b-unielec-u7981-01-emmc
-  DEVICE_VARIANT := (EMMC)
-  $(call Device/unielec_u7981-01)
-endef
-TARGET_DEVICES += unielec_u7981-01-emmc
-
-define Device/unielec_u7981-01-nand
-  DEVICE_DTS := mt7981b-unielec-u7981-01-nand
-  DEVICE_VARIANT := (NAND)
-  $(call Device/unielec_u7981-01)
-endef
-TARGET_DEVICES += unielec_u7981-01-nand
-
-define Device/wavlink_wl-wn536ax6-a
-  DEVICE_VENDOR := WAVLINK
-  DEVICE_MODEL := WL-WN536AX6
-  DEVICE_VARIANT := Rev a
-  DEVICE_DTS := mt7986a-wavlink-wl-wn536ax6-a
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x47000000
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_INITRAMFS_SUFFIX := .itb
-  KERNEL_IN_UBI := 1
-  DEVICE_PACKAGES := kmod-ledtrig-network kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware kmod-usb3
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += wavlink_wl-wn536ax6-a
-
-define Device/wavlink_wl-wn551x3
-  DEVICE_VENDOR := WAVLINK
-  DEVICE_MODEL := WL-WN551X3
-  DEVICE_DTS := mt7981b-wavlink-wl-wn551x3
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x47000000
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_INITRAMFS_SUFFIX := .itb
-  KERNEL_IN_UBI := 1
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += wavlink_wl-wn551x3
-
-define Device/wavlink_wl-wn586x3
-  DEVICE_VENDOR := WAVLINK
-  DEVICE_MODEL := WL-WN586X3
-  DEVICE_DTS := mt7981b-wavlink-wl-wn586x3
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x47000000
-  IMAGE_SIZE := 15424k
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-endef
-TARGET_DEVICES += wavlink_wl-wn586x3
-
-define Device/wavlink_wl-wn586x3b
-  DEVICE_VENDOR := WAVLINK
-  DEVICE_MODEL := WL-WN586X3B
-  DEVICE_DTS := mt7981b-wavlink-wl-wn586x3b
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x47000000
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_INITRAMFS_SUFFIX := .itb
-  KERNEL_IN_UBI := 1
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  IMAGES := factory.bin initramfs-kernel.bin sysupgrade.bin
-  IMAGE/factory.bin := append-ubi | check-size $$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += wavlink_wl-wn586x3b
-
-define Device/wavlink_wl-wn573hx3
-  DEVICE_VENDOR := WAVLINK
-  DEVICE_MODEL := WL-WN573HX3
-  DEVICE_ALT0_VENDOR := 7Links
-  DEVICE_ALT0_MODEL := WLR-1300
-  DEVICE_DTS := mt7981b-wavlink-wl-wn573hx3
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x47000000
-  IMAGE_SIZE := 14336k
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  SUPPORTED_DEVICES += mediatek,mt7981-spim-nor-rfb
-  IMAGES = WN573HX3-sysupgrade.bin
-  IMAGE/WN573HX3-sysupgrade.bin := append-kernel | pad-to 128k | append-rootfs | pad-rootfs | check-size | append-metadata
-endef
-TARGET_DEVICES += wavlink_wl-wn573hx3
-
-define Device/wavlink_wl-wnt100x3
-  DEVICE_VENDOR := WAVLINK
-  DEVICE_MODEL := WL-WNT100X3
-  DEVICE_DTS := mt7981b-wavlink-wl-wnt100x3
-  DEVICE_DTS_DIR := ../dts
-  IMAGE_SIZE := 65536k
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware \
-  	mt7981-wo-firmware kmod-hwmon-pwmfan
-  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += wavlink_wl-wnt100x3
-
-define Device/wavlink_wl-wnt100x3-ubootmod
-  DEVICE_VENDOR := WAVLINK
-  DEVICE_MODEL := WL-WNT100X3
-  DEVICE_VARIANT := (OpenWrt U-Boot layout)
-  DEVICE_DTS := mt7981b-wavlink-wl-wnt100x3-ubootmod
-  DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | \
-	append-metadata
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware \
-  	mt7981-wo-firmware kmod-hwmon-pwmfan
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot wavlink_wl-wnt100x3
-endef
-TARGET_DEVICES += wavlink_wl-wnt100x3-ubootmod
-
-define Device/widelantech_wap430x
-  DEVICE_VENDOR := Widelantech
-  DEVICE_MODEL := WAP430X
-  DEVICE_ALT1_VENDOR := Widelantech
-  DEVICE_ALT1_MODEL := AX3000AM
-  DEVICE_ALT1_VENDOR := UeeVii
-  DEVICE_ALT1_MODEL := UAP200
-  DEVICE_DTS := mt7981b-widelantech-wap430x
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  IMAGE_SIZE := 14784k
-  SUPPORTED_DEVICES += UAP200 AX3000AM # allow upgrade via GECOOS UART menu
-endef
-TARGET_DEVICES += widelantech_wap430x
-
-define Device/xiaomi_mi-router-ax3000t
-  DEVICE_VENDOR := Xiaomi
-  DEVICE_MODEL := Mi Router AX3000T
-  DEVICE_DTS := mt7981b-xiaomi-mi-router-ax3000t
-  DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-ifeq ($(IB),)
-ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
-  ARTIFACTS := initramfs-factory.ubi
-  ARTIFACT/initramfs-factory.ubi := append-image-stage initramfs-kernel.bin | ubinize-kernel
-endif
-endif
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += xiaomi_mi-router-ax3000t
-
-define Device/xiaomi_mi-router-ax3000t-ubootmod
-  DEVICE_VENDOR := Xiaomi
-  DEVICE_MODEL := Mi Router AX3000T (OpenWrt U-Boot layout)
-  DEVICE_DTS := mt7981b-xiaomi-mi-router-ax3000t-ubootmod
-  DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot xiaomi_mi-router-ax3000t
-ifeq ($(IB),)
-ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
-  ARTIFACTS += initramfs-factory.ubi
-  ARTIFACT/initramfs-factory.ubi := append-image-stage initramfs-recovery.itb | ubinize-kernel
-endif
-endif
-endef
-TARGET_DEVICES += xiaomi_mi-router-ax3000t-ubootmod
-
-define Device/xiaomi_mi-router-wr30u-stock
-  DEVICE_VENDOR := Xiaomi
-  DEVICE_MODEL := Mi Router WR30U (stock layout)
-  DEVICE_DTS := mt7981b-xiaomi-mi-router-wr30u-stock
-  DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-ifeq ($(IB),)
-ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
-  ARTIFACTS := initramfs-factory.ubi
-  ARTIFACT/initramfs-factory.ubi := append-image-stage initramfs-kernel.bin | ubinize-kernel
-endif
-endif
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += xiaomi_mi-router-wr30u-stock
-
-define Device/xiaomi_mi-router-wr30u-ubootmod
-  DEVICE_VENDOR := Xiaomi
-  DEVICE_MODEL := Mi Router WR30U (OpenWrt U-Boot layout)
-  DEVICE_DTS := mt7981b-xiaomi-mi-router-wr30u-ubootmod
-  DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot xiaomi_mi-router-wr30u
-ifeq ($(IB),)
-ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
-  ARTIFACTS += initramfs-factory.ubi
-  ARTIFACT/initramfs-factory.ubi := append-image-stage initramfs-recovery.itb | ubinize-kernel
-endif
-endif
-endef
-TARGET_DEVICES += xiaomi_mi-router-wr30u-ubootmod
-
-define Device/xiaomi_redmi-router-ax6000-stock
-  DEVICE_VENDOR := Xiaomi
-  DEVICE_MODEL := Redmi Router AX6000 (stock layout)
-  DEVICE_DTS := mt7986a-xiaomi-redmi-router-ax6000-stock
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-leds-ws2812b kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-ifeq ($(IB),)
-ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
-  ARTIFACTS := initramfs-factory.ubi
-  ARTIFACT/initramfs-factory.ubi := append-image-stage initramfs-kernel.bin | ubinize-kernel
-endif
-endif
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += xiaomi_redmi-router-ax6000-stock
-
-define Device/xiaomi_redmi-router-ax6000-ubootmod
-  DEVICE_VENDOR := Xiaomi
-  DEVICE_MODEL := Redmi Router AX6000 (OpenWrt U-Boot layout)
-  DEVICE_DTS := mt7986a-xiaomi-redmi-router-ax6000-ubootmod
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-leds-ws2812b kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  IMAGES := sysupgrade.itb
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7986-bl2 spim-nand-ddr4
-  ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot xiaomi_redmi-router-ax6000
-ifeq ($(IB),)
-ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
-  ARTIFACTS += initramfs-factory.ubi
-  ARTIFACT/initramfs-factory.ubi := append-image-stage initramfs-recovery.itb | ubinize-kernel
-endif
-endif
-endef
-TARGET_DEVICES += xiaomi_redmi-router-ax6000-ubootmod
-
-define Device/yuncore_ax835
-  DEVICE_VENDOR := YunCore
-  DEVICE_MODEL := AX835
-  DEVICE_DTS := mt7981b-yuncore-ax835
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x47000000
-  IMAGES := sysupgrade.bin
-  IMAGE_SIZE := 14336k
-  SUPPORTED_DEVICES += mediatek,mt7981-spim-nor-rfb
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.bin := append-kernel | pad-to 128k | append-rootfs | pad-rootfs | check-size | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-endef
-TARGET_DEVICES += yuncore_ax835
+TARGET_DEVICES += ubiquiti_ubnt-uap-max
 
 define Device/zbtlink_zbt-z8102ax
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-Z8102AX
   DEVICE_DTS := mt7981b-zbtlink-zbt-z8102ax
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3 kmod-usb-net-qmi-wwan kmod-usb-serial-option
-  KERNEL_IN_UBI := 1
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$(IMAGE_SIZE)
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 kmod-fs-f2fs mkf2fs
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += zbtlink_zbt-z8102ax
-
-define Device/zbtlink_zbt-z8102ax-v2
-  DEVICE_VENDOR := Zbtlink
-  DEVICE_MODEL := ZBT-Z8102AX-V2
-  DEVICE_DTS := mt7981b-zbtlink-zbt-z8102ax-v2
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3 kmod-usb-net-qmi-wwan kmod-usb-serial-option
-  KERNEL_IN_UBI := 1
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_COMPAT_VERSION := 1.1
-  DEVICE_COMPAT_MESSAGE := Partition layout has been changed to fit the bootloader
-endef
-TARGET_DEVICES += zbtlink_zbt-z8102ax-v2
-
-define Device/zbtlink_zbt-z8103ax
-  DEVICE_VENDOR := Zbtlink
-  DEVICE_MODEL := ZBT-Z8103AX
-  DEVICE_DTS := mt7981b-zbtlink-zbt-z8103ax
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  KERNEL_IN_UBI := 1
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += zbtlink_zbt-z8103ax
-
-define Device/zbtlink_zbt-z8103ax-c
-  DEVICE_VENDOR := Zbtlink
-  DEVICE_MODEL := ZBT-Z8103AX-C
-  DEVICE_ALT0_VENDOR := Zbtlink
-  DEVICE_ALT0_MODEL := ZBT-Z8103AX-D
-  DEVICE_DTS := mt7981b-zbtlink-zbt-z8103ax-c
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  KERNEL_IN_UBI := 1
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += zbtlink_zbt-z8103ax-c
-
-define Device/zbtlink_zbt-z8106ax-s
-  DEVICE_VENDOR := Zbtlink
-  DEVICE_MODEL := ZBT-Z8106AX-S
-  SUPPORTED_DEVICES += zbtlink,z8106ax-2sim
-  DEVICE_DTS := mt7981b-zbtlink-zbt-z8106ax-s
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3 kmod-usb-net-qmi-wwan kmod-usb-serial-option
-  KERNEL_IN_UBI := 1
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += zbtlink_zbt-z8106ax-s
-
-define Device/zbtlink_zbt-z8106ax-t
-  DEVICE_VENDOR := Zbtlink
-  DEVICE_MODEL := ZBT-Z8106AX-T
-  DEVICE_ALT0_VENDOR := Zbtlink
-  DEVICE_ALT0_MODEL := ZBT-Z8106AX-M2-T
-  SUPPORTED_DEVICES += zbtlink,z8106ax-2sim
-  DEVICE_DTS := mt7981b-zbtlink-zbt-z8106ax-t
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3 kmod-usb-net-qmi-wwan kmod-usb-serial-option
-  KERNEL_IN_UBI := 1
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += zbtlink_zbt-z8106ax-t
-
-define Device/zbtlink_zbt-z8803be
-  DEVICE_VENDOR := Zbtlink
-  DEVICE_MODEL := ZBT-Z8803BE
-  DEVICE_DTS := mt7988a-zbtlink-zbt-z8803be
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-sfp kmod-hwmon-pwmfan kmod-usb3 kmod-mt7996-firmware mt7988-2p5g-phy-firmware mt7988-wo-firmware
-  DEVICE_DTC_FLAGS := --pad 4096
-  SUPPORTED_DEVICES += zbtlink,zbt-z8803be,mt7988a-nand
-  KERNEL := kernel-bin | gzip | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGES := sysupgrade.bin
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += zbtlink_zbt-z8803be
-
-define Device/zyxel_ex5601-t0-stock
-  DEVICE_VENDOR := Zyxel
-  DEVICE_MODEL := EX5601-T0
-  DEVICE_ALT0_VENDOR := Zyxel
-  DEVICE_ALT0_MODEL := EX5601-T1
-  DEVICE_ALT1_VENDOR := Zyxel
-  DEVICE_ALT1_MODEL := T-56
-  DEVICE_VARIANT := (stock layout)
-  DEVICE_DTS := mt7986a-zyxel-ex5601-t0-stock
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware kmod-usb3
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 256k
-  PAGESIZE := 4096
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += zyxel_ex5601-t0-stock
-
-define Device/zyxel_ex5601-t0-ubootmod
-  DEVICE_VENDOR := Zyxel
-  DEVICE_MODEL := EX5601-T0
-  DEVICE_ALT0_VENDOR := Zyxel
-  DEVICE_ALT0_MODEL := EX5601-T1
-  DEVICE_ALT1_VENDOR := Zyxel
-  DEVICE_ALT1_MODEL := T-56
-  DEVICE_VARIANT := (OpenWrt U-Boot layout)
-  DEVICE_DTS := mt7986a-zyxel-ex5601-t0-ubootmod
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware kmod-usb3
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  IMAGES := sysupgrade.itb
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 256k
-  PAGESIZE := 4096
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  KERNEL := kernel-bin | lzma
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7986-bl2 spim-nand-4k-ddr4
-  ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot zyxel_ex5601-t0
-ifeq ($(IB),)
-ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
-  ARTIFACTS += initramfs-factory.ubi
-  ARTIFACT/initramfs-factory.ubi := append-image-stage initramfs-recovery.itb | ubinize-kernel
-endif
-endif
-endef
-TARGET_DEVICES += zyxel_ex5601-t0-ubootmod
-
-define Device/zyxel_ex5700-telenor
-  DEVICE_VENDOR := Zyxel
-  DEVICE_MODEL := EX5700 (Telenor)
-  DEVICE_DTS := mt7986a-zyxel-ex5700-telenor
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-ubootenv-nvram kmod-usb3 kmod-mt7915e kmod-mt7916-firmware kmod-mt7986-firmware mt7986-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += zyxel_ex5700-telenor
-
-define Device/zyxel_nwa50ax-pro
-  DEVICE_VENDOR := Zyxel
-  DEVICE_MODEL := NWA50AX Pro
-  DEVICE_ALT0_VENDOR := Zyxel
-  DEVICE_ALT0_MODEL := NWA90AX Pro
-  DEVICE_DTS := mt7981b-zyxel-nwa50ax-pro
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware zyxel-bootconfig
-  DEVICE_DTS_LOADADDR := 0x44000000
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 51200k
-  KERNEL_IN_UBI := 1
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE) | zyxel-nwa-fit-filogic
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += zyxel_nwa50ax-pro
-
-define Device/zyxel_wx5600-t0-ubootmod
-  DEVICE_VENDOR := Zyxel
-  DEVICE_MODEL := WX5600-T0
-  DEVICE_VARIANT := (OpenWrt U-Boot layout)
-  DEVICE_DTS := mt7986b-zyxel-wx5600-t0-ubootmod
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  IMAGES := sysupgrade.itb
-  BLOCKSIZE := 256k
-  PAGESIZE := 4096
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  KERNEL := kernel-bin | lzma
-  IMAGE/sysupgrade.itb := append-kernel | \
-        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7986-bl2 spim-nand-4k-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot zyxel_wx5600-t0
-ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
-  ARTIFACTS += initramfs-factory.ubi
-  ARTIFACT/initramfs-factory.ubi := append-image-stage initramfs-recovery.itb | ubinize-kernel
-endif
-endef
-TARGET_DEVICES += zyxel_wx5600-t0-ubootmod


### PR DESCRIPTION
Hardware specifications:
- SoC: MT7981
- Switch: MT7531 with 4x 1G PoE ports (xs2184), 1x 1G, 1x 2.5G SFP
- Flash: 16M SPI NOR + 8G eMMC
- USB: 1x USB 3.0
- LEDs: Power and System status
- Button: Reset button

Changes include:
- Device tree configuration for MT7981B
- LED configuration
- Network interface setup (5 LAN + SFP)
- MAC address configuration
- eMMC upgrade support
- GPIO and peripheral configuration

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
