### PR TITLE
scripts: dhcpv4/v6: option to override preferred Client ID per interface

### DIFF
--- a/package/network/config/netifd/Makefile
+++ b/package/network/config/netifd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netifd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/netifd.git

--- a/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
+++ b/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
@@ -15,6 +15,7 @@ proto_dhcp_init_config() {
 	proto_config_add_string 'ipaddr:ipaddr'
 	proto_config_add_string 'hostname:hostname'
 	proto_config_add_string clientid
+	proto_config_add_string sendclientid
 	proto_config_add_string vendorid
 	proto_config_add_boolean 'broadcast:bool'
 	proto_config_add_boolean 'norelease:bool'
@@ -58,8 +59,8 @@ proto_dhcp_setup() {
 	local config="$1"
 	local iface="$2"
 
-	local ipaddr hostname clientid vendorid broadcast norelease reqopts defaultreqopts iface6rd sendopts delegate zone6rd zone mtu6rd customroutes classlessroute timeout retry tryagain
-	json_get_vars ipaddr hostname clientid vendorid broadcast norelease reqopts defaultreqopts iface6rd delegate zone6rd zone mtu6rd customroutes classlessroute timeout retry tryagain
+	local ipaddr hostname clientid sendclientid vendorid broadcast norelease reqopts defaultreqopts iface6rd sendopts delegate zone6rd zone mtu6rd customroutes classlessroute timeout retry tryagain
+	json_get_vars ipaddr hostname clientid sendclientid vendorid broadcast norelease reqopts defaultreqopts iface6rd delegate zone6rd zone mtu6rd customroutes classlessroute timeout retry tryagain
 
 	local opt dhcpopts
 	for opt in $reqopts; do
@@ -74,12 +75,28 @@ proto_dhcp_setup() {
 	[ "$defaultreqopts" = 0 ] && defaultreqopts="-o" || defaultreqopts=
 	[ "$broadcast" = 1 ] && broadcast="-B" || broadcast=
 	[ "$norelease" = 1 ] && norelease="" || norelease="-R"
-	[ -n "$clientid" ] && {
-		clientid="$(hexdump_2hex "$clientid")"
-		[ -z "$clientid" ] && logger -p warn -t dhcp "$iface: ignoring invalid clientid value"
-	}
-	[ -z "$clientid" ] && clientid="$(proto_dhcp_get_default_clientid "$iface")"
-	[ -n "$clientid" ] && clientid="-x 0x3d:$clientid"
+	case "$sendclientid" in
+		global)
+			clientid="$(proto_dhcp_get_default_clientid "$iface")"
+			;;
+		hardware)
+			clientid=''
+			;;
+		none)
+			clientid='-C'
+			;;
+		auto|\
+		*)
+			[ -n "$clientid" ] && {
+				clientid="$(hexdump_2hex "$clientid")"
+				[ -z "$clientid" ] && {
+					logger -p warn -t dhcp "$iface: ignoring invalid clientid value"
+				}
+			}
+			[ -z "$clientid" ] && clientid="$(proto_dhcp_get_default_clientid "$iface")"
+			;;
+	esac
+	[ -n "${clientid##-C}" ] && clientid="-x 0x3d:$clientid"
 	[ -n "$vendorid" ] && append dhcpopts "-x 0x3c:$(echo -n "$vendorid" | hexdump -ve '1/1 "%02x"')"
 	[ -n "$iface6rd" ] && proto_export "IFACE6RD=$iface6rd"
 	[ "$iface6rd" != 0 -a -f /lib/netifd/proto/6rd.sh ] && append dhcpopts "-O 212"

--- a/package/network/ipv6/odhcp6c/Makefile
+++ b/package/network/ipv6/odhcp6c/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=odhcp6c
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/odhcp6c.git

