### PR TITLE
ath79: fix u-boot-env nvmem-layout on enterasys,ws-ap3705i

### DIFF
--- a/target/linux/ath79/dts/ar9344_enterasys_ws-ap3705i.dts
+++ b/target/linux/ath79/dts/ar9344_enterasys_ws-ap3705i.dts
@@ -132,7 +132,8 @@
 				read-only;
 
 				nvmem-layout {
-					compatible = "u-boot,env";
+					compatible = "u-boot,env-redundant-count";
+					env-size = <0x1000>;
 
 					macaddr_uboot_ethaddr: ethaddr {
 					};


### PR DESCRIPTION
## Summary

The `u-boot-env0` partition on the Enterasys WS-AP3705i stores a
*redundant* U-Boot environment (4-byte CRC32 + 1-byte flag + data),
with the flag byte differing between the `u-boot-env0`/`u-boot-env1`
copies (`0x00` vs `0x01`, confirmed by reading the raw flash on real
hardware). The actual environment size used by U-Boot for the CRC
calculation is `0x1000` bytes, not the full `0x10000` byte partition
(also confirmed by brute-forcing the CRC32 over the dumped flash
content).

The DTS declares this as the plain, non-redundant `"u-boot,env"`
layout with no `env-size`, so the kernel's `u-boot-env` nvmem-layout
driver miscomputes the CRC and fails to probe:

```
u-boot-env-layout ...nvmem-layout: Invalid calculated CRC32: 0xbc490a68 (expected: 0xfae56b95)
u-boot-env-layout ...nvmem-layout: probe with driver u-boot-env-layout failed with error -22
```

Because the probe fails, the `macaddr_uboot_ethaddr` nvmem cell is
never created, so `eth0`'s `nvmem-cells` reference never resolves and
the `ag71xx-legacy` platform device is stuck in "deferred probe
pending" forever — **the device boots with no functioning Ethernet
interface at all**.

This switches to `"u-boot,env-redundant-count"` (matching the
redundant-env layout already used on other boards from this vendor
lineage, e.g. `qca9557_extreme-networks_ws-ap3805i.dts`) and sets
`env-size` to the verified `0x1000`, which fixes CRC validation and
lets `eth0` probe successfully.

## Test plan

Verified on real WS-AP3705i hardware via serial console + U-Boot TFTP
recovery:

- [x] Before the fix: confirmed the exact CRC failure and resulting
      `eth0` deferred-probe-forever against the official 25.12.5
      release image.
- [x] Independently verified the redundant-env format and correct
      `env-size` by dumping the raw `u-boot-env0`/`u-boot-env1` flash
      content and brute-forcing the CRC32 over candidate
      offsets/sizes — confirmed a match only for the redundant format
      (1-byte flag skipped) with `env-size = 0x1000`.
- [x] After the fix: `eth0` links up normally, `dmesg` is free of any
      CRC/nvmem-layout errors, and the jffs2/overlay filesystem mounts
      correctly.
- [x] Re-verified after rebuilding with the device's actual installed
      package set (`luci`, `luci-app-usteer`,
      `luci-app-attendedsysupgrade`, `wpad-mbedtls`) — LuCI web UI
      reachable, config preserved across sysupgrade.