### PR TITLE
Ipqess rcu timeout

### DIFF
--- a/target/linux/ipq40xx/patches-6.12/713-net-qualcomm-ipqess-protect-threaded-NAPI-with-RCU.patch
+++ b/target/linux/ipq40xx/patches-6.12/713-net-qualcomm-ipqess-protect-threaded-NAPI-with-RCU.patch
@@ -1,0 +1,67 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Denis Yarkovoy <dyarkovoy@gmail.com>
+Date: Mon, 6 Jul 2026 10:00:00 +0300
+Subject: [PATCH] net: qualcomm: ipqess: protect threaded NAPI with RCU
+ read lock
+
+ipqess enables threaded NAPI by default. With threaded NAPI the poll
+callbacks no longer run in the usual softirq context, so the poll path
+must provide its own RCU read-side protection before entering networking
+paths that dereference RCU-protected state.
+
+Add explicit RCU read-side sections around TX completion and RX polling.
+This keeps the threaded NAPI configuration while preserving the RCU
+protection expected by the networking stack and DSA paths.
+
+Signed-off-by: Denis Yarkovoy <dyarkovoy@gmail.com>
+---
+ drivers/net/ethernet/qualcomm/ipqess/ipqess.c | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/ethernet/qualcomm/ipqess/ipqess.c
++++ b/drivers/net/ethernet/qualcomm/ipqess/ipqess.c
+@@ -17,6 +17,7 @@
+ #include <linux/of_device.h>
+ #include <linux/of_mdio.h>
+ #include <linux/of_net.h>
++#include <linux/rcupdate.h>
+ #include <linux/phylink.h>
+ #include <linux/platform_device.h>
+ #include <linux/reset.h>
+@@ -494,7 +495,9 @@ static int ipqess_tx_napi(struct napi_st
+ 	tx_status = ipqess_r32(tx_ring->ess, IPQESS_REG_TX_ISR);
+ 	tx_status &= BIT(tx_ring->idx);
+ 
++	rcu_read_lock();
+ 	work_done = ipqess_tx_complete(tx_ring, budget);
++	rcu_read_unlock();
+ 
+ 	ipqess_w32(tx_ring->ess, IPQESS_REG_TX_ISR, tx_status);
+ 
+@@ -517,6 +520,8 @@ static int ipqess_rx_napi(struct napi_st
+ 	int rx_done;
+ 	u32 status;
+ 
++	rcu_read_lock();
++
+ 	do {
+ 		ipqess_w32(ess, IPQESS_REG_RX_ISR, rx_mask);
+ 		rx_done = ipqess_rx_poll(rx_ring, remaining_budget);
+@@ -525,12 +530,16 @@ static int ipqess_rx_napi(struct napi_st
+ 		status = ipqess_r32(ess, IPQESS_REG_RX_ISR);
+ 	} while (remaining_budget > 0 && (status & rx_mask));
+ 
+-	if (remaining_budget <= 0)
++	if (remaining_budget <= 0) {
++		rcu_read_unlock();
+ 		return budget;
++	}
+ 
+ 	if (napi_complete_done(napi, budget - remaining_budget))
+ 		ipqess_w32(ess, IPQESS_REG_RX_INT_MASK_Q(rx_ring->idx), 0x1);
+ 
++	rcu_read_unlock();
++
+ 	return budget - remaining_budget;
+ }
+ 

--- a/target/linux/ipq40xx/patches-6.12/714-net-qualcomm-ipqess-recover-TX-queue-on-watchdog-timeout.patch
+++ b/target/linux/ipq40xx/patches-6.12/714-net-qualcomm-ipqess-recover-TX-queue-on-watchdog-timeout.patch
@@ -1,0 +1,57 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Denis Yarkovoy <dyarkovoy@gmail.com>
+Date: Mon, 6 Jul 2026 10:05:00 +0300
+Subject: [PATCH] net: qualcomm: ipqess: recover TX queue on watchdog timeout
+
+The current ipqess TX timeout handler only logs the timeout. If TX
+completion interrupts are lost or left masked, descriptors can remain
+pending indefinitely and the master Ethernet device stays wedged until a
+reboot.
+
+Log the TX ring indexes and interrupt state to make future failures
+useful, then force the TX completion NAPI path to run and re-kick the TX
+producer index. This gives the driver a chance to reclaim pending TX
+descriptors and wake the queue instead of reporting the same watchdog
+forever.
+
+Signed-off-by: Denis Yarkovoy <dyarkovoy@gmail.com>
+---
+ drivers/net/ethernet/qualcomm/ipqess/ipqess.c | 26 +++++++++++++++++++++++++-
+ 1 file changed, 25 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/ethernet/qualcomm/ipqess/ipqess.c
++++ b/drivers/net/ethernet/qualcomm/ipqess/ipqess.c
+@@ -958,8 +958,32 @@ static void ipqess_tx_timeout(struct net
+ {
+ 	struct ipqess *ess = netdev_priv(netdev);
+ 	struct ipqess_tx_ring *tr = &ess->tx_ring[txq_id];
++	u32 idx;
++	u32 prod;
++	u32 cons;
++	u32 sw_cons;
++	u32 tx_isr;
++	u32 tx_imr;
+ 
+-	netdev_warn(netdev, "TX timeout on queue %d\n", tr->idx);
++	idx = ipqess_r32(ess, IPQESS_REG_TPD_IDX_Q(tr->idx));
++	prod = (idx >> IPQESS_TPD_PROD_IDX_SHIFT) & IPQESS_TPD_PROD_IDX_MASK;
++	cons = (idx >> IPQESS_TPD_CONS_IDX_SHIFT) & IPQESS_TPD_CONS_IDX_MASK;
++	sw_cons = ipqess_r32(ess, IPQESS_REG_TX_SW_CONS_IDX_Q(tr->idx));
++	tx_isr = ipqess_r32(ess, IPQESS_REG_TX_ISR);
++	tx_imr = ipqess_r32(ess, IPQESS_REG_TX_INT_MASK_Q(tr->idx));
++
++	netdev_warn(netdev,
++		    "TX timeout on queue %d head=%u tail=%u hw_prod=%u hw_cons=%u sw_cons=%u tx_isr=%08x tx_imr=%08x\n",
++		    tr->idx, tr->head, tr->tail, prod, cons, sw_cons, tx_isr, tx_imr);
++
++	/* A lost or masked TX completion interrupt leaves descriptors pending
++	 * forever. Force the TX completion path to run and re-kick the producer.
++	 */
++	ipqess_w32(ess, IPQESS_REG_TX_INT_MASK_Q(tr->idx), 0x0);
++	if (napi_schedule_prep(&tr->napi_tx))
++		__napi_schedule(&tr->napi_tx);
++
++	ipqess_kick_tx(tr);
+ }
+ 
+ static const struct net_device_ops ipqess_axi_netdev_ops = {


### PR DESCRIPTION
Fix ipqess stability issues observed on MikroTik hAP ac3 / IPQ4019 with OpenWrt 25.12.x.

This series contains two fixes:

1. Protect ipqess threaded NAPI poll paths with explicit RCU read-side sections.

   ipqess enables threaded NAPI by default. With threaded NAPI, the poll callbacks no longer run in the usual softirq context, but RX/TX poll paths still enter networking and DSA code that expects RCU read-side protection.

   This is relevant to the warning reported in #23315, where the stack was running from napi_threaded_poll_loop / napi/eth0-* context and hit a refcount underflow / possible use-after-free in the UDP/GRO receive path.

2. Make ipqess_tx_timeout() useful.

   The current timeout handler only logs the timeout. If TX completion stalls or a TX completion interrupt is lost/masked, eth0 can remain wedged until reboot.

   This patch logs useful ring state and forces the TX completion NAPI path to run, then re-kicks TX.

Observed symptoms included:

```text
refcount_t: underflow; use-after-free
Comm: napi/eth0-8
napi_threaded_poll_loop
```

and later:

```text
ipqess-edma c080000.ethernet eth0: NETDEV WATCHDOG: transmit queue 0 timed out
ipqess-edma c080000.ethernet eth0: TX timeout on queue 0
```

Tested on MikroTik hAP ac3.

With this series plus the ath10k-ct recovery guards, the router has been stable for over 14 days with no reboots. eth0 threaded NAPI is disabled in my runtime config as an extra local mitigation, but this series keeps the default threaded-NAPI behavior and adds the missing RCU protection. All eth0 tx_timeout counters remained zero during the stable run.

References: #23315
