### PR TITLE
realtek: backport irq and spi driver patches for SWAP_IO_SPACE

### DIFF
--- a/target/linux/realtek/patches-6.18/037-v7.3-spi-realtek-rtl-change-to-__raw-reads-and-writes.patch
+++ b/target/linux/realtek/patches-6.18/037-v7.3-spi-realtek-rtl-change-to-__raw-reads-and-writes.patch
@@ -1,0 +1,109 @@
+From 4bc5a274edab3f9afd11ec500eb526de7e7d91ae Mon Sep 17 00:00:00 2001
+From: Rustam Adilov <adilov@disroot.org>
+Date: Sat, 11 Jul 2026 13:34:11 +0500
+Subject: spi: realtek-rtl: change to __raw reads and writes
+
+To make the spi driver operable with SWAP_IO_SPACE config
+enabled, replace all instances of readl/writel with their
+__raw variants. Otherwise readl/writel will do a byte swap
+which this driver does not intend to do.
+
+Tested-by: Carlo Szelinsky <github@szelinsky.de>
+Signed-off-by: Rustam Adilov <adilov@disroot.org>
+Link: https://patch.msgid.link/20260711083411.45836-1-adilov@disroot.org
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ drivers/spi/spi-realtek-rtl.c | 26 +++++++++++++-------------
+ 1 file changed, 13 insertions(+), 13 deletions(-)
+
+--- a/drivers/spi/spi-realtek-rtl.c
++++ b/drivers/spi/spi-realtek-rtl.c
+@@ -36,58 +36,58 @@ static void rt_set_cs(struct spi_device
+ 	u32 value;
+ 
+ 	/* CS0 bit is active low */
+-	value = readl(REG(RTL_SPI_SFCSR));
++	value = __raw_readl(REG(RTL_SPI_SFCSR));
+ 	if (active)
+ 		value |= RTL_SPI_SFCSR_CSB0;
+ 	else
+ 		value &= ~RTL_SPI_SFCSR_CSB0;
+-	writel(value, REG(RTL_SPI_SFCSR));
++	__raw_writel(value, REG(RTL_SPI_SFCSR));
+ }
+ 
+ static void set_size(struct rtspi *rtspi, int size)
+ {
+ 	u32 value;
+ 
+-	value = readl(REG(RTL_SPI_SFCSR));
++	value = __raw_readl(REG(RTL_SPI_SFCSR));
+ 	value &= RTL_SPI_SFCSR_LEN_MASK;
+ 	if (size == 4)
+ 		value |= RTL_SPI_SFCSR_LEN4;
+ 	else if (size == 1)
+ 		value |= RTL_SPI_SFCSR_LEN1;
+-	writel(value, REG(RTL_SPI_SFCSR));
++	__raw_writel(value, REG(RTL_SPI_SFCSR));
+ }
+ 
+ static inline void wait_ready(struct rtspi *rtspi)
+ {
+-	while (!(readl(REG(RTL_SPI_SFCSR)) & RTL_SPI_SFCSR_RDY))
++	while (!(__raw_readl(REG(RTL_SPI_SFCSR)) & RTL_SPI_SFCSR_RDY))
+ 		cpu_relax();
+ }
+ static void send4(struct rtspi *rtspi, const u32 *buf)
+ {
+ 	wait_ready(rtspi);
+ 	set_size(rtspi, 4);
+-	writel(*buf, REG(RTL_SPI_SFDR));
++	__raw_writel(*buf, REG(RTL_SPI_SFDR));
+ }
+ 
+ static void send1(struct rtspi *rtspi, const u8 *buf)
+ {
+ 	wait_ready(rtspi);
+ 	set_size(rtspi, 1);
+-	writel(buf[0] << 24, REG(RTL_SPI_SFDR));
++	__raw_writel(buf[0] << 24, REG(RTL_SPI_SFDR));
+ }
+ 
+ static void rcv4(struct rtspi *rtspi, u32 *buf)
+ {
+ 	wait_ready(rtspi);
+ 	set_size(rtspi, 4);
+-	*buf = readl(REG(RTL_SPI_SFDR));
++	*buf = __raw_readl(REG(RTL_SPI_SFDR));
+ }
+ 
+ static void rcv1(struct rtspi *rtspi, u8 *buf)
+ {
+ 	wait_ready(rtspi);
+ 	set_size(rtspi, 1);
+-	*buf = readl(REG(RTL_SPI_SFDR)) >> 24;
++	*buf = __raw_readl(REG(RTL_SPI_SFDR)) >> 24;
+ }
+ 
+ static int transfer_one(struct spi_controller *ctrl, struct spi_device *spi,
+@@ -135,16 +135,16 @@ static void init_hw(struct rtspi *rtspi)
+ 	u32 value;
+ 
+ 	/* Turn on big-endian byte ordering */
+-	value = readl(REG(RTL_SPI_SFCR));
++	value = __raw_readl(REG(RTL_SPI_SFCR));
+ 	value |= RTL_SPI_SFCR_RBO | RTL_SPI_SFCR_WBO;
+-	writel(value, REG(RTL_SPI_SFCR));
++	__raw_writel(value, REG(RTL_SPI_SFCR));
+ 
+-	value = readl(REG(RTL_SPI_SFCSR));
++	value = __raw_readl(REG(RTL_SPI_SFCSR));
+ 	/* Permanently disable CS1, since it's never used */
+ 	value |= RTL_SPI_SFCSR_CSB1;
+ 	/* Select CS0 for use */
+ 	value &= RTL_SPI_SFCSR_CS;
+-	writel(value, REG(RTL_SPI_SFCSR));
++	__raw_writel(value, REG(RTL_SPI_SFCSR));
+ }
+ 
+ static int realtek_rtl_spi_probe(struct platform_device *pdev)

