### PR TITLE
kernel: replace strcpy/strcat with strscpy/strlcat

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/swconfig_leds.c
+++ b/target/linux/generic/files/drivers/net/phy/swconfig_leds.c
@@ -213,15 +213,15 @@ static ssize_t swconfig_trig_mode_show(struct device *dev,
 	read_unlock(&trig_data->lock);
 
 	if (mode == 0) {
-		strcpy(buf, "none\n");
+		strscpy(buf, "none\n", PAGE_SIZE);
 	} else {
 		if (mode & SWCONFIG_LED_MODE_LINK)
-			strcat(buf, "link ");
+			strlcat(buf, "link ", PAGE_SIZE);
 		if (mode & SWCONFIG_LED_MODE_TX)
-			strcat(buf, "tx ");
+			strlcat(buf, "tx ", PAGE_SIZE);
 		if (mode & SWCONFIG_LED_MODE_RX)
-			strcat(buf, "rx ");
-		strcat(buf, "\n");
+			strlcat(buf, "rx ", PAGE_SIZE);
+		strlcat(buf, "\n", PAGE_SIZE);
 	}
 
 	return strlen(buf)+1;

--- a/target/linux/realtek/files-6.18/drivers/clk/realtek/clk-rtl83xx.c
+++ b/target/linux/realtek/files-6.18/drivers/clk/realtek/clk-rtl83xx.c
@@ -773,8 +773,8 @@ static void rtcl_ccu_log_early(void)
 		sprintf(clkinfo, ", %s %lu MHz", rtcl_clk_info[clk_idx].display_name,
 			rtcl_ccu->clks[clk_idx].startup / 1000000);
 		if (clk_idx == CLK_MEM)
-			strcat(clkinfo, meminfo);
-		strcat(msg, clkinfo);
+			strlcat(clkinfo, meminfo, sizeof(clkinfo));
+		strlcat(msg, clkinfo, sizeof(msg));
 	}
 	pr_info("%s\n", msg);
 }
@@ -790,10 +790,10 @@ static void rtcl_ccu_log_late(void)
 		overclock |= rclk->max > rclk->startup;
 		sprintf(clkinfo, ", %s %lu-%lu MHz", rtcl_clk_info[clk_idx].display_name,
 			rclk->min / 1000000, rclk->max / 1000000);
-		strcat(msg, clkinfo);
+		strlcat(msg, clkinfo, sizeof(msg));
 	}
 	if (overclock)
-		strcat(msg, ", OVERCLOCK AT OWN RISK");
+		strlcat(msg, ", OVERCLOCK AT OWN RISK", sizeof(msg));
 
 	dev_info(&rtcl_ccu->pdev->dev, "%s\n", msg);
 }

--- a/target/linux/uml/patches-6.12/102-pseudo-random-mac.patch
+++ b/target/linux/uml/patches-6.12/102-pseudo-random-mac.patch
@@ -69,8 +69,8 @@ Applies to vanilla kernel 3.9.4.
 +	if (!vmif)
 +		goto out;
 +
-+	strcpy (vmif, umid);
-+	strcat (vmif, ifname);
++	strscpy (vmif, umid, 1024);
++	strlcat (vmif, ifname, 1024);
 +
 +	tfm = crypto_alloc_ahash("sha1", 0, CRYPTO_ALG_ASYNC);
 +	if (IS_ERR(tfm))


### PR DESCRIPTION
Replace deprecated strcpy/strcat calls with strscpy/strlcat for bounds-checked string operations in swconfig_leds, clk-rtl83xx, and UML pseudo-random MAC patch.