### PR TITLE
airoha: device tree node and definition improvements（cherry-pick from master)

### DIFF
--- a/target/linux/airoha/dts/an7581.dtsi
+++ b/target/linux/airoha/dts/an7581.dtsi
@@ -575,14 +575,14 @@
 			#phy-cells = <1>;
 		};
 
-		crypto@1e004000 {
+		crypto@1fb70000 {
 			compatible = "inside-secure,safexcel-eip93ies";
 			reg = <0x0 0x1fb70000 0x0 0x1000>;
 
 			interrupts = <GIC_SPI 44 IRQ_TYPE_LEVEL_HIGH>;
 		};
 
-		thermal: thermal-sensor@1efbd800 {
+		thermal: thermal-sensor@1efbd000 {
 			compatible = "airoha,en7581-thermal";
 			reg = <0x0 0x1efbd000 0x0 0xd5c>;
 			interrupts = <GIC_SPI 23 IRQ_TYPE_LEVEL_HIGH>;

--- a/target/linux/airoha/dts/an7583.dtsi
+++ b/target/linux/airoha/dts/an7583.dtsi
@@ -747,7 +747,7 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 
-				gsw_phy1: ethernet-phy@1 {
+				gsw_phy1: ethernet-phy@9 {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <9>;
 					phy-mode = "internal";
@@ -770,7 +770,7 @@
 					};
 				};
 
-				gsw_phy2: ethernet-phy@2 {
+				gsw_phy2: ethernet-phy@a {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <10>;
 					phy-mode = "internal";
@@ -793,7 +793,7 @@
 					};
 				};
 
-				gsw_phy3: ethernet-phy@3 {
+				gsw_phy3: ethernet-phy@b {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <11>;
 					phy-mode = "internal";
@@ -816,7 +816,7 @@
 					};
 				};
 
-				gsw_phy4: ethernet-phy@4 {
+				gsw_phy4: ethernet-phy@c {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <12>;
 					phy-mode = "internal";

--- a/target/linux/airoha/dts/an7583.dtsi
+++ b/target/linux/airoha/dts/an7583.dtsi
@@ -539,7 +539,7 @@
 			status = "disabled";
 		};
 
-		crypto@1e004000 {
+		crypto@1fb70000 {
 			compatible = "inside-secure,safexcel-eip93ies";
 			reg = <0x0 0x1fb70000 0x0 0x1000>;
 

--- a/target/linux/airoha/image/an7583.mk
+++ b/target/linux/airoha/image/an7583.mk
@@ -11,7 +11,6 @@ define Device/airoha_an7583-evb
   DEVICE_PACKAGES := kmod-phy-aeonsemi-as21xxx kmod-leds-pwm kmod-pwm-airoha kmod-input-gpio-keys-polled
   DEVICE_DTS := an7583-evb
   DEVICE_DTS_CONFIG := config@1
-  KERNEL_LOADADDR := 0x80088000
   IMAGE/sysupgrade.bin := append-kernel | pad-to 128k | append-rootfs | pad-rootfs | append-metadata
 endef
 TARGET_DEVICES += airoha_an7583-evb


### PR DESCRIPTION
This PR includes the following updates: （cherry-pick from master)

Corrected node addresses for crypto and thermal-sensor

Fixed device tree node addresses for these modules to ensure proper hardware access.
Aligned ethernet-phy node name with reg property

Updated the ethernet-phy node name to match its 'reg' property for better consistency and readability.
Removed KERNEL_LOADADDR from airoha_an7583-evb device definition