### PR TITLE
[25.12]: wifi-scripts: ucode: fix eap client mode

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
@@ -196,6 +196,10 @@
 			"description": "Specifies the path the CA certificate used for authentication",
 			"type": "string"
 		},
+		"ca_cert2": {
+			"description": "Path to the inner-tunnel (phase 2) CA certificate for EAP-TLS",
+			"type": "string"
+		},
 		"ca_cert2_usesystem": {
 			"type": "boolean"
 		},
@@ -213,6 +217,10 @@
 		},
 		"client_cert": {
 			"description": "File path to client certificate file (PEM/DER)",
+			"type": "string"
+		},
+		"client_cert2": {
+			"description": "File path to the inner-tunnel (phase 2) client certificate for EAP-TLS",
 			"type": "string"
 		},
 		"dae_client": {
@@ -854,8 +862,16 @@
 			"description": "Private key matching with the server certificate for EAP-TLS/PEAP/TTLS",
 			"type": "string"
 		},
+		"private_key2": {
+			"description": "Inner-tunnel (phase 2) private key for EAP-TLS",
+			"type": "string"
+		},
 		"private_key_passwd": {
 			"description": "Passphrase for private key",
+			"type": "string"
+		},
+		"private_key2_passwd": {
+			"description": "Passphrase for the inner-tunnel (phase 2) private key",
 			"type": "string"
 		},
 		"proxy_arp": {

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
@@ -853,10 +853,20 @@
 			"default": true
 		},
 		"priv_key": {
-			"type": "string"
+			"type": "alias",
+			"default": "private_key"
 		},
 		"priv_key_pwd": {
-			"type": "string"
+			"type": "alias",
+			"default": "private_key_passwd"
+		},
+		"priv_key2": {
+			"type": "alias",
+			"default": "private_key2"
+		},
+		"priv_key2_pwd": {
+			"type": "alias",
+			"default": "private_key2_passwd"
 		},
 		"private_key": {
 			"description": "Private key matching with the server certificate for EAP-TLS/PEAP/TTLS",

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
@@ -160,7 +160,20 @@ function setup_sta(data, config) {
 		case 'peap':
 		case 'ttls':
 			set_default(config, 'auth', 'MSCHAPV2');
-			config.phase2 = `"auth=${config.auth}"`;
+
+			let auth = config.auth;
+			let phase2proto = 'auth=';
+			if (index(auth, 'auth') == 0) {
+				/* user already provided a full "auth=..." spec */
+				phase2proto = '';
+			} else if (index(auth, 'EAP-') == 0) {
+				/* inner EAP method, e.g. EAP-MSCHAPV2 -> MSCHAPV2 */
+				auth = substr(auth, 4);
+				if (config.eap_type == 'ttls')
+					phase2proto = 'autheap=';
+			}
+			config.phase2 = `"${phase2proto}${auth}"`;
+
 			if (config.auth == 'EAP-TLS') {
 				if (config.ca_cert2_usesystem && fs.stat('/etc/ssl/certs/ca-certificates.crt'))
 					config.ca_cert2 = '/etc/ssl/certs/ca-certificates.crt';

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
@@ -207,9 +207,24 @@ function setup_sta(data, config) {
 
 	config.mcast_rate = ratestr(config.mcast_rate);
 
+	/*
+	 * Certificate constraint lists are semicolon-separated strings in the
+	 * wpa_supplicant config, while UCI stores them as arrays. Join them here
+	 * so they are emitted as a single quoted value below.
+	 */
+	for (let key in [ 'altsubject_match', 'altsubject_match2',
+			  'domain_match', 'domain_match2',
+			  'domain_suffix_match', 'domain_suffix_match2' ])
+		if (type(config[key]) == 'array')
+			config[key] = length(config[key]) ? join(';', config[key]) : null;
+
 	network_append_string_vars(config, [ 'ssid',
 		'identity', 'anonymous_identity', 'password',
-		'ca_cert', 'ca_cert2', 'client_cert', 'client_cert2', 'subject_match',
+		'ca_cert', 'ca_cert2', 'client_cert', 'client_cert2',
+		'subject_match', 'subject_match2',
+		'altsubject_match', 'altsubject_match2',
+		'domain_match', 'domain_match2',
+		'domain_suffix_match', 'domain_suffix_match2',
 		'private_key', 'private_key_passwd', 'private_key2', 'private_key2_passwd',
 		 ]);
 	network_append_vars(config, [
@@ -218,7 +233,6 @@ function setup_sta(data, config) {
 		'proto', 'mesh_fwding', 'mesh_rssi_threshold', 'frequency', 'fixed_freq',
 		'disable_ht', 'disable_ht40', 'disable_vht', 'vht', 'max_oper_chwidth',
 		'ht40', 'beacon_int', 'ieee80211w', 'rates', 'mesh_basic_rates', 'mcast_rate',
-		'altsubject_match', 'domain_match', 'domain_suffix_match',
 		'bssid_blacklist', 'bssid_whitelist', 'erp', 'eap', 'phase2',
 	]);
 }


### PR DESCRIPTION
 * wifi-scripts: ucode: fix EAP phase2 authentication method
    
    The supplicant config generator emitted the phase2 directive as
    phase2="auth=${auth}" for every PEAP/TTLS/FAST configuration. That is
    wrong whenever the configured inner method is an EAP method: for
    auth='EAP-MSCHAPV2' it produced phase2="auth=EAP-MSCHAPV2", which
    wpa_supplicant rejects with:
    
      TLS: Unsupported Phase2 EAP method 'EAP-MSCHAPV2'
    
    breaking WPA-Enterprise clients that use an EAP inner method.
    
    Mirror the shell config generator (hostapd.sh): strip the "EAP-" prefix
    and pick the phase2 prefix from the method type, i.e. "autheap=" for a
    tunneled EAP method with TTLS and "auth=" for a non-EAP method or a
    full "auth=..." spec provided by the user.
    
    Fixes: https://github.com/openwrt/openwrt/issues/24086
    Fixes: c92ded2f6e7a ("wifi-scripts: fix EAP STA support in supplicant config generation")
    Assisted-by: Claude:claude-opus-4-8
    Link: https://github.com/openwrt/openwrt/pull/24088
    Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
    (cherry picked from commit 0cdf956ee1fe729ef2ccb81affcadb807a751c43)

 * wifi-scripts: ucode: fix EAP certificate constraint handling
    
    The supplicant config generator emitted the altsubject_match,
    domain_match and domain_suffix_match server certificate constraints
    through the plain (unquoted) variable list. As these are UCI arrays,
    they were rendered space-separated and without quotes, e.g.
    
      altsubject_match=DNS:a.example.com DNS:b.example.com
    
    wpa_supplicant parses an unquoted string value as a hex blob, so such a
    line fails to parse and the constraint is dropped. wpa_supplicant
    expects a single quoted, semicolon-separated string:
    
      altsubject_match="DNS:a.example.com;DNS:b.example.com"
    
    Join these lists with semicolons and emit them as quoted strings.
    
    The inner-tunnel (phase 2) constraints subject_match2, altsubject_match2,
    domain_match2 and domain_suffix_match2 were not written to the config at
    all; emit them as well. Add the matching inner EAP-TLS options ca_cert2,
    client_cert2, private_key2 and private_key2_passwd to the schema so they
    validate cleanly.
    
    Fixes: 218f3884d2fb ("wifi-scripts: add ucode based scripts")
    Assisted-by: Claude:claude-opus-4-8
    Link: https://github.com/openwrt/openwrt/pull/24088
    Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
    (cherry picked from commit 7be144ad83e33544b8f354429eb012a63b2aeecb)

 * wifi-scripts: restore priv_key/priv_key_pwd as config aliases
    
    The shell config generator read the client private key from the UCI
    options priv_key / priv_key_pwd (and priv_key2 / priv_key2_pwd for the
    inner tunnel). The ucode generator was switched to private_key /
    private_key_passwd (matching the wpa_supplicant field names), and LuCI
    was updated accordingly, but existing configurations still carry the old
    option names.
    
    Such configs silently lose their private key: for an EAP-TLS client this
    leaves wpa_supplicant without a client key and authentication fails after
    upgrading from 24.10.
    
    The schema already lists priv_key / priv_key_pwd, but as plain strings,
    so validate() never migrates them. Declare them (and the missing
    priv_key2 / priv_key2_pwd) as aliases of the private_key* options so the
    old names keep working.
    
    Fixes: https://github.com/openwrt/openwrt/issues/22599
    Fixes: 218f3884d2fb ("wifi-scripts: add ucode based scripts")
    Assisted-by: Claude:claude-opus-4-8
    Link: https://github.com/openwrt/openwrt/pull/24088
    Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
    (cherry picked from commit 649b42331c8332db5f91074b0c6143c7919a6973)