--- a/package/network/ipv6/odhcp6c/files/dhcpv6.sh
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.sh
@@ -12,6 +12,7 @@ proto_dhcpv6_init_config() {
 	proto_config_add_string 'reqaddress:or("try","force","none")'
 	proto_config_add_string reqprefix
 	proto_config_add_string clientid
+	proto_config_add_string 'sendclientid:or("auto","global","hardware")'
 	proto_config_add_string 'reqopts:list(uinteger)'
 	proto_config_add_string 'defaultreqopts:bool'
 	proto_config_add_string 'noslaaconly:bool'
@@ -48,6 +49,18 @@ proto_dhcpv6_init_config() {
 	proto_config_add_boolean dynamic
 }
 
+proto_dhcpv6_get_default_duid() {
+	local duid="$(uci_get network @globals[0] dhcp_default_duid)"
+	[ -n "$duid" ] && {
+		duid="$(hexdump_2hex "$duid")"
+		[ -z "$duid" ] && {
+			logger -p warn -t dhcpv6 "$iface: ignoring invalid dhcp_default_duid value"
+		}
+	}
+	[ -z "$duid" ] && return
+	echo -n $duid
+}
+
 proto_dhcpv6_add_prefix() {
 	append "$3" "$1"
 }
@@ -60,7 +73,7 @@ proto_dhcpv6_setup() {
 	local config="$1"
 	local iface="$2"
 
-	local reqaddress reqprefix clientid reqopts defaultreqopts
+	local reqaddress reqprefix clientid sendclientid reqopts defaultreqopts
 	local noslaaconly forceprefix extendprefix norelease strict_rfc7550
 	local noserverunicast noclientfqdn noacceptreconfig iface_dslite
 	local iface_map iface_464xlat ip6ifaceid userclass vendorclass
@@ -70,7 +83,7 @@ proto_dhcpv6_setup() {
 
 	local ip6prefix ip6prefixes
 
-	json_get_vars reqaddress reqprefix clientid reqopts defaultreqopts
+	json_get_vars reqaddress reqprefix clientid sendclientid reqopts defaultreqopts
 	json_get_vars noslaaconly forceprefix extendprefix norelease strict_rfc7550
 	json_get_vars noserverunicast noclientfqdn noacceptreconfig iface_dslite
 	json_get_vars iface_map iface_464xlat ip6ifaceid userclass vendorclass
@@ -106,15 +119,24 @@ proto_dhcpv6_setup() {
 		append opts "-P$reqprefix"
 	}
 
-	[ -n "$clientid" ] && {
-		clientid="$(hexdump_2hex "$clientid")"
-		[ -z "$clientid" ] && logger -p warn -t dhcpv6 "$iface: ignoring invalid clientid value"
-	}
-	[ -z "$clientid" ] && clientid="$(uci_get network @globals[0] dhcp_default_duid)"
-	[ -n "$clientid" ] && {
-		clientid="$(hexdump_2hex "$clientid")"
-		[ -z "$clientid" ] && logger -p warn -t dhcpv6 "$iface: ignoring invalid dhcp_default_duid value"
-	}
+	case "$sendclientid" in
+		global)
+			clientid="$(proto_dhcpv6_get_default_duid)"
+			;;
+		hardware)
+			clientid=''
+			;;
+		auto|\
+		*)
+			[ -n "$clientid" ] && {
+				clientid="$(hexdump_2hex "$clientid")"
+				[ -z "$clientid" ] && {
+					logger -p warn -t dhcpv6 "$iface: ignoring invalid clientid value"
+				}
+			}
+			[ -z "$clientid" ] && clientid="$(proto_dhcpv6_get_default_duid)"
+			;;
+	esac
 	[ -n "$clientid" ] && append opts "-c$clientid"
 
 	[ "$defaultreqopts" = "0" ] && append opts "-R"


### PR DESCRIPTION
Since 387b49d89aa5c2c62c5437c51ee9ea4c58a13c8d, a DHCPv4 option tag 61 is sent by default  in DHCPv4 requests.

Since OpenWrt 25.12, a type 4 DUID(-UUID) is used by default in DHCPv6 requests, instead of the i/f's DUID-LL. This DUID-UUID is generated at first boot or sysupgrade (if it didn't exist), therefore it also affects upgraded systems, not just fresh installs. This auto-generated DHCPv6 global default DUID is also used in the DHCPv4 option tag 61 (Client ID), for RFC6355 compliance.

No possibility is available to fall back to using the i/f hardware ID (MAC address resp. DUID-LL). This breaks existing DHCP reservations and causes compatibility issues with certain ISPs.

Introduce a new, optional setting to override the behavior on a per-interface basis:

`network.<ifname>.sendclientid='auto|global|hardware|none'`

This setting will determine which type of client ID is preferrably being used in DHCPv4/DHCPv6 requests:

- `auto` or not setting this option (default) will keep the behavior as before this PR: Any explicitly defined client ID is used. If no explcit client ID is defined, the global default DUID is used as client ID. If this isn't defined either, DUID-LL resp. MAC address is used as per `odhcp6c`/`udhcpc` default.
- `global` means to prefer RFC6355 compliance even if an explicit client ID is specified. The global default DUID-UUID, if configured, will be used in DHCPv4 resp. DHCPv6 requests.
- `hardware` will not pass a client ID to `odhcp6c`/`udhcpc`, which results in `udhcpc`/`odhcp6c` using the i/f MAC address for DHCPv4 option tag 61, resp. the i/f's type 3 DUID for DHCPv6
- `none` (IPv4 only) will not add an option tag 61 at all to DHCPv4 requests (ie. the pre-25.12 behavior)

Setting `hardware` for `wan6` and `none` for `wan` will largely revert to the pre-25.12 behavior, solving the following issues:

Fixes: #20815 (possibly)
Fixes: #21350
Fixes: #21671
Fixes: #22277
Fixes: #22309 (possibly)
Fixes: #22332 (possibly)
Fixes: #24065
... and perhaps some more.

This PR is a similar, but more comprehensive approach to #24087.
