### PR TITLE
tools: gnulib: rename macro file for cond module

### DIFF
--- a/tools/gnulib/Makefile
+++ b/tools/gnulib/Makefile
@@ -20,10 +20,8 @@ endef
 define Host/Install
 	$(call Host/Uninstall)
 	$(INSTALL_DIR) $(1)/share/aclocal
-	for m4 in $(HOST_BUILD_DIR)/m4/*.m4; do \
-		$(INSTALL_DATA) $(HOST_BUILD_DIR)/m4/$$$$(basename $$$$m4) \
-				$(1)/share/aclocal/gl_$$$$(basename $$$$m4); \
-	done
+	$(foreach m4,$(notdir $(wildcard $(HOST_BUILD_DIR)/m4/*.m4)),
+		$(INSTALL_DATA) $(HOST_BUILD_DIR)/m4/$(m4) $(1)/share/aclocal/gl_$(m4))
 	$(CP) $(HOST_BUILD_DIR)/ $(1)/share/gnulib/
 	ln -sf ../share/gnulib/gnulib-tool $(STAGING_DIR_HOST)/bin/gnulib-tool
 endef

--- a/tools/gnulib/Makefile
+++ b/tools/gnulib/Makefile
@@ -13,15 +13,10 @@ include $(INCLUDE_DIR)/host-build.mk
 define Host/Configure
 endef
 
-# On installing the .m4 files, we add a gl_ prefix to prevent any conflict with
-# automake. It was found that there is currently a conflict for the cond.m4 that
-# is also shipped by automake, making the gnulib one having priority causing
-# problem with finding AM_CONDITIONAL macro.
 define Host/Install
 	$(call Host/Uninstall)
 	$(INSTALL_DIR) $(1)/share/aclocal
-	$(foreach m4,$(notdir $(wildcard $(HOST_BUILD_DIR)/m4/*.m4)),
-		$(INSTALL_DATA) $(HOST_BUILD_DIR)/m4/$(m4) $(1)/share/aclocal/gl_$(m4))
+	$(INSTALL_DATA) $(HOST_BUILD_DIR)/m4/*.m4 $(1)/share/aclocal/
 	$(CP) $(HOST_BUILD_DIR)/ $(1)/share/gnulib/
 	ln -sf ../share/gnulib/gnulib-tool $(STAGING_DIR_HOST)/bin/gnulib-tool
 endef

--- a/tools/gnulib/patches/310-modules-cond.patch
+++ b/tools/gnulib/patches/310-modules-cond.patch
@@ -1,0 +1,41 @@
+--- a/m4/cond.m4
++++ /dev/null
+@@ -1,12 +0,0 @@
+-# cond.m4
+-# serial 2
+-dnl Copyright (C) 2008-2025 Free Software Foundation, Inc.
+-dnl This file is free software; the Free Software Foundation
+-dnl gives unlimited permission to copy and/or distribute it,
+-dnl with or without modifications, as long as this notice is preserved.
+-dnl This file is offered as-is, without any warranty.
+-
+-AC_DEFUN([gl_COND],
+-[
+-  AC_REQUIRE([gl_THREADLIB])
+-])
+--- /dev/null
++++ b/m4/glthread_cond.m4
+@@ -0,0 +1,12 @@
++# glthread_cond.m4
++# serial 2
++dnl Copyright (C) 2008-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++AC_DEFUN([gl_COND],
++[
++  AC_REQUIRE([gl_THREADLIB])
++])
+--- a/modules/cond
++++ b/modules/cond
+@@ -4,7 +4,7 @@ Condition variables for multithreading.
+ Files:
+ lib/glthread/cond.h
+ lib/glthread/cond.c
+-m4/cond.m4
++m4/glthread_cond.m4
+ 
+ Depends-on:
+ threadlib


### PR DESCRIPTION
ping @Ansuel

With the macro filename 'gl' prefix added
I have a build error regarding the obstack module when building elfutils

This is the proper way to handle it.
I tried to look for another case like this in the macro files,
but this seems to be the only odd one.
This is an upstreamable solution as well...