### PR TITLE
wifi-scripts: ucode: fix he_spr_sr_control logic to allow BSS Color PSR

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -417,6 +417,8 @@ function device_htmode_append(config) {
 				config.he_spr_sr_control |= 1 << 2;
 			if (!config.he_spr_psr_enabled)
 				config.he_spr_sr_control |= 1;
+			else
+				config.he_spr_sr_control &= ~1;
 			append_vars(config, [ 'he_bss_color', 'he_spr_non_srg_obss_pd_max_offset', 'he_spr_sr_control' ]);
 		}
 


### PR DESCRIPTION
Add an else branch to clear bit 0 (PSR disallowed) when PSR is enabled, since the schema default of 3 sets this bit by default. Without this, he_spr_psr_enabled had no effect and PSR was always disallowed.

The schema default is harmless when bss_color is disabled because he_spr_sr_control is only appended inside the if (config.he_bss_color_enabled) block.

