### PR TITLE
wifi-scripts ucode fixes

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -473,7 +473,7 @@ function iface_transition_disable(config) {
 		if (s == 'on' || s == '1') {
 			bits = 0;
 			switch (config.auth_type) {
-			case 'sae':    bits = 0x01; break;
+			case 'sae':    bits |= 0x01; break;
 			case 'eap2':
 			case 'eap192': bits = 0x04; break;
 			case 'owe':    if (!config.owe_transition) bits = 0x08; break;
@@ -483,7 +483,7 @@ function iface_transition_disable(config) {
 		switch (s) {
 		case 'sae':    bits |= 0x01; break;
 		case 'sae-pk': bits |= 0x02; break;
-		case 'wpa3':   bits |= 0x04; break;
+		case 'wpa3':   bits = 0x04; break;
 		case 'owe':    bits |= 0x08; break;
 		}
 	}

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -474,7 +474,7 @@ function device_htmode_append(config) {
 }
 
 function device_extended_features(data, flag) {
-	return !!(data[flag / 8] | (1 << (flag % 8)));
+	return !!(data[flag / 8] & (1 << (flag % 8)));
 }
 
 function device_capabilities(config) {


### PR DESCRIPTION
1. transition_disable `on` override (ap.uc)
When `auth_type='on'`, the bitmap was derived using `|=` instead of `=`. Changed to `=` so the `on` value replaces rather than accumulates (the `break` after the switch already exits the loop, so intent was always to override).

2. device_extended_features bit test (hostapd.uc)
Two bugs:
- `|` used instead of `&`, always returning true regardless of hardware

Both make `ftm_responder` and `radar_background` appear supported when they weren't.