### PR TITLE
wireguard-tools: ignore empty list entries

### DIFF
--- a/package/network/utils/wireguard-tools/Makefile
+++ b/package/network/utils/wireguard-tools/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=wireguard-tools
 
 PKG_VERSION:=1.0.20260223
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=wireguard-tools-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://git.zx2c4.com/wireguard-tools/snapshot/

--- a/package/network/utils/wireguard-tools/files/wireguard.uc
+++ b/package/network/utils/wireguard-tools/files/wireguard.uc
@@ -31,7 +31,7 @@ function ensure_key_is_generated(cursor, section_name) {
 }
 
 function to_array(val) {
-	return type(val) == 'array' ? val : split(val, /\s+/);
+	return type(val) == 'array' ? val : split(trim(val), /\s+/);
 }
 
 function parse_address(addr) {


### PR DESCRIPTION
maintainer: Felix Fietkau [nbd@nbd.name](mailto:nbd@nbd.name) @nbd168

The ucode split helper keeps empty fields when a list has leading, trailing, or repeated whitespace (often times when copying from documentation/examples, this happens).

Filter those empty entries so addresses and allowed_ips keep the old shell handler behavior and do not produce empty address or AllowedIPs entries.

Prior to this, a value like:

```text
  10.0.0.1/24  fd00::1/64
```

produced empty entries around the real addresses.

After the change, only the real entries remain:

```text
10.0.0.1/24
fd00::1/64
```
