### PR TITLE
mvebu: turris-mox: fix USB2 detection

### DIFF
--- a/target/linux/mvebu/patches-6.18/101-arm64-dts-armada-3720-turris-mox-fix-usb3-phys.patch
+++ b/target/linux/mvebu/patches-6.18/101-arm64-dts-armada-3720-turris-mox-fix-usb3-phys.patch
@@ -1,0 +1,37 @@
+From 57b95de489769259fee99a4b70f10cedc6f24641 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tom=C3=A1=C5=A1=20Macholda?= <tomas.macholda@nic.cz>
+Date: Tue, 7 Jul 2026 13:48:03 +0200
+Subject: [PATCH mvebu-dt64] arm64: dts: turris-mox: fix usb3 phys
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+After commit 00e6d608fe80b0f6 ("arm64: dts: marvell: armada-37xx: swap
+PHYs' order in USB3 controller node") swapped USB3 PHY order, USB
+initialization breaks on Turris MOX.
+
+This regression was exposed by commit 91ddf6f722084383 ("phy: marvell:
+mvebu-a3700-utmi: fix incorrect USB2_PHY_CTRL register access") which
+made USB2 devices not work at all.
+
+Fix the issue by explicitly adding all USB3 PHYs and PHY names to
+Turris MOX device-tree.
+
+Fixes: 7109d817db2e ("arm64: dts: marvell: add DTS for Turris Mox")
+Signed-off-by: Tomáš Macholda <tomas.macholda@nic.cz>
+---
+ arch/arm64/boot/dts/marvell/armada-3720-turris-mox.dts | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/arch/arm64/boot/dts/marvell/armada-3720-turris-mox.dts
++++ b/arch/arm64/boot/dts/marvell/armada-3720-turris-mox.dts
+@@ -290,7 +290,8 @@
+ 
+ &usb3 {
+ 	status = "okay";
+-	phys = <&comphy2 0>;
++	phys = <&usb2_utmi_otg_phy>, <&comphy2 0>;
++	phy-names = "usb2-phy", "usb3-phy";
+ };
+ 
+ &mdio {


### PR DESCRIPTION
Fix Turris MOX not detecting USB2 devices by explicitly adding all USB3 PHYs and PHY names to Turris MOX device-tree.

The patch has been sent to Linux: https://lore.kernel.org/all/20260707210830.3708-1-tomas.macholda@nic.cz/

CC @daleckystepan