### PR TITLE
airoha: enable USB support in FEATURES

### DIFF
--- a/target/linux/airoha/Makefile
+++ b/target/linux/airoha/Makefile
@@ -4,7 +4,7 @@ ARCH:=arm
 BOARD:=airoha
 BOARDNAME:=Airoha ARM
 SUBTARGETS:=en7523 an7581 an7583
-FEATURES:=dt squashfs nand ramdisk gpio
+FEATURES:=dt squashfs nand ramdisk gpio usb
 
 KERNEL_PATCHVER:=6.18
 


### PR DESCRIPTION
Add 'usb' to the FEATURES variable to ensure that USB drivers and support are enabled by default for the en7523, an7581, and an7583 platforms. This allows for automatic inclusion of USB-related modules and improves device compatibility and expandability.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
