### PR TITLE
treewide: remove fwnode_for_each_available_child_node

### DIFF
--- a/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
+++ b/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
@@ -363,13 +363,12 @@ static irqreturn_t button_handle_irq(int irq, void *_bdata)
 static struct gpio_keys_platform_data *
 gpio_keys_get_devtree_pdata(struct device *dev)
 {
-	struct device_node *node = dev->of_node;
 	struct gpio_keys_platform_data *pdata;
 	struct gpio_keys_button *buttons;
 	int nbuttons;
 	int i = 0;
 
-	nbuttons = of_get_available_child_count(node);
+	nbuttons = device_get_child_node_count(dev);
 	if (nbuttons == 0)
 		return ERR_PTR(-EINVAL);
 
@@ -377,28 +376,32 @@ gpio_keys_get_devtree_pdata(struct device *dev)
 	if (!buttons)
 		return ERR_PTR(-ENOMEM);
 
-	for_each_available_child_of_node_scoped(node, pp) {
+	device_for_each_child_node_scoped(dev, pp) {
 		struct gpio_keys_button *button = &buttons[i++];
 
-		if (of_property_read_u32(pp, "linux,code", &button->code)) {
+		if (fwnode_property_read_u32(pp, "linux,code", &button->code)) {
 			dev_err(dev, "Button node '%s' without keycode\n",
-				pp->full_name);
+				fwnode_get_name(pp));
 			return ERR_PTR(-EINVAL);
 		}
 
-		button->desc = of_get_property(pp, "label", NULL);
+		if (fwnode_property_read_string(pp, "label", &button->desc))
+			button->desc = NULL;
 
-		if (of_property_read_u32(pp, "linux,input-type", &button->type))
+		if (fwnode_property_read_u32(pp, "linux,input-type", &button->type))
 			button->type = EV_KEY;
 
-		button->wakeup = of_property_present(pp, "gpio-key,wakeup");
-
-		if (of_property_read_u32(pp, "debounce-interval",
+		if (fwnode_property_read_u32(pp, "debounce-interval",
 					&button->debounce_interval))
 			button->debounce_interval = 5;
 
-		button->irq = irq_of_parse_and_map(pp, 0);
+		button->wakeup = fwnode_property_present(pp, "gpio-key,wakeup");
 		button->gpio = -ENOENT; /* mark this as device-tree */
+		button->irq = fwnode_irq_get(pp, 0);
+		if (button->irq == -EPROBE_DEFER)
+			return ERR_PTR(button->irq);
+		if (button->irq < 0)
+			button->irq = 0;
 	}
 
 	pdata = devm_kzalloc(dev, sizeof(struct gpio_keys_platform_data), GFP_KERNEL);
@@ -407,8 +410,8 @@ gpio_keys_get_devtree_pdata(struct device *dev)
 
 	pdata->nbuttons = nbuttons;
 	pdata->buttons = buttons;
-	pdata->rep = of_property_present(node, "autorepeat");
-	of_property_read_u32(node, "poll-interval", &pdata->poll_interval);
+	pdata->rep = device_property_present(dev, "autorepeat");
+	device_property_read_u32(dev, "poll-interval", &pdata->poll_interval);
 
 	return pdata;
 }

--- a/target/linux/bmips/files/drivers/leds/leds-sercomm-msp430.c
+++ b/target/linux/bmips/files/drivers/leds/leds-sercomm-msp430.c
@@ -326,15 +326,13 @@ static inline int msp430_check_workmode(struct spi_device *spi)
 static int msp430_leds_probe(struct spi_device *spi)
 {
 	struct device *dev = &spi->dev;
-	struct fwnode_handle *fw = dev_fwnode(dev);
-	struct fwnode_handle *child;
 	int rc;
 
 	rc = msp430_check_workmode(spi);
 	if (rc)
 		return rc;
 
-	fwnode_for_each_available_child_node(fw, child) {
+	device_for_each_child_node_scoped(dev, child) {
 		u32 reg;
 
 		if (fwnode_property_read_u32(child, "reg", &reg))
@@ -347,10 +345,8 @@ static int msp430_leds_probe(struct spi_device *spi)
 		}
 
 		rc = msp430_led_probe(spi, child, reg);
-		if (rc < 0) {
-			fwnode_handle_put(child);
+		if (rc < 0)
 			return rc;
-		}
 	}
 
 	return 0;

--- a/target/linux/mediatek/files/drivers/leds/leds-smartrg-system.c
+++ b/target/linux/mediatek/files/drivers/leds/leds-smartrg-system.c
@@ -166,7 +166,6 @@ static int
 srg_led_probe(struct i2c_client *client)
 {
 	struct device *dev = &client->dev;
-	struct fwnode_handle *fw = dev_fwnode(dev);
 	struct srg_led_ctrl *sysled_ctrl;
 	int err;
 
@@ -182,7 +181,7 @@ srg_led_probe(struct i2c_client *client)
 
 	i2c_set_clientdata(client, sysled_ctrl);
 
-	fwnode_for_each_available_child_node_scoped(fw, child) {
+	device_for_each_child_node_scoped(dev, child) {
 		if (srg_led_init_led(sysled_ctrl, child))
 			continue;
 

--- a/target/linux/realtek/patches-6.18/804-leds-Add-support-for-RTL8231-LED-scan-matrix.patch
+++ b/target/linux/realtek/patches-6.18/804-leds-Add-support-for-RTL8231-LED-scan-matrix.patch
@@ -50,7 +50,7 @@ Signed-off-by: Sander Vanheule <sander@svanheule.net>
  obj-$(CONFIG_LEDS_SUN50I_A100)		+= leds-sun50i-a100.o
 --- /dev/null
 +++ b/drivers/leds/leds-rtl8231.c
-@@ -0,0 +1,290 @@
+@@ -0,0 +1,289 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +
 +#include <linux/device.h>
@@ -288,7 +288,6 @@ Signed-off-by: Sander Vanheule <sander@svanheule.net>
 +{
 +	struct device *dev = &pdev->dev;
 +	const unsigned int *port_counts;
-+	struct fwnode_handle *child;
 +	struct regmap *map;
 +	int err;
 +
@@ -314,7 +313,7 @@ Signed-off-by: Sander Vanheule <sander@svanheule.net>
 +	if (err)
 +		return err;
 +
-+	fwnode_for_each_available_child_node(dev->fwnode, child) {
++	device_for_each_child_node_scoped(dev, child) {
 +		err = rtl8231_led_probe_single(dev, map, port_counts, child);
 +		if (err)
 +			dev_warn(dev, "failed to register LED %pfwP", child);


### PR DESCRIPTION
It's used in probe to be a generic way to iterate over the children. Confusingly, device_for_each_child_node_scoped internally calls the available loop despite not mentioning it.

Avoid pointless variables.