### PR TITLE
[25.12] mediatek: add support for Hiveton H5000M

### DIFF
--- a/target/linux/mediatek/dts/mt7987a-hiveton-h5000m.dts
+++ b/target/linux/mediatek/dts/mt7987a-hiveton-h5000m.dts
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include "mt7987a.dtsi"
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Hiveton H5000M";
+	compatible = "hiveton,h5000m", "mediatek,mt7987a", "mediatek,mt7987";
+
+	aliases {
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_amber;
+		led-upgrade = &led_status_amber;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		bootargs = "earlycon=uart8250,mmio32,0x11000000 \
+			    root=PARTLABEL=rootfs rootwait pci=pcie_bus_perf";
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <10>;
+		};
+
+		button-wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+			debounce-interval = <10>;
+		};
+	};
+
+	/*
+	 * LED Indicator Layout
+	 * -------------------
+	 * Total of 5 LED indicators, viewed from front with antenna facing up (left to right):
+	 *
+	 * LED 1: 5G Module indicator
+	 * LED 2: Built-in 2.5G Ethernet port indicator (configurable in system)
+	 * LED 3: User-definable (configurable in system)
+	 * LED 4: User-definable (configurable in system)
+	 * LED 5: Power indicator
+	 *
+	 * Note:
+	 * - LEDs 1 and 5 are hardware-controlled and cannot be modified via software
+	 * - In vendor firmware, LEDs 3 and 4 are used as WiFi link activity indicators
+	 *   for dual-band (2.4GHz/5GHz) respectively
+	 */
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_amber: led-3 {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&pio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: led-4 {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	reg_usb_5v: regulator-usb-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "usb-5v";
+		regulator-max-microvolt = <5000000>;
+		regulator-min-microvolt = <5000000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+};
+
+&eth {
+	status = "okay";
+};
+
+&fan {
+	pwms = <&pwm 1 50000 0>;
+	status = "okay";
+};
+
+&gmac0 {
+	phy-mode = "2500base-x";
+	phy-handle = <&phy0>;
+	status = "okay";
+};
+
+&gmac1 {
+	phy-mode = "internal";
+	phy-handle = <&phy1>;
+	status = "okay";
+};
+
+&mdio {
+	/* RTL8221B-VB-CG 2.5Gbps PHY (away from power) eth0 */
+	phy0: phy@1 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <1>;
+		reset-gpios = <&pio 42 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <100000>;
+		reset-deassert-us = <100000>;
+		interrupt-parent = <&pio>;
+		interrupts = <41 IRQ_TYPE_LEVEL_LOW>;
+		realtek,aldps-enable;
+	};
+
+	/* built-in 2.5G Ethernet PHY (near power) eth1 */
+	phy1: phy@15 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <15>;
+		pinctrl-names = "i2p5gbe-led";
+		pinctrl-0 = <&i2p5gbe_led0_pins>;
+
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led@0 {
+				reg = <0>;
+				function = LED_FUNCTION_WAN;
+				color = <LED_COLOR_ID_RED>;
+			};
+		};
+	};
+};
+
+&mmc0 {
+	pinctrl-names = "default", "state_uhs";
+	pinctrl-0 = <&mmc_pins_default>;
+	pinctrl-1 = <&mmc_pins_uhs>;
+	bus-width = <8>;
+	max-frequency = <48000000>;
+	cap-mmc-highspeed;
+	vmmc-supply = <&reg_3p3v>;
+	non-removable;
+	status = "okay";
+
+	card@0 {
+		compatible = "mmc-card";
+		reg = <0>;
+
+		block {
+			compatible = "block-device";
+
+			partitions {
+				block-partition-factory {
+					partname = "factory";
+
+					nvmem-layout {
+						compatible = "fixed-layout";
+						#address-cells = <1>;
+						#size-cells = <1>;
+
+						eeprom_factory_0: eeprom@0 {
+							reg = <0x0 0x1e00>;
+						};
+					};
+				};
+			};
+		};
+	};
+};
+
+&pcie0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_pins>;
+	reset-gpios = <&pio 36 GPIO_ACTIVE_HIGH>;
+	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		device_type = "pci";
+
+		mt7992@0,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+
+			nvmem-cells = <&eeprom_factory_0>;
+			nvmem-cell-names = "eeprom";
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			ieee80211-freq-limit = <2400000 2500000>,
+					       <5170000 5835000>;
+		};
+	};
+};
+
+&pcie1 {
+	status = "disabled";
+};
+
+&pio {
+	pwm_fan_pins: pwm-fan-pins {
+		mux {
+			function = "pwm";
+			groups = "pwm1_0";
+		};
+	};
+};
+
+&pwm {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm_fan_pins>;
+};
+
+&ssusb {
+	status = "okay";
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&reg_usb_5v>;
+};
+
+&tphyu3port0 {
+	status = "okay";
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_pins>;
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -111,6 +111,10 @@ glinet,gl-xe3000)
 	ucidef_set_led_netdev "wlan2g" "WLAN2G" "green:wifi2g" "phy0-ap0"
 	ucidef_set_led_netdev "wlan5g" "WLAN5G" "green:wifi5g" "phy1-ap0"
 	;;
+hiveton,h5000m)
+	ucidef_set_led_netdev "wlan2g" "wlan-2ghz" "amber:wlan-2ghz" "phy0.0-ap0" "link tx rx"
+	ucidef_set_led_netdev "wlan5g" "wlan-5ghz" "blue:wlan-5ghz" "phy0.1-ap0" "link tx rx"
+	;;
 huasifei,wh3000)
 	ucidef_set_led_netdev "wan" "WAN" "red:wan" "eth1" "link tx rx"
 	;;

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -133,6 +133,7 @@ mediatek_setup_interfaces()
 	airpi,ap3000m|\
 	bananapi,bpi-r3-mini|\
 	edgecore,eap111|\
