### PR TITLE
rockchip: add support for ArmSoM Sige5 (Banana Pi BPI-M5 Pro)

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -356,6 +356,13 @@ define U-Boot/rock-4d-rk3576
     radxa_rock-4d
 endef
 
+define U-Boot/sige5-rk3576
+  $(U-Boot/rk3576/Default)
+  NAME:=Sige5
+  BUILD_DEVICES:= \
+    armsom_sige5
+endef
+
 
 # RK358x boards
 
@@ -476,6 +483,7 @@ UBOOT_TARGETS := \
   generic-rk3576 \
   nanopi-m5-rk3576 \
   rock-4d-rk3576 \
+  sige5-rk3576 \
   generic-rk3588 \
   nanopc-t6-rk3588 \
   rock-5-itx-rk3588 \

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -7,6 +7,7 @@ rockchip_setup_interfaces()
 	local board="$1"
 
 	case "$board" in
+	armsom,sige5|\
 	armsom,sige7|\
 	friendlyarm,nanopi-m5|\
 	friendlyarm,nanopi-r2c|\
@@ -79,6 +80,7 @@ rockchip_setup_macs()
 	local label_mac=""
 
 	case "$board" in
+	armsom,sige5|\
 	armsom,sige7|\
 	friendlyarm,nanopc-t6|\
 	friendlyarm,nanopi-m5|\

--- a/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
+++ b/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
@@ -52,6 +52,7 @@ xunlong,orangepi-r1-plus-lts)
 	set_interface_core 2 "eth0"
 	set_interface_core 4 "eth1" "xhci-hcd:usb[0-9]+"
 	;;
+armsom,sige5|\
 friendlyarm,nanopi-m5|\
 friendlyarm,nanopi-r4s|\
 friendlyarm,nanopi-r4s-enterprise|\

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -52,6 +52,16 @@ define Device/rk3588s
   KERNEL_LOADADDR := 0x03000000
 endef
 
+define Device/armsom_sige5
+  $(Device/rk3576)
+  DEVICE_VENDOR := ArmSoM
+  DEVICE_MODEL := Sige5
+  DEVICE_ALT0_VENDOR := Bananapi
+  DEVICE_ALT0_MODEL := BPi-M5 Pro
+  DEVICE_DTS := rk3576-armsom-sige5
+endef
+TARGET_DEVICES += armsom_sige5
+
 define Device/armsom_sige7
   $(Device/rk3588)
   DEVICE_VENDOR := ArmSoM

--- a/target/linux/rockchip/patches-6.18/142-arm64-dts-rockchip-Update-LED-properties-for-ArmSom-Sige5.patch
+++ b/target/linux/rockchip/patches-6.18/142-arm64-dts-rockchip-Update-LED-properties-for-ArmSom-Sige5.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: firepinn <firepinn@gmail.com>
+Date: Thu, 10 Jul 2026 00:00:00 +0000
+Subject: [PATCH] arm64: dts: rockchip: Update LED properties for ArmSom
+ Sige5
+
+Add OpenWrt's LED aliases for showing system status.
+
+Signed-off-by: firepinn <firepinn@gmail.com>
+---
+
+--- a/arch/arm64/boot/dts/rockchip/rk3576-armsom-sige5.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3576-armsom-sige5.dts
+@@ -21,6 +21,11 @@
+ 	aliases {
+ 		ethernet0 = &gmac0;
+ 		ethernet1 = &gmac1;
++
++		led-boot = &green_led;
++		led-failsafe = &green_led;
++		led-running = &green_led;
++		led-upgrade = &green_led;
+ 	};
+ 
+ 	chosen {
+@@ -45,7 +50,7 @@
+ 			color = <LED_COLOR_ID_GREEN>;
++			default-state = "on";
+ 			function = LED_FUNCTION_HEARTBEAT;
+ 			gpios = <&gpio4 RK_PB2 GPIO_ACTIVE_HIGH>;
+-			linux,default-trigger = "heartbeat";
+ 		};
+ 
+ 		red_led: red-led {


### PR DESCRIPTION
## Description

Adds support for the **ArmSoM Sige5** (also sold as **Banana Pi BPI-M5 Pro**), a single board computer based on the Rockchip RK3576 SoC.

### Hardware
- Rockchip RK3576 (4x Cortex-A72 + 4x Cortex-A53)
- 2/4/8/16 GB LPDDR5 RAM
- 2x Gigabit Ethernet (RGMII, Motorcomm PHY, in-kernel `dwmac-rockchip`)
- eMMC + microSD
- HDMI 2.1, M.2 M-Key (PCIe) and E-Key (SDIO Wi-Fi/BT), 2x USB 3.0
- ES8388 audio codec, RK806 PMIC, HYM8563 RTC

The device tree `rk3576-armsom-sige5` is already in Linux 6.18 and the `sige5-rk3576` U-Boot defconfig in U-Boot 2026.01, so the only kernel patch needed is one adjusting the LED properties: it adds OpenWrt's LED aliases so the green system LED reflects boot, failsafe, running and upgrade status, and drops the kernel heartbeat trigger so OpenWrt can drive the LED.

### Testing
Built and tested on real hardware from current master (kernel 6.18): boots from eMMC and microSD, both Ethernet ports link up, USB 3.0 host and Type-C, and sysupgrade all work.
