### PR TITLE
kernel: minimize kmod-sched-ctinfo dependencies

### DIFF
--- a/package/kernel/linux/modules/netsupport.mk
+++ b/package/kernel/linux/modules/netsupport.mk
@@ -836,7 +836,7 @@ $(eval $(call KernelPackage,sched-connmark))
 define KernelPackage/sched-ctinfo
   SUBMENU:=$(NETWORK_SUPPORT_MENU)
   TITLE:=Traffic shaper ctinfo support
-  DEPENDS:=+kmod-sched-core +kmod-ipt-core +kmod-ipt-conntrack-extra
+  DEPENDS:=+kmod-sched-core +kmod-nf-conntrack
   KCONFIG:=CONFIG_NET_ACT_CTINFO
   FILES:=$(LINUX_DIR)/net/sched/act_ctinfo.ko
   AUTOLOAD:=$(call AutoLoad,71, act_ctinfo)


### PR DESCRIPTION
Do not pull iptables core for kmod-sched-ctinfo, only nf-conntrack, reflecting kernel config dependencies.

There is no use of this module in openwrt repos, but it is used by @hudra0 qosmate
and some less popular qos scripts neither of which use iptables