+	hiveton,h5000m|\
 	huasifei,wh3000|\
 	huasifei,wh3000-pro-emmc|\
 	huasifei,wh3000-pro-nand)
@@ -264,6 +265,11 @@ mediatek_setup_macs()
 	h3c,magic-nx30-pro)
 		wan_mac=$(mtd_get_mac_ascii pdt_data_1 ethaddr)
 		lan_mac=$(macaddr_add "$wan_mac" 1)
+		label_mac=$wan_mac
+		;;
+	hiveton,h5000m)
+		lan_mac=$(macaddr_generate_from_mmc_cid mmcblk0)
+		wan_mac=$(macaddr_add "$lan_mac" 1)
 		label_mac=$wan_mac
 		;;
 	jiorouter,ax6000-jidu6101)

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -133,6 +133,11 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
 		;;
+	hiveton,h5000m)
+		base_mac=$(macaddr_generate_from_mmc_cid mmcblk0)
+		[ "$PHYNBR" = "0" ] && macaddr_add $base_mac 2 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $base_mac 3 > /sys${DEVPATH}/macaddress
+		;;
 	iptime,ax3000q)
 		addr=$(mtd_get_mac_binary "Factory" 0x4)
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $addr > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -164,6 +164,7 @@ platform_do_upgrade() {
 	glinet,gl-mt6000|\
 	glinet,gl-x3000|\
 	glinet,gl-xe3000|\
+	hiveton,h5000m|\
 	huasifei,wh3000|\
 	huasifei,wh3000-pro-emmc|\
 	smartrg,sdg-8612|\
@@ -358,6 +359,7 @@ platform_check_image() {
 		;;
 	creatlentem,clt-r30b1|\
 	creatlentem,clt-r30b1-112m|\
+	hiveton,h5000m|\
 	nradio,c8-668gl)
 		# tar magic `ustar`
 		magic="$(dd if="$1" bs=1 skip=257 count=5 2>/dev/null)"
@@ -403,6 +405,7 @@ platform_copy_config() {
 	glinet,gl-mt6000|\
 	glinet,gl-x3000|\
 	glinet,gl-xe3000|\
+	hiveton,h5000m|\
 	huasifei,wh3000|\
 	huasifei,wh3000-pro-emmc|\
 	jdcloud,re-cp-03|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1785,6 +1785,20 @@ define Device/h3c_magic-nx30-pro
 endef
 TARGET_DEVICES += h3c_magic-nx30-pro
 
+define Device/hiveton_h5000m
+  DEVICE_VENDOR := Hiveton
+  DEVICE_MODEL := H5000M
+  DEVICE_ALT0_VENDOR := Airpi
+  DEVICE_ALT0_MODEL := H5000M
+  DEVICE_DTS := mt7987a-hiveton-h5000m
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-hwmon-pwmfan kmod-usb3 mt7987-2p5g-phy-firmware \
+	kmod-mt7996e kmod-mt7992-23-firmware f2fsck mkf2fs
+  KERNEL_LOADADDR := 0x40000000
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += hiveton_h5000m
+
 define Device/huasifei_wh3000
   DEVICE_VENDOR := Huasifei
   DEVICE_MODEL := WH3000


### PR DESCRIPTION
Hardware specification:
SoC: MediaTek MT7987A
Flash: 8GB eMMC
RAM: 1GB DDR4
Ethernet: 2x 2.5GbE (RTL8221B PHY + Internal PHY)
WiFi: MediaTek MT7992 / 2+3 antenna variant
Interface: M.2 USB for 5G module
LED: Power (hw-controlled), 2.5G WAN (user-definable), 5G Module (hw-controlled), LED-3 (user-definable), LED-4 (user-definable)
Button: Reset, WPS
Power: USB Type-C PD
Other: PWM Fan control

MAC address assignment is unconventional: the board has no Factory partition with pre-programmed MACs. Instead, all addresses are derived from the eMMC CID at runtime:

  LAN : macaddr_generate_from_mmc_cid mmcblk0
  WAN : LAN + 1 (label_mac)
  phy0: LAN + 2
  phy1: LAN + 3

This matches the vendor firmware behaviour and ensures stable, unique addresses across reboots without a dedicated EEPROM region for MACs.

Flash instructions:

Factory `mmcblk0p2` partition is empty,
stock ImmortalWrt-798x-mt799x-6.6-mtwifi from PadavanOnly firmware uses `MT7991_MT7976_EEPROM_BE5040_iPAiLNA.bin`.
Flashing this eeprom before flashing OpenWrt will make OpenWrt read eeprom:
```
dd if=/lib/firmware/MT7991_MT7976_EEPROM_BE5040_iPAiLNA.bin of=/dev/mmcblk0p2 bs=1 count=7680
sync
```
But it will have wifi issues for now. It's better to use OpenWrt fallback eeprom for now.

Power off the device.
Press and hold the Reset button.
Power on the device while keeping the Reset button pressed. Wait for the device to enter U-Boot recovery mode. Connect to the device via Ethernet (default IP: 192.168.1.1). Set your PC's IP to 192.168.1.x (e.g., 192.168.1.100). Open a web browser and navigate to http://192.168.1.1 Upload and flash the OpenWrt firmware
Wait for the flashing process to complete and the device to reboot.


Link: https://github.com/openwrt/openwrt/pull/21398

(cherry picked from commit 6487cc9a1f4caa07486772be851aaed3d155345d)