### PR TITLE
Ath10k ct recovery guards

### DIFF
--- a/package/kernel/ath10k-ct/patches/301-ath10k-ct-guard-beacon-tx-null-ar.patch
+++ b/package/kernel/ath10k-ct/patches/301-ath10k-ct-guard-beacon-tx-null-ar.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Denis Yarkovoy <dyarkovoy@gmail.com>
+Date: Mon, 6 Jul 2026 10:10:00 +0300
+Subject: [PATCH] wifi: ath10k-ct: guard beacon TX against NULL ar
+
+During firmware recovery ath10k can still walk beaconing vif state while
+an ath10k_vif has already lost its owning ath10k pointer. The existing
+ath10k-ct guard only rejects an invalid arvif pointer, then immediately
+dereferences arvif->ar and locks ar->data_lock.
+
+If arvif->ar is NULL this crashes in the recovery path at
+_raw_spin_lock_bh() with an access near NULL. Reject a missing or invalid
+ar pointer before taking the lock, and make the existing arvif diagnostic
+more specific.
+
+Signed-off-by: Denis Yarkovoy <dyarkovoy@gmail.com>
+---
+ ath10k-6.18/wmi.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+--- a/ath10k-6.18/wmi.c
++++ b/ath10k-6.18/wmi.c
+@@ -1946,9 +1946,14 @@ static void ath10k_wmi_tx_beacon_nowait(struct ath10k_vif *arvif)
+ 	/* Crash was seen here after FW crash.  ar and/or arvif were effectively NULL. */
+ 	if ((unsigned long)(arvif) < 8000) {
+-		pr_err("wmi-tx-beacon-nowait, arvif: %p\n", arvif);
++		pr_err("wmi-tx-beacon-nowait, arvif too small: %p\n", arvif);
+ 		WARN_ON_ONCE(1);
+ 		return;
+ 	}
+ 
+ 	ar = arvif->ar;
++	if (!ar || (unsigned long)(ar) < 8000) {
++		pr_err("wmi-tx-beacon-nowait, ar invalid: arvif=%p ar=%p\n", arvif, ar);
++		WARN_ON_ONCE(1);
++		return;
++	}
+ 	spin_lock_bh(&ar->data_lock);

--- a/package/kernel/ath10k-ct/patches/302-ath10k-ct-guard-empty-rx-ring-slots.patch
+++ b/package/kernel/ath10k-ct/patches/302-ath10k-ct-guard-empty-rx-ring-slots.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Denis Yarkovoy <dyarkovoy@gmail.com>
+Date: Mon, 6 Jul 2026 10:15:00 +0300
+Subject: [PATCH] wifi: ath10k-ct: guard empty RX ring slots
+
+ath10k_htt_rx_netbuf_pop() checks whether the RX ring has a non-zero
+fill count, but it assumes the indexed ring slot contains an skb. If the
+firmware or ring state points at an already-empty slot, the function
+continues and dereferences the NULL skb while unmapping DMA.
+
+Return NULL for an empty slot after consuming that ring position. The
+existing caller already treats a NULL return as RX ring corruption,
+purges the partial AMSDU, and stops further RX processing instead of
+crashing in interrupt context.
+
+Signed-off-by: Denis Yarkovoy <dyarkovoy@gmail.com>
+---
+ ath10k-6.18/htt_rx.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+--- a/ath10k-6.18/htt_rx.c
++++ b/ath10k-6.18/htt_rx.c
+@@ -341,6 +341,15 @@ static inline struct sk_buff *ath10k_htt_rx_netbuf_pop(struct ath10k_htt *htt)
+ 	idx = htt->rx_ring.sw_rd_idx.msdu_payld;
+ 	msdu = htt->rx_ring.netbufs_ring[idx];
+ 	htt->rx_ring.netbufs_ring[idx] = NULL;
++	if (!msdu) {
++		ath10k_warn(ar, "rx ring slot %d empty while popping netbuf\n", idx);
++		ath10k_htt_reset_paddrs_ring(htt, idx);
++		idx++;
++		idx &= htt->rx_ring.size_mask;
++		htt->rx_ring.sw_rd_idx.msdu_payld = idx;
++		htt->rx_ring.fill_cnt--;
++		return NULL;
++	}
+ 	ath10k_htt_reset_paddrs_ring(htt, idx);
+ 
+ 	idx++;


### PR DESCRIPTION
Fix ath10k-ct recovery-path crashes observed on MikroTik hAP ac3 / QCA4019 with OpenWrt 25.12.x.

This series adds two defensive guards:

1. Guard ath10k_wmi_tx_beacon_nowait() against arvif->ar == NULL.

   The existing ath10k-ct code already checked for an invalid arvif pointer, but then immediately dereferenced arvif->ar and locked ar->data_lock.

   During firmware recovery, arvif->ar can be NULL, causing a kernel crash while taking ar->data_lock.

2. Guard ath10k_htt_rx_netbuf_pop() against empty RX ring slots.

   The function checked whether the RX ring had a non-zero fill count, but assumed the indexed RX ring slot contained an skb.

   If the slot is already empty, the code dereferenced a NULL skb while unmapping DMA. The existing caller already handles a NULL return by treating it as RX ring corruption, purging the partial AMSDU, and stopping further RX processing.

Relevant report: #22793

Observed symptoms included repeated QCA4019 firmware crashes followed by kernel paging-request Oops during ath10k recovery.

The firmware crash itself still exists, but with these guards the driver survives recovery instead of panicking.

Tested on MikroTik hAP ac3 with standard QCA4019 firmware 10.4-3.6-00140.

With these guards plus the ipqess fixes, the router has been stable for over 14 days with no reboots. Firmware crash recoveries completed without triggering the previous ath10k recovery-path panics.

References: #22793
