### PR TITLE
base-files: add ucidef_set_led_network for new network LED trigger

### DIFF
--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -425,6 +425,16 @@ generate_led() {
 			EOF
 		;;
 
+		network)
+			local family mode
+			json_get_vars family mode
+			uci -q batch <<-EOF
+				set system.$cfg.trigger='network'
+				set system.$cfg.mode='$mode'
+				set system.$cfg.family='$family'
+			EOF
+		;;
+
 		usb)
 			local device
 			json_get_vars device

--- a/package/base-files/files/etc/init.d/led
+++ b/package/base-files/files/etc/init.d/led
@@ -45,6 +45,7 @@ load_led() {
 	local sysfs
 	local trigger
 	local dev
+	local family
 	local ports
 	local mode
 	local default
@@ -57,6 +58,7 @@ load_led() {
 	config_get name $1 name "$sysfs"
 	config_get trigger $1 trigger "none"
 	config_get dev $1 dev
+	config_get family $1 family
 	config_get ports $1 port
 	config_get mode $1 mode
 	config_get_bool default $1 default "0"
@@ -132,6 +134,16 @@ load_led() {
 						echo 1 > /sys/class/leds/${sysfs}/$m
 				done
 				echo $interval > /sys/class/leds/${sysfs}/interval 2>/dev/null
+			}
+			;;
+
+		"network")
+			[ -n "$family" ] && {
+				echo $family > /sys/class/leds/${sysfs}/family
+				for m in $mode; do
+					[ -e "/sys/class/leds/${sysfs}/$m" ] && \
+						echo 1 > /sys/class/leds/${sysfs}/$m
+				done
 			}
 			;;
 

--- a/package/base-files/files/lib/functions/uci-defaults.sh
+++ b/package/base-files/files/lib/functions/uci-defaults.sh
@@ -481,6 +481,19 @@ ucidef_set_led_netdev() {
 	json_select ..
 }
 
+ucidef_set_led_network() {
+	local mode="${5:-link tx rx}"
+
+	_ucidef_set_led_common "$1" "$2" "$3"
+
+	json_add_string type network
+	json_add_string family "$4"
+	json_add_string mode "$mode"
+	json_select ..
+
+	json_select ..
+}
+
 ucidef_set_led_oneshot() {
 	_ucidef_set_led_timer $1 $2 $3 "oneshot" $4 $5
 }


### PR DESCRIPTION
This helper allows using the new "network" LED trigger directly. It requires network compatible syntax and supports specifying the family and mode.

This adds a proper object to the board.json, e.g.: 

```
"leds": {
	"lan_led": {
		"name": "LAN",
		"type": "network",
		"sysfs": "devicename:colour:function",
		"family": "lan",
		"mode": "link tx rx"
	}
}
```

The board.json data is then translated into the appropriate UCI section by config_generate, mapping "family" and "mode" to their respective options for the network trigger.