--- a/target/linux/realtek/patches-6.18/038-v7.3-irqchip-irq-realtek-rtl-change-to-__raw-reads-and-writes.patch
+++ b/target/linux/realtek/patches-6.18/038-v7.3-irqchip-irq-realtek-rtl-change-to-__raw-reads-and-writes.patch
@@ -1,0 +1,81 @@
+From 58b34b72b64bfbfc5f8ad4d8f229942aff76597e Mon Sep 17 00:00:00 2001
+From: Rustam Adilov <adilov@disroot.org>
+Date: Thu, 20 Aug 2026 21:20:17 +0500
+Subject: irqchip/irq-realtek-rtl: Use readl_be()/writel_be() instead of
+ readl()/writel()
+
+When CONFIG_SWAP_IO_SPACE is enabled, readl() performs a swap from little
+endian device to big endian CPU and vice versa for writel().
+
+This is incorrect for Realtek Interrupt controller as that is a big endian
+device and so the LE to BE conversions are unwanted.
+
+Fix this by converting the MMIO accesses to readl_be() and writel_be().
+
+Fixes: 9f3a0f34b84a ("irqchip: Add support for Realtek RTL838x/RTL839x interrupt controller")
+Signed-off-by: Rustam Adilov <adilov@disroot.org>
+Signed-off-by: Thomas Gleixner <tglx@kernel.org>
+Tested-by: Carlo Szelinsky <github@szelinsky.de>
+Link: https://patch.msgid.link/20260820162017.28507-1-adilov@disroot.org
+---
+ drivers/irqchip/irq-realtek-rtl.c | 20 +++++++++++++-------
+ 1 file changed, 13 insertions(+), 7 deletions(-)
+
+--- a/drivers/irqchip/irq-realtek-rtl.c
++++ b/drivers/irqchip/irq-realtek-rtl.c
+@@ -1,5 +1,10 @@
+ // SPDX-License-Identifier: GPL-2.0-only
+ /*
++ * Realtek Interrupt controller.
++ *
++ * The Realtek Interrupt controller is a big endian device found in the
++ * Realtek MIPS SoCs.
++ *
+  * Copyright (C) 2020 Birger Koblitz <mail@birger-koblitz.de>
+  * Copyright (C) 2020 Bert Vermeulen <bert@biot.com>
+  * Copyright (C) 2020 John Crispin <john@phrozen.org>
+@@ -50,18 +55,18 @@ static inline void enable_gimr(unsigned
+ {
+ 	u32 gimr;
+ 
+-	gimr = readl(REG(cpu, RTL_ICTL_GIMR));
++	gimr = readl_be(REG(cpu, RTL_ICTL_GIMR));
+ 	gimr |= BIT(hw_irq);
+-	writel(gimr, REG(cpu, RTL_ICTL_GIMR));
++	writel_be(gimr, REG(cpu, RTL_ICTL_GIMR));
+ }
+ 
+ static inline void disable_gimr(unsigned int cpu, unsigned int hw_irq)
+ {
+ 	u32 gimr;
+ 
+-	gimr = readl(REG(cpu, RTL_ICTL_GIMR));
++	gimr = readl_be(REG(cpu, RTL_ICTL_GIMR));
+ 	gimr &= ~BIT(hw_irq);
+-	writel(gimr, REG(cpu, RTL_ICTL_GIMR));
++	writel_be(gimr, REG(cpu, RTL_ICTL_GIMR));
+ }
+ 
+ static void write_irr(unsigned int cpu, int hw_irq, u32 value)
+@@ -71,9 +76,9 @@ static void write_irr(unsigned int cpu,
+ 	unsigned int shift = IRR_SHIFT(hw_irq);
+ 	u32 irr;
+ 
+-	irr = readl(irr0 + offset) & ~(0xf << shift);
++	irr = readl_be(irr0 + offset) & ~(0xf << shift);
+ 	irr |= (value & 0xf) << shift;
+-	writel(irr, irr0 + offset);
++	writel_be(irr, irr0 + offset);
+ }
+ 
+ static void realtek_ictl_unmask_irq(struct irq_data *i)
+@@ -159,7 +164,8 @@ static void realtek_irq_dispatch(struct
+ 	unsigned int hw_irq;
+ 
+ 	chained_irq_enter(chip, desc);
+-	pending = readl(REG(cpu, RTL_ICTL_GIMR)) & readl(REG(cpu, RTL_ICTL_GISR)) & output->mask;
++	pending = readl_be(REG(cpu, RTL_ICTL_GIMR)) &
++		  readl_be(REG(cpu, RTL_ICTL_GISR)) & output->mask;
+ 
+ 	if (unlikely(!pending)) {
+ 		spurious_interrupt();


### PR DESCRIPTION
This gets us even closer to a working SWAP_IO_SPACE on rtl930x and rtl931x..

I grouped these patches together because i can't test both of them as RTL9607C uses GIC for its interrupts and spi-snand driver. Which is also why i am sending them here first before upstream so that i can get tested-by tags.

@carlosz1986 @jonasjelonek @plappermaul testing would be highly appreciated.