### PR TITLE
treewide: use libdeflate for gzip

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -471,11 +471,6 @@ define Build/libdeflate-gzip
 	@mv $@.new $@
 endef
 
-define Build/gzip
-	$(STAGING_DIR_HOST)/bin/gzip -f -9n -c $@ $(1) > $@.new
-	@mv $@.new $@
-endef
-
 define Build/gzip-filename
 	@mkdir -p $@.tmp
 	@cp $@ $@.tmp/$(word 1,$(1))

--- a/include/image.mk
+++ b/include/image.mk
@@ -185,14 +185,6 @@ define Image/BuildKernel/MkuImage
 		-n '$(call toupper,$(ARCH)) $(VERSION_DIST) Linux-$(LINUX_VERSION)' -d $(4) $(5)
 endef
 
-ifdef CONFIG_TARGET_IMAGES_GZIP
-  define Image/Gzip
-	rm -f $(1).gz
-	gzip -9n $(1)
-  endef
-endif
-
-
 # Disable noisy checks by default as in upstream
 DTC_WARN_FLAGS := \
   -Wno-interrupt_provider \
@@ -337,7 +329,7 @@ endef
 define Image/mkfs/targz
 	$(TAR) -cp --numeric-owner --owner=0 --group=0 --mode=a-s --sort=name \
 		$(if $(SOURCE_DATE_EPOCH),--mtime="@$(SOURCE_DATE_EPOCH)") \
-		-C $(call mkfs_target_dir,$(1)) . | gzip -9n > $@
+		-C $(call mkfs_target_dir,$(1)) . | libdeflate-gzip -12 -c > $@
 endef
 
 define Image/Manifest
@@ -363,11 +355,11 @@ define Image/gzip-ext4-padded-squashfs
   endef
 
   ifneq ($(CONFIG_TARGET_IMAGES_GZIP),)
-    define Image/Build/gzip/ext4
-      $(call Image/Build/gzip,ext4)
+    define Image/Build/libdeflate-gzip/ext4
+      $(call Image/Build/libdeflate-gzip,ext4)
     endef
-    define Image/Build/gzip/squashfs
-      $(call Image/Build/gzip,squashfs)
+    define Image/Build/libdeflate-gzip/squashfs
+      $(call Image/Build/libdeflate-gzip,squashfs)
     endef
   endif
 
@@ -378,7 +370,7 @@ ifdef CONFIG_TARGET_ROOTFS_TARGZ
   define Image/Build/targz
 	$(TAR) -cp --numeric-owner --owner=0 --group=0 --mode=a-s --sort=name \
 		$(if $(SOURCE_DATE_EPOCH),--mtime="@$(SOURCE_DATE_EPOCH)") \
-		-C $(TARGET_DIR)/ . | gzip -9n > $(BIN_DIR)/$(IMG_PREFIX)$(if $(PROFILE_SANITIZED),-$(PROFILE_SANITIZED))-rootfs.tar.gz
+		-C $(TARGET_DIR)/ . | libdeflate-gzip -12 -c > $(BIN_DIR)/$(IMG_PREFIX)$(if $(PROFILE_SANITIZED),-$(PROFILE_SANITIZED))-rootfs.tar.gz
   endef
 endif
 endif
@@ -386,7 +378,7 @@ endif
 ifeq ($(filter-out cpiogz,$(ROOTFS_FILESYSTEM)),)
 ifdef CONFIG_TARGET_ROOTFS_CPIOGZ
   define Image/Build/cpiogz
-	( cd $(TARGET_DIR); find . | $(STAGING_DIR_HOST)/bin/cpio -o -H newc -R 0:0 | gzip -9n >$(BIN_DIR)/$(IMG_ROOTFS).cpio.gz )
+	( cd $(TARGET_DIR); find . | $(STAGING_DIR_HOST)/bin/cpio -o -H newc -R 0:0 | libdeflate-gzip -12 -c >$(BIN_DIR)/$(IMG_ROOTFS).cpio.gz )
   endef
 endif
 endif
@@ -786,7 +778,7 @@ define Device/Build/image
   .IGNORE: $(BIN_DIR)/$(call DEVICE_IMG_NAME,$(1),$(2))
 
   $(BIN_DIR)/$(call DEVICE_IMG_NAME,$(1),$(2)).gz: $(KDIR)/tmp/$(call DEVICE_IMG_NAME,$(1),$(2))
-	gzip -c -9n $$^ > $$@
+	libdeflate-gzip -12 -c $$^ > $$@
 
   $(BIN_DIR)/$(call DEVICE_IMG_NAME,$(1),$(2)): $(KDIR)/tmp/$(call DEVICE_IMG_NAME,$(1),$(2))
 	cp $$^ $$@

