### PR TITLE
mac80211: ath12k: fix regulatory range for wideband radios

### DIFF
--- a/package/kernel/mac80211/patches/ath12k/104-wifi-ath12k-fix-regulatory-range-for-wideband-radios.patch
+++ b/package/kernel/mac80211/patches/ath12k/104-wifi-ath12k-fix-regulatory-range-for-wideband-radios.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Robert Marko <robert.marko@sartura.hr>
+Date: Mon, 6 Jul 2026 15:11:35 +0200
+Subject: [PATCH] wifi: ath12k: fix regulatory range for wideband radios
+
+ath12k_regd_update() assumes that a radio advertising 6 GHz cannot also
+operate on 5 GHz.  This is not true for wideband QCN9274 radios.  As a
+result, a regulatory update drops 5 GHz from ar->freq_range even though
+the 5 GHz band remains registered with cfg80211.
+
+Use the hardware frequency bounds, as ath12k_mac_setup_channels_rates()
+does, and update both portions when a radio spans 5 GHz and 6 GHz.
+
+Signed-off-by: Robert Marko <robert.marko@sartura.hr>
+---
+ drivers/net/wireless/ath/ath12k/reg.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath12k/reg.c
++++ b/drivers/net/wireless/ath/ath12k/reg.c
+@@ -310,7 +310,8 @@ int ath12k_regd_update(struct ath12k *ar
+ 		ath12k_mac_update_freq_range(ar, freq_low, freq_high);
+ 	}
+ 
+-	if (supported_bands & WMI_HOST_WLAN_5GHZ_CAP && !ar->supports_6ghz) {
++	if (supported_bands & WMI_HOST_WLAN_5GHZ_CAP &&
++	    reg_cap->low_5ghz_chan < ATH12K_MIN_6GHZ_FREQ) {
+ 		if (ab->hw_params->single_pdev_only) {
+ 			phy_id = ar->pdev->cap.band[WMI_HOST_WLAN_5GHZ_CAP].phy_id;
+ 			reg_cap = &ab->hal_reg_cap[phy_id];
+@@ -322,7 +323,8 @@ int ath12k_regd_update(struct ath12k *ar
+ 		ath12k_mac_update_freq_range(ar, freq_low, freq_high);
+ 	}
+ 
+-	if (supported_bands & WMI_HOST_WLAN_5GHZ_CAP && ar->supports_6ghz) {
++	if (supported_bands & WMI_HOST_WLAN_5GHZ_CAP &&
++	    reg_cap->high_5ghz_chan >= ATH12K_MIN_6GHZ_FREQ) {
+ 		freq_low = max(reg_cap->low_5ghz_chan, ab->reg_freq_6ghz.start_freq);
+ 		freq_high = min(reg_cap->high_5ghz_chan, ab->reg_freq_6ghz.end_freq);
+ 


### PR DESCRIPTION
Currently, trying to start a 5GHz radio on 8devices Kiwi will fail as despite the phy listing the 5GHz channels in iw phy dump, no radio actually claims the 5GHz range.

This is because driver assumes that if radio supports 6GHz then it cannot be used for 5Ghz, this is however not correct for wideband radios.

So, similar to the 103-wifi-ath12k-fix-5GHz-operation-on-wideband-QCN.patch patch ath12k_regd_update() so that 5Ghz range is listed as well.
