### PR TITLE
ramips: mt7621: add support for TRENDnet TEW-827DRU v2

### DIFF
--- a/target/linux/ramips/dts/mt7621_trendnet_tew-827dru-v2.dts
+++ b/target/linux/ramips/dts/mt7621_trendnet_tew-827dru-v2.dts
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "trendnet,tew-827dru-v2", "mediatek,mt7621-soc";
+	model = "TRENDnet TEW-827DRU v2.0";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_USB;
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+			trigger-sources = <&xhci_ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x4da8>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+
+					macaddr_factory_e000: macaddr@e000 {
+						reg = <0xe000 0x6>;
+					};
+
+					macaddr_factory_e006: macaddr@e006 {
+						reg = <0xe006 0x6>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfa0000>;
+			};
+
+			partition@ff0000 {
+				label = "art_block";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "lan4";
+	phy-handle = <&ethphy0>;
+
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethphy0 {
+	/delete-property/ interrupts;
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_e006>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <2400000 2500000>;
+
+		led {
+			led-sources = <0>;
+			led-active-low;
+		};
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-sources = <0>;
+			led-active-low;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "wdt", "jtag", "i2c";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -3235,6 +3235,21 @@ define Device/tplink_tl-wpa8631p-v3
 endef
 TARGET_DEVICES += tplink_tl-wpa8631p-v3
 
+define Device/trendnet_tew-827dru-v2
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 16000k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | append-rootfs | pad-rootfs | \
+	append-string MT7621_TRENDNET_AC2600RT | check-size
+  DEVICE_VENDOR := TRENDnet
+  DEVICE_MODEL := TEW-827DRU
+  DEVICE_VARIANT := v2.0
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 \
+	kmod-usb-ledtrig-usbport -uboot-envtools
+endef
+TARGET_DEVICES += trendnet_tew-827dru-v2
+
 define Device/ubnt_edgerouter_common
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)


### PR DESCRIPTION
Add support for the TRENDnet TEW-827DRU v2.0.

Hardware:

* SoC: MediaTek MT7621
* RAM: 128 MiB DDR3
* Flash: 16 MiB SPI NOR, Macronix MX25L12835F
* Ethernet: MediaTek MT7530 switch
  * 4x Gigabit LAN
  * 1x Gigabit WAN
* Wi-Fi: 2x MediaTek MT7615E PCIe
  * 2.4 GHz
  * 5 GHz
* USB: 1x USB 3.0
* Buttons: reset and WPS
* LEDs: all blue, Power, WAN, LAN1-LAN4, 2.4 GHz WLAN, 5 GHz WLAN and USB
* UART: 3.3 V TTL, 57600 8N1
  * 4-pin header near the LED edge, from pin 1 (boxed): 3V3, GND, TX, RX

Flash layout:

* 0x000000-0x030000: u-boot
* 0x030000-0x040000: config
* 0x040000-0x050000: factory
* 0x050000-0xff0000: firmware
* 0xff0000-0x1000000: art_block

Factory data:

* 2.4 GHz EEPROM: factory offset 0x0000
* 5 GHz EEPROM: factory offset 0x8000
* LAN MAC address: factory offset 0xe000
* WAN MAC address: factory offset 0xe006

The MAC address and Wi-Fi calibration locations were checked against the vendor firmware and a hardware flash dump.

The stock U-Boot cannot boot the usual LZMA-compressed OpenWrt kernel from flash:

  Uncompressing Kernel Image ... LZMA ERROR 1

Use the ramips uimage-lzma-loader wrapper so U-Boot starts an uncompressed loader, which then decompresses and starts the OpenWrt kernel.

The stock web upgrader expects the TRENDnet/Cameo hardware ID at the end of the uploaded image:

  MT7621_TRENDNET_AC2600RT

The factory image appends this string after the kernel/rootfs image.

Installation:

* Stock web UI: Upload the factory image through Administrator -> Upload Firmware at 192.168.10.1.

* U-Boot/initramfs: Connect UART at 57600 8N1. On the tested unit the boot menu did not wait at the prompt, so start sending repeated "4" characters before applying power and continue until the U-Boot prompt appears.

  Then boot the initramfs image with TFTP:

    setenv ipaddr 192.168.10.1
    setenv serverip 192.168.10.111
    tftpboot 0x82000000 openwrt-ramips-mt7621-trendnet_tew-827dru-v2-initramfs-kernel.bin
    bootm 0x82000000

  The tested bootloader did not provide bdinfo, iminfo or ping. Do not run saveenv while testing. From initramfs, copy the sysupgrade image to /tmp and install it with sysupgrade -n.

Tested:

* initramfs boot through U-Boot/TFTP
* sysupgrade from initramfs to SPI NOR
* persistent boot from SPI NOR
* DSA Ethernet initialization
* correct LAN and WAN MAC addresses
* all LAN and WAN ports
* stock web UI installation of the factory image
* OpenWrt LuCI restore to stock using the OEM firmware image
* both MT7615E PCIe radios initialize
* Wi-Fi calibration data is read from the factory partition
* 5 GHz VHT80 client traffic
  * packet steering mode 2 plus Ethernet and Wi-Fi IRQ affinity to CPU1 improves AP-to-client throughput on the tested unit
* 2.4 GHz client traffic
* USB 3.0 controller and storage
* reset and WPS button events
* Power, WAN, LAN and USB LEDs

