### PR TITLE
wifi-scripts: add support for mesh mac filter

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
@@ -36,7 +36,9 @@ function reset_config(phy, radio) {
 	let prev_config = `/var/run/hostapd-${name}.conf`;
 
 	global.ubus.call('hostapd', 'config_set', { phy, radio, config: '', prev_config });
+	global.ubus.event('hostapd', { action: "config_set" });
 	global.ubus.call('wpa_supplicant', 'config_set', { phy, radio, config: []});
+	global.ubus.event('wpa_supplicant', { action: "config_set" });
 
 	name = phy + phy_suffix(radio, ":");
 	system(`ucode /usr/share/hostap/wdev.uc ${name} set_config '{}'`);
@@ -179,6 +181,7 @@ function setup() {
 	let active_ifnames = [];
 
 	log('Starting');
+	global.ubus.event('wifi-scripts', { action: "start" });
 
 	let config = data.config;
 

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
@@ -568,7 +568,7 @@
 		"macfilter": {
 			"description": "Allow/deny associations based on the clients MAC",
 			"type": "string",
-			"enum": [ "allow", "deny" ]
+			"enum": [ "allow", "deny", "block", "open" ]
 		},
 		"maclist": {
 			"description": "List of MACs used by the macfilter option",

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -280,6 +280,12 @@ function iface_ftm(config, phy_features) {
 function iface_macfilter(config) {
 	let path = `/var/run/hostapd-${config.ifname}.maclist`;
 
+	let file = fs.open(path, 'w');
+	if (!file) {
+		warn(`Failed to open ${path}`);
+		return;
+	}
+
 	switch(config.macfilter) {
 	case 'allow':
 		append('accept_mac_file', path);
@@ -293,12 +299,7 @@ function iface_macfilter(config) {
 		break;
 
 	default:
-		return;
-	}
-
-	let file = fs.open(path, 'w');
-	if (!file) {
-		warn(`Failed to open ${path}`);
+		file.truncate();
 		return;
 	}
 

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -614,6 +614,7 @@ export function setup(data) {
 	if (!global.ubus.list('hostapd'))
 		system('ubus wait_for hostapd');
 	let ret = global.ubus.call('hostapd', 'config_set', msg);
+	global.ubus.event('hostapd', { action: "config_set" });
 
 	if (ret)
 		netifd.add_process('/usr/sbin/hostapd', ret.pid, true, true);

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
@@ -308,6 +308,7 @@ export function setup(config, data) {
 		num_global_macaddr: data.config.num_global_macaddr,
 		macaddr_base: data.config.macaddr_base ?? "",
 	});
+	global.ubus.event('wpa_supplicant', { action: "config_set" });
 
 	if (ret)
 		netifd.add_process('/usr/sbin/wpa_supplicant', ret.pid, true, true);
@@ -323,4 +324,5 @@ export function start(data) {
 		num_global_macaddr: data.config.num_global_macaddr,
 		macaddr_base: data.config.macaddr_base ?? "",
 	});
+	global.ubus.event('wpa_supplicant', { action: "config_set" });
 };

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
@@ -57,6 +57,36 @@ export function ratelist(rates) {
 	return join(",", map(rates, (rate) => ratestr(rate)));
 };
 
+function set_macfilter(config) {
+	let path = `/var/run/wpa-supplicant-${config.ifname}.maclist`;
+
+	let file = fs.open(path, 'w');
+	if (!file) {
+		warn(`Failed to open ${path}`);
+		return;
+	}
+
+	switch(config.macfilter) {
+	case 'block':
+		break;
+
+	case 'open':
+		break;
+
+	default:
+		file.truncate();
+		return;
+	}
+
+	if (config.maclist)
+		file.write(join('\n', config.maclist));
+
+	let macfile = fs.readfile(config.macfile);
+	if (macfile)
+		file.write(macfile);
+	file.close();
+}
+
 function setup_sta(data, config) {
 	iface.parse_encryption(config);
 
@@ -180,6 +210,8 @@ function setup_sta(data, config) {
 	}
 
 	config.key_mgmt ??= 'NONE';
+
+	set_macfilter(config);
 
 	/*
 	 * Map UCI basic_rate to the correct wpa_supplicant network field:

--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -1056,6 +1056,7 @@ hostapd_set_bss_options() {
 			append bss_conf "deny_mac_file=$_macfile" "$N"
 		;;
 		*)
+			: > "$_macfile"
 			_macfile=""
 		;;
 	esac
@@ -1064,7 +1065,6 @@ hostapd_set_bss_options() {
 		json_get_vars macfile
 		json_get_values maclist maclist
 
-		rm -f "$_macfile"
 		(
 			for mac in $maclist; do
 				echo "$mac"

--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -1362,6 +1362,7 @@ wpa_supplicant_add_network() {
 		mcast_rate \
 		ieee80211w ieee80211r fils ocv beacon_prot \
 		multi_ap \
+		macfilter \
 		default_disabled
 
 	json_get_values basic_rate_list basic_rate
@@ -1639,6 +1640,30 @@ wpa_supplicant_add_network() {
 
 	[ -n "$bssid_blacklist" ] && append network_data "bssid_blacklist=$bssid_blacklist" "$N$T"
 	[ -n "$bssid_whitelist" ] && append network_data "bssid_whitelist=$bssid_whitelist" "$N$T"
+
+	_macfile="/var/run/wpa-supplicant-$ifname.maclist"
+	case "$macfilter" in
+		block)
+		;;
+		open)
+		;;
+		*)
+			: > "$_macfile"
+			_macfile=""
+		;;
+	esac
+
+	[ -n "$_macfile" ] && {
+		json_get_vars macfile
+		json_get_values maclist maclist
+
+		(
+			for mac in $maclist; do
+				echo "$mac"
+			done
+			[ -n "$macfile" -a -f "$macfile" ] && cat "$macfile"
+		) > "$_macfile"
+	}
 
 	[ -n "$basic_rate_list" ] && {
 		local br rate rate_list=

--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless-device.uc
+++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless-device.uc
@@ -35,6 +35,7 @@ function wireless_config_done()
 			data: {},
 		},
 	});
+	ubus.event('wifi-scripts', { action: "config_done" });
 }
 
 function delete_wdev(name)

--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
@@ -978,6 +978,7 @@ wpa_supplicant_set_config() {
 	ret="$?"
 	[ "$ret" != 0 -o -z "$supplicant_res" ] && wireless_setup_vif_failed WPA_SUPPLICANT_FAILED
 
+	ubus send wpa_supplicant '{ "action": "config_set" }'
 	wireless_add_process "$(jsonfilter -s "$supplicant_res" -l 1 -e @.pid)" "/usr/sbin/wpa_supplicant" 1 1
 
 }
@@ -988,6 +989,7 @@ hostapd_set_config() {
 
 	[ -n "$hostapd_ctrl" ] || {
 		ubus_call hostapd config_set '{ "phy": "'"$phy"'", "radio": '"$radio"', "config": "", "prev_config": "'"${hostapd_conf_file}.prev"'" }' > /dev/null
+		ubus send hostapd '{ "action": "config_set" }'
 		return 0;
 	}
 
@@ -998,6 +1000,8 @@ hostapd_set_config() {
 		wireless_setup_failed HOSTAPD_START_FAILED
 		return
 	}
+
+	ubus send hostapd '{ "action": "config_set" }'
 	wireless_add_process "$(jsonfilter -s "$hostapd_res" -l 1 -e @.pid)" "/usr/sbin/hostapd" 1 1
 }
 
@@ -1009,6 +1013,7 @@ wpa_supplicant_start() {
 	[ -n "$wpa_supp_init" ] || return 0
 
 	ubus_call wpa_supplicant config_set '{ "phy": "'"$phy"'", "radio": '"$radio"', "num_global_macaddr": '"$num_global_macaddr"', "macaddr_base": "'"$macaddr_base"'" }' > /dev/null
+	ubus send wpa_supplicant '{ "action": "config_set" }'
 }
 
 mac80211_setup_supplicant() {
@@ -1115,7 +1120,9 @@ drv_mac80211_cleanup() {
 mac80211_reset_config() {
 	hostapd_conf_file="/var/run/hostapd-$phy$vif_phy_suffix.conf"
 	ubus_call hostapd config_set '{ "phy": "'"$phy"'", "radio": '"$radio"', "config": "", "prev_config": "'"$hostapd_conf_file"'" }' > /dev/null
+	ubus send hostapd '{ "action": "config_set" }'
 	ubus_call wpa_supplicant config_set '{ "phy": "'"$phy"'", "radio": '"$radio"', "config": [] }' > /dev/null
+	ubus send wpa_supplicant '{ "action": "config_set" }'
 	wdev_tool "$phy$phy_suffix" set_config '{}'
 }
 

--- a/package/network/config/wifi-scripts/files/sbin/wifi
+++ b/package/network/config/wifi-scripts/files/sbin/wifi
@@ -49,10 +49,12 @@ wifi_updown() {
 		cmd=reconf
 	}
 	ubus_wifi_cmd "$cmd" "$2"
+	ubus send network '{ "action": "reload" }'
 }
 
 wifi_reload() {
 	ubus call network reload
+	ubus send network '{ "action": "reload" }'
 }
 
 wifi_detect_notice() {

--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -766,6 +766,18 @@ define Package/wpad/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wpad $(1)/usr/sbin/
 	$(LN) wpad $(1)/usr/sbin/hostapd
 	$(LN) wpad $(1)/usr/sbin/wpa_supplicant
+  ifeq ($(LOCAL_VARIANT),mesh)
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/net
+	$(INSTALL_DIR) $(1)/lib/netifd/wireless
+	$(INSTALL_DATA) ./files/95-mesh-macfilter $(1)/etc/hotplug.d/net
+	$(INSTALL_BIN) ./files/mesh-macfilter.uc $(1)/lib/netifd/wireless
+  endif
+  ifeq ($(LOCAL_VARIANT),full)
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/net
+	$(INSTALL_DIR) $(1)/lib/netifd/wireless
+	$(INSTALL_DATA) ./files/95-mesh-macfilter $(1)/etc/hotplug.d/net
+	$(INSTALL_BIN) ./files/mesh-macfilter.uc $(1)/lib/netifd/wireless
+  endif
 endef
 Package/wpad-basic/install = $(Package/wpad/install)
 Package/wpad-basic-openssl/install = $(Package/wpad/install)
@@ -782,6 +794,18 @@ Package/wpad-mesh-mbedtls/install = $(Package/wpad/install)
 define Package/wpa-supplicant/install
 	$(call Install/supplicant,$(1))
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wpa_supplicant/wpa_supplicant $(1)/usr/sbin/
+  ifeq ($(LOCAL_VARIANT),mesh)
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/net
+	$(INSTALL_DIR) $(1)/lib/netifd/wireless
+	$(INSTALL_DATA) ./files/95-mesh-macfilter $(1)/etc/hotplug.d/net
+	$(INSTALL_BIN) ./files/mesh-macfilter.uc $(1)/lib/netifd/wireless
+  endif
+  ifeq ($(LOCAL_VARIANT),full)
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/net
+	$(INSTALL_DIR) $(1)/lib/netifd/wireless
+	$(INSTALL_DATA) ./files/95-mesh-macfilter $(1)/etc/hotplug.d/net
+	$(INSTALL_BIN) ./files/mesh-macfilter.uc $(1)/lib/netifd/wireless
+  endif
 endef
 Package/wpa-supplicant-basic/install = $(Package/wpa-supplicant/install)
 Package/wpa-supplicant-mini/install = $(Package/wpa-supplicant/install)

--- a/package/network/services/hostapd/files/95-mesh-macfilter
+++ b/package/network/services/hostapd/files/95-mesh-macfilter
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+start_plink_macfilter() {
+	local mode
+	local device
+	local path
+
+	config_get mode $1 mode
+	[ "$mode" = "mesh" ] || return
+
+	config_get device $1 device
+	config_get path $device path
+	[ -d "/sys/devices/$path/net/$DEVICENAME" ] || return
+
+	ps | grep mesh-macfilter | grep $device | grep -q $DEVICENAME && return
+	/usr/bin/ucode /lib/netifd/wireless/mesh-macfilter.uc $device $DEVICENAME
+}
+
+if [ "$ACTION" = "add" ]; then
+	case "$DEVICENAME" in
+		*"mesh"*)
+			[ -e /etc/config/wireless ] && config_load wireless || return
+			config_foreach start_plink_macfilter wifi-iface
+		;;
+	esac
+fi

--- a/package/network/services/hostapd/files/mesh-macfilter.uc
+++ b/package/network/services/hostapd/files/mesh-macfilter.uc
@@ -1,0 +1,95 @@
+'use strict';
+import * as nl80211 from "nl80211";
+import * as ubus from "ubus";
+import * as uloop from "uloop";
+import { open } from "fs";
+
+let rad = ARGV[0];
+let dev = ARGV[1];
+let mode_prev = "";
+const monitor = ubus.connect();
+if (!monitor) die();
+
+system(["logger", "starting ucode 802.11s mesh peer link macfilter for interface", dev]);
+
+function grep_i_file(search, filename) {
+	let file = open(filename, "r");
+	if (!file) return 2;
+
+	for (let line = file.read('line'); length(line); line = file.read('line')) {
+		if (trim(lc(line)) == lc(search)) {
+			file.close();
+			return 0;
+		}
+	}
+	file.close();
+	return 1;
+}
+
+function wpa_maclist_cmp(dev, station, mode) {
+	let modes = {};
+
+	modes[mode] = grep_i_file(station.mac, `/var/run/wpa-supplicant-${dev}.maclist`);
+	return (modes.deny == 0 || modes.block == 0 || modes.allow == 1 || modes.open == 1) ? 1 : 0;
+}
+
+function ubus_config_get_wifi_iface(conf, phy, iface) {
+	let i = 0;
+	const status = ubus.call("network.wireless", "status", {});
+
+	while (status[phy].interfaces[i] != null) {
+		if (status[phy].interfaces[i].ifname && status[phy].interfaces[i].ifname == iface)
+			break;
+		i++;
+	}
+	if (status[phy].interfaces[i] && status[phy].interfaces[i].config[conf])
+		return status[phy].interfaces[i].config[conf];
+	return null;
+}
+
+function station_dump(dev) {
+	return nl80211.request(nl80211.const.NL80211_CMD_GET_STATION, nl80211.const.NLM_F_DUMP, {
+		dev: dev
+	});
+}
+
+function plink_action_block(dev, station) {
+	nl80211.request(nl80211.const.NL80211_CMD_SET_STATION, 0, {
+		dev: dev,
+		mac: station.mac,
+		sta_plink_action: nl80211.const.NL80211_PLINK_ACTION_BLOCK
+	});
+}
+
+function mesh_macfilter(mode) {
+	let stations = station_dump(dev);
+	for (let station in stations) {
+		if (station.sta_info.plink_state != nl80211.const.NL80211_PLINK_ESTAB)
+			continue;
+		if (wpa_maclist_cmp(dev, station, mode))
+			plink_action_block(dev, station);
+	}
+}
+
+uloop.init();
+
+const check = uloop.timer(-1, () => {
+	let mode = ubus_config_get_wifi_iface("macfilter", rad, dev);
+	mesh_macfilter(mode);
+	if (mode_prev != mode && mode_prev != "")
+		system(["/sbin/wifi", "up", rad]);
+	mode_prev = mode;
+});
+
+nl80211.listener(() => {
+	check.set(10000);
+});
+
+monitor.listener('*', (type, data) => {
+	if (type == "wifi-scripts" && data.action && data.action == "config_done")
+		check.set(10000);
+	if (type == "network" && data.action && data.action == "reload")
+		check.set(10000);
+});
+
+uloop.run();


### PR DESCRIPTION
~~Waiting on this for object names:~~
~~https://github.com/jow-/ucode/pull/412~~

@jow- @nbd168 @ynezz
This is my first time writing in ucode
I would appreciate your reviews if you have the time

This ucode script is an implementation for automated MAC filtering
on an 802.11s mesh network using kernel-level mesh peer link blocking.
It listens to ubus and netlink events with their respective modules,
and sets a delay timer to compare the list of current stations to a list
of MAC addresses in UCI to be blocked and sends the netlink request.