--- a/include/rootfs.mk
+++ b/include/rootfs.mk
@@ -78,7 +78,7 @@ define prepare_rootfs
 		cd $(1); \
 		if [ -n "$(CONFIG_USE_APK)" ]; then \
 			IPKG_POSTINST_PATH=./lib/apk/db/*.post-install; \
-			$(STAGING_DIR_HOST)/bin/gzip -d ./lib/apk/db/scripts.tar; \
+			$(STAGING_DIR_HOST)/bin/libdeflate-gzip -d -S ".gz" ./lib/apk/db/scripts.tar; \
 			$(STAGING_DIR_HOST)/bin/tar -C ./lib/apk/db/ -xf ./lib/apk/db/scripts.tar --wildcards "*.post-install"; \
 		else \
 			IPKG_POSTINST_PATH=./usr/lib/opkg/info/*.postinst; \
@@ -92,7 +92,7 @@ define prepare_rootfs
 			fi; \
 			[ -n "$(CONFIG_USE_APK)" ] && $(STAGING_DIR_HOST)/bin/tar --delete -f ./lib/apk/db/scripts.tar $$(basename $$script); \
 		done; \
-		[ -n "$(CONFIG_USE_APK)" ] && $(STAGING_DIR_HOST)/bin/gzip -f -9n -S ".gz" ./lib/apk/db/scripts.tar; \
+		[ -n "$(CONFIG_USE_APK)" ] && $(STAGING_DIR_HOST)/bin/libdeflate-gzip -f -12 -S ".gz" ./lib/apk/db/scripts.tar; \
 		if [ -z "$(CONFIG_USE_APK)" ]; then \
 			$(if $(IB),,awk -i inplace \
 				'/^Status:/ { \

--- a/package/Makefile
+++ b/package/Makefile
@@ -164,7 +164,7 @@ else
 			{ echo ""; echo ""; } >> Packages;; \
 		esac; \
 		$(SCRIPT_DIR)/make-index-json.py -f opkg -a "$(ARCH_PACKAGES)" Packages > index.json; \
-		gzip -9nc Packages > Packages.gz; \
+		libdeflate-gzip -12 -c Packages > Packages.gz; \
 	); done
 ifdef CONFIG_SIGNED_PACKAGES
 	@echo Signing package index...

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -216,7 +216,7 @@ package_index: FORCE
 	@mkdir -p $(TMP_DIR) $(TARGET_DIR)/tmp
 ifeq ($(CONFIG_USE_APK),)
 	(cd $(PACKAGE_DIR); $(SCRIPT_DIR)/ipkg-make-index.sh . > Packages && \
-		gzip -9nc Packages > Packages.gz; \
+		libdeflate-gzip -12 -c Packages > Packages.gz; \
 		$(if $(CONFIG_SIGNATURE_CHECK), \
 			$(STAGING_DIR_HOST)/bin/usign -S -m Packages -s $(BUILD_KEY)) \
 	) >/dev/null 2>/dev/null

--- a/target/linux/airoha/image/an7581.mk
+++ b/target/linux/airoha/image/an7581.mk
@@ -109,7 +109,7 @@ define Device/gemtek_w1700k-ubi
   PAGESIZE := 2048
   UBOOTENV_IN_UBI := 1
   KERNEL_IN_UBI := 1
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 128k
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
@@ -167,7 +167,7 @@ define Device/nokia_xg-040g-md-ubi
   DEVICE_DTS := an7581-nokia_xg-040g-md-ubi
   UBOOTENV_IN_UBI := 1
   KERNEL_IN_UBI := 1
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 128k
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb

--- a/target/linux/apm821xx/image/Makefile
+++ b/target/linux/apm821xx/image/Makefile
@@ -66,7 +66,7 @@ define Build/prepend-dtb
 endef
 
 define Image/cpiogz
-	( cd $(TARGET_DIR); find . | cpio -o -H newc | gzip -9n >$(KDIR_TMP)/$(IMG_PREFIX)-rootfs.cpio.gz )
+	( cd $(TARGET_DIR); find . | cpio -o -H newc | libdeflate-gzip -12 -c >$(KDIR_TMP)/$(IMG_PREFIX)-rootfs.cpio.gz )
 endef
 
 define Device/Default

--- a/target/linux/armsr/image/Makefile
+++ b/target/linux/armsr/image/Makefile
@@ -72,9 +72,9 @@ endef
 DEVICE_VARS += GRUB2_VARIANT UBOOT
 define Device/efi-default
   IMAGE/rootfs.img := append-rootfs | pad-to $(ROOTFS_PARTSIZE)
-  IMAGE/rootfs.img.gz := append-rootfs | pad-to $(ROOTFS_PARTSIZE) | gzip
+  IMAGE/rootfs.img.gz := append-rootfs | pad-to $(ROOTFS_PARTSIZE) | libdeflate-gzip
   IMAGE/combined-efi.img := grub-config efi | combined efi | grub-install efi | append-metadata
-  IMAGE/combined-efi.img.gz := grub-config efi | combined efi | grub-install efi | gzip | append-metadata
+  IMAGE/combined-efi.img.gz := grub-config efi | combined efi | grub-install efi | libdeflate-gzip | append-metadata
   IMAGE/combined-efi.vmdk := grub-config efi | combined efi | grub-install efi | qemu-image vmdk
  ifeq ($(CONFIG_TARGET_IMAGES_GZIP),y)
     IMAGES-y := rootfs.img.gz

--- a/target/linux/at91/image/Makefile
+++ b/target/linux/at91/image/Makefile
@@ -55,7 +55,7 @@ define Device/evaluation-dtb
   $(Device/evaluation)
   $(Device/dtb)
   KERNEL_SUFFIX := -fit-zImage.itb
-  KERNEL = kernel-bin | gzip | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb
+  KERNEL = kernel-bin | libdeflate-gzip | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb
 endef
 
 define Device/evaluation-fit

--- a/target/linux/at91/image/sam9x.mk
+++ b/target/linux/at91/image/sam9x.mk
@@ -39,7 +39,7 @@ define Build/at91-sdcard
 	$(AT91_SD_BOOT_PARTSIZE) \
 	$(CONFIG_TARGET_ROOTFS_PARTSIZE)
 
-  gzip -nc9 $@.img > $@
+  libdeflate-gzip -12 -c $@.img > $@
 
   rm -f $@.img $@.boot $@-uboot.env $@-uboot-env.txt)
 endef

--- a/target/linux/at91/image/sama5.mk
+++ b/target/linux/at91/image/sama5.mk
@@ -43,7 +43,7 @@ define Build/at91-sdcard
 	$(AT91_SD_BOOT_PARTSIZE) \
 	$(CONFIG_TARGET_ROOTFS_PARTSIZE)
 
-  gzip -nc9 $@.img > $@
+  libdeflate-gzip -12 -c $@.img > $@
 
   rm -f $@.img $@.boot $@-uboot.env $@-uboot-env.txt)
 endef

--- a/target/linux/at91/image/sama7.mk
+++ b/target/linux/at91/image/sama7.mk
@@ -39,7 +39,7 @@ define Build/at91-sdcard
 	$(AT91_SD_BOOT_PARTSIZE) \
 	$(CONFIG_TARGET_ROOTFS_PARTSIZE)
 
-  gzip -nc9 $@.img > $@
+  libdeflate-gzip -12 -c $@.img > $@
 
   rm -f $@.img $@.boot $@-uboot.env $@-uboot-env.txt)
 endef

--- a/target/linux/ath79/image/common-senao.mk
+++ b/target/linux/ath79/image/common-senao.mk
@@ -23,7 +23,7 @@ define Build/senao-tar-gz
 	$(CP) $@ $@.tmp/openwrt-$(word 1,$(1))-root.squashfs && \
 	$(TAR) -cp --numeric-owner --owner=0 --group=0 --mode=a-s --sort=name \
 		$(if $(SOURCE_DATE_EPOCH),--mtime="@$(SOURCE_DATE_EPOCH)") \
-		-C $@.tmp . | gzip -9n > $@ && \
+		-C $@.tmp . | libdeflate-gzip -12 -c > $@ && \
 	rm -rf $@.tmp $@.len $@.md5
 endef
 

--- a/target/linux/ath79/image/common-tp-link.mk
+++ b/target/linux/ath79/image/common-tp-link.mk
@@ -32,7 +32,7 @@ define Device/tplink-nolzma
   COMPILE/loader-$(1).gz := loader-okli-compile
   KERNEL := kernel-bin | append-dtb | lzma | uImage lzma -M 0x4f4b4c49 | \
 	loader-okli $(1) 7680
-  KERNEL_INITRAMFS := kernel-bin | append-dtb | gzip | tplink-v1-header
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | libdeflate-gzip | tplink-v1-header
 endef
 
 define Device/tplink-4m

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -130,7 +130,7 @@ define Build/pisen_wmb001n-factory
   cp "bin/pisen_wmb001n_factory-header.bin" "$@" && \
   $(TAR) -cp --numeric-owner --owner=0 --group=0 --mode=a-s --sort=name \
     $(if $(SOURCE_DATE_EPOCH),--mtime="@$(SOURCE_DATE_EPOCH)") \
-    -C "$@.tmp" . | gzip -9n >> "$@" && \
+    -C "$@.tmp" . | libdeflate-gzip -12 -c >> "$@" && \
   rm -rf "$@.tmp"
 endef
 

--- a/target/linux/ath79/image/lzma-loader/Makefile
+++ b/target/linux/ath79/image/lzma-loader/Makefile
@@ -53,7 +53,7 @@ loader.gz: $(PKG_BUILD_DIR)/loader.bin
 	# (TP-Link TL-WR1043ND v1) don't work correctly when
 	# the uncompressed loader is too small (probably a cache
 	# invalidation issue)
-	dd if=$< bs=512K conv=sync | gzip -nc9 > $(LOADER_GZ)
+	dd if=$< bs=512K conv=sync | libdeflate-gzip -12 -c > $(LOADER_GZ)
 
 loader.elf: $(PKG_BUILD_DIR)/loader.elf
 	$(CP) $< $(LOADER_ELF)

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -552,7 +552,7 @@ define Device/zyxel_nbg6716
   IMAGE/sysupgrade.tar/squashfs := append-rootfs | pad-to $$$$(BLOCKSIZE) | \
 	sysupgrade-tar rootfs=$$$$@ | append-metadata
   IMAGE/sysupgrade-4M-Kernel.bin/squashfs := append-kernel | \
-	pad-to $$$$(KERNEL_SIZE) | append-ubi | pad-to 263192576 | gzip
+	pad-to $$$$(KERNEL_SIZE) | append-ubi | pad-to 263192576 | libdeflate-gzip
   IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | \
 	zyxel-factory
   UBINIZE_OPTS := -E 5

--- a/target/linux/bcm27xx/image/Makefile
+++ b/target/linux/bcm27xx/image/Makefile
@@ -76,8 +76,8 @@ define Device/Default
   KERNEL := kernel-bin
   KERNEL_IMG := kernel.img
   IMAGES := factory.img.gz sysupgrade.img.gz
-  IMAGE/sysupgrade.img.gz := boot-common | boot-2708 | sdcard-img | gzip | append-metadata
-  IMAGE/factory.img.gz := boot-common | boot-2708 | sdcard-img | gzip
+  IMAGE/sysupgrade.img.gz := boot-common | boot-2708 | sdcard-img | libdeflate-gzip | append-metadata
+  IMAGE/factory.img.gz := boot-common | boot-2708 | sdcard-img | libdeflate-gzip
 endef
 
 define Device/rpi
@@ -137,8 +137,8 @@ define Device/rpi-2
 	$(WIFI_43430_FW) \
 	$(WIFI_43455_FW) \
 	$(BRCM_WIFI_DRIVER)
-  IMAGE/sysupgrade.img.gz := boot-common | boot-2708 | boot-2711 | sdcard-img | gzip | append-metadata
-  IMAGE/factory.img.gz := boot-common | boot-2708 | boot-2711 | sdcard-img | gzip
+  IMAGE/sysupgrade.img.gz := boot-common | boot-2708 | boot-2711 | sdcard-img | libdeflate-gzip | append-metadata
+  IMAGE/factory.img.gz := boot-common | boot-2708 | boot-2711 | sdcard-img | libdeflate-gzip
 endef
 ifeq ($(SUBTARGET),bcm2709)
   TARGET_DEVICES += rpi-2
@@ -193,8 +193,8 @@ define Device/rpi-4
 	$(WIFI_43455_FW) \
 	$(BRCM_WIFI_DRIVER) \
 	$(LAN_DRIVERS)
-  IMAGE/sysupgrade.img.gz := boot-common | boot-2711 | sdcard-img | gzip | append-metadata
-  IMAGE/factory.img.gz := boot-common | boot-2711 | sdcard-img | gzip
+  IMAGE/sysupgrade.img.gz := boot-common | boot-2711 | sdcard-img | libdeflate-gzip | append-metadata
+  IMAGE/factory.img.gz := boot-common | boot-2711 | sdcard-img | libdeflate-gzip
 endef
 ifeq ($(SUBTARGET),bcm2711)
   TARGET_DEVICES += rpi-4
@@ -221,8 +221,8 @@ define Device/rpi-5
 	$(BRCM_WIFI_DRIVER) \
 	$(LAN_DRIVERS) \
 	kmod-hwmon-pwmfan kmod-thermal
-  IMAGE/sysupgrade.img.gz := boot-common | sdcard-img | gzip | append-metadata
-  IMAGE/factory.img.gz := boot-common | sdcard-img | gzip
+  IMAGE/sysupgrade.img.gz := boot-common | sdcard-img | libdeflate-gzip | append-metadata
+  IMAGE/factory.img.gz := boot-common | sdcard-img | libdeflate-gzip
 endef
 ifeq ($(SUBTARGET),bcm2712)
   TARGET_DEVICES += rpi-5

--- a/target/linux/bcm47xx/image/Makefile
+++ b/target/linux/bcm47xx/image/Makefile
@@ -19,7 +19,7 @@ define Image/Prepare
 	# Less optimal LZMA compression (no dictionary), handled by CFE.
 	$(STAGING_DIR_HOST)/bin/lzma e -so -d16 $(KDIR)/vmlinux > $(KDIR)/vmlinux-nodictionary.lzma
 
-	gzip -nc9 $(KDIR)/vmlinux > $(KDIR)/vmlinux.gz
+	libdeflate-gzip -12 -c $(KDIR)/vmlinux > $(KDIR)/vmlinux.gz
 ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
 	cat $(KDIR)/vmlinux-initramfs | $(STAGING_DIR_HOST)/bin/lzma e -si -so -eos -lc1 -lp2 -pb2 > $(KDIR)/vmlinux-initramfs.lzma
 	$(STAGING_DIR_HOST)/bin/lzma e -so -d16 $(KDIR)/vmlinux-initramfs > $(KDIR)/vmlinux-initramfs-nodictionary.lzma

--- a/target/linux/bcm47xx/image/lzma-loader/src/Makefile
+++ b/target/linux/bcm47xx/image/lzma-loader/src/Makefile
@@ -3,7 +3,7 @@
 #
 # Copyright 2001-2003, Broadcom Corporation
 # All Rights Reserved.
-# 
+#
 # THIS SOFTWARE IS OFFERED "AS IS", AND BROADCOM GRANTS NO WARRANTIES OF ANY
 # KIND, EXPRESS OR IMPLIED, BY STATUTE, COMMUNICATION OR OTHERWISE. BROADCOM
 # SPECIFICALLY DISCLAIMS ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS
@@ -43,7 +43,7 @@ dep:
 install:
 
 loader.gz: loader
-	gzip -nc9 $< > $@
+	libdeflate-gzip -12 -c $< > $@
 
 loader.elf: loader.o
 	cp $< $@

--- a/target/linux/bmips/image/Makefile
+++ b/target/linux/bmips/image/Makefile
@@ -357,7 +357,7 @@ define Device/sercomm-nand
   $(Device/bcm63xx-nand)
   IMAGES := factory.img sysupgrade.bin
   IMAGE/factory.img := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi |\
-    cfe-sercomm-part | gzip | cfe-sercomm-load | cfe-sercomm-crypto
+    cfe-sercomm-part | libdeflate-gzip | cfe-sercomm-load | cfe-sercomm-crypto
   SERCOMM_FSVER :=
   SERCOMM_HWVER :=
   SERCOMM_SWVER :=

--- a/target/linux/d1/image/Makefile
+++ b/target/linux/d1/image/Makefile
@@ -34,12 +34,12 @@ define Device/Default
   KERNEL_NAME := Image
   KERNEL := kernel-bin
   IMAGES := sdcard.img.gz
-  IMAGE/sdcard.img.gz := riscv-sdcard | append-metadata | gzip
+  IMAGE/sdcard.img.gz := riscv-sdcard | append-metadata | libdeflate-gzip
 endef
 
 define Device/FitImageGzip
 	KERNEL_SUFFIX := -fit-uImage.itb
-	KERNEL = kernel-bin | gzip | fit gzip $$(DTS_DIR)/$$(DEVICE_DTS).dtb
+	KERNEL = kernel-bin | libdeflate-gzip | fit gzip $$(DTS_DIR)/$$(DEVICE_DTS).dtb
 	KERNEL_NAME := Image
 endef
 

--- a/target/linux/gemini/image/Makefile
+++ b/target/linux/gemini/image/Makefile
@@ -227,7 +227,7 @@ define Device/dlink_dns-313
 	BLOCKSIZE := 1k
 	FILESYSTEMS := ext4
 	IMAGES := factory.bin.gz
-	IMAGE/factory.bin.gz := dns313-images | gzip
+	IMAGE/factory.bin.gz := dns313-images | libdeflate-gzip
 endef
 TARGET_DEVICES += dlink_dns-313
 

--- a/target/linux/imx/image/cortexa53.mk
+++ b/target/linux/imx/image/cortexa53.mk
@@ -81,7 +81,7 @@ define Device/gateworks_venice
 	kmod-can kmod-can-flexcan kmod-can-mcp251x \
 	kmod-dsa-ksz9477-i2c
   IMAGES := img.gz
-  IMAGE/img.gz := boot-scr | boot-img-ext4 | sdcard-img-ext4 | gzip | append-metadata
+  IMAGE/img.gz := boot-scr | boot-img-ext4 | sdcard-img-ext4 | libdeflate-gzip | append-metadata
 endef
 TARGET_DEVICES += gateworks_venice
 
@@ -102,6 +102,6 @@ define Device/kontron_osm-s-imx8mp
 	kmod-rtc-rv3028
   UBOOT := kontron-osm-s-mx8mp
   IMAGES := img.gz
-  IMAGE/img.gz := boot-scr | boot-img-ext4 | sdcard-img-ext4 | sdcard-img-add-uboot | gzip | append-metadata
+  IMAGE/img.gz := boot-scr | boot-img-ext4 | sdcard-img-ext4 | sdcard-img-add-uboot | libdeflate-gzip | append-metadata
 endef
 TARGET_DEVICES += kontron_osm-s-imx8mp

--- a/target/linux/imx/image/cortexa9.mk
+++ b/target/linux/imx/image/cortexa9.mk
@@ -128,7 +128,7 @@ define Device/gateworks_ventana
   IMAGE/nand.ubi := append-ubi
   IMAGE/bootfs.tar.gz := bootfs.tar.gz
   IMAGE/dtb := install-dtb
-  IMAGE/img.gz := append-rootfs | pad-extra 128k | ventana-img | gzip
+  IMAGE/img.gz := append-rootfs | pad-extra 128k | ventana-img | libdeflate-gzip
   UBINIZE_PARTS = boot=$$(KDIR_KERNEL_IMAGE).boot.ubifs=15
   PAGESIZE := 2048
   BLOCKSIZE := 128k

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -12,7 +12,7 @@ endef
 
 define Device/FitImage
 	KERNEL_SUFFIX := -uImage.itb
-	KERNEL = kernel-bin | gzip | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb
+	KERNEL = kernel-bin | libdeflate-gzip | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb
 	KERNEL_NAME := Image
 endef
 
@@ -317,7 +317,7 @@ TARGET_DEVICES += buffalo_wtr-m2133hp
 
 define Device/cellc_rtl30vw
 	KERNEL_SUFFIX := -zImage.itb
-	KERNEL_INITRAMFS = kernel-bin | gzip | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb
+	KERNEL_INITRAMFS = kernel-bin | libdeflate-gzip | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb
 	KERNEL = kernel-bin | fit none $$(KDIR)/image-$$(DEVICE_DTS).dtb | uImage lzma | pad-to 2048
 	KERNEL_NAME := zImage
 	KERNEL_IN_UBI :=
@@ -386,7 +386,7 @@ define Device/devolo_magic-2-wifi-next
 
 	# If the bootloader sees 0xDEADC0DE and this trailer at the 64k boundary of a TFTP image
 	# it will bootm it, just like we want for the initramfs.
-	KERNEL_INITRAMFS := kernel-bin | gzip | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb | pad-to 64k |\
+	KERNEL_INITRAMFS := kernel-bin | libdeflate-gzip | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb | pad-to 64k |\
 		append-string -e '\xDE\xAD\xC0\xDE{"fl_initramfs":""}\x00'
 
 	IMAGE_SIZE := 26624k
@@ -624,7 +624,7 @@ define Device/glinet_gl-b2200
 	IMAGE/emmc.img.gz := qsdk-ipq-app-gpt |\
 		pad-to 1024k | append-kernel |\
 		pad-to 33792k | append-rootfs |\
-		append-metadata | gzip
+		append-metadata | libdeflate-gzip
 	IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct \
 		kmod-fs-ext4 kmod-mmc kmod-spi-dev mkf2fs e2fsprogs kmod-fs-f2fs

--- a/target/linux/ipq806x/image/Makefile
+++ b/target/linux/ipq806x/image/Makefile
@@ -22,7 +22,7 @@ endef
 
 define Device/FitImage
 	KERNEL_SUFFIX := -fit-uImage.itb
-	KERNEL = kernel-bin | gzip | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb
+	KERNEL = kernel-bin | libdeflate-gzip | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb
 	KERNEL_NAME := Image
 endef
 

--- a/target/linux/lantiq/image/lzma-loader/Makefile
+++ b/target/linux/lantiq/image/lzma-loader/Makefile
@@ -53,7 +53,7 @@ loader-compile: $(PKG_BUILD_DIR)/.prepared
 		clean all
 
 loader.gz: $(PKG_BUILD_DIR)/loader.bin
-	gzip -nc9 $< > $(LOADER_GZ)
+	libdeflate-gzip -12 -c $< > $(LOADER_GZ)
 
 loader.elf: $(PKG_BUILD_DIR)/loader.elf
 	$(CP) $< $(LOADER_ELF)

--- a/target/linux/layerscape/image/armv7.mk
+++ b/target/linux/layerscape/image/armv7.mk
@@ -8,7 +8,7 @@ define Device/Default
   IMAGES := firmware.bin sysupgrade.bin
   DEVICE_DTS_DIR := $(DTS_DIR)/nxp/ls
   KERNEL := kernel-bin | uImage none
-  KERNEL_INITRAMFS = kernel-bin | gzip | fit gzip $$(DEVICE_DTS_DIR)/$$(DEVICE_DTS).dtb
+  KERNEL_INITRAMFS = kernel-bin | libdeflate-gzip | fit gzip $$(DEVICE_DTS_DIR)/$$(DEVICE_DTS).dtb
   KERNEL_NAME := zImage
   KERNEL_LOADADDR := 0x80008000
   DEVICE_DTS = $(lastword $(subst _, ,$(1)))
@@ -21,7 +21,7 @@ define Device/Default
 endef
 
 define Device/fsl-sdboot
-  KERNEL = kernel-bin | gzip | fit gzip $$(DEVICE_DTS_DIR)/$$(DEVICE_DTS).dtb
+  KERNEL = kernel-bin | libdeflate-gzip | fit gzip $$(DEVICE_DTS_DIR)/$$(DEVICE_DTS).dtb
   IMAGES := sdcard.img.gz sysupgrade.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
@@ -55,7 +55,7 @@ define Device/fsl_ls1021a-twr-sdboot
     ls-append $(1)-uboot.bin | pad-to 3M | \
     ls-append $(1)-uboot-env.bin | pad-to 16M | \
     ls-append-kernel | pad-to $(LS_SD_ROOTFSPART_OFFSET)M | \
-    append-rootfs | pad-to $(LS_SD_IMAGE_SIZE)M | gzip
+    append-rootfs | pad-to $(LS_SD_IMAGE_SIZE)M | libdeflate-gzip
 endef
 TARGET_DEVICES += fsl_ls1021a-twr-sdboot
 
@@ -73,6 +73,6 @@ define Device/fsl_ls1021a-iot-sdboot
     ls-append $(1)-uboot.bin | pad-to 1M | \
     ls-append $(1)-uboot-env.bin | pad-to 16M | \
     ls-append-kernel | pad-to $(LS_SD_ROOTFSPART_OFFSET)M | \
-    append-rootfs | pad-to $(LS_SD_IMAGE_SIZE)M | gzip
+    append-rootfs | pad-to $(LS_SD_IMAGE_SIZE)M | libdeflate-gzip
 endef
 TARGET_DEVICES += fsl_ls1021a-iot-sdboot

--- a/target/linux/layerscape/image/armv8_64b.mk
+++ b/target/linux/layerscape/image/armv8_64b.mk
@@ -8,8 +8,8 @@ define Device/Default
   DEVICE_DTS_DIR := $(DTS_DIR)/freescale
   DEVICE_DTS = $(subst _,-,$(1))
   FILESYSTEMS := squashfs
-  KERNEL := kernel-bin | gzip | uImage gzip
-  KERNEL_INITRAMFS = kernel-bin | gzip | fit gzip $$(DEVICE_DTS_DIR)/$$(DEVICE_DTS).dtb
+  KERNEL := kernel-bin | libdeflate-gzip | uImage gzip
+  KERNEL_INITRAMFS = kernel-bin | libdeflate-gzip | fit gzip $$(DEVICE_DTS_DIR)/$$(DEVICE_DTS).dtb
   KERNEL_LOADADDR := 0x80000000
   IMAGE_SIZE := 64m
   IMAGE/sysupgrade.bin = \
@@ -20,7 +20,7 @@ define Device/Default
 endef
 
 define Device/fsl-sdboot
-  KERNEL = kernel-bin | gzip | fit gzip $$(DEVICE_DTS_DIR)/$$(DEVICE_DTS).dtb
+  KERNEL = kernel-bin | libdeflate-gzip | fit gzip $$(DEVICE_DTS_DIR)/$$(DEVICE_DTS).dtb
   IMAGES := sdcard.img.gz sysupgrade.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
@@ -45,7 +45,7 @@ define Device/fsl_ls1012a-frdm
     append-kernel | pad-to $$(BLOCKSIZE) | \
     append-rootfs | pad-rootfs | \
     check-size $(LS_SYSUPGRADE_IMAGE_SIZE) | append-metadata
-  KERNEL := kernel-bin | gzip | fit gzip $$(DEVICE_DTS_DIR)/$$(DEVICE_DTS).dtb
+  KERNEL := kernel-bin | libdeflate-gzip | fit gzip $$(DEVICE_DTS_DIR)/$$(DEVICE_DTS).dtb
 endef
 TARGET_DEVICES += fsl_ls1012a-frdm
 
@@ -92,7 +92,7 @@ define Device/fsl_ls1012a-frwy-sdboot
     ls-clean | \
     ls-append-sdhead $(1) | pad-to 16M | \
     ls-append-kernel | pad-to $(LS_SD_ROOTFSPART_OFFSET)M | \
-    append-rootfs | pad-to $(LS_SD_IMAGE_SIZE)M | gzip
+    append-rootfs | pad-to $(LS_SD_IMAGE_SIZE)M | libdeflate-gzip
 endef
 TARGET_DEVICES += fsl_ls1012a-frwy-sdboot
 
@@ -100,7 +100,7 @@ define Device/fsl_ls1028a-rdb
   DEVICE_VENDOR := NXP
   DEVICE_MODEL := LS1028A-RDB
   DEVICE_VARIANT := Default
-  KERNEL = kernel-bin | gzip | fit gzip $$(DEVICE_DTS_DIR)/$$(DEVICE_DTS).dtb
+  KERNEL = kernel-bin | libdeflate-gzip | fit gzip $$(DEVICE_DTS_DIR)/$$(DEVICE_DTS).dtb
   DEVICE_PACKAGES += \
     kmod-hwmon-ina2xx \
     kmod-hwmon-lm90 \
@@ -136,7 +136,7 @@ define Device/fsl_ls1028a-rdb-sdboot
     ls-append $(1)-fip.bin | pad-to 5M | \
     ls-append $(1)-uboot-env.bin | pad-to 16M | \
     ls-append-kernel | pad-to $(LS_SD_ROOTFSPART_OFFSET)M | \
-    append-rootfs | pad-to $(LS_SD_IMAGE_SIZE)M | gzip
+    append-rootfs | pad-to $(LS_SD_IMAGE_SIZE)M | libdeflate-gzip
 endef
 TARGET_DEVICES += fsl_ls1028a-rdb-sdboot
 
@@ -180,7 +180,7 @@ define Device/fsl_ls1043a-rdb-sdboot
     ls-append $(1)-uboot-env.bin | pad-to 9M | \
     ls-append fsl_ls1043a-rdb-fman.bin | pad-to 16M | \
     ls-append-kernel | pad-to $(LS_SD_ROOTFSPART_OFFSET)M | \
-    append-rootfs | pad-to $(LS_SD_IMAGE_SIZE)M | gzip
+    append-rootfs | pad-to $(LS_SD_IMAGE_SIZE)M | libdeflate-gzip
 endef
 TARGET_DEVICES += fsl_ls1043a-rdb-sdboot
 
@@ -214,7 +214,7 @@ define Device/fsl_ls1046a-frwy-sdboot
     ls-append $(1)-uboot-env.bin | pad-to 9M | \
     ls-append fsl_ls1046a-rdb-fman.bin | pad-to 16M | \
     ls-append-kernel | pad-to $(LS_SD_ROOTFSPART_OFFSET)M | \
-    append-rootfs | pad-to $(LS_SD_IMAGE_SIZE)M | gzip
+    append-rootfs | pad-to $(LS_SD_IMAGE_SIZE)M | libdeflate-gzip
 endef
 TARGET_DEVICES += fsl_ls1046a-frwy-sdboot
 
@@ -258,7 +258,7 @@ define Device/fsl_ls1046a-rdb-sdboot
     ls-append $(1)-uboot-env.bin | pad-to 9M | \
     ls-append fsl_ls1046a-rdb-fman.bin | pad-to 16M | \
     ls-append-kernel | pad-to $(LS_SD_ROOTFSPART_OFFSET)M | \
-    append-rootfs | pad-to $(LS_SD_IMAGE_SIZE)M | gzip
+    append-rootfs | pad-to $(LS_SD_IMAGE_SIZE)M | libdeflate-gzip
 endef
 TARGET_DEVICES += fsl_ls1046a-rdb-sdboot
 
@@ -308,7 +308,7 @@ define Device/fsl_ls1088a-rdb-sdboot
     ls-append fsl_ls1088a-rdb-dpl.dtb | pad-to 14M | \
     ls-append fsl_ls1088a-rdb-dpc.dtb | pad-to 16M | \
     ls-append-kernel | pad-to $(LS_SD_ROOTFSPART_OFFSET)M | \
-    append-rootfs | pad-to $(LS_SD_IMAGE_SIZE)M | gzip
+    append-rootfs | pad-to $(LS_SD_IMAGE_SIZE)M | libdeflate-gzip
 endef
 TARGET_DEVICES += fsl_ls1088a-rdb-sdboot
 
@@ -371,7 +371,7 @@ define Device/fsl_lx2160a-rdb-sdboot
     ls-append fsl_lx2160a-rdb-dpl.dtb | pad-to 14M | \
     ls-append fsl_lx2160a-rdb-dpc.dtb | pad-to 16M | \
     ls-append-kernel | pad-to $(LS_SD_ROOTFSPART_OFFSET)M | \
-    append-rootfs | pad-to $(LS_SD_IMAGE_SIZE)M | gzip
+    append-rootfs | pad-to $(LS_SD_IMAGE_SIZE)M | libdeflate-gzip
 endef
 TARGET_DEVICES += fsl_lx2160a-rdb-sdboot
 
@@ -395,7 +395,7 @@ define Device/traverse_ten64-mtd
   KERNEL_SUFFIX := -kernel.itb
   DEVICE_DTS := fsl-ls1088a-ten64
   IMAGES := nand.ubi sysupgrade.bin
-  KERNEL := kernel-bin | gzip | traverse-fit-ls1088 gzip $$(DTS_DIR)/$$(DEVICE_DTS).dtb $$(FDT_LOADADDR)
+  KERNEL := kernel-bin | libdeflate-gzip | traverse-fit-ls1088 gzip $$(DTS_DIR)/$$(DEVICE_DTS).dtb $$(FDT_LOADADDR)
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   IMAGE/nand.ubi := append-ubi
   KERNEL_IN_UBI := 1

--- a/target/linux/malta/image/Makefile
+++ b/target/linux/malta/image/Makefile
@@ -16,10 +16,10 @@ define Device/Default
   FILESYSTEMS := ext4 squashfs
   IMAGES := rootfs.img rootfs.img.gz
   IMAGE/rootfs.img := append-rootfs | pad-to $(ROOTFS_PARTSIZE)
-  IMAGE/rootfs.img.gz := append-rootfs | pad-to $(ROOTFS_PARTSIZE) | gzip
+  IMAGE/rootfs.img.gz := append-rootfs | pad-to $(ROOTFS_PARTSIZE) | libdeflate-gzip
   ARTIFACTS := uImage-lzma uImage-gzip
   ARTIFACT/uImage-lzma := kernel-bin | lzma | uImage lzma
-  ARTIFACT/uImage-gzip := kernel-bin | gzip | uImage gzip
+  ARTIFACT/uImage-gzip := kernel-bin | libdeflate-gzip | uImage gzip
   SUPPORTED_DEVICES :=
 endef
 

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -159,7 +159,7 @@ define Device/abt_asr3000
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -245,7 +245,7 @@ define Device/acer_predator-w6x-ubootmod
   PAGESIZE := 2048
   KERNEL_IN_UBI := 1
   UBOOTENV_IN_UBI := 1
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -408,7 +408,7 @@ define Device/arcadyan_mozart
   DEVICE_DTS_LOADADDR := 0x45f00000
   DEVICE_PACKAGES := kmod-hwmon-pwmfan e2fsprogs f2fsck mkf2fs kmod-mt7996-firmware
   KERNEL_LOADADDR := 0x46000000
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   KERNEL_INITRAMFS_SUFFIX := .itb
@@ -546,7 +546,7 @@ define Device/asus_zenwifi-bt8
   DEVICE_DTS := mt7988d-asus-zenwifi-bt8
   DEVICE_DTS_DIR := ../dts
   DEVICE_PACKAGES := kmod-usb3 mt7988-2p5g-phy-firmware kmod-mt7996-firmware mt7988-wo-firmware
-  KERNEL := kernel-bin | gzip | \
+  KERNEL := kernel-bin | libdeflate-gzip | \
 	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
@@ -573,7 +573,7 @@ define Device/asus_zenwifi-bt8-ubootmod
   ARTIFACTS := preloader.bin bl31-uboot.fip
   ARTIFACT/preloader.bin := mt7988-bl2 spim-nand-ubi-ddr4
   ARTIFACT/bl31-uboot.fip := mt7988-bl31-uboot asus_zenwifi-bt8
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
@@ -628,11 +628,11 @@ define Device/bananapi_bpi-r3
 				$(if $(CONFIG_TARGET_ROOTFS_SQUASHFS),\
 				   pad-to 64M | append-image squashfs-sysupgrade.itb | check-size |\
 				) \
-				  gzip
+				  libdeflate-gzip
 ifeq ($(DUMP),)
   IMAGE_SIZE := $$(shell expr 64 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
 endif
-  KERNEL			:= kernel-bin | gzip
+  KERNEL			:= kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | pad-rootfs | append-metadata
@@ -652,7 +652,7 @@ define Device/bananapi_bpi-r3-mini
   DEVICE_PACKAGES := kmod-eeprom-at24 kmod-hwmon-pwmfan kmod-mt7915e kmod-mt7986-firmware \
 		     kmod-phy-airoha-en8811h kmod-usb3 e2fsprogs f2fsck mkf2fs mt7986-wo-firmware
   KERNEL_LOADADDR := 0x44000000
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
     fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
@@ -726,7 +726,7 @@ define Device/bananapi_bpi-r4-common
 				$(if $(CONFIG_TARGET_ROOTFS_SQUASHFS),\
 				   pad-to 64M | append-image squashfs-sysupgrade.itb | check-size |\
 				) \
-				  gzip
+				  libdeflate-gzip
   ARTIFACT/sdcard_8g.img.gz	:= mt798x-gpt sdmmc |\
 				   pad-to 17k | mt7988-bl2 sdmmc-comb-4bg |\
 				   pad-to 6656k | mt7988-bl31-uboot $$(DEVICE_NAME)-sdmmc |\
@@ -741,9 +741,9 @@ define Device/bananapi_bpi-r4-common
 				$(if $(CONFIG_TARGET_ROOTFS_SQUASHFS),\
 				   pad-to 64M | append-image squashfs-sysupgrade.itb | check-size |\
 				) \
-				  gzip
+				  libdeflate-gzip
   IMAGE_SIZE := $$(shell expr 64 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
-  KERNEL			:= kernel-bin | gzip
+  KERNEL			:= kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | pad-rootfs | append-metadata
@@ -785,7 +785,7 @@ define Device/bananapi_bpi-r4-lite
   KERNEL_IN_UBI := 1
   UBOOTENV_IN_UBI := 1
   KERNEL_LOADADDR := 0x40000000
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGES := sysupgrade.itb
@@ -820,7 +820,7 @@ define Device/bananapi_bpi-r4-lite
 				$(if $(CONFIG_TARGET_ROOTFS_SQUASHFS),\
 				   pad-to 64M | append-image squashfs-sysupgrade.itb | check-size |\
 				) \
-				  gzip
+				  libdeflate-gzip
 ifeq ($(DUMP),)
   IMAGE_SIZE := $$(shell expr 64 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
 endif
@@ -841,7 +841,7 @@ define Device/bazis_ax3000wm
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -934,7 +934,7 @@ define Device/cmcc_a10-ubootmod
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -958,7 +958,7 @@ define Device/cmcc_rax3000m
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3 \
 	e2fsprogs f2fsck mkf2fs
   KERNEL_LOADADDR := 0x44000000
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
@@ -1050,7 +1050,7 @@ define Device/comfast_cf-wr632ax-ubootmod-common
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -1144,7 +1144,7 @@ define Device/creatlentem_clt-r30b1-ubi
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -1241,7 +1241,7 @@ define Device/cudy_m3000-v1-ubootmod
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -1286,7 +1286,7 @@ define Device/cudy_m3000-v2-yt8821-ubootmod
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -1362,7 +1362,7 @@ define Device/cudy_tr3000-v1-ubootmod
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -1421,7 +1421,7 @@ define Device/cudy_wr3000e-v1-ubootmod
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -1463,7 +1463,7 @@ define Device/cudy_wr3000s-v1-ubootmod
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -1505,7 +1505,7 @@ define Device/cudy_wr3000h-v1-ubootmod
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -1547,7 +1547,7 @@ define Device/cudy_wr3000p-v1-ubootmod
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -1606,7 +1606,7 @@ define Device/cudy_wbr3000uax-v1-ubootmod
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -1755,8 +1755,8 @@ define Device/gatonetworks_gdsp
   ARTIFACT/preloader.bin := mt7981-bl2 nor-ddr3
   ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot gatonetworks_gdsp
   ARTIFACT/sdcard.img.gz := simplefit |\
-  append-image squashfs-sysupgrade.itb | check-size | gzip
-  KERNEL := kernel-bin | gzip
+  append-image squashfs-sysupgrade.itb | check-size | libdeflate-gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | pad-rootfs | append-metadata
@@ -1910,7 +1910,7 @@ define Device/h3c_magic-nx30-pro
   IMAGE_SIZE := 65536k
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -2004,7 +2004,7 @@ define Device/imou_hx21
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -2118,7 +2118,7 @@ define Device/jcg_q30-pro
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -2140,7 +2140,7 @@ define Device/jdcloud_re-cp-03
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware \
 	e2fsprogs f2fsck mkf2fs
   KERNEL_LOADADDR := 0x44000000
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
@@ -2314,7 +2314,7 @@ define Device/konka_komi-a31
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -2349,7 +2349,7 @@ define Device/mediatek_mt7981-rfb
   DEVICE_DTS_LOADADDR := 0x43f00000
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware kmod-usb3 e2fsprogs f2fsck mkf2fs mt7981-wo-firmware
   KERNEL_LOADADDR := 0x44000000
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   KERNEL_INITRAMFS_SUFFIX := .itb
@@ -2387,7 +2387,7 @@ define Device/mediatek_mt7981-rfb
 				$(if $(CONFIG_TARGET_ROOTFS_SQUASHFS),\
 				   pad-to 64M | append-image squashfs-sysupgrade.itb | check-size |\
 				) \
-				  gzip
+				  libdeflate-gzip
 endef
 TARGET_DEVICES += mediatek_mt7981-rfb
 
@@ -2450,7 +2450,7 @@ define Device/mediatek_mt7987a-rfb
   DEVICE_DTS_LOADADDR := 0x4ff00000
   DEVICE_PACKAGES := mt7987-2p5g-phy-firmware kmod-sfp
   KERNEL_LOADADDR := 0x40000000
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGES := sysupgrade.itb
@@ -2474,7 +2474,7 @@ define Device/mediatek_mt7987a-rfb
 				$(if $(CONFIG_TARGET_ROOTFS_SQUASHFS),\
 				  pad-to 64M | append-image squashfs-sysupgrade.itb | check-size |\
 				) \
-				  gzip
+				  libdeflate-gzip
 endef
 TARGET_DEVICES += mediatek_mt7987a-rfb
 
@@ -2501,7 +2501,7 @@ define Device/mediatek_mt7988a-rfb
   DEVICE_DTS_LOADADDR := 0x45f00000
   DEVICE_PACKAGES := mt7988-2p5g-phy-firmware kmod-sfp kmod-phy-aquantia
   KERNEL_LOADADDR := 0x46000000
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   KERNEL_INITRAMFS_SUFFIX := .itb
@@ -2537,7 +2537,7 @@ define Device/mediatek_mt7988a-rfb
 				$(if $(CONFIG_TARGET_ROOTFS_SQUASHFS),\
 				   pad-to 64M | append-image squashfs-sysupgrade.itb | check-size |\
 				) \
-				  gzip
+				  libdeflate-gzip
 endef
 TARGET_DEVICES += mediatek_mt7988a-rfb
 
@@ -2597,7 +2597,7 @@ define Device/mercusys_mr90x-v1-ubi
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | \
 	pad-to 64k
@@ -2622,7 +2622,7 @@ define Device/netcore_n60
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -2649,7 +2649,7 @@ define Device/netcore_n60-pro
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -2751,7 +2751,7 @@ define Device/netis_eap930-v1
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -2810,7 +2810,7 @@ define Device/netis_nx30v2
   DEVICE_DTS_LOADADDR := 0x43f00000
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
   KERNEL_LOADADDR := 0x44000000
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   KERNEL_INITRAMFS_SUFFIX := .itb
   KERNEL_IN_UBI := 1
@@ -2836,7 +2836,7 @@ define Device/netis_nx31
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -2861,7 +2861,7 @@ define Device/netis_nx32u
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -2888,7 +2888,7 @@ define Device/nokia_ea0326gmp
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -2953,7 +2953,7 @@ define Device/openwrt_one
   DEVICE_DTS_LOADADDR := 0x43f00000
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-rtc-pcf8563 kmod-usb3 kmod-phy-airoha-en8811h
   KERNEL_LOADADDR := 0x44000000
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   KERNEL_INITRAMFS_SUFFIX := .itb
@@ -3000,7 +3000,7 @@ define Device/qihoo_360t7-common
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | \
 	pad-to 64k
@@ -3057,7 +3057,7 @@ define Device/routerich_ax3000-ubootmod
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -3095,7 +3095,7 @@ define Device/routerich_be7200
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
   KERNEL_LOADADDR := 0x40000000
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | \
 	pad-to 64k
@@ -3132,7 +3132,7 @@ define Device/snr_snr-cpe-ax2
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -3270,7 +3270,7 @@ define Device/tplink_be450-ubi
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | \
 	pad-to 64k
@@ -3359,7 +3359,7 @@ define Device/tplink_tl-xdr-common
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -3541,7 +3541,7 @@ define Device/wavlink_wl-wnt100x3-ubootmod
   PAGESIZE := 2048
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -3602,7 +3602,7 @@ define Device/xiaomi_mi-router-ax3000t-ubootmod
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -3651,7 +3651,7 @@ define Device/xiaomi_mi-router-wr30u-ubootmod
   UBOOTENV_IN_UBI := 1
   IMAGES := sysupgrade.itb
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -3700,7 +3700,7 @@ define Device/xiaomi_redmi-router-ax6000-ubootmod
   PAGESIZE := 2048
   KERNEL_IN_UBI := 1
   UBOOTENV_IN_UBI := 1
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
@@ -3851,7 +3851,7 @@ define Device/zbtlink_zbt-z8803be
   DEVICE_PACKAGES := kmod-sfp kmod-hwmon-pwmfan kmod-usb3 kmod-mt7996-firmware mt7988-2p5g-phy-firmware mt7988-wo-firmware
   DEVICE_DTC_FLAGS := --pad 4096
   SUPPORTED_DEVICES += zbtlink,zbt-z8803be,mt7988a-nand
-  KERNEL := kernel-bin | gzip | \
+  KERNEL := kernel-bin | libdeflate-gzip | \
 	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k

--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -111,11 +111,11 @@ define Device/bananapi_bpi-r64
 				$(if $(CONFIG_TARGET_ROOTFS_SQUASHFS), \
 				   pad-to 46080k | append-image squashfs-sysupgrade.itb | check-size |\
 				) \
-				  gzip
+				  libdeflate-gzip
 ifeq ($(DUMP),)
   IMAGE_SIZE := $$(shell expr 45 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
 endif
-  KERNEL			:= kernel-bin | gzip
+  KERNEL			:= kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS		:= kernel-bin | lzma | fit lzma $$(DTS_DIR)/$$(DEVICE_DTS).dtb with-initrd | pad-to 128k
   IMAGE/sysupgrade.itb		:= append-kernel | fit gzip $$(DTS_DIR)/$$(DEVICE_DTS).dtb external-static-with-rootfs | append-metadata
   DEVICE_COMPAT_VERSION := 1.2
@@ -284,7 +284,7 @@ define Device/linksys_e8450-ubi
   PAGESIZE := 2048
   UBOOTENV_IN_UBI := 1
   KERNEL_IN_UBI := 1
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
 # recovery can also be used with stock firmware web-ui, hence the padding...
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 128k
@@ -488,7 +488,7 @@ define Device/xiaomi_redmi-router-ax6s
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 128k
   PAGESIZE := 2048
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
   IMAGES := sysupgrade.itb

--- a/target/linux/mediatek/image/mt7623.mk
+++ b/target/linux/mediatek/image/mt7623.mk
@@ -97,9 +97,9 @@ define Device/bananapi_bpi-r2
   UBOOT_IMAGE := u-boot.bin
   UBOOT_PATH := $(STAGING_DIR_IMAGE)/$$(UBOOT_TARGET)-$$(UBOOT_IMAGE)
   IMAGES := sysupgrade.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL_INITRAMFS := kernel-bin | gzip | fit gzip $$(DTS_DIR)/$$(DEVICE_DTS).dtb with-initrd
+  KERNEL_INITRAMFS := kernel-bin | libdeflate-gzip | fit gzip $$(DTS_DIR)/$$(DEVICE_DTS).dtb with-initrd
 ifeq ($(DUMP),)
   IMAGE_SIZE := $$(shell expr 48 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
 endif
@@ -117,7 +117,7 @@ endif
 			    $(if $(CONFIG_TARGET_ROOTFS_SQUASHFS),\
 			    pad-to 48M | append-image squashfs-sysupgrade.itb | check-size |\
 			    ) \
-			    gzip
+			    libdeflate-gzip
   ARTIFACTS := u-boot.bin preloader.bin sdcard.img.gz
   SUPPORTED_DEVICES := bananapi,bpi-r2
   DEVICE_COMPAT_VERSION := 1.1
@@ -142,9 +142,9 @@ ifeq ($(DUMP),)
   IMAGE_SIZE := $$(shell expr 48 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
 endif
   IMAGES := sysupgrade.itb
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL_INITRAMFS := kernel-bin | gzip | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
+  KERNEL_INITRAMFS := kernel-bin | libdeflate-gzip | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
   IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
   ARTIFACT/u-boot.bin := append-uboot
 # vendor Preloader seems not to care about SDMMC_BOOT/EMMC_BOOT header,
@@ -157,7 +157,7 @@ endif
 			    $(if $(CONFIG_TARGET_ROOTFS_SQUASHFS),\
 			    pad-to 48M | append-image squashfs-sysupgrade.itb | check-size |\
 			    ) \
-			    gzip | append-metadata
+			    libdeflate-gzip | append-metadata
   ARTIFACT/scatter.txt := scatterfile emmc.img.gz
   ARTIFACTS := u-boot.bin scatter.txt emmc.img.gz
   SUPPORTED_DEVICES += unielec,u7623-02-emmc-512m
@@ -190,7 +190,7 @@ define Device/unielec_u7623-02-emmc-512m-legacy
   IMAGE/sysupgrade.bin.gz := append-kernel |\
 				pad-to 4864k | fat-recovery-fs |\
 				pad-to 7936k | append-rootfs |\
-				gzip | append-metadata
+				libdeflate-gzip | append-metadata
   SUPPORTED_DEVICES := unielec,u7623-02-emmc-512m
 endef
 TARGET_DEVICES += unielec_u7623-02-emmc-512m-legacy

--- a/target/linux/microchipsw/image/lan969x.mk
+++ b/target/linux/microchipsw/image/lan969x.mk
@@ -47,13 +47,13 @@ define Device/microchip_ev23x71a
 	IMAGE/emmc-atf-gpt.gz := lan969x-gpt-emmc |\
 		pad-to 1M | lan969x-fip ev23x71a |\
 		pad-to 9M | lan969x-fip ev23x71a |\
-		gzip
+		libdeflate-gzip
 	IMAGE/emmc-gpt.img.gz := lan969x-gpt-emmc flash |\
 		pad-to 1M | lan969x-fip ev23x71a |\
 		pad-to 9M | lan969x-fip ev23x71a |\
 		pad-to 19M | append-kernel-part |\
 		append-rootfs |\
-		gzip
+		libdeflate-gzip
 endef
 TARGET_DEVICES += microchip_ev23x71a
 
@@ -66,17 +66,17 @@ define Device/novarq_tactical-1000
 		kmod-gpio-pwm kmod-hwmon-pwmfan kmod-hwmon-gpiofan \
 		kmod-rtc-ds1307 kmod-hwmon-lm75
 	IMAGES += emmc-gpt-table.gz emmc-atf-gpt.gz emmc-gpt.img.gz
-	IMAGE/emmc-gpt-table.gz := tactical-1000-gpt-emmc | gzip
+	IMAGE/emmc-gpt-table.gz := tactical-1000-gpt-emmc | libdeflate-gzip
 	IMAGE/emmc-atf-gpt.gz := tactical-1000-gpt-emmc |\
 		pad-to 1M | lan969x-fip tactical-1000 |\
 		pad-to 129M | lan969x-fip tactical-1000 |\
-		gzip
+		libdeflate-gzip
 	IMAGE/emmc-gpt.img.gz := tactical-1000-gpt-emmc flash |\
 		pad-to 1M | lan969x-fip tactical-1000 |\
 		pad-to 129M | lan969x-fip tactical-1000 |\
 		pad-to 259M | append-kernel-part |\
 		append-rootfs |\
-		gzip
+		libdeflate-gzip
 	SUPPORTED_DEVICES += novarq,tactical-1000-v3
 endef
 TARGET_DEVICES += novarq_tactical-1000

--- a/target/linux/mxs/image/Makefile
+++ b/target/linux/mxs/image/Makefile
@@ -74,7 +74,7 @@ define Device/i2se_duckbill
   SOC := imx28
   KERNEL := kernel-bin
   DEVICE_DTS := imx28-duckbill imx28-duckbill-2 imx28-duckbill-2-485 imx28-duckbill-2-spi
-  IMAGE/sdcard.img.gz = mxs-ext4-rootfs-with-boot | mxs-sdcard-ext4-ext4 | append-metadata | gzip
+  IMAGE/sdcard.img.gz = mxs-ext4-rootfs-with-boot | mxs-sdcard-ext4-ext4 | append-metadata | libdeflate-gzip
 endef
 TARGET_DEVICES += i2se_duckbill
 
@@ -86,7 +86,7 @@ define Device/olinuxino_maxi
   SUPPORTED_DEVICES := olimex,imx23-olinuxino
   SOC := imx23
   DEVICE_DTS := imx23-olinuxino
-  IMAGE/sdcard.img.gz = mxs-sdcard-vfat-ext4 | append-metadata | gzip
+  IMAGE/sdcard.img.gz = mxs-sdcard-vfat-ext4 | append-metadata | libdeflate-gzip
 endef
 TARGET_DEVICES += olinuxino_maxi
 
@@ -98,7 +98,7 @@ define Device/olinuxino_micro
   SUPPORTED_DEVICES := olimex,imx23-olinuxino
   SOC := imx23
   DEVICE_DTS := imx23-olinuxino
-  IMAGE/sdcard.img.gz = mxs-sdcard-vfat-ext4 | append-metadata | gzip
+  IMAGE/sdcard.img.gz = mxs-sdcard-vfat-ext4 | append-metadata | libdeflate-gzip
 endef
 TARGET_DEVICES += olinuxino_micro
 

--- a/target/linux/omap/image/Makefile
+++ b/target/linux/omap/image/Makefile
@@ -36,7 +36,7 @@ define Device/Default
   DTS_DIR := $(DTS_DIR)/ti/omap
   DEVICE_DTS = $(lastword $(subst _, ,$(1)))
   IMAGES := sdcard.img.gz
-  IMAGE/sdcard.img.gz := omap-sdcard | append-metadata | gzip
+  IMAGE/sdcard.img.gz := omap-sdcard | append-metadata | libdeflate-gzip
 endef
 
 #uboot-omap-am335x_evm uboot-omap-omap3_beagle uboot-omap-omap4_panda

--- a/target/linux/pistachio/image/Makefile
+++ b/target/linux/pistachio/image/Makefile
@@ -11,7 +11,7 @@ define Device/Default
   PROFILES := Default
   FILESYSTEMS := squashfs
   KERNEL_DEPENDS = $$(wildcard $$(DTS_DIR)/$$(DEVICE_DTS).dts)
-  KERNEL = kernel-bin | gzip | fit gzip $$(DTS_DIR)/$$(DEVICE_DTS).dtb
+  KERNEL = kernel-bin | libdeflate-gzip | fit gzip $$(DTS_DIR)/$$(DEVICE_DTS).dtb
   KERNEL_SUFFIX := -kernel.itb
   KERNEL_INSTALL := 1
   KERNEL_IN_UBI := 1

--- a/target/linux/ramips/image/common-sercomm.mk
+++ b/target/linux/ramips/image/common-sercomm.mk
@@ -218,7 +218,7 @@ define Device/sercomm_dxx
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   IMAGE/factory.img := append-ubi | check-size | \
 	sercomm-part-tag rootfs | sercomm-prepend-tagged-kernel kernel | \
-	gzip | sercomm-payload | sercomm-crypto
+	libdeflate-gzip | sercomm-payload | sercomm-crypto
 endef
 
 define Device/sercomm_s1500

--- a/target/linux/ramips/image/lzma-loader/Makefile
+++ b/target/linux/ramips/image/lzma-loader/Makefile
@@ -53,7 +53,7 @@ loader-compile: $(PKG_BUILD_DIR)/.prepared
 		clean all
 
 loader.gz: $(PKG_BUILD_DIR)/loader.bin
-	gzip -nc9 $< > $(LOADER_GZ)
+	libdeflate-gzip -12 -c $< > $(LOADER_GZ)
 
 loader.elf: $(PKG_BUILD_DIR)/loader.elf
 	$(CP) $< $(LOADER_ELF)

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -1141,7 +1141,7 @@ define Device/rostelecom_rt-fl-1
 ifeq ($(IB),)
   ARTIFACT/initramfs-factory.img := \
 	append-image-stage initramfs-kernel.bin | check-size | \
-	sercomm-factory-cpj | gzip | sercomm-payload | \
+	sercomm-factory-cpj | libdeflate-gzip | sercomm-payload | \
 	sercomm-pid-setbit 0x11 | sercomm-crypto
 endif
 endef
@@ -1154,7 +1154,7 @@ define Device/rostelecom_s1010
 ifeq ($(IB),)
   ARTIFACT/initramfs-factory.img := \
 	append-image-stage initramfs-kernel.bin | check-size | \
-	sercomm-factory-cpj | gzip | sercomm-payload | sercomm-crypto
+	sercomm-factory-cpj | libdeflate-gzip | sercomm-payload | sercomm-crypto
 endif
 endef
 TARGET_DEVICES += rostelecom_s1010

--- a/target/linux/rockchip/image/Makefile
+++ b/target/linux/rockchip/image/Makefile
@@ -11,7 +11,7 @@ endef
 
 ### Image scripts ###
 define Build/boot-common
-	# This creates a new folder copies the dtb (as rockchip.dtb) 
+	# This creates a new folder copies the dtb (as rockchip.dtb)
 	# and the kernel image (as kernel.img)
 	rm -fR $@.boot
 	mkdir -p $@.boot
@@ -25,10 +25,10 @@ define Build/boot-script
 endef
 
 define Build/pine64-img
-	# Creates the final SD/eMMC images, 
+	# Creates the final SD/eMMC images,
 	# combining boot partition, root partition as well as the u-boot bootloader
 
-	# Generate a new partition table in $@ with 32 MiB of 
+	# Generate a new partition table in $@ with 32 MiB of
 	# alignment padding for the u-boot-rockchip.bin (idbloader + u-boot) to fit:
 	# http://opensource.rock-chips.com/wiki_Boot_option#Boot_flow
 	#
@@ -50,7 +50,7 @@ define Device/Default
   KERNEL_LOADADDR :=
   BOOT_SCRIPT :=
   IMAGES := sysupgrade.img.gz
-  IMAGE/sysupgrade.img.gz = boot-common | boot-script $$(BOOT_SCRIPT) | pine64-img | gzip | append-metadata
+  IMAGE/sysupgrade.img.gz = boot-common | boot-script $$(BOOT_SCRIPT) | pine64-img | libdeflate-gzip | append-metadata
   DEVICE_DTS_DIR = $$(DTS_DIR)/rockchip
   DEVICE_DTS = $$(SOC)-$(lastword $(subst _, ,$(1)))
   UBOOT_DEVICE_NAME = $(lastword $(subst _, ,$(1)))-$$(SOC)

--- a/target/linux/sifiveu/image/Makefile
+++ b/target/linux/sifiveu/image/Makefile
@@ -33,7 +33,7 @@ define Device/Default
   KERNEL_NAME := Image
   KERNEL := kernel-bin | libdeflate-gzip
   IMAGES := sdcard.img.gz
-  IMAGE/sdcard.img.gz := riscv-sdcard | append-metadata | gzip
+  IMAGE/sdcard.img.gz := riscv-sdcard | append-metadata | libdeflate-gzip
 endef
 
 define Device/sifive_unleashed

--- a/target/linux/siflower/image/sf21.mk
+++ b/target/linux/siflower/image/sf21.mk
@@ -13,7 +13,7 @@ define Device/Default
 endef
 
 define Device/NAND
-  KERNEL := kernel-bin | gzip
+  KERNEL := kernel-bin | libdeflate-gzip
   KERNEL_INITRAMFS = kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 128k
   IMAGE/sysupgrade.bin = append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata

--- a/target/linux/starfive/image/Makefile
+++ b/target/linux/starfive/image/Makefile
@@ -38,7 +38,7 @@ define Device/Default
   KERNEL_NAME := Image
   KERNEL := kernel-bin
   IMAGES := sdcard.img.gz
-  IMAGE/sdcard.img.gz := boot-scr-jh7110 | riscv-sdcard | append-metadata | gzip
+  IMAGE/sdcard.img.gz := boot-scr-jh7110 | riscv-sdcard | append-metadata | libdeflate-gzip
 endef
 
 define Device/JH7100
@@ -46,7 +46,7 @@ define Device/JH7100
   KERNEL_NAME := Image
   KERNEL := kernel-bin
   IMAGES := sdcard.img.gz
-  IMAGE/sdcard.img.gz := boot-scr-jh7100 | riscv-sdcard | append-metadata | gzip
+  IMAGE/sdcard.img.gz := boot-scr-jh7100 | riscv-sdcard | append-metadata | libdeflate-gzip
 endef
 
 define Device/visionfive2-v1.2a

--- a/target/linux/stm32/image/Makefile
+++ b/target/linux/stm32/image/Makefile
@@ -34,8 +34,8 @@ define Device/Default
   PROFILES := Default
   DEVICE_VENDOR := STMicroelectronics
   IMAGES := factory.img.gz sysupgrade.img.gz
-  IMAGE/factory.img.gz := boot-img-ext4 | sdcard-img | gzip
-  IMAGE/sysupgrade.img.gz := boot-img-ext4 | sdcard-img | gzip | append-metadata
+  IMAGE/factory.img.gz := boot-img-ext4 | sdcard-img | libdeflate-gzip
+  IMAGE/sysupgrade.img.gz := boot-img-ext4 | sdcard-img | libdeflate-gzip | append-metadata
   KERNEL := kernel-bin
   KERNEL_NAME := zImage
   KERNEL_IMG := zImage

--- a/target/linux/sunxi/image/Makefile
+++ b/target/linux/sunxi/image/Makefile
@@ -32,7 +32,7 @@ define Device/Default
   KERNEL_NAME := zImage
   KERNEL := kernel-bin | uImage none
   IMAGES := sdcard.img.gz
-  IMAGE/sdcard.img.gz := sunxi-sdcard | append-metadata | gzip
+  IMAGE/sdcard.img.gz := sunxi-sdcard | append-metadata | libdeflate-gzip
   SUNXI_DTS_DIR := allwinner/
   SUNXI_DTS = $$(SUNXI_DTS_DIR)$$(SOC)-$(lastword $(subst _, ,$(1)))
 endef
@@ -42,7 +42,7 @@ define Device/FitImageLzma
 endef
 
 define Device/FitImageGzip
-  KERNEL = kernel-bin | gzip | fit gzip $$(DTS_DIR)/$$(SUNXI_DTS).dtb
+  KERNEL = kernel-bin | libdeflate-gzip | fit gzip $$(DTS_DIR)/$$(SUNXI_DTS).dtb
 endef
 
 include $(SUBTARGET).mk

--- a/target/linux/sunxi/image/cortexa7.mk
+++ b/target/linux/sunxi/image/cortexa7.mk
@@ -339,7 +339,7 @@ define Device/myir_myd-yt113x-emmc
   DEVICE_MODEL := MYD-YT113X (eMMC)
   DEVICE_PACKAGES := kmod-rtc-sunxi kmod-eeprom-at24 kmod-gpio-pca953x kmod-rtc-rx8025
   SOC := sun8i-t113s
-  IMAGE/sdcard.img.gz := sunxi-sdcard | append-metadata | gzip
+  IMAGE/sdcard.img.gz := sunxi-sdcard | append-metadata | libdeflate-gzip
 endef
 TARGET_DEVICES += myir_myd-yt113x-emmc
 
@@ -358,7 +358,7 @@ define Device/olimex_olinuxino
   DEVICE_MODEL := Olinuxino T113
   DEVICE_PACKAGES:=kmod-rtc-sunxi
   SOC := sun8i-t113s
-  IMAGE/sdcard.img.gz := sunxi-sdcard | append-metadata | gzip
+  IMAGE/sdcard.img.gz := sunxi-sdcard | append-metadata | libdeflate-gzip
 endef
 TARGET_DEVICES += olimex_olinuxino
 
@@ -368,6 +368,6 @@ define Device/rongpin_rp-t113
   DEVICE_MODEL := RP-T113
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-rtl8xxxu rtl8723bu-firmware wpad-basic-mbedtls
   SOC := sun8i-t113s
-  IMAGE/sdcard.img.gz := sunxi-sdcard | append-metadata | gzip
+  IMAGE/sdcard.img.gz := sunxi-sdcard | append-metadata | libdeflate-gzip
 endef
 TARGET_DEVICES += rongpin_rp-t113

--- a/target/linux/tegra/image/Makefile
+++ b/target/linux/tegra/image/Makefile
@@ -34,7 +34,7 @@ define Device/Default
   BOOT_SCRIPT := generic-bootscript
   DEVICE_DTS_DIR := $$(DTS_DIR)/nvidia
   IMAGES := sdcard.img.gz
-  IMAGE/sdcard.img.gz := append-rootfs | pad-extra 128k | tegra-sdcard | gzip | append-metadata
+  IMAGE/sdcard.img.gz := append-rootfs | pad-extra 128k | tegra-sdcard | libdeflate-gzip | append-metadata
   KERNEL_NAME := zImage
   KERNEL := kernel-bin
   PROFILES := Default

--- a/target/linux/zynq/image/Makefile
+++ b/target/linux/zynq/image/Makefile
@@ -34,12 +34,12 @@ define Device/Default
 	KERNEL_DEPENDS = $$(wildcard $(DTS_DIR)/$$(DEVICE_DTS).dts)
 	KERNEL_LOADADDR := 0x8000
 	IMAGES := sdcard.img.gz
-	IMAGE/sdcard.img.gz := zynq-sdcard | gzip
+	IMAGE/sdcard.img.gz := zynq-sdcard | libdeflate-gzip
 endef
 
 define Device/FitImageGzip
 	KERNEL_SUFFIX := -fit-uImage.itb
-	KERNEL = kernel-bin | gzip | fit gzip $$(DTS_DIR)/$$(DEVICE_DTS).dtb
+	KERNEL = kernel-bin | libdeflate-gzip | fit gzip $$(DTS_DIR)/$$(DEVICE_DTS).dtb
 	KERNEL_NAME := Image
 endef
 


### PR DESCRIPTION
Slightly smaller size.

n option removed. From the libdeflate-gzip source:

 *
 * -n means don't save or restore the original filename
 *  in the gzip header.  Currently this implementation
 *  already behaves this way by default, so accept the
 *  option as a no-op. */

c kept for places needing to pipe.

Only converted places that do a compression size of 9.