### PR TITLE
airoha: backport multiple fix for 24.10

### DIFF
--- a/target/linux/airoha/patches-6.6/132-v7.1-net-airoha-Reset-PPE-default-cput-port-in-airoha_ppe.patch
+++ b/target/linux/airoha/patches-6.6/132-v7.1-net-airoha-Reset-PPE-default-cput-port-in-airoha_ppe.patch
@@ -1,0 +1,162 @@
+From df8e1e4a2eb5f8ecdef36c502601e8afbc6ad891 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Wed, 24 Dec 2025 17:29:33 +0100
+Subject: [PATCH] net: airoha: Reset PPE default cput port in
+ airoha_ppe_hw_init()
+
+Before this patch the default PPE cpu port used for a specific GDM
+device was set running ndo_init() callback during device initialization.
+The selected PPE cpu port configured for the specific GDM device depends
+on the QDMA block assigned to the GDM device. The selected QDMA block
+depends on LAN/WAN configuration as specified in commmit XXXX.
+However, the user selected PPE cpu port can be different with respect to
+the one hardcoded in the NPU firmware binary. The hardcoded PPE cput port
+value is loaded initializing the PPE engine running npu ops ppe_init()
+callback in airoha_ppe_offload_setup routine.
+Reset the default value for PPE cpu ports in airoha_ppe_hw_init routine
+in order to apply the user requested configuration according to the device
+DTS setup.
+Please note this patch is fixing an issue not visible to the user (so we
+do not need to backport it) since airoha_eth driver currently supports just
+the internal phy available via the MT7530 DSA switch and there are no WAN
+interfaces officially supporte since PCS/external phy is not merged mainline
+yet (it will be posted with following patches).
+
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c  | 28 +++++------------------
+ drivers/net/ethernet/airoha/airoha_eth.h  |  2 ++
+ drivers/net/ethernet/airoha/airoha_ppe.c  | 23 ++++++++++++++++++-
+ drivers/net/ethernet/airoha/airoha_regs.h |  7 +++---
+ 4 files changed, 33 insertions(+), 27 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -1755,8 +1755,7 @@ static int airoha_dev_init(struct net_de
+ {
+ 	struct airoha_gdm_port *port = netdev_priv(dev);
+ 	struct airoha_eth *eth = port->eth;
+-	u32 fe_cpu_port;
+-	u8 ppe_id;
++	int i;
+ 
+ 	/* QDMA0 is used for lan ports while QDMA1 is used for WAN ports */
+ 	port->qdma = &eth->qdma[!airoha_is_lan_gdm_port(port)];
+@@ -1774,28 +1773,13 @@ static int airoha_dev_init(struct net_de
+ 			if (err)
+ 				return err;
+ 		}
+-		fallthrough;
+-	case AIROHA_GDM2_IDX:
+-		if (airoha_ppe_is_enabled(eth, 1)) {
+-			/* For PPE2 always use secondary cpu port. */
+-			fe_cpu_port = FE_PSE_PORT_CDM2;
+-			ppe_id = 1;
+-			break;
+-		}
+-		fallthrough;
+-	default: {
+-		u8 qdma_id = port->qdma - &eth->qdma[0];
+-
+-		/* For PPE1 select cpu port according to the running QDMA. */
+-		fe_cpu_port = qdma_id ? FE_PSE_PORT_CDM2 : FE_PSE_PORT_CDM1;
+-		ppe_id = 0;
+ 		break;
+-	}
++	default:
++		break;
+ 	}
+ 
+-	airoha_fe_rmw(eth, REG_PPE_DFT_CPORT0(ppe_id),
+-		      DFT_CPORT_MASK(port->id),
+-		      __field_prep(DFT_CPORT_MASK(port->id), fe_cpu_port));
++	for (i = 0; i < eth->soc->num_ppe; i++)
++		airoha_ppe_set_cpu_port(port, i);
+ 
+ 	return 0;
+ }
+@@ -1898,7 +1882,7 @@ static u32 airoha_get_dsa_tag(struct sk_
+ #endif
+ }
+ 
+-static int airoha_get_fe_port(struct airoha_gdm_port *port)
++int airoha_get_fe_port(struct airoha_gdm_port *port)
+ {
+ 	struct airoha_qdma *qdma = port->qdma;
+ 	struct airoha_eth *eth = qdma->eth;
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -646,9 +646,11 @@ static inline bool airoha_is_7583(struct
+ 	return eth->soc->version == 0x7583;
+ }
+ 
++int airoha_get_fe_port(struct airoha_gdm_port *port);
+ bool airoha_is_valid_gdm_port(struct airoha_eth *eth,
+ 			      struct airoha_gdm_port *port);
+ 
++void airoha_ppe_set_cpu_port(struct airoha_gdm_port *port, u8 ppe_id);
+ bool airoha_ppe_is_enabled(struct airoha_eth *eth, int index);
+ void airoha_ppe_check_skb(struct airoha_ppe_dev *dev, struct sk_buff *skb,
+ 			  u16 hash, bool rx_wlan);
+--- a/drivers/net/ethernet/airoha/airoha_ppe.c
++++ b/drivers/net/ethernet/airoha/airoha_ppe.c
+@@ -85,6 +85,20 @@ static u32 airoha_ppe_get_timestamp(stru
+ 	return FIELD_GET(AIROHA_FOE_IB1_BIND_TIMESTAMP, timestamp);
+ }
+ 
++void airoha_ppe_set_cpu_port(struct airoha_gdm_port *port, u8 ppe_id)
++{
++	struct airoha_qdma *qdma = port->qdma;
++	u8 fport = airoha_get_fe_port(port);
++	struct airoha_eth *eth = qdma->eth;
++	u8 qdma_id = qdma - &eth->qdma[0];
++	u32 fe_cpu_port;
++
++	fe_cpu_port = qdma_id ? FE_PSE_PORT_CDM2 : FE_PSE_PORT_CDM1;
++	airoha_fe_rmw(eth, REG_PPE_DFT_CPORT(ppe_id, fport),
++		      DFT_CPORT_MASK(fport),
++		      __field_prep(DFT_CPORT_MASK(fport), fe_cpu_port));
++}
++
+ static void airoha_ppe_hw_init(struct airoha_ppe *ppe)
+ {
+ 	u32 sram_ppe_num_data_entries = PPE_SRAM_NUM_ENTRIES, sram_num_entries;
+@@ -147,7 +161,9 @@ static void airoha_ppe_hw_init(struct ai
+ 
+ 		airoha_fe_wr(eth, REG_PPE_HASH_SEED(i), PPE_HASH_SEED);
+ 
+-		for (p = 0; p < ARRAY_SIZE(eth->ports); p++)
++		for (p = 0; p < ARRAY_SIZE(eth->ports); p++) {
++			struct airoha_gdm_port *port = eth->ports[p];
++
+ 			airoha_fe_rmw(eth, REG_PPE_MTU(i, p),
+ 				      FP0_EGRESS_MTU_MASK |
+ 				      FP1_EGRESS_MTU_MASK,
+@@ -155,6 +171,11 @@ static void airoha_ppe_hw_init(struct ai
+ 						 AIROHA_MAX_MTU) |
+ 				      FIELD_PREP(FP1_EGRESS_MTU_MASK,
+ 						 AIROHA_MAX_MTU));
++			if (!port)
++				continue;
++
++			airoha_ppe_set_cpu_port(port, i);
++		}
+ 	}
+ }
+ 
+--- a/drivers/net/ethernet/airoha/airoha_regs.h
++++ b/drivers/net/ethernet/airoha/airoha_regs.h
+@@ -312,10 +312,9 @@
+ #define REG_PPE_HASH_SEED(_n)			(((_n) ? PPE2_BASE : PPE1_BASE) + 0x244)
+ #define PPE_HASH_SEED				0x12345678
+ 
+-#define REG_PPE_DFT_CPORT0(_n)			(((_n) ? PPE2_BASE : PPE1_BASE) + 0x248)
+-#define DFT_CPORT_MASK(_n)			GENMASK(3 + ((_n) << 2), ((_n) << 2))
+-
+-#define REG_PPE_DFT_CPORT1(_n)			(((_n) ? PPE2_BASE : PPE1_BASE) + 0x24c)
++#define REG_PPE_DFT_CPORT_BASE(_n)		(((_n) ? PPE2_BASE : PPE1_BASE) + 0x248)
++#define REG_PPE_DFT_CPORT(_m, _n)		(REG_PPE_DFT_CPORT_BASE(_m) + (((_n) / 8) << 2))
++#define DFT_CPORT_MASK(_n)			GENMASK(3 + (((_n) % 8) << 2), (((_n) % 8) << 2))
+ 
+ #define REG_PPE_TB_HASH_CFG(_n)			(((_n) ? PPE2_BASE : PPE1_BASE) + 0x250)
+ #define PPE_DRAM_HASH1_MODE_MASK		GENMASK(31, 28)

--- a/target/linux/airoha/patches-6.6/133-v7.1-net-airoha-Rework-the-code-flow-in-airoha_remove-and.patch
+++ b/target/linux/airoha/patches-6.6/133-v7.1-net-airoha-Rework-the-code-flow-in-airoha_remove-and.patch
@@ -1,0 +1,165 @@
+From b1c803d5c8167026791abfaed96fd3e6a1fcd750 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Sat, 21 Mar 2026 15:41:44 +0100
+Subject: [PATCH] net: airoha: Rework the code flow in airoha_remove() and in
+ airoha_probe() error path
+
+As suggested by Simon in [0], rework the code flow in airoha_remove()
+and in the airoha_probe() error path in order to rely on a more common
+approach un-registering configured net-devices first and destroying the
+hw resources at the end of the code.
+Introduce airoha_qdma_cleanup routine to release QDMA resources.
+
+[0] https://lore.kernel.org/netdev/20251214-airoha-fix-dev-registration-v1-1-860e027ad4c6@kernel.org/
+
+Suggested-by: Simon Horman <horms@kernel.org>
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Link: https://patch.msgid.link/20260321-airoha-remove-rework-v2-1-16c7bade5fe5@kernel.org
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 76 ++++++++++++++----------
+ 1 file changed, 44 insertions(+), 32 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -1368,6 +1368,33 @@ static int airoha_qdma_init(struct platf
+ 	return airoha_qdma_hw_init(qdma);
+ }
+ 
++static void airoha_qdma_cleanup(struct airoha_qdma *qdma)
++{
++	int i;
++
++	for (i = 0; i < ARRAY_SIZE(qdma->q_rx); i++) {
++		if (!qdma->q_rx[i].ndesc)
++			continue;
++
++		netif_napi_del(&qdma->q_rx[i].napi);
++		airoha_qdma_cleanup_rx_queue(&qdma->q_rx[i]);
++		if (qdma->q_rx[i].page_pool) {
++			page_pool_destroy(qdma->q_rx[i].page_pool);
++			qdma->q_rx[i].page_pool = NULL;
++		}
++	}
++
++	for (i = 0; i < ARRAY_SIZE(qdma->q_tx_irq); i++)
++		netif_napi_del(&qdma->q_tx_irq[i].napi);
++
++	for (i = 0; i < ARRAY_SIZE(qdma->q_tx); i++) {
++		if (!qdma->q_tx[i].ndesc)
++			continue;
++
++		airoha_qdma_cleanup_tx_queue(&qdma->q_tx[i]);
++	}
++}
++
+ static int airoha_hw_init(struct platform_device *pdev,
+ 			  struct airoha_eth *eth)
+ {
+@@ -1395,41 +1422,30 @@ static int airoha_hw_init(struct platfor
+ 	for (i = 0; i < ARRAY_SIZE(eth->qdma); i++) {
+ 		err = airoha_qdma_init(pdev, eth, &eth->qdma[i]);
+ 		if (err)
+-			return err;
++			goto error;
+ 	}
+ 
+ 	err = airoha_ppe_init(eth);
+ 	if (err)
+-		return err;
++		goto error;
+ 
+ 	set_bit(DEV_STATE_INITIALIZED, &eth->state);
+ 
+ 	return 0;
++error:
++	for (i = 0; i < ARRAY_SIZE(eth->qdma); i++)
++		airoha_qdma_cleanup(&eth->qdma[i]);
++
++	return err;
+ }
+ 
+-static void airoha_hw_cleanup(struct airoha_qdma *qdma)
++static void airoha_hw_cleanup(struct airoha_eth *eth)
+ {
+ 	int i;
+ 
+-	for (i = 0; i < ARRAY_SIZE(qdma->q_rx); i++) {
+-		if (!qdma->q_rx[i].ndesc)
+-			continue;
+-
+-		netif_napi_del(&qdma->q_rx[i].napi);
+-		airoha_qdma_cleanup_rx_queue(&qdma->q_rx[i]);
+-		if (qdma->q_rx[i].page_pool)
+-			page_pool_destroy(qdma->q_rx[i].page_pool);
+-	}
+-
+-	for (i = 0; i < ARRAY_SIZE(qdma->q_tx_irq); i++)
+-		netif_napi_del(&qdma->q_tx_irq[i].napi);
+-
+-	for (i = 0; i < ARRAY_SIZE(qdma->q_tx); i++) {
+-		if (!qdma->q_tx[i].ndesc)
+-			continue;
+-
+-		airoha_qdma_cleanup_tx_queue(&qdma->q_tx[i]);
+-	}
++	for (i = 0; i < ARRAY_SIZE(eth->qdma); i++)
++		airoha_qdma_cleanup(&eth->qdma[i]);
++	airoha_ppe_deinit(eth);
+ }
+ 
+ static void airoha_qdma_start_napi(struct airoha_qdma *qdma)
+@@ -3012,7 +3028,7 @@ static int airoha_probe(struct platform_
+ 
+ 	err = airoha_hw_init(pdev, eth);
+ 	if (err)
+-		goto error_hw_cleanup;
++		goto error_netdev_free;
+ 
+ 	for (i = 0; i < ARRAY_SIZE(eth->qdma); i++)
+ 		airoha_qdma_start_napi(&eth->qdma[i]);
+@@ -3040,10 +3056,6 @@ static int airoha_probe(struct platform_
+ error_napi_stop:
+ 	for (i = 0; i < ARRAY_SIZE(eth->qdma); i++)
+ 		airoha_qdma_stop_napi(&eth->qdma[i]);
+-	airoha_ppe_deinit(eth);
+-error_hw_cleanup:
+-	for (i = 0; i < ARRAY_SIZE(eth->qdma); i++)
+-		airoha_hw_cleanup(&eth->qdma[i]);
+ 
+ 	for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
+ 		struct airoha_gdm_port *port = eth->ports[i];
+@@ -3055,6 +3067,8 @@ error_hw_cleanup:
+ 			unregister_netdev(port->dev);
+ 		airoha_metadata_dst_free(port);
+ 	}
++	airoha_hw_cleanup(eth);
++error_netdev_free:
+ 	free_netdev(eth->napi_dev);
+ 	platform_set_drvdata(pdev, NULL);
+ 
+@@ -3066,10 +3080,8 @@ static void airoha_remove(struct platfor
+ 	struct airoha_eth *eth = platform_get_drvdata(pdev);
+ 	int i;
+ 
+-	for (i = 0; i < ARRAY_SIZE(eth->qdma); i++) {
++	for (i = 0; i < ARRAY_SIZE(eth->qdma); i++)
+ 		airoha_qdma_stop_napi(&eth->qdma[i]);
+-		airoha_hw_cleanup(&eth->qdma[i]);
+-	}
+ 
+ 	for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
+ 		struct airoha_gdm_port *port = eth->ports[i];
+@@ -3080,9 +3092,9 @@ static void airoha_remove(struct platfor
+ 		unregister_netdev(port->dev);
+ 		airoha_metadata_dst_free(port);
+ 	}
+-	free_netdev(eth->napi_dev);
++	airoha_hw_cleanup(eth);
+ 
+-	airoha_ppe_deinit(eth);
++	free_netdev(eth->napi_dev);
+ 	platform_set_drvdata(pdev, NULL);
+ }
+ 

--- a/target/linux/airoha/patches-6.6/134-v7.1-net-airoha-Delay-offloading-until-all-net_devices-ar.patch
+++ b/target/linux/airoha/patches-6.6/134-v7.1-net-airoha-Delay-offloading-until-all-net_devices-ar.patch
@@ -1,0 +1,63 @@
+From cedc1bf327de62ec30af9743bd1f601c2de30553 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Sun, 29 Mar 2026 12:32:27 +0200
+Subject: [PATCH] net: airoha: Delay offloading until all net_devices are fully
+ registered
+
+Netfilter flowtable can theoretically try to offload flower rules as soon
+as a net_device is registered while all the other ones are not
+registered or initialized, triggering a possible NULL pointer dereferencing
+of qdma pointer in airoha_ppe_set_cpu_port routine. Moreover, if
+register_netdev() fails for a particular net_device, there is a small
+race if Netfilter tries to offload flowtable rules before all the
+net_devices are properly unregistered in airoha_probe() error patch,
+triggering a NULL pointer dereferencing in airoha_ppe_set_cpu_port
+routine. In order to avoid any possible race, delay offloading until
+all net_devices are registered in the networking subsystem.
+
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260329-airoha-regiser-race-fix-v2-1-f4ebb139277b@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 2 ++
+ drivers/net/ethernet/airoha/airoha_eth.h | 1 +
+ drivers/net/ethernet/airoha/airoha_ppe.c | 7 +++++++
+ 3 files changed, 10 insertions(+)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -2957,6 +2957,8 @@ static int airoha_register_gdm_devices(s
+ 			return err;
+ 	}
+ 
++	set_bit(DEV_STATE_REGISTERED, &eth->state);
++
+ 	return 0;
+ }
+ 
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -88,6 +88,7 @@ enum {
+ 
+ enum {
+ 	DEV_STATE_INITIALIZED,
++	DEV_STATE_REGISTERED,
+ };
+ 
+ enum {
+--- a/drivers/net/ethernet/airoha/airoha_ppe.c
++++ b/drivers/net/ethernet/airoha/airoha_ppe.c
+@@ -1387,6 +1387,13 @@ int airoha_ppe_setup_tc_block_cb(struct
+ 	struct airoha_eth *eth = ppe->eth;
+ 	int err = 0;
+ 
++	/* Netfilter flowtable can try to offload flower rules while not all
++	 * the net_devices are registered or initialized. Delay offloading
++	 * until all net_devices are registered in the system.
++	 */
++	if (!test_bit(DEV_STATE_REGISTERED, &eth->state))
++		return -EBUSY;
++
+ 	mutex_lock(&flow_offload_mutex);
+ 
+ 	if (!eth->npu)

--- a/target/linux/airoha/patches-6.6/135-v7.1-net-airoha-Add-missing-cleanup-bits-in-airoha_qdma_c.patch
+++ b/target/linux/airoha/patches-6.6/135-v7.1-net-airoha-Add-missing-cleanup-bits-in-airoha_qdma_c.patch
@@ -1,0 +1,57 @@
+From 514aac3599879a7ed48b7dc19e31145beb6958ac Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Fri, 27 Mar 2026 10:48:21 +0100
+Subject: [PATCH] net: airoha: Add missing cleanup bits in
+ airoha_qdma_cleanup_rx_queue()
+
+In order to properly cleanup hw rx QDMA queues and bring the device to
+the initial state, reset rx DMA queue head/tail index. Moreover, reset
+queued DMA descriptor fields.
+
+Fixes: 23020f049327 ("net: airoha: Introduce ethernet support for EN7581 SoC")
+Tested-by: Madhur Agrawal <Madhur.Agrawal@airoha.com>
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260327-airoha_qdma_cleanup_rx_queue-fix-v1-1-369d6ab1511a@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -794,18 +794,34 @@ static int airoha_qdma_init_rx_queue(str
+ 
+ static void airoha_qdma_cleanup_rx_queue(struct airoha_queue *q)
+ {
+-	struct airoha_eth *eth = q->qdma->eth;
++	struct airoha_qdma *qdma = q->qdma;
++	struct airoha_eth *eth = qdma->eth;
++	int qid = q - &qdma->q_rx[0];
+ 
+ 	while (q->queued) {
+ 		struct airoha_queue_entry *e = &q->entry[q->tail];
++		struct airoha_qdma_desc *desc = &q->desc[q->tail];
+ 		struct page *page = virt_to_head_page(e->buf);
+ 
+ 		dma_sync_single_for_cpu(eth->dev, e->dma_addr, e->dma_len,
+ 					page_pool_get_dma_dir(q->page_pool));
+ 		page_pool_put_full_page(q->page_pool, page, false);
++		/* Reset DMA descriptor */
++		WRITE_ONCE(desc->ctrl, 0);
++		WRITE_ONCE(desc->addr, 0);
++		WRITE_ONCE(desc->data, 0);
++		WRITE_ONCE(desc->msg0, 0);
++		WRITE_ONCE(desc->msg1, 0);
++		WRITE_ONCE(desc->msg2, 0);
++		WRITE_ONCE(desc->msg3, 0);
++
+ 		q->tail = (q->tail + 1) % q->ndesc;
+ 		q->queued--;
+ 	}
++
++	q->head = q->tail;
++	airoha_qdma_rmw(qdma, REG_RX_DMA_IDX(qid), RX_RING_DMA_IDX_MASK,
++			FIELD_PREP(RX_RING_DMA_IDX_MASK, q->tail));
+ }
+ 
+ static int airoha_qdma_init_rx(struct airoha_qdma *qdma)

--- a/target/linux/airoha/patches-6.6/136-v7.1-net-airoha-Add-dma_rmb-and-READ_ONCE-in-airoha_qdma_.patch
+++ b/target/linux/airoha/patches-6.6/136-v7.1-net-airoha-Add-dma_rmb-and-READ_ONCE-in-airoha_qdma_.patch
@@ -1,0 +1,78 @@
+From 4ae0604a0673e11e2075b178387151fcad5111b5 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Tue, 7 Apr 2026 08:48:04 +0200
+Subject: [PATCH] net: airoha: Add dma_rmb() and READ_ONCE() in
+ airoha_qdma_rx_process()
+
+Add missing dma_rmb() in airoha_qdma_rx_process routine to make sure the
+DMA read operations are completed when the NIC reports the processing on
+the current descriptor is done. Moreover, add missing READ_ONCE() in
+airoha_qdma_rx_process() for DMA descriptor control fields in order to
+avoid any compiler reordering.
+
+Fixes: 23020f0493270 ("net: airoha: Introduce ethernet support for EN7581 SoC")
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260407-airoha_qdma_rx_process-fix-reordering-v3-1-91c36e9da31f@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 16 ++++++++++------
+ 1 file changed, 10 insertions(+), 6 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -584,7 +584,7 @@ static int airoha_qdma_fill_rx_queue(str
+ static int airoha_qdma_get_gdm_port(struct airoha_eth *eth,
+ 				    struct airoha_qdma_desc *desc)
+ {
+-	u32 port, sport, msg1 = le32_to_cpu(desc->msg1);
++	u32 port, sport, msg1 = le32_to_cpu(READ_ONCE(desc->msg1));
+ 
+ 	sport = FIELD_GET(QDMA_ETH_RXMSG_SPORT_MASK, msg1);
+ 	switch (sport) {
+@@ -612,21 +612,24 @@ static int airoha_qdma_rx_process(struct
+ 	while (done < budget) {
+ 		struct airoha_queue_entry *e = &q->entry[q->tail];
+ 		struct airoha_qdma_desc *desc = &q->desc[q->tail];
+-		u32 hash, reason, msg1 = le32_to_cpu(desc->msg1);
+-		struct page *page = virt_to_head_page(e->buf);
+-		u32 desc_ctrl = le32_to_cpu(desc->ctrl);
++		u32 hash, reason, msg1, desc_ctrl;
+ 		struct airoha_gdm_port *port;
+ 		int data_len, len, p;
++		struct page *page;
+ 
++		desc_ctrl = le32_to_cpu(READ_ONCE(desc->ctrl));
+ 		if (!(desc_ctrl & QDMA_DESC_DONE_MASK))
+ 			break;
+ 
++		dma_rmb();
++
+ 		q->tail = (q->tail + 1) % q->ndesc;
+ 		q->queued--;
+ 
+ 		dma_sync_single_for_cpu(eth->dev, e->dma_addr,
+ 					SKB_WITH_OVERHEAD(q->buf_size), dir);
+ 
++		page = virt_to_head_page(e->buf);
+ 		len = FIELD_GET(QDMA_DESC_LEN_MASK, desc_ctrl);
+ 		data_len = q->skb ? q->buf_size
+ 				  : SKB_WITH_OVERHEAD(q->buf_size);
+@@ -670,8 +673,8 @@ static int airoha_qdma_rx_process(struct
+ 			 * DMA descriptor. Report DSA tag to the DSA stack
+ 			 * via skb dst info.
+ 			 */
+-			u32 sptag = FIELD_GET(QDMA_ETH_RXMSG_SPTAG,
+-					      le32_to_cpu(desc->msg0));
++			u32 msg0 = le32_to_cpu(READ_ONCE(desc->msg0));
++			u32 sptag = FIELD_GET(QDMA_ETH_RXMSG_SPTAG, msg0);
+ 
+ 			if (sptag < ARRAY_SIZE(port->dsa_meta) &&
+ 			    port->dsa_meta[sptag])
+@@ -679,6 +682,7 @@ static int airoha_qdma_rx_process(struct
+ 						  &port->dsa_meta[sptag]->dst);
+ 		}
+ 
++		msg1 = le32_to_cpu(READ_ONCE(desc->msg1));
+ 		hash = FIELD_GET(AIROHA_RXD4_FOE_ENTRY, msg1);
+ 		if (hash != AIROHA_RXD4_FOE_ENTRY)
+ 			skb_set_hash(q->skb, jhash_1word(hash, 0),

--- a/target/linux/airoha/patches-6.6/137-v7.1-net-airoha-Add-missing-PPE-configurations-in-airoha_.patch
+++ b/target/linux/airoha/patches-6.6/137-v7.1-net-airoha-Add-missing-PPE-configurations-in-airoha_.patch
@@ -1,0 +1,62 @@
+From b9d8b856689d2b968495d79fe653d87fcb8ad98c Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Sun, 12 Apr 2026 10:43:26 +0200
+Subject: [PATCH] net: airoha: Add missing PPE configurations in
+ airoha_ppe_hw_init()
+
+Add the following PPE configuration in airoha_ppe_hw_init routine:
+- 6RD hw offloading is currently not supported by Netfilter flowtable.
+  Disable explicitly PPE 6RD offloading in order to prevent PPE to learn
+  6RD flows and eventually interrupt the traffic.
+- Add missing PPE bind rate configuration for L3 and L2 traffic.
+  PPE bind rate configuration specifies the pps threshold to move a PPE
+  entry state from UNBIND to BIND. Without this configuration this value
+  is random.
+- Set ageing thresholds to the values used in the vendor SDK in order to
+  improve connection stability under load and avoid packet loss caused by
+  fast aging.
+
+Fixes: 00a7678310fe3 ("net: airoha: Introduce flowtable offload support")
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Link: https://patch.msgid.link/20260412-airoha_ppe_hw_init-missing-bits-v1-1-06ac670819e3@kernel.org
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ drivers/net/ethernet/airoha/airoha_ppe.c | 14 +++++++++++---
+ 1 file changed, 11 insertions(+), 3 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_ppe.c
++++ b/drivers/net/ethernet/airoha/airoha_ppe.c
+@@ -125,13 +125,13 @@ static void airoha_ppe_hw_init(struct ai
+ 		airoha_fe_rmw(eth, REG_PPE_BND_AGE0(i),
+ 			      PPE_BIND_AGE0_DELTA_NON_L4 |
+ 			      PPE_BIND_AGE0_DELTA_UDP,
+-			      FIELD_PREP(PPE_BIND_AGE0_DELTA_NON_L4, 1) |
+-			      FIELD_PREP(PPE_BIND_AGE0_DELTA_UDP, 12));
++			      FIELD_PREP(PPE_BIND_AGE0_DELTA_NON_L4, 60) |
++			      FIELD_PREP(PPE_BIND_AGE0_DELTA_UDP, 60));
+ 		airoha_fe_rmw(eth, REG_PPE_BND_AGE1(i),
+ 			      PPE_BIND_AGE1_DELTA_TCP_FIN |
+ 			      PPE_BIND_AGE1_DELTA_TCP,
+ 			      FIELD_PREP(PPE_BIND_AGE1_DELTA_TCP_FIN, 1) |
+-			      FIELD_PREP(PPE_BIND_AGE1_DELTA_TCP, 7));
++			      FIELD_PREP(PPE_BIND_AGE1_DELTA_TCP, 60));
+ 
+ 		airoha_fe_rmw(eth, REG_PPE_TB_HASH_CFG(i),
+ 			      PPE_SRAM_TABLE_EN_MASK |
+@@ -159,7 +159,15 @@ static void airoha_ppe_hw_init(struct ai
+ 			      FIELD_PREP(PPE_DRAM_TB_NUM_ENTRY_MASK,
+ 					 dram_num_entries));
+ 
++		airoha_fe_rmw(eth, REG_PPE_BIND_RATE(i),
++			      PPE_BIND_RATE_L2B_BIND_MASK |
++			      PPE_BIND_RATE_BIND_MASK,
++			      FIELD_PREP(PPE_BIND_RATE_L2B_BIND_MASK, 0x1e) |
++			      FIELD_PREP(PPE_BIND_RATE_BIND_MASK, 0x1e));
++
+ 		airoha_fe_wr(eth, REG_PPE_HASH_SEED(i), PPE_HASH_SEED);
++		airoha_fe_clear(eth, REG_PPE_PPE_FLOW_CFG(i),
++				PPE_FLOW_CFG_IP6_6RD_MASK);
+ 
+ 		for (p = 0; p < ARRAY_SIZE(eth->ports); p++) {
+ 			struct airoha_gdm_port *port = eth->ports[p];

--- a/target/linux/airoha/patches-6.6/138-v7.1-net-airoha-Add-missing-RX_CPU_IDX-configuration-in-a.patch
+++ b/target/linux/airoha/patches-6.6/138-v7.1-net-airoha-Add-missing-RX_CPU_IDX-configuration-in-a.patch
@@ -1,0 +1,34 @@
+From 656121b155030086b01cfce9bd31b0c925ee6860 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Wed, 8 Apr 2026 20:26:56 +0200
+Subject: [PATCH] net: airoha: Add missing RX_CPU_IDX() configuration in
+ airoha_qdma_cleanup_rx_queue()
+
+When the descriptor index written in REG_RX_CPU_IDX() is equal to the one
+stored in REG_RX_DMA_IDX(), the hw will stop since the QDMA RX ring is
+empty.
+Add missing REG_RX_CPU_IDX() configuration in airoha_qdma_cleanup_rx_queue
+routine during QDMA RX ring cleanup.
+
+Fixes: 514aac359987 ("net: airoha: Add missing cleanup bits in airoha_qdma_cleanup_rx_queue()")
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260408-airoha-cpu-idx-airoha_qdma_cleanup_rx_queue-v1-1-8efa64844308@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -824,6 +824,11 @@ static void airoha_qdma_cleanup_rx_queue
+ 	}
+ 
+ 	q->head = q->tail;
++	/* Set RX_DMA_IDX to RX_CPU_IDX to notify the hw the QDMA RX ring is
++	 * empty.
++	 */
++	airoha_qdma_rmw(qdma, REG_RX_CPU_IDX(qid), RX_RING_CPU_IDX_MASK,
++			FIELD_PREP(RX_RING_CPU_IDX_MASK, q->head));
+ 	airoha_qdma_rmw(qdma, REG_RX_DMA_IDX(qid), RX_RING_DMA_IDX_MASK,
+ 			FIELD_PREP(RX_RING_DMA_IDX_MASK, q->tail));
+ }

--- a/target/linux/airoha/patches-6.6/139-v7.1-net-airoha-Fix-FE_PSE_BUF_SET-configuration-if-PPE2-.patch
+++ b/target/linux/airoha/patches-6.6/139-v7.1-net-airoha-Fix-FE_PSE_BUF_SET-configuration-if-PPE2-.patch
@@ -1,0 +1,45 @@
+From 02f72964395911e7a09bb2ea2fe6f79eda4ea2c2 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Wed, 8 Apr 2026 12:20:09 +0200
+Subject: [PATCH] net: airoha: Fix FE_PSE_BUF_SET configuration if PPE2 is
+ available
+
+airoha_fe_set routine is used to set specified bits to 1 in the selected
+register. In the FE_PSE_BUF_SET case this can due to a overestimation of
+the required buffers for I/O queues since we can miss to set some bits
+of PSE_ALLRSV_MASK subfield to 0. Fix the issue relying on airoha_fe_rmw
+routine instead.
+
+Fixes: 8e38e08f2c560 ("net: airoha: fix PSE memory configuration in airoha_fe_pse_ports_init()")
+Tested-by: Xuegang Lu <xuegang.lu@airoha.com>
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260408-airoha-reg_fe_pse_buf_set-v1-1-0c4fa8f4d1d9@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -293,16 +293,18 @@ static void airoha_fe_pse_ports_init(str
+ 		[FE_PSE_PORT_GDM4] = 2,
+ 		[FE_PSE_PORT_CDM5] = 2,
+ 	};
+-	u32 all_rsv;
+ 	int q;
+ 
+-	all_rsv = airoha_fe_get_pse_all_rsv(eth);
+ 	if (airoha_ppe_is_enabled(eth, 1)) {
++		u32 all_rsv;
++
+ 		/* hw misses PPE2 oq rsv */
++		all_rsv = airoha_fe_get_pse_all_rsv(eth);
+ 		all_rsv += PSE_RSV_PAGES *
+ 			   pse_port_num_queues[FE_PSE_PORT_PPE2];
++		airoha_fe_rmw(eth, REG_FE_PSE_BUF_SET, PSE_ALLRSV_MASK,
++			      FIELD_PREP(PSE_ALLRSV_MASK, all_rsv));
+ 	}
+-	airoha_fe_set(eth, REG_FE_PSE_BUF_SET, all_rsv);
+ 
+ 	/* CMD1 */
+ 	for (q = 0; q < pse_port_num_queues[FE_PSE_PORT_CDM1]; q++)

--- a/target/linux/airoha/patches-6.6/140-v7.1-net-airoha-Fix-memory-leak-in-airoha_qdma_rx_process.patch
+++ b/target/linux/airoha/patches-6.6/140-v7.1-net-airoha-Fix-memory-leak-in-airoha_qdma_rx_process.patch
@@ -1,0 +1,37 @@
+From 285fa6b1e03cff78ead0383e1b259c44b95faf90 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Thu, 2 Apr 2026 14:57:10 +0200
+Subject: [PATCH] net: airoha: Fix memory leak in airoha_qdma_rx_process()
+
+If an error occurs on the subsequents buffers belonging to the
+non-linear part of the skb (e.g. due to an error in the payload length
+reported by the NIC or if we consumed all the available fragments for
+the skb), the page_pool fragment will not be linked to the skb so it will
+not return to the pool in the airoha_qdma_rx_process() error path. Fix the
+memory leak partially reverting commit 'd6d2b0e1538d ("net: airoha: Fix
+page recycling in airoha_qdma_rx_process()")' and always running
+page_pool_put_full_page routine in the airoha_qdma_rx_process() error
+path.
+
+Fixes: d6d2b0e1538d ("net: airoha: Fix page recycling in airoha_qdma_rx_process()")
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Link: https://patch.msgid.link/20260402-airoha_qdma_rx_process-mem-leak-fix-v1-1-b5706f402d3c@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -703,9 +703,8 @@ free_frag:
+ 		if (q->skb) {
+ 			dev_kfree_skb(q->skb);
+ 			q->skb = NULL;
+-		} else {
+-			page_pool_put_full_page(q->page_pool, page, true);
+ 		}
++		page_pool_put_full_page(q->page_pool, page, true);
+ 	}
+ 	airoha_qdma_fill_rx_queue(q);
+ 

--- a/target/linux/airoha/patches-6.6/141-v7.1-net-airoha-Fix-VIP-configuration-for-AN7583-SoC.patch
+++ b/target/linux/airoha/patches-6.6/141-v7.1-net-airoha-Fix-VIP-configuration-for-AN7583-SoC.patch
@@ -1,0 +1,164 @@
+From 1acdfbdb516b32165a8ecd1d5f8c68e4eac64637 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Sun, 12 Apr 2026 09:57:29 +0200
+Subject: [PATCH] net: airoha: Fix VIP configuration for AN7583 SoC
+
+EN7581 and AN7583 SoCs have different VIP definitions. Introduce
+get_vip_port callback in airoha_eth_soc_data struct in order to take
+into account EN7581 and AN7583 VIP register layout and definition
+differences.
+Introduce nbq parameter in airoha_gdm_port struct. At the moment nbq
+is set statically to value previously used in airhoha_set_gdm2_loopback
+routine and it will be read from device tree in subsequent patches.
+
+Fixes: e4e5ce823bdd ("net: airoha: Add AN7583 SoC support")
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260412-airoha-7583-vip-fix-v1-1-c35e02b054bb@kernel.org
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 66 ++++++++++++++++++------
+ drivers/net/ethernet/airoha/airoha_eth.h |  2 +
+ 2 files changed, 51 insertions(+), 17 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -107,19 +107,7 @@ static int airoha_set_vip_for_gdm_port(s
+ 	struct airoha_eth *eth = port->qdma->eth;
+ 	u32 vip_port;
+ 
+-	switch (port->id) {
+-	case AIROHA_GDM3_IDX:
+-		/* FIXME: handle XSI_PCIE1_PORT */
+-		vip_port = XSI_PCIE0_VIP_PORT_MASK;
+-		break;
+-	case AIROHA_GDM4_IDX:
+-		/* FIXME: handle XSI_USB_PORT */
+-		vip_port = XSI_ETH_VIP_PORT_MASK;
+-		break;
+-	default:
+-		return 0;
+-	}
+-
++	vip_port = eth->soc->ops.get_vip_port(port, port->nbq);
+ 	if (enable) {
+ 		airoha_fe_set(eth, REG_FE_VIP_PORT_EN, vip_port);
+ 		airoha_fe_set(eth, REG_FE_IFC_PORT_EN, vip_port);
+@@ -1738,7 +1726,7 @@ static int airoha_dev_set_macaddr(struct
+ static int airhoha_set_gdm2_loopback(struct airoha_gdm_port *port)
+ {
+ 	struct airoha_eth *eth = port->qdma->eth;
+-	u32 val, pse_port, chan, nbq;
++	u32 val, pse_port, chan;
+ 	int src_port;
+ 
+ 	/* Forward the traffic to the proper GDM port */
+@@ -1768,9 +1756,7 @@ static int airhoha_set_gdm2_loopback(str
+ 	airoha_fe_clear(eth, REG_FE_VIP_PORT_EN, BIT(AIROHA_GDM2_IDX));
+ 	airoha_fe_clear(eth, REG_FE_IFC_PORT_EN, BIT(AIROHA_GDM2_IDX));
+ 
+-	/* XXX: handle XSI_USB_PORT and XSI_PCE1_PORT */
+-	nbq = port->id == AIROHA_GDM3_IDX && airoha_is_7581(eth) ? 4 : 0;
+-	src_port = eth->soc->ops.get_src_port_id(port, nbq);
++	src_port = eth->soc->ops.get_src_port_id(port, port->nbq);
+ 	if (src_port < 0)
+ 		return src_port;
+ 
+@@ -2962,6 +2948,8 @@ static int airoha_alloc_gdm_port(struct
+ 	port->eth = eth;
+ 	port->dev = dev;
+ 	port->id = id;
++	/* XXX: Read nbq from DTS */
++	port->nbq = id == AIROHA_GDM3_IDX && airoha_is_7581(eth) ? 4 : 0;
+ 	eth->ports[p] = port;
+ 
+ 	return airoha_metadata_dst_alloc(port);
+@@ -3158,6 +3146,28 @@ static int airoha_en7581_get_src_port_id
+ 	return -EINVAL;
+ }
+ 
++static u32 airoha_en7581_get_vip_port(struct airoha_gdm_port *port, int nbq)
++{
++	switch (port->id) {
++	case AIROHA_GDM3_IDX:
++		if (nbq == 4)
++			return XSI_PCIE0_VIP_PORT_MASK;
++		if (nbq == 5)
++			return XSI_PCIE1_VIP_PORT_MASK;
++		break;
++	case AIROHA_GDM4_IDX:
++		if (!nbq)
++			return XSI_ETH_VIP_PORT_MASK;
++		if (nbq == 1)
++			return XSI_USB_VIP_PORT_MASK;
++		break;
++	default:
++		break;
++	}
++
++	return 0;
++}
++
+ static const char * const an7583_xsi_rsts_names[] = {
+ 	"xsi-mac",
+ 	"hsi0-mac",
+@@ -3187,6 +3197,26 @@ static int airoha_an7583_get_src_port_id
+ 	return -EINVAL;
+ }
+ 
++static u32 airoha_an7583_get_vip_port(struct airoha_gdm_port *port, int nbq)
++{
++	switch (port->id) {
++	case AIROHA_GDM3_IDX:
++		if (!nbq)
++			return XSI_ETH_VIP_PORT_MASK;
++		break;
++	case AIROHA_GDM4_IDX:
++		if (!nbq)
++			return XSI_PCIE0_VIP_PORT_MASK;
++		if (nbq == 1)
++			return XSI_USB_VIP_PORT_MASK;
++		break;
++	default:
++		break;
++	}
++
++	return 0;
++}
++
+ static const struct airoha_eth_soc_data en7581_soc_data = {
+ 	.version = 0x7581,
+ 	.xsi_rsts_names = en7581_xsi_rsts_names,
+@@ -3194,6 +3224,7 @@ static const struct airoha_eth_soc_data
+ 	.num_ppe = 2,
+ 	.ops = {
+ 		.get_src_port_id = airoha_en7581_get_src_port_id,
++		.get_vip_port = airoha_en7581_get_vip_port,
+ 	},
+ };
+ 
+@@ -3204,6 +3235,7 @@ static const struct airoha_eth_soc_data
+ 	.num_ppe = 1,
+ 	.ops = {
+ 		.get_src_port_id = airoha_an7583_get_src_port_id,
++		.get_vip_port = airoha_an7583_get_vip_port,
+ 	},
+ };
+ 
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -537,6 +537,7 @@ struct airoha_gdm_port {
+ 	struct airoha_eth *eth;
+ 	struct net_device *dev;
+ 	int id;
++	int nbq;
+ 
+ 	struct airoha_hw_stats stats;
+ 
+@@ -577,6 +578,7 @@ struct airoha_eth_soc_data {
+ 	int num_ppe;
+ 	struct {
+ 		int (*get_src_port_id)(struct airoha_gdm_port *port, int nbq);
++		u32 (*get_vip_port)(struct airoha_gdm_port *port, int nbq);
+ 	} ops;
+ };
+ 

--- a/target/linux/airoha/patches-6.6/142-01-v7.1-net-airoha-Rely-on-net_device-pointer-in-airoha_dev_.patch
+++ b/target/linux/airoha/patches-6.6/142-01-v7.1-net-airoha-Rely-on-net_device-pointer-in-airoha_dev_.patch
@@ -1,0 +1,64 @@
+From 360d745a5319f09849a94dee0974c8ead721e392 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Sun, 12 Apr 2026 19:13:12 +0200
+Subject: [PATCH 1/4] net: airoha: Rely on net_device pointer in
+ airoha_dev_setup_tc_block signature
+
+Remove airoha_gdm_port dependency in airoha_dev_setup_tc_block routine
+signature and rely on net_device pointer instead. Please note this patch
+does not introduce any logical change and it is a preliminary patch to
+support multiple net_devices connected to the GDM3 or GDM4 ports via an
+external hw arbiter.
+
+Tested-by: Xuegang Lu <xuegang.lu@airoha.com>
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260412-airoha-multi-serdes-preliminary-patch-v1-1-08d5b670ca8f@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -2683,7 +2683,7 @@ static int airoha_dev_setup_tc_block_cb(
+ 	}
+ }
+ 
+-static int airoha_dev_setup_tc_block(struct airoha_gdm_port *port,
++static int airoha_dev_setup_tc_block(struct net_device *dev,
+ 				     struct flow_block_offload *f)
+ {
+ 	flow_setup_cb_t *cb = airoha_dev_setup_tc_block_cb;
+@@ -2696,12 +2696,12 @@ static int airoha_dev_setup_tc_block(str
+ 	f->driver_block_list = &block_cb_list;
+ 	switch (f->command) {
+ 	case FLOW_BLOCK_BIND:
+-		block_cb = flow_block_cb_lookup(f->block, cb, port->dev);
++		block_cb = flow_block_cb_lookup(f->block, cb, dev);
+ 		if (block_cb) {
+ 			flow_block_cb_incref(block_cb);
+ 			return 0;
+ 		}
+-		block_cb = flow_block_cb_alloc(cb, port->dev, port->dev, NULL);
++		block_cb = flow_block_cb_alloc(cb, dev, dev, NULL);
+ 		if (IS_ERR(block_cb))
+ 			return PTR_ERR(block_cb);
+ 
+@@ -2710,7 +2710,7 @@ static int airoha_dev_setup_tc_block(str
+ 		list_add_tail(&block_cb->driver_list, &block_cb_list);
+ 		return 0;
+ 	case FLOW_BLOCK_UNBIND:
+-		block_cb = flow_block_cb_lookup(f->block, cb, port->dev);
++		block_cb = flow_block_cb_lookup(f->block, cb, dev);
+ 		if (!block_cb)
+ 			return -ENOENT;
+ 
+@@ -2809,7 +2809,7 @@ static int airoha_dev_tc_setup(struct ne
+ 		return airoha_tc_setup_qdisc_htb(port, type_data);
+ 	case TC_SETUP_BLOCK:
+ 	case TC_SETUP_FT:
+-		return airoha_dev_setup_tc_block(port, type_data);
++		return airoha_dev_setup_tc_block(dev, type_data);
+ 	default:
+ 		return -EOPNOTSUPP;
+ 	}

--- a/target/linux/airoha/patches-6.6/142-02-v7.1-net-airoha-Rely-on-net_device-pointer-in-HTB-callbac.patch
+++ b/target/linux/airoha/patches-6.6/142-02-v7.1-net-airoha-Rely-on-net_device-pointer-in-HTB-callbac.patch
@@ -1,0 +1,163 @@
+From 8baf4bf72ef94c955ef89d4644f1986603ee8320 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Sun, 12 Apr 2026 19:13:13 +0200
+Subject: [PATCH 2/4] net: airoha: Rely on net_device pointer in HTB callbacks
+
+Remove airoha_gdm_port dependency in HTB tc callback signatures and rely
+on net_device pointer instead. Please note this patch does not introduce
+any logical change and it is a preliminary patch in order to support
+multiple net_devices connected to the same GDM3 or GDM4 port via an
+external hw arbiter.
+
+Tested-by: Xuegang Lu <xuegang.lu@airoha.com>
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260412-airoha-multi-serdes-preliminary-patch-v1-2-08d5b670ca8f@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 45 +++++++++++++-----------
+ 1 file changed, 24 insertions(+), 21 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -2488,10 +2488,11 @@ static int airoha_qdma_set_trtcm_token_b
+ 					   mode, val);
+ }
+ 
+-static int airoha_qdma_set_tx_rate_limit(struct airoha_gdm_port *port,
++static int airoha_qdma_set_tx_rate_limit(struct net_device *dev,
+ 					 int channel, u32 rate,
+ 					 u32 bucket_size)
+ {
++	struct airoha_gdm_port *port = netdev_priv(dev);
+ 	int i, err;
+ 
+ 	for (i = 0; i <= TRTCM_PEAK_MODE; i++) {
+@@ -2511,21 +2512,20 @@ static int airoha_qdma_set_tx_rate_limit
+ 	return 0;
+ }
+ 
+-static int airoha_tc_htb_alloc_leaf_queue(struct airoha_gdm_port *port,
++static int airoha_tc_htb_alloc_leaf_queue(struct net_device *dev,
+ 					  struct tc_htb_qopt_offload *opt)
+ {
+ 	u32 channel = TC_H_MIN(opt->classid) % AIROHA_NUM_QOS_CHANNELS;
+ 	u32 rate = div_u64(opt->rate, 1000) << 3; /* kbps */
+-	struct net_device *dev = port->dev;
+-	int num_tx_queues = dev->real_num_tx_queues;
+-	int err;
++	int err, num_tx_queues = dev->real_num_tx_queues;
++	struct airoha_gdm_port *port = netdev_priv(dev);
+ 
+ 	if (opt->parent_classid != TC_HTB_CLASSID_ROOT) {
+ 		NL_SET_ERR_MSG_MOD(opt->extack, "invalid parent classid");
+ 		return -EINVAL;
+ 	}
+ 
+-	err = airoha_qdma_set_tx_rate_limit(port, channel, rate, opt->quantum);
++	err = airoha_qdma_set_tx_rate_limit(dev, channel, rate, opt->quantum);
+ 	if (err) {
+ 		NL_SET_ERR_MSG_MOD(opt->extack,
+ 				   "failed configuring htb offload");
+@@ -2537,7 +2537,7 @@ static int airoha_tc_htb_alloc_leaf_queu
+ 
+ 	err = netif_set_real_num_tx_queues(dev, num_tx_queues + 1);
+ 	if (err) {
+-		airoha_qdma_set_tx_rate_limit(port, channel, 0, opt->quantum);
++		airoha_qdma_set_tx_rate_limit(dev, channel, 0, opt->quantum);
+ 		NL_SET_ERR_MSG_MOD(opt->extack,
+ 				   "failed setting real_num_tx_queues");
+ 		return err;
+@@ -2724,44 +2724,47 @@ static int airoha_dev_setup_tc_block(str
+ 	}
+ }
+ 
+-static void airoha_tc_remove_htb_queue(struct airoha_gdm_port *port, int queue)
++static void airoha_tc_remove_htb_queue(struct net_device *dev, int queue)
+ {
+-	struct net_device *dev = port->dev;
++	struct airoha_gdm_port *port = netdev_priv(dev);
+ 
+ 	netif_set_real_num_tx_queues(dev, dev->real_num_tx_queues - 1);
+-	airoha_qdma_set_tx_rate_limit(port, queue + 1, 0, 0);
++	airoha_qdma_set_tx_rate_limit(dev, queue + 1, 0, 0);
+ 	clear_bit(queue, port->qos_sq_bmap);
+ }
+ 
+-static int airoha_tc_htb_delete_leaf_queue(struct airoha_gdm_port *port,
++static int airoha_tc_htb_delete_leaf_queue(struct net_device *dev,
+ 					   struct tc_htb_qopt_offload *opt)
+ {
+ 	u32 channel = TC_H_MIN(opt->classid) % AIROHA_NUM_QOS_CHANNELS;
++	struct airoha_gdm_port *port = netdev_priv(dev);
+ 
+ 	if (!test_bit(channel, port->qos_sq_bmap)) {
+ 		NL_SET_ERR_MSG_MOD(opt->extack, "invalid queue id");
+ 		return -EINVAL;
+ 	}
+ 
+-	airoha_tc_remove_htb_queue(port, channel);
++	airoha_tc_remove_htb_queue(dev, channel);
+ 
+ 	return 0;
+ }
+ 
+-static int airoha_tc_htb_destroy(struct airoha_gdm_port *port)
++static int airoha_tc_htb_destroy(struct net_device *dev)
+ {
++	struct airoha_gdm_port *port = netdev_priv(dev);
+ 	int q;
+ 
+ 	for_each_set_bit(q, port->qos_sq_bmap, AIROHA_NUM_QOS_CHANNELS)
+-		airoha_tc_remove_htb_queue(port, q);
++		airoha_tc_remove_htb_queue(dev, q);
+ 
+ 	return 0;
+ }
+ 
+-static int airoha_tc_get_htb_get_leaf_queue(struct airoha_gdm_port *port,
++static int airoha_tc_get_htb_get_leaf_queue(struct net_device *dev,
+ 					    struct tc_htb_qopt_offload *opt)
+ {
+ 	u32 channel = TC_H_MIN(opt->classid) % AIROHA_NUM_QOS_CHANNELS;
++	struct airoha_gdm_port *port = netdev_priv(dev);
+ 
+ 	if (!test_bit(channel, port->qos_sq_bmap)) {
+ 		NL_SET_ERR_MSG_MOD(opt->extack, "invalid queue id");
+@@ -2773,23 +2776,23 @@ static int airoha_tc_get_htb_get_leaf_qu
+ 	return 0;
+ }
+ 
+-static int airoha_tc_setup_qdisc_htb(struct airoha_gdm_port *port,
++static int airoha_tc_setup_qdisc_htb(struct net_device *dev,
+ 				     struct tc_htb_qopt_offload *opt)
+ {
+ 	switch (opt->command) {
+ 	case TC_HTB_CREATE:
+ 		break;
+ 	case TC_HTB_DESTROY:
+-		return airoha_tc_htb_destroy(port);
++		return airoha_tc_htb_destroy(dev);
+ 	case TC_HTB_NODE_MODIFY:
+ 	case TC_HTB_LEAF_ALLOC_QUEUE:
+-		return airoha_tc_htb_alloc_leaf_queue(port, opt);
++		return airoha_tc_htb_alloc_leaf_queue(dev, opt);
+ 	case TC_HTB_LEAF_DEL:
+ 	case TC_HTB_LEAF_DEL_LAST:
+ 	case TC_HTB_LEAF_DEL_LAST_FORCE:
+-		return airoha_tc_htb_delete_leaf_queue(port, opt);
++		return airoha_tc_htb_delete_leaf_queue(dev, opt);
+ 	case TC_HTB_LEAF_QUERY_QUEUE:
+-		return airoha_tc_get_htb_get_leaf_queue(port, opt);
++		return airoha_tc_get_htb_get_leaf_queue(dev, opt);
+ 	default:
+ 		return -EOPNOTSUPP;
+ 	}
+@@ -2806,7 +2809,7 @@ static int airoha_dev_tc_setup(struct ne
+ 	case TC_SETUP_QDISC_ETS:
+ 		return airoha_tc_setup_qdisc_ets(port, type_data);
+ 	case TC_SETUP_QDISC_HTB:
+-		return airoha_tc_setup_qdisc_htb(port, type_data);
++		return airoha_tc_setup_qdisc_htb(dev, type_data);
+ 	case TC_SETUP_BLOCK:
+ 	case TC_SETUP_FT:
+ 		return airoha_dev_setup_tc_block(dev, type_data);

--- a/target/linux/airoha/patches-6.6/142-03-v7.1-net-airoha-Rely-on-net_device-pointer-in-ETS-callbac.patch
+++ b/target/linux/airoha/patches-6.6/142-03-v7.1-net-airoha-Rely-on-net_device-pointer-in-ETS-callbac.patch
@@ -1,0 +1,118 @@
+From ae32f80018f0f0f4ebc7a0a70d4092d08a1545e8 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Sun, 12 Apr 2026 19:13:14 +0200
+Subject: [PATCH 3/4] net: airoha: Rely on net_device pointer in ETS callbacks
+
+Remove airoha_gdm_port dependency in ETS tc callback signatures and rely
+on net_device pointer instead. Please note this patch does not introduce
+any logical change and it is a preliminary patch in order to support
+multiple net_devices connected to the same GDM3 or GDM4 port via an
+external hw arbiter.
+
+Tested-by: Xuegang Lu <xuegang.lu@airoha.com>
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260412-airoha-multi-serdes-preliminary-patch-v1-3-08d5b670ca8f@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 30 +++++++++++-------------
+ 1 file changed, 14 insertions(+), 16 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -2134,10 +2134,11 @@ airoha_ethtool_get_rmon_stats(struct net
+ 	} while (u64_stats_fetch_retry(&port->stats.syncp, start));
+ }
+ 
+-static int airoha_qdma_set_chan_tx_sched(struct airoha_gdm_port *port,
++static int airoha_qdma_set_chan_tx_sched(struct net_device *dev,
+ 					 int channel, enum tx_sched_mode mode,
+ 					 const u16 *weights, u8 n_weights)
+ {
++	struct airoha_gdm_port *port = netdev_priv(dev);
+ 	int i;
+ 
+ 	for (i = 0; i < AIROHA_NUM_TX_RING; i++)
+@@ -2169,17 +2170,15 @@ static int airoha_qdma_set_chan_tx_sched
+ 	return 0;
+ }
+ 
+-static int airoha_qdma_set_tx_prio_sched(struct airoha_gdm_port *port,
+-					 int channel)
++static int airoha_qdma_set_tx_prio_sched(struct net_device *dev, int channel)
+ {
+ 	static const u16 w[AIROHA_NUM_QOS_QUEUES] = {};
+ 
+-	return airoha_qdma_set_chan_tx_sched(port, channel, TC_SCH_SP, w,
++	return airoha_qdma_set_chan_tx_sched(dev, channel, TC_SCH_SP, w,
+ 					     ARRAY_SIZE(w));
+ }
+ 
+-static int airoha_qdma_set_tx_ets_sched(struct airoha_gdm_port *port,
+-					int channel,
++static int airoha_qdma_set_tx_ets_sched(struct net_device *dev, int channel,
+ 					struct tc_ets_qopt_offload *opt)
+ {
+ 	struct tc_ets_qopt_offload_replace_params *p = &opt->replace_params;
+@@ -2220,20 +2219,21 @@ static int airoha_qdma_set_tx_ets_sched(
+ 	else if (nstrict < AIROHA_NUM_QOS_QUEUES - 1)
+ 		mode = nstrict + 1;
+ 
+-	return airoha_qdma_set_chan_tx_sched(port, channel, mode, w,
++	return airoha_qdma_set_chan_tx_sched(dev, channel, mode, w,
+ 					     ARRAY_SIZE(w));
+ }
+ 
+-static int airoha_qdma_get_tx_ets_stats(struct airoha_gdm_port *port,
+-					int channel,
++static int airoha_qdma_get_tx_ets_stats(struct net_device *dev, int channel,
+ 					struct tc_ets_qopt_offload *opt)
+ {
++	struct airoha_gdm_port *port = netdev_priv(dev);
+ 	u64 cpu_tx_packets = airoha_qdma_rr(port->qdma,
+ 					    REG_CNTR_VAL(channel << 1));
+ 	u64 fwd_tx_packets = airoha_qdma_rr(port->qdma,
+ 					    REG_CNTR_VAL((channel << 1) + 1));
+ 	u64 tx_packets = (cpu_tx_packets - port->cpu_tx_packets) +
+ 			 (fwd_tx_packets - port->fwd_tx_packets);
++
+ 	_bstats_update(opt->stats.bstats, 0, tx_packets);
+ 
+ 	port->cpu_tx_packets = cpu_tx_packets;
+@@ -2242,7 +2242,7 @@ static int airoha_qdma_get_tx_ets_stats(
+ 	return 0;
+ }
+ 
+-static int airoha_tc_setup_qdisc_ets(struct airoha_gdm_port *port,
++static int airoha_tc_setup_qdisc_ets(struct net_device *dev,
+ 				     struct tc_ets_qopt_offload *opt)
+ {
+ 	int channel;
+@@ -2255,12 +2255,12 @@ static int airoha_tc_setup_qdisc_ets(str
+ 
+ 	switch (opt->command) {
+ 	case TC_ETS_REPLACE:
+-		return airoha_qdma_set_tx_ets_sched(port, channel, opt);
++		return airoha_qdma_set_tx_ets_sched(dev, channel, opt);
+ 	case TC_ETS_DESTROY:
+ 		/* PRIO is default qdisc scheduler */
+-		return airoha_qdma_set_tx_prio_sched(port, channel);
++		return airoha_qdma_set_tx_prio_sched(dev, channel);
+ 	case TC_ETS_STATS:
+-		return airoha_qdma_get_tx_ets_stats(port, channel, opt);
++		return airoha_qdma_get_tx_ets_stats(dev, channel, opt);
+ 	default:
+ 		return -EOPNOTSUPP;
+ 	}
+@@ -2803,11 +2803,9 @@ static int airoha_tc_setup_qdisc_htb(str
+ static int airoha_dev_tc_setup(struct net_device *dev, enum tc_setup_type type,
+ 			       void *type_data)
+ {
+-	struct airoha_gdm_port *port = netdev_priv(dev);
+-
+ 	switch (type) {
+ 	case TC_SETUP_QDISC_ETS:
+-		return airoha_tc_setup_qdisc_ets(port, type_data);
++		return airoha_tc_setup_qdisc_ets(dev, type_data);
+ 	case TC_SETUP_QDISC_HTB:
+ 		return airoha_tc_setup_qdisc_htb(dev, type_data);
+ 	case TC_SETUP_BLOCK:

--- a/target/linux/airoha/patches-6.6/142-04-v7.1-net-airoha-Remove-PCE_MC_EN_MASK-bit-in-REG_FE_PCE_C.patch
+++ b/target/linux/airoha/patches-6.6/142-04-v7.1-net-airoha-Remove-PCE_MC_EN_MASK-bit-in-REG_FE_PCE_C.patch
@@ -1,0 +1,33 @@
+From 34e1a98ff2a87cf4b8de3ccebe9d45273f014aeb Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Sun, 12 Apr 2026 11:56:25 +0200
+Subject: [PATCH 4/4] net: airoha: Remove PCE_MC_EN_MASK bit in REG_FE_PCE_CFG
+ configuration
+
+PCE_MC_EN_MASK bit in REG_FE_PCE_CFG configuration performed in
+airoha_fe_init() is used to duplicate multicast packets and send a copy
+to the CPU when the traffic is offloaded. This is necessary just if
+it is requested by the user. Disable multicast packets duplication by
+default.
+
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260412-airoha_fe_init_remove_mc_en_bit-v1-1-7b6a5a25a74d@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -448,9 +448,8 @@ static int airoha_fe_init(struct airoha_
+ 		      FIELD_PREP(PSE_IQ_RES2_P5_MASK, 0x40) |
+ 		      FIELD_PREP(PSE_IQ_RES2_P4_MASK, 0x34));
+ 
+-	/* enable FE copy engine for MC/KA/DPI */
+-	airoha_fe_wr(eth, REG_FE_PCE_CFG,
+-		     PCE_DPI_EN_MASK | PCE_KA_EN_MASK | PCE_MC_EN_MASK);
++	/* enable FE copy engine for KA/DPI */
++	airoha_fe_wr(eth, REG_FE_PCE_CFG, PCE_DPI_EN_MASK | PCE_KA_EN_MASK);
+ 	/* set vip queue selection to ring 1 */
+ 	airoha_fe_rmw(eth, REG_CDM_FWD_CFG(1), CDM_VIP_QSEL_MASK,
+ 		      FIELD_PREP(CDM_VIP_QSEL_MASK, 0x4));

--- a/target/linux/airoha/patches-6.6/143-v7.1-net-airoha-Fix-typo-in-airoha_set_gdm2_loopback-rout.patch
+++ b/target/linux/airoha/patches-6.6/143-v7.1-net-airoha-Fix-typo-in-airoha_set_gdm2_loopback-rout.patch
@@ -1,0 +1,35 @@
+From a94ddc191f19579a7e0a5da2c012f1048ce10262 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Mon, 30 Mar 2026 00:03:49 +0200
+Subject: [PATCH] net: airoha: Fix typo in airoha_set_gdm2_loopback routine
+ name
+
+Rename airhoha_set_gdm2_loopback() in airoha_set_gdm2_loopback()
+
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260330-airoha_set_gdm2_loopback-fix-typo-v1-1-a1320ff6b6cc@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -1722,7 +1722,7 @@ static int airoha_dev_set_macaddr(struct
+ 	return 0;
+ }
+ 
+-static int airhoha_set_gdm2_loopback(struct airoha_gdm_port *port)
++static int airoha_set_gdm2_loopback(struct airoha_gdm_port *port)
+ {
+ 	struct airoha_eth *eth = port->qdma->eth;
+ 	u32 val, pse_port, chan;
+@@ -1796,7 +1796,7 @@ static int airoha_dev_init(struct net_de
+ 		if (!eth->ports[1]) {
+ 			int err;
+ 
+-			err = airhoha_set_gdm2_loopback(port);
++			err = airoha_set_gdm2_loopback(port);
+ 			if (err)
+ 				return err;
+ 		}

--- a/target/linux/airoha/patches-6.6/144-v7.1-net-airoha-Set-REG_RX_CPU_IDX-once-in-airoha_qdma_fi.patch
+++ b/target/linux/airoha/patches-6.6/144-v7.1-net-airoha-Set-REG_RX_CPU_IDX-once-in-airoha_qdma_fi.patch
@@ -1,0 +1,34 @@
+From 269389ba539834ec80e4d55583fca2cd70e4dc9c Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Tue, 31 Mar 2026 12:33:24 +0200
+Subject: [PATCH] net: airoha: Set REG_RX_CPU_IDX() once in
+ airoha_qdma_fill_rx_queue()
+
+It is not necessary to update REG_RX_CPU_IDX register for each iteration
+of the descriptor loop in airoha_qdma_fill_rx_queue routine.
+Move REG_RX_CPU_IDX configuration out of the descriptor loop and rely on
+the last queue head value updated in the descriptor loop.
+
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260331-airoha-cpu-idx-out-off-loop-v1-1-75c66b428f50@kernel.org
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -561,11 +561,12 @@ static int airoha_qdma_fill_rx_queue(str
+ 		WRITE_ONCE(desc->msg1, 0);
+ 		WRITE_ONCE(desc->msg2, 0);
+ 		WRITE_ONCE(desc->msg3, 0);
++	}
+ 
++	if (nframes)
+ 		airoha_qdma_rmw(qdma, REG_RX_CPU_IDX(qid),
+ 				RX_RING_CPU_IDX_MASK,
+ 				FIELD_PREP(RX_RING_CPU_IDX_MASK, q->head));
+-	}
+ 
+ 	return nframes;
+ }

--- a/target/linux/airoha/patches-6.6/145-01-v7.1-net-airoha-Move-ndesc-initialization-at-end-of-airoh.patch
+++ b/target/linux/airoha/patches-6.6/145-01-v7.1-net-airoha-Move-ndesc-initialization-at-end-of-airoh.patch
@@ -1,0 +1,55 @@
+From f329924bb49458c65297f1361f545816a5b90998 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Fri, 17 Apr 2026 08:36:31 +0200
+Subject: [PATCH 1/2] net: airoha: Move ndesc initialization at end of
+ airoha_qdma_init_tx()
+
+If queue entry list allocation fails in airoha_qdma_init_tx_queue routine,
+airoha_qdma_cleanup_tx_queue() will trigger a NULL pointer dereference
+accessing the queue entry array. The issue is due to the early ndesc
+initialization in airoha_qdma_init_tx_queue(). Fix the issue moving ndesc
+initialization at end of airoha_qdma_init_tx routine.
+
+Fixes: 3f47e67dff1f7 ("net: airoha: Add the capability to consume out-of-order DMA tx descriptors")
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260417-airoha_qdma_cleanup_tx_queue-fix-net-v4-1-e04bcc2c9642@kernel.org
+Reviewed-by: Simon Horman <horms@kernel.org>
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -954,27 +954,27 @@ static int airoha_qdma_init_tx_queue(str
+ 	dma_addr_t dma_addr;
+ 
+ 	spin_lock_init(&q->lock);
+-	q->ndesc = size;
+ 	q->qdma = qdma;
+ 	q->free_thr = 1 + MAX_SKB_FRAGS;
+ 	INIT_LIST_HEAD(&q->tx_list);
+ 
+-	q->entry = devm_kzalloc(eth->dev, q->ndesc * sizeof(*q->entry),
++	q->entry = devm_kzalloc(eth->dev, size * sizeof(*q->entry),
+ 				GFP_KERNEL);
+ 	if (!q->entry)
+ 		return -ENOMEM;
+ 
+-	q->desc = dmam_alloc_coherent(eth->dev, q->ndesc * sizeof(*q->desc),
++	q->desc = dmam_alloc_coherent(eth->dev, size * sizeof(*q->desc),
+ 				      &dma_addr, GFP_KERNEL);
+ 	if (!q->desc)
+ 		return -ENOMEM;
+ 
+-	for (i = 0; i < q->ndesc; i++) {
++	for (i = 0; i < size; i++) {
+ 		u32 val = FIELD_PREP(QDMA_DESC_DONE_MASK, 1);
+ 
+ 		list_add_tail(&q->entry[i].list, &q->tx_list);
+ 		WRITE_ONCE(q->desc[i].ctrl, cpu_to_le32(val));
+ 	}
++	q->ndesc = size;
+ 
+ 	/* xmit ring drop default setting */
+ 	airoha_qdma_set(qdma, REG_TX_RING_BLOCKING(qid),

--- a/target/linux/airoha/patches-6.6/145-02-v7.1-net-airoha-Add-missing-bits-in-airoha_qdma_cleanup_t.patch
+++ b/target/linux/airoha/patches-6.6/145-02-v7.1-net-airoha-Add-missing-bits-in-airoha_qdma_cleanup_t.patch
@@ -1,0 +1,73 @@
+From 3309965fe44c00fd65af7cef5016e9e782c021a7 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Fri, 17 Apr 2026 08:36:32 +0200
+Subject: [PATCH 2/2] net: airoha: Add missing bits in
+ airoha_qdma_cleanup_tx_queue()
+
+Similar to airoha_qdma_cleanup_rx_queue(), reset DMA TX descriptors in
+airoha_qdma_cleanup_tx_queue routine. Moreover, reset TX_DMA_IDX to
+TX_CPU_IDX to notify the NIC the QDMA TX ring is empty.
+
+Fixes: 23020f0493270 ("net: airoha: Introduce ethernet support for EN7581 SoC")
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260417-airoha_qdma_cleanup_tx_queue-fix-net-v4-2-e04bcc2c9642@kernel.org
+Reviewed-by: Simon Horman <horms@kernel.org>
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 32 ++++++++++++++++++++++--
+ 1 file changed, 30 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -1039,12 +1039,15 @@ static int airoha_qdma_init_tx(struct ai
+ 
+ static void airoha_qdma_cleanup_tx_queue(struct airoha_queue *q)
+ {
+-	struct airoha_eth *eth = q->qdma->eth;
+-	int i;
++	struct airoha_qdma *qdma = q->qdma;
++	struct airoha_eth *eth = qdma->eth;
++	int i, qid = q - &qdma->q_tx[0];
++	u16 index = 0;
+ 
+ 	spin_lock_bh(&q->lock);
+ 	for (i = 0; i < q->ndesc; i++) {
+ 		struct airoha_queue_entry *e = &q->entry[i];
++		struct airoha_qdma_desc *desc = &q->desc[i];
+ 
+ 		if (!e->dma_addr)
+ 			continue;
+@@ -1055,8 +1058,33 @@ static void airoha_qdma_cleanup_tx_queue
+ 		e->dma_addr = 0;
+ 		e->skb = NULL;
+ 		list_add_tail(&e->list, &q->tx_list);
++
++		/* Reset DMA descriptor */
++		WRITE_ONCE(desc->ctrl, 0);
++		WRITE_ONCE(desc->addr, 0);
++		WRITE_ONCE(desc->data, 0);
++		WRITE_ONCE(desc->msg0, 0);
++		WRITE_ONCE(desc->msg1, 0);
++		WRITE_ONCE(desc->msg2, 0);
++
+ 		q->queued--;
+ 	}
++
++	if (!list_empty(&q->tx_list)) {
++		struct airoha_queue_entry *e;
++
++		e = list_first_entry(&q->tx_list, struct airoha_queue_entry,
++				     list);
++		index = e - q->entry;
++	}
++	/* Set TX_DMA_IDX to TX_CPU_IDX to notify the hw the QDMA TX ring is
++	 * empty.
++	 */
++	airoha_qdma_rmw(qdma, REG_TX_CPU_IDX(qid), TX_RING_CPU_IDX_MASK,
++			FIELD_PREP(TX_RING_CPU_IDX_MASK, index));
++	airoha_qdma_rmw(qdma, REG_TX_DMA_IDX(qid), TX_RING_DMA_IDX_MASK,
++			FIELD_PREP(TX_RING_DMA_IDX_MASK, index));
++
+ 	spin_unlock_bh(&q->lock);
+ }
+ 

--- a/target/linux/airoha/patches-6.6/146-v7.1-net-airoha-Wait-for-NPU-PPE-configuration-to-complet.patch
+++ b/target/linux/airoha/patches-6.6/146-v7.1-net-airoha-Wait-for-NPU-PPE-configuration-to-complet.patch
@@ -1,0 +1,63 @@
+From f3206328bb52c2787197d80d7cbd687946047d5f Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Tue, 14 Apr 2026 16:08:52 +0200
+Subject: [PATCH] net: airoha: Wait for NPU PPE configuration to complete in
+ airoha_ppe_offload_setup()
+
+In order to properly enable flowtable hw offloading, poll
+REG_PPE_FLOW_CFG register in airoha_ppe_offload_setup routine and
+wait for NPU PPE configuration triggered by ppe_init callback to complete
+before running airoha_ppe_hw_init().
+
+Fixes: 00a7678310fe3 ("net: airoha: Introduce flowtable offload support")
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260414-airoha-wait-for-npu-config-offload-setup-v2-1-5a9bf6d43aee@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_ppe.c | 28 ++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
+--- a/drivers/net/ethernet/airoha/airoha_ppe.c
++++ b/drivers/net/ethernet/airoha/airoha_ppe.c
+@@ -1354,6 +1354,29 @@ static struct airoha_npu *airoha_ppe_npu
+ 	return npu;
+ }
+ 
++static int airoha_ppe_wait_for_npu_init(struct airoha_eth *eth)
++{
++	int err;
++	u32 val;
++
++	/* PPE_FLOW_CFG default register value is 0. Since we reset FE
++	 * during the device probe we can just check the configured value
++	 * is not 0 here.
++	 */
++	err = read_poll_timeout(airoha_fe_rr, val, val, USEC_PER_MSEC,
++				100 * USEC_PER_MSEC, false, eth,
++				REG_PPE_PPE_FLOW_CFG(0));
++	if (err)
++		return err;
++
++	if (airoha_ppe_is_enabled(eth, 1))
++		err = read_poll_timeout(airoha_fe_rr, val, val, USEC_PER_MSEC,
++					100 * USEC_PER_MSEC, false, eth,
++					REG_PPE_PPE_FLOW_CFG(1));
++
++	return err;
++}
++
+ static int airoha_ppe_offload_setup(struct airoha_eth *eth)
+ {
+ 	struct airoha_npu *npu = airoha_ppe_npu_get(eth);
+@@ -1367,6 +1390,11 @@ static int airoha_ppe_offload_setup(stru
+ 	if (err)
+ 		goto error_npu_put;
+ 
++	/* Wait for NPU PPE configuration to complete */
++	err = airoha_ppe_wait_for_npu_init(eth);
++	if (err)
++		goto error_npu_put;
++
+ 	ppe_num_stats_entries = airoha_ppe_get_total_num_stats_entries(ppe);
+ 	if (ppe_num_stats_entries > 0) {
+ 		err = npu->ops.ppe_init_stats(npu, ppe->foe_stats_dma,

--- a/target/linux/airoha/patches-6.6/147-v7.1-net-airoha-Fix-PPE-cpu-port-configuration-for-GDM2-l.patch
+++ b/target/linux/airoha/patches-6.6/147-v7.1-net-airoha-Fix-PPE-cpu-port-configuration-for-GDM2-l.patch
@@ -1,0 +1,91 @@
+From d647f2545219754603b2064de948425cdfd93fba Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Fri, 17 Apr 2026 17:24:41 +0200
+Subject: [PATCH] net: airoha: Fix PPE cpu port configuration for GDM2 loopback
+ path
+
+When QoS loopback is enabled for GDM3 or GDM4, incoming packets are
+forwarded to GDM2. However, the PPE cpu port for GDM2 is not configured
+in this path, causing traffic originating from GDM3/GDM4, which may
+be set up as WAN ports backed by QDMA1, to be incorrectly directed
+to QDMA0 instead.
+Configure the PPE cpu port for GDM2 when QoS loopback is active on
+GDM3 or GDM4 to ensure traffic is routed to the correct QDMA instance.
+
+Fixes: 9cd451d414f6 ("net: airoha: Add loopback support for GDM2")
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260417-airoha-ppe-cpu-port-for-gdm2-loopback-v1-1-c7a9de0f6f57@kernel.org
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 8 ++++++--
+ drivers/net/ethernet/airoha/airoha_eth.h | 3 ++-
+ drivers/net/ethernet/airoha/airoha_ppe.c | 6 +++---
+ 3 files changed, 11 insertions(+), 6 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -1755,7 +1755,7 @@ static int airoha_set_gdm2_loopback(stru
+ {
+ 	struct airoha_eth *eth = port->qdma->eth;
+ 	u32 val, pse_port, chan;
+-	int src_port;
++	int i, src_port;
+ 
+ 	/* Forward the traffic to the proper GDM port */
+ 	pse_port = port->id == AIROHA_GDM3_IDX ? FE_PSE_PORT_GDM3
+@@ -1797,6 +1797,9 @@ static int airoha_set_gdm2_loopback(stru
+ 		      SP_CPORT_MASK(val),
+ 		      __field_prep(SP_CPORT_MASK(val), FE_PSE_PORT_CDM2));
+ 
++	for (i = 0; i < eth->soc->num_ppe; i++)
++		airoha_ppe_set_cpu_port(port, i, AIROHA_GDM2_IDX);
++
+ 	if (port->id == AIROHA_GDM4_IDX && airoha_is_7581(eth)) {
+ 		u32 mask = FC_ID_OF_SRC_PORT_MASK(port->nbq);
+ 
+@@ -1835,7 +1838,8 @@ static int airoha_dev_init(struct net_de
+ 	}
+ 
+ 	for (i = 0; i < eth->soc->num_ppe; i++)
+-		airoha_ppe_set_cpu_port(port, i);
++		airoha_ppe_set_cpu_port(port, i,
++					airoha_get_fe_port(port));
+ 
+ 	return 0;
+ }
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -653,7 +653,8 @@ int airoha_get_fe_port(struct airoha_gdm
+ bool airoha_is_valid_gdm_port(struct airoha_eth *eth,
+ 			      struct airoha_gdm_port *port);
+ 
+-void airoha_ppe_set_cpu_port(struct airoha_gdm_port *port, u8 ppe_id);
++void airoha_ppe_set_cpu_port(struct airoha_gdm_port *port, u8 ppe_id,
++			     u8 fport);
+ bool airoha_ppe_is_enabled(struct airoha_eth *eth, int index);
+ void airoha_ppe_check_skb(struct airoha_ppe_dev *dev, struct sk_buff *skb,
+ 			  u16 hash, bool rx_wlan);
+--- a/drivers/net/ethernet/airoha/airoha_ppe.c
++++ b/drivers/net/ethernet/airoha/airoha_ppe.c
+@@ -85,10 +85,9 @@ static u32 airoha_ppe_get_timestamp(stru
+ 	return FIELD_GET(AIROHA_FOE_IB1_BIND_TIMESTAMP, timestamp);
+ }
+ 
+-void airoha_ppe_set_cpu_port(struct airoha_gdm_port *port, u8 ppe_id)
++void airoha_ppe_set_cpu_port(struct airoha_gdm_port *port, u8 ppe_id, u8 fport)
+ {
+ 	struct airoha_qdma *qdma = port->qdma;
+-	u8 fport = airoha_get_fe_port(port);
+ 	struct airoha_eth *eth = qdma->eth;
+ 	u8 qdma_id = qdma - &eth->qdma[0];
+ 	u32 fe_cpu_port;
+@@ -182,7 +181,8 @@ static void airoha_ppe_hw_init(struct ai
+ 			if (!port)
+ 				continue;
+ 
+-			airoha_ppe_set_cpu_port(port, i);
++			airoha_ppe_set_cpu_port(port, i,
++						airoha_get_fe_port(port));
+ 		}
+ 	}
+ }

--- a/target/linux/airoha/patches-6.6/148-v7.1-net-airoha-Fix-possible-TX-queue-stall-in-airoha_qdm.patch
+++ b/target/linux/airoha/patches-6.6/148-v7.1-net-airoha-Fix-possible-TX-queue-stall-in-airoha_qdm.patch
@@ -1,0 +1,104 @@
+From b94769eb2f30e61e86cd8551c084c34134290d89 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Thu, 16 Apr 2026 12:30:12 +0200
+Subject: [PATCH] net: airoha: Fix possible TX queue stall in
+ airoha_qdma_tx_napi_poll()
+
+Since multiple net_device TX queues can share the same hw QDMA TX queue,
+there is no guarantee we have inflight packets queued in hw belonging to a
+net_device TX queue stopped in the xmit path because hw QDMA TX queue
+can be full. In this corner case the net_device TX queue will never be
+re-activated. In order to avoid any potential net_device TX queue stall,
+we need to wake all the net_device TX queues feeding the same hw QDMA TX
+queue in airoha_qdma_tx_napi_poll routine.
+
+Fixes: 23020f0493270 ("net: airoha: Introduce ethernet support for EN7581 SoC")
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Link: https://patch.msgid.link/20260416-airoha-txq-potential-stall-v2-1-42c732074540@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 37 ++++++++++++++++++++----
+ drivers/net/ethernet/airoha/airoha_eth.h |  1 +
+ 2 files changed, 33 insertions(+), 5 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -843,6 +843,21 @@ static int airoha_qdma_init_rx(struct ai
+ 	return 0;
+ }
+ 
++static void airoha_qdma_wake_netdev_txqs(struct airoha_queue *q)
++{
++	struct airoha_qdma *qdma = q->qdma;
++	struct airoha_eth *eth = qdma->eth;
++	int i;
++
++	for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
++		struct airoha_gdm_port *port = eth->ports[i];
++
++		if (port && port->qdma == qdma)
++			netif_tx_wake_all_queues(port->dev);
++	}
++	q->txq_stopped = false;
++}
++
+ static int airoha_qdma_tx_napi_poll(struct napi_struct *napi, int budget)
+ {
+ 	struct airoha_tx_irq_queue *irq_q;
+@@ -919,12 +934,21 @@ static int airoha_qdma_tx_napi_poll(stru
+ 
+ 			txq = netdev_get_tx_queue(skb->dev, queue);
+ 			netdev_tx_completed_queue(txq, 1, skb->len);
+-			if (netif_tx_queue_stopped(txq) &&
+-			    q->ndesc - q->queued >= q->free_thr)
+-				netif_tx_wake_queue(txq);
+-
+ 			dev_kfree_skb_any(skb);
+ 		}
++
++		if (q->txq_stopped && q->ndesc - q->queued >= q->free_thr) {
++			/* Since multiple net_device TX queues can share the
++			 * same hw QDMA TX queue, there is no guarantee we have
++			 * inflight packets queued in hw belonging to a
++			 * net_device TX queue stopped in the xmit path.
++			 * In order to avoid any potential net_device TX queue
++			 * stall, we need to wake all the net_device TX queues
++			 * feeding the same hw QDMA TX queue.
++			 */
++			airoha_qdma_wake_netdev_txqs(q);
++		}
++
+ unlock:
+ 		spin_unlock_bh(&q->lock);
+ 	}
+@@ -2016,6 +2040,7 @@ static netdev_tx_t airoha_dev_xmit(struc
+ 	if (q->queued + nr_frags >= q->ndesc) {
+ 		/* not enough space in the queue */
+ 		netif_tx_stop_queue(txq);
++		q->txq_stopped = true;
+ 		spin_unlock_bh(&q->lock);
+ 		return NETDEV_TX_BUSY;
+ 	}
+@@ -2071,8 +2096,10 @@ static netdev_tx_t airoha_dev_xmit(struc
+ 				TX_RING_CPU_IDX_MASK,
+ 				FIELD_PREP(TX_RING_CPU_IDX_MASK, index));
+ 
+-	if (q->ndesc - q->queued < q->free_thr)
++	if (q->ndesc - q->queued < q->free_thr) {
+ 		netif_tx_stop_queue(txq);
++		q->txq_stopped = true;
++	}
+ 
+ 	spin_unlock_bh(&q->lock);
+ 
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -193,6 +193,7 @@ struct airoha_queue {
+ 	int ndesc;
+ 	int free_thr;
+ 	int buf_size;
++	bool txq_stopped;
+ 
+ 	struct napi_struct napi;
+ 	struct page_pool *page_pool;

--- a/target/linux/airoha/patches-6.6/149-v7.1-net-airoha-Move-ndesc-initialization-at-end-of-airoh.patch
+++ b/target/linux/airoha/patches-6.6/149-v7.1-net-airoha-Move-ndesc-initialization-at-end-of-airoh.patch
@@ -1,0 +1,61 @@
+From 379050947a1828826ad7ea50c95245a56929b35a Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Mon, 20 Apr 2026 10:07:47 +0200
+Subject: [PATCH] net: airoha: Move ndesc initialization at end of
+ airoha_qdma_init_rx_queue()
+
+If queue entry or DMA descriptor list allocation fails in
+airoha_qdma_init_rx_queue routine, airoha_qdma_cleanup() will trigger a
+NULL pointer dereference running netif_napi_del() for RX queue NAPIs
+since netif_napi_add() has never been executed to this particular RX NAPI.
+The issue is due to the early ndesc initialization in
+airoha_qdma_init_rx_queue() since airoha_qdma_cleanup() relies on ndesc
+value to check if the queue is properly initialized. Fix the issue moving
+ndesc initialization at end of airoha_qdma_init_tx routine.
+Move page_pool allocation after descriptor list allocation in order to
+avoid memory leaks if desc allocation fails.
+
+Fixes: 23020f049327 ("net: airoha: Introduce ethernet support for EN7581 SoC")
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260420-airoha_qdma_init_rx_queue-fix-v2-1-d99347e5c18d@kernel.org
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -745,14 +745,18 @@ static int airoha_qdma_init_rx_queue(str
+ 	dma_addr_t dma_addr;
+ 
+ 	q->buf_size = PAGE_SIZE / 2;
+-	q->ndesc = ndesc;
+ 	q->qdma = qdma;
+ 
+-	q->entry = devm_kzalloc(eth->dev, q->ndesc * sizeof(*q->entry),
++	q->entry = devm_kzalloc(eth->dev, ndesc * sizeof(*q->entry),
+ 				GFP_KERNEL);
+ 	if (!q->entry)
+ 		return -ENOMEM;
+ 
++	q->desc = dmam_alloc_coherent(eth->dev, ndesc * sizeof(*q->desc),
++				      &dma_addr, GFP_KERNEL);
++	if (!q->desc)
++		return -ENOMEM;
++
+ 	q->page_pool = page_pool_create(&pp_params);
+ 	if (IS_ERR(q->page_pool)) {
+ 		int err = PTR_ERR(q->page_pool);
+@@ -761,11 +765,7 @@ static int airoha_qdma_init_rx_queue(str
+ 		return err;
+ 	}
+ 
+-	q->desc = dmam_alloc_coherent(eth->dev, q->ndesc * sizeof(*q->desc),
+-				      &dma_addr, GFP_KERNEL);
+-	if (!q->desc)
+-		return -ENOMEM;
+-
++	q->ndesc = ndesc;
+ 	netif_napi_add(eth->napi_dev, &q->napi, airoha_qdma_rx_napi_poll);
+ 
+ 	airoha_qdma_wr(qdma, REG_RX_RING_BASE(qid), dma_addr);

--- a/target/linux/airoha/patches-6.6/150-v7.1-net-airoha-Add-size-check-for-TX-NAPIs-in-airoha_qdm.patch
+++ b/target/linux/airoha/patches-6.6/150-v7.1-net-airoha-Add-size-check-for-TX-NAPIs-in-airoha_qdm.patch
@@ -1,0 +1,57 @@
+From 4b91cb65789b794bfc8d50554b8994f8e0f16309 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Mon, 20 Apr 2026 10:07:48 +0200
+Subject: [PATCH] net: airoha: Add size check for TX NAPIs in
+ airoha_qdma_cleanup()
+
+If airoha_qdma_init routine fails before airoha_qdma_tx_irq_init() runs
+successfully for all TX NAPIs, airoha_qdma_cleanup() will
+unconditionally runs netif_napi_del() on TX NAPIs, triggering a NULL
+pointer dereference. Fix the issue relying on q_tx_irq size value to
+check if the TX NAPIs is properly initialized in airoha_qdma_cleanup().
+Moreover, run netif_napi_add_tx() just if irq_q queue is properly
+allocated.
+
+Fixes: 23020f049327 ("net: airoha: Introduce ethernet support for EN7581 SoC")
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260420-airoha_qdma_init_rx_queue-fix-v2-2-d99347e5c18d@kernel.org
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -1020,8 +1020,6 @@ static int airoha_qdma_tx_irq_init(struc
+ 	struct airoha_eth *eth = qdma->eth;
+ 	dma_addr_t dma_addr;
+ 
+-	netif_napi_add_tx(eth->napi_dev, &irq_q->napi,
+-			  airoha_qdma_tx_napi_poll);
+ 	irq_q->q = dmam_alloc_coherent(eth->dev, size * sizeof(u32),
+ 				       &dma_addr, GFP_KERNEL);
+ 	if (!irq_q->q)
+@@ -1031,6 +1029,9 @@ static int airoha_qdma_tx_irq_init(struc
+ 	irq_q->size = size;
+ 	irq_q->qdma = qdma;
+ 
++	netif_napi_add_tx(eth->napi_dev, &irq_q->napi,
++			  airoha_qdma_tx_napi_poll);
++
+ 	airoha_qdma_wr(qdma, REG_TX_IRQ_BASE(id), dma_addr);
+ 	airoha_qdma_rmw(qdma, REG_TX_IRQ_CFG(id), TX_IRQ_DEPTH_MASK,
+ 			FIELD_PREP(TX_IRQ_DEPTH_MASK, size));
+@@ -1450,8 +1451,12 @@ static void airoha_qdma_cleanup(struct a
+ 		}
+ 	}
+ 
+-	for (i = 0; i < ARRAY_SIZE(qdma->q_tx_irq); i++)
++	for (i = 0; i < ARRAY_SIZE(qdma->q_tx_irq); i++) {
++		if (!qdma->q_tx_irq[i].size)
++			continue;
++
+ 		netif_napi_del(&qdma->q_tx_irq[i].napi);
++	}
+ 
+ 	for (i = 0; i < ARRAY_SIZE(qdma->q_tx); i++) {
+ 		if (!qdma->q_tx[i].ndesc)

--- a/target/linux/airoha/patches-6.6/151-v7.1-net-airoha-fix-BQL-imbalance-in-TX-path.patch
+++ b/target/linux/airoha/patches-6.6/151-v7.1-net-airoha-fix-BQL-imbalance-in-TX-path.patch
@@ -1,0 +1,59 @@
+From 2d9f5a118205da2683ffcec78b9347f1f01a820e Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Tue, 21 Apr 2026 08:35:11 +0200
+Subject: [PATCH] net: airoha: fix BQL imbalance in TX path
+
+Fix a possible BQL imbalance in airoha_dev_xmit(), where inflight
+packets are accounted only for the AIROHA_NUM_TX_RING netdev TX
+queues. The queue index is computed as:
+
+    qid = skb_get_queue_mapping(skb) % ARRAY_SIZE(qdma->q_tx)
+    txq = netdev_get_tx_queue(dev, qid);
+
+However, airoha_qdma_tx_napi_poll() accounts completions across all
+netdev TX queues (num_tx_queues), leading to inconsistent BQL
+accounting.
+
+Also reset all netdev TX queues in the ndo_stop callback.
+
+Fixes: 1d304174106c ("net: airoha: Implement BQL support")
+Fixes: c9f947769b77 ("net: airoha: Reset BQL stopping the netdevice")
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260421-airoha-fix-bql-v1-1-f135afe4275b@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -929,10 +929,9 @@ static int airoha_qdma_tx_napi_poll(stru
+ 		q->queued--;
+ 
+ 		if (skb) {
+-			u16 queue = skb_get_queue_mapping(skb);
+ 			struct netdev_queue *txq;
+ 
+-			txq = netdev_get_tx_queue(skb->dev, queue);
++			txq = skb_get_tx_queue(skb->dev, skb);
+ 			netdev_tx_completed_queue(txq, 1, skb->len);
+ 			dev_kfree_skb_any(skb);
+ 		}
+@@ -1744,7 +1743,7 @@ static int airoha_dev_stop(struct net_de
+ 	if (err)
+ 		return err;
+ 
+-	for (i = 0; i < ARRAY_SIZE(qdma->q_tx); i++)
++	for (i = 0; i < dev->num_tx_queues; i++)
+ 		netdev_tx_reset_subqueue(dev, i);
+ 
+ 	airoha_set_gdm_port_fwd_cfg(qdma->eth, REG_GDM_FWD_CFG(port->id),
+@@ -2039,7 +2038,7 @@ static netdev_tx_t airoha_dev_xmit(struc
+ 
+ 	spin_lock_bh(&q->lock);
+ 
+-	txq = netdev_get_tx_queue(dev, qid);
++	txq = skb_get_tx_queue(dev, skb);
+ 	nr_frags = 1 + skb_shinfo(skb)->nr_frags;
+ 
+ 	if (q->queued + nr_frags >= q->ndesc) {

--- a/target/linux/airoha/patches-6.6/152-v7.1-net-airoha-stop-net_device-TX-queue-before-updating-.patch
+++ b/target/linux/airoha/patches-6.6/152-v7.1-net-airoha-stop-net_device-TX-queue-before-updating-.patch
@@ -1,0 +1,46 @@
+From 3854de7b38be742cf7558476956d12414cb274f2 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Tue, 21 Apr 2026 08:43:07 +0200
+Subject: [PATCH] net: airoha: stop net_device TX queue before updating CPU
+ index
+
+Currently, airoha_eth driver updates the CPU index register prior of
+verifying whether the number of free descriptors has fallen below the
+threshold.
+Move net_device TX queue length check before updating the TX CPU index
+in order to update TX CPU index even if there are more packets to be
+transmitted but the net_device TX queue is going to be stopped
+accounting the inflight packets.
+
+Fixes: 1d304174106c ("net: airoha: Implement BQL support")
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260421-airoha-xmit-stop-condition-v1-1-e670d6a48467@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 9 ++++-----
+ 1 file changed, 4 insertions(+), 5 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -2094,17 +2094,16 @@ static netdev_tx_t airoha_dev_xmit(struc
+ 
+ 	skb_tx_timestamp(skb);
+ 	netdev_tx_sent_queue(txq, skb->len);
++	if (q->ndesc - q->queued < q->free_thr) {
++		netif_tx_stop_queue(txq);
++		q->txq_stopped = true;
++	}
+ 
+ 	if (netif_xmit_stopped(txq) || !netdev_xmit_more())
+ 		airoha_qdma_rmw(qdma, REG_TX_CPU_IDX(qid),
+ 				TX_RING_CPU_IDX_MASK,
+ 				FIELD_PREP(TX_RING_CPU_IDX_MASK, index));
+ 
+-	if (q->ndesc - q->queued < q->free_thr) {
+-		netif_tx_stop_queue(txq);
+-		q->txq_stopped = true;
+-	}
+-
+ 	spin_unlock_bh(&q->lock);
+ 
+ 	return NETDEV_TX_OK;

--- a/target/linux/airoha/patches-6.6/153-v7.1-net-airoha-Do-not-wake-all-netdev-TX-queues-in-airoh.patch
+++ b/target/linux/airoha/patches-6.6/153-v7.1-net-airoha-Do-not-wake-all-netdev-TX-queues-in-airoh.patch
@@ -1,0 +1,75 @@
+From e070aac63b42bf81f4dc565f9f841ff47e6c992f Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Tue, 21 Apr 2026 10:53:33 +0200
+Subject: [PATCH] net: airoha: Do not wake all netdev TX queues in
+ airoha_qdma_wake_netdev_txqs()
+
+Do not wake every netdev TX queue across all ports sharing the QDMA
+running netif_tx_wake_all_queues routine in airoha_qdma_wake_netdev_txqs()
+but only the ones that are mapped the specific QDMA stopped hw TX queue.
+This patch can potentially avoid waking already stopped netdev TX queues
+that are mapped to a different QDMA hw TX queue.
+Introduce airoha_qdma_get_txq utility routine.
+
+Fixes: b94769eb2f30 ("net: airoha: Fix possible TX queue stall in airoha_qdma_tx_napi_poll()")
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260421-airoha-wake_netdev_txqs-optmization-v1-1-e0be95115d53@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 19 +++++++++++++++----
+ drivers/net/ethernet/airoha/airoha_eth.h |  5 +++++
+ 2 files changed, 20 insertions(+), 4 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -847,13 +847,24 @@ static void airoha_qdma_wake_netdev_txqs
+ {
+ 	struct airoha_qdma *qdma = q->qdma;
+ 	struct airoha_eth *eth = qdma->eth;
+-	int i;
++	int i, qid = q - &qdma->q_tx[0];
+ 
+ 	for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
+ 		struct airoha_gdm_port *port = eth->ports[i];
++		int j;
+ 
+-		if (port && port->qdma == qdma)
+-			netif_tx_wake_all_queues(port->dev);
++		if (!port)
++			continue;
++
++		if (port->qdma != qdma)
++			continue;
++
++		for (j = 0; j < port->dev->num_tx_queues; j++) {
++			if (airoha_qdma_get_txq(qdma, j) != qid)
++				continue;
++
++			netif_wake_subqueue(port->dev, j);
++		}
+ 	}
+ 	q->txq_stopped = false;
+ }
+@@ -2001,7 +2012,7 @@ static netdev_tx_t airoha_dev_xmit(struc
+ 	u16 index;
+ 	u8 fport;
+ 
+-	qid = skb_get_queue_mapping(skb) % ARRAY_SIZE(qdma->q_tx);
++	qid = airoha_qdma_get_txq(qdma, skb_get_queue_mapping(skb));
+ 	tag = airoha_get_dsa_tag(skb, dev);
+ 
+ 	msg0 = FIELD_PREP(QDMA_ETH_TXMSG_CHAN_MASK,
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -631,6 +631,11 @@ u32 airoha_rmw(void __iomem *base, u32 o
+ #define airoha_qdma_clear(qdma, offset, val)			\
+ 	airoha_rmw((qdma)->regs, (offset), (val), 0)
+ 
++static inline u16 airoha_qdma_get_txq(struct airoha_qdma *qdma, u16 qid)
++{
++	return qid % ARRAY_SIZE(qdma->q_tx);
++}
++
+ static inline bool airoha_is_lan_gdm_port(struct airoha_gdm_port *port)
+ {
+ 	/* GDM1 port on EN7581 SoC is connected to the lan dsa switch.

--- a/target/linux/airoha/patches-6.6/154-v7.1-net-airoha-Do-not-read-uninitialized-fragment-addres.patch
+++ b/target/linux/airoha/patches-6.6/154-v7.1-net-airoha-Do-not-read-uninitialized-fragment-addres.patch
@@ -1,0 +1,64 @@
+From bde34e84edc8b5571fbde7e941e175a4293ee1eb Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Fri, 24 Apr 2026 11:00:28 +0200
+Subject: [PATCH] net: airoha: Do not read uninitialized fragment address in
+ airoha_dev_xmit()
+
+The transmit loop in airoha_dev_xmit() reads fragment address and length
+during its final iteration, when the loop index equals
+skb_shinfo(skb)->nr_frags, at which point the fragment data is
+uninitialized. While these values are never consumed, the read itself is
+unsafe and may trigger a page fault. Fix this by avoiding the fragment
+read on the last iteration.
+Additionally, move the skb pointer from the first to the last used packet
+descriptor, so that airoha_qdma_tx_napi_poll() defers freeing the skb
+until the final descriptor is processed.
+
+Fixes: 23020f0493270 ("net: airoha: Introduce ethernet support for EN7581 SoC")
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260424-airoha-xmit-fix-read-frag-v1-1-fdc0a83c79e8@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -2007,8 +2007,8 @@ static netdev_tx_t airoha_dev_xmit(struc
+ 	struct netdev_queue *txq;
+ 	struct airoha_queue *q;
+ 	LIST_HEAD(tx_list);
++	int i = 0, qid;
+ 	void *data;
+-	int i, qid;
+ 	u16 index;
+ 	u8 fport;
+ 
+@@ -2067,7 +2067,7 @@ static netdev_tx_t airoha_dev_xmit(struc
+ 			     list);
+ 	index = e - q->entry;
+ 
+-	for (i = 0; i < nr_frags; i++) {
++	while (true) {
+ 		struct airoha_qdma_desc *desc = &q->desc[index];
+ 		skb_frag_t *frag = &skb_shinfo(skb)->frags[i];
+ 		dma_addr_t addr;
+@@ -2079,7 +2079,7 @@ static netdev_tx_t airoha_dev_xmit(struc
+ 			goto error_unmap;
+ 
+ 		list_move_tail(&e->list, &tx_list);
+-		e->skb = i ? NULL : skb;
++		e->skb = i == nr_frags - 1 ? skb : NULL;
+ 		e->dma_addr = addr;
+ 		e->dma_len = len;
+ 
+@@ -2098,6 +2098,9 @@ static netdev_tx_t airoha_dev_xmit(struc
+ 		WRITE_ONCE(desc->msg1, cpu_to_le32(msg1));
+ 		WRITE_ONCE(desc->msg2, cpu_to_le32(0xffff));
+ 
++		if (++i == nr_frags)
++			break;
++
+ 		data = skb_frag_address(frag);
+ 		len = skb_frag_size(frag);
+ 	}

--- a/target/linux/airoha/patches-6.6/155-v7.2-net-airoha-Rename-get_src_port_id-callback-in-get_sp.patch
+++ b/target/linux/airoha/patches-6.6/155-v7.2-net-airoha-Rename-get_src_port_id-callback-in-get_sp.patch
@@ -1,0 +1,75 @@
+From c06a2f2903f6fba0a3088ad05fc5cf61a66e5d89 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Tue, 28 Apr 2026 07:23:38 +0200
+Subject: [PATCH] net: airoha: Rename get_src_port_id callback in get_sport
+
+For code consistency, rename get_src_port_id callback in get_sport.
+Please note this patch does not introduce any logical change and it is
+just a cosmetic patch.
+
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260428-airoha-get_src_port_id-callback-v1-1-3f765c91c1e8@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 10 +++++-----
+ drivers/net/ethernet/airoha/airoha_eth.h |  2 +-
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -1823,7 +1823,7 @@ static int airoha_set_gdm2_loopback(stru
+ 	airoha_fe_clear(eth, REG_FE_VIP_PORT_EN, BIT(AIROHA_GDM2_IDX));
+ 	airoha_fe_clear(eth, REG_FE_IFC_PORT_EN, BIT(AIROHA_GDM2_IDX));
+ 
+-	src_port = eth->soc->ops.get_src_port_id(port, port->nbq);
++	src_port = eth->soc->ops.get_sport(port, port->nbq);
+ 	if (src_port < 0)
+ 		return src_port;
+ 
+@@ -3199,7 +3199,7 @@ static const char * const en7581_xsi_rst
+ 	"xfp-mac",
+ };
+ 
+-static int airoha_en7581_get_src_port_id(struct airoha_gdm_port *port, int nbq)
++static int airoha_en7581_get_sport(struct airoha_gdm_port *port, int nbq)
+ {
+ 	switch (port->id) {
+ 	case AIROHA_GDM3_IDX:
+@@ -3252,7 +3252,7 @@ static const char * const an7583_xsi_rst
+ 	"xfp-mac",
+ };
+ 
+-static int airoha_an7583_get_src_port_id(struct airoha_gdm_port *port, int nbq)
++static int airoha_an7583_get_sport(struct airoha_gdm_port *port, int nbq)
+ {
+ 	switch (port->id) {
+ 	case AIROHA_GDM3_IDX:
+@@ -3300,7 +3300,7 @@ static const struct airoha_eth_soc_data
+ 	.num_xsi_rsts = ARRAY_SIZE(en7581_xsi_rsts_names),
+ 	.num_ppe = 2,
+ 	.ops = {
+-		.get_src_port_id = airoha_en7581_get_src_port_id,
++		.get_sport = airoha_en7581_get_sport,
+ 		.get_vip_port = airoha_en7581_get_vip_port,
+ 	},
+ };
+@@ -3311,7 +3311,7 @@ static const struct airoha_eth_soc_data
+ 	.num_xsi_rsts = ARRAY_SIZE(an7583_xsi_rsts_names),
+ 	.num_ppe = 1,
+ 	.ops = {
+-		.get_src_port_id = airoha_an7583_get_src_port_id,
++		.get_sport = airoha_an7583_get_sport,
+ 		.get_vip_port = airoha_an7583_get_vip_port,
+ 	},
+ };
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -578,7 +578,7 @@ struct airoha_eth_soc_data {
+ 	int num_xsi_rsts;
+ 	int num_ppe;
+ 	struct {
+-		int (*get_src_port_id)(struct airoha_gdm_port *port, int nbq);
++		int (*get_sport)(struct airoha_gdm_port *port, int nbq);
+ 		u32 (*get_vip_port)(struct airoha_gdm_port *port, int nbq);
+ 	} ops;
+ };

--- a/target/linux/airoha/patches-6.6/156-v7.2-net-airoha-Do-not-return-err-in-ndo_stop-callback.patch
+++ b/target/linux/airoha/patches-6.6/156-v7.2-net-airoha-Do-not-return-err-in-ndo_stop-callback.patch
@@ -1,0 +1,36 @@
+From 4ca01292ea2f2363660610a65ba0285d7c3309ed Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Tue, 28 Apr 2026 08:53:16 +0200
+Subject: [PATCH] net: airoha: Do not return err in ndo_stop() callback
+
+Always complete the airoha_dev_stop() routine regardless of the
+airoha_set_vip_for_gdm_port() return value, since errors from
+ndo_stop() are ignored by the networking stack and the interface is
+always considered down after the call.
+
+Fixes: 23020f049327 ("net: airoha: Introduce ethernet support for EN7581 SoC")
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260428-airoha-ndo-stop-not-err-v1-1-674506d29a91@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 7 ++-----
+ 1 file changed, 2 insertions(+), 5 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -1747,13 +1747,10 @@ static int airoha_dev_stop(struct net_de
+ {
+ 	struct airoha_gdm_port *port = netdev_priv(dev);
+ 	struct airoha_qdma *qdma = port->qdma;
+-	int i, err;
++	int i;
+ 
+ 	netif_tx_disable(dev);
+-	err = airoha_set_vip_for_gdm_port(port, false);
+-	if (err)
+-		return err;
+-
++	airoha_set_vip_for_gdm_port(port, false);
+ 	for (i = 0; i < dev->num_tx_queues; i++)
+ 		netdev_tx_reset_subqueue(dev, i);
+ 

--- a/target/linux/airoha/patches-6.6/157-v7.2-net-airoha-Move-entries-to-queue-head-in-case-of-DMA.patch
+++ b/target/linux/airoha/patches-6.6/157-v7.2-net-airoha-Move-entries-to-queue-head-in-case-of-DMA.patch
@@ -1,0 +1,38 @@
+From 75df490c9e8457990c8b227650f6491218ce018b Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Wed, 29 Apr 2026 14:02:31 +0200
+Subject: [PATCH] net: airoha: Move entries to queue head in case of DMA
+ mapping failure in airoha_dev_xmit()
+
+In order to respect the original descriptor order and avoid any
+potential IOMMU fault or memory corruption, move pending queue entries
+to the head of hw queue tx_list if the DMA mapping of current inflight
+packet fails in airoha_dev_xmit routine.
+
+Fixes: 3f47e67dff1f7 ("net: airoha: Add the capability to consume out-of-order DMA tx descriptors")
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260429-airoha-xmit-unmap-error-path-v2-1-32e43b7c6d25@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -2120,14 +2120,12 @@ static netdev_tx_t airoha_dev_xmit(struc
+ 	return NETDEV_TX_OK;
+ 
+ error_unmap:
+-	while (!list_empty(&tx_list)) {
+-		e = list_first_entry(&tx_list, struct airoha_queue_entry,
+-				     list);
++	list_for_each_entry(e, &tx_list, list) {
+ 		dma_unmap_single(dev->dev.parent, e->dma_addr, e->dma_len,
+ 				 DMA_TO_DEVICE);
+ 		e->dma_addr = 0;
+-		list_move_tail(&e->list, &q->tx_list);
+ 	}
++	list_splice(&tx_list, &q->tx_list);
+ 
+ 	spin_unlock_bh(&q->lock);
+ error:

--- a/target/linux/airoha/patches-6.6/158-v7.2-net-airoha-configure-QoS-channel-for-HW-accelerated-.patch
+++ b/target/linux/airoha/patches-6.6/158-v7.2-net-airoha-configure-QoS-channel-for-HW-accelerated-.patch
@@ -1,0 +1,44 @@
+From 286efd34d1a1ef5d83f9441b5e59421a26738169 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Thu, 30 Apr 2026 10:47:38 +0200
+Subject: [PATCH] net: airoha: configure QoS channel for HW accelerated
+ flowtable traffic
+
+As done for the SW path, configure the QoS channel for HW accelerated
+traffic according to the user port index when forwarding to a DSA port,
+or rely on the GDM port identifier otherwise. This allows HTB shaping
+to be applied to HW accelerated traffic.
+
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260430-airoha-ppe-qos-channel-v1-1-5ef9221e85c1@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_ppe.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_ppe.c
++++ b/drivers/net/ethernet/airoha/airoha_ppe.c
+@@ -332,7 +332,7 @@ static int airoha_ppe_foe_entry_prepare(
+ 						info.wcid);
+ 		} else {
+ 			struct airoha_gdm_port *port = netdev_priv(dev);
+-			u8 pse_port;
++			u8 pse_port, channel;
+ 
+ 			if (!airoha_is_valid_gdm_port(eth, port))
+ 				return -EINVAL;
+@@ -345,6 +345,14 @@ static int airoha_ppe_foe_entry_prepare(
+ 					       * loopback
+ 					       */
+ 
++			/* For traffic forwarded to DSA devices select QoS
++			 * channel according to the DSA user port index, rely
++			 * on port id otherwise.
++			 */
++			channel = dsa_port >= 0 ? dsa_port : port->id;
++			channel = channel % AIROHA_NUM_QOS_CHANNELS;
++			qdata |= FIELD_PREP(AIROHA_FOE_CHANNEL, channel);
++
+ 			val |= FIELD_PREP(AIROHA_FOE_IB2_PSE_PORT, pse_port) |
+ 			       AIROHA_FOE_IB2_PSE_QOS;
+ 			/* For downlink traffic consume SRAM memory for hw

--- a/target/linux/airoha/patches-6.6/159-v7.2-net-airoha-Introduce-airoha_fe_get-airoha_qdma_get-r.patch
+++ b/target/linux/airoha/patches-6.6/159-v7.2-net-airoha-Introduce-airoha_fe_get-airoha_qdma_get-r.patch
@@ -1,0 +1,95 @@
+From 98e490930de3af9afa0bbb2d1d79d6d5b5513012 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Fri, 1 May 2026 09:49:11 +0200
+Subject: [PATCH] net: airoha: Introduce airoha_fe_get()/airoha_qdma_get()
+ register read helpers
+
+Add airoha_fe_get() and airoha_qdma_get() as utility routines for reading
+a masked field from a specified register.
+This is a non-functional refactor, no logical changes are introduced to
+the existing codebase.
+
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260501-airoha_fe_get-airoha_qdma_get-v3-1-126c6f647ccb@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 13 ++++---------
+ drivers/net/ethernet/airoha/airoha_eth.h |  4 ++++
+ drivers/net/ethernet/airoha/airoha_ppe.c |  5 ++---
+ 3 files changed, 10 insertions(+), 12 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -201,15 +201,13 @@ static void airoha_fe_vip_setup(struct a
+ static u32 airoha_fe_get_pse_queue_rsv_pages(struct airoha_eth *eth,
+ 					     u32 port, u32 queue)
+ {
+-	u32 val;
+-
+ 	airoha_fe_rmw(eth, REG_FE_PSE_QUEUE_CFG_WR,
+ 		      PSE_CFG_PORT_ID_MASK | PSE_CFG_QUEUE_ID_MASK,
+ 		      FIELD_PREP(PSE_CFG_PORT_ID_MASK, port) |
+ 		      FIELD_PREP(PSE_CFG_QUEUE_ID_MASK, queue));
+-	val = airoha_fe_rr(eth, REG_FE_PSE_QUEUE_CFG_VAL);
+ 
+-	return FIELD_GET(PSE_CFG_OQ_RSV_MASK, val);
++	return airoha_fe_get(eth, REG_FE_PSE_QUEUE_CFG_VAL,
++			     PSE_CFG_OQ_RSV_MASK);
+ }
+ 
+ static void airoha_fe_set_pse_queue_rsv_pages(struct airoha_eth *eth,
+@@ -227,9 +225,7 @@ static void airoha_fe_set_pse_queue_rsv_
+ 
+ static u32 airoha_fe_get_pse_all_rsv(struct airoha_eth *eth)
+ {
+-	u32 val = airoha_fe_rr(eth, REG_FE_PSE_BUF_SET);
+-
+-	return FIELD_GET(PSE_ALLRSV_MASK, val);
++	return airoha_fe_get(eth, REG_FE_PSE_BUF_SET, PSE_ALLRSV_MASK);
+ }
+ 
+ static int airoha_fe_set_pse_oq_rsv(struct airoha_eth *eth,
+@@ -247,8 +243,7 @@ static int airoha_fe_set_pse_oq_rsv(stru
+ 		      FIELD_PREP(PSE_ALLRSV_MASK, all_rsv));
+ 
+ 	/* modify hthd */
+-	tmp = airoha_fe_rr(eth, PSE_FQ_CFG);
+-	fq_limit = FIELD_GET(PSE_FQ_LIMIT_MASK, tmp);
++	fq_limit = airoha_fe_get(eth, PSE_FQ_CFG, PSE_FQ_LIMIT_MASK);
+ 	tmp = fq_limit - all_rsv - 0x20;
+ 	airoha_fe_rmw(eth, REG_PSE_SHARE_USED_THD,
+ 		      PSE_SHARE_USED_HTHD_MASK,
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -619,6 +619,8 @@ u32 airoha_rmw(void __iomem *base, u32 o
+ 	airoha_rmw((eth)->fe_regs, (offset), 0, (val))
+ #define airoha_fe_clear(eth, offset, val)			\
+ 	airoha_rmw((eth)->fe_regs, (offset), (val), 0)
++#define airoha_fe_get(eth, offset, mask)			\
++	FIELD_GET((mask), airoha_fe_rr((eth), (offset)))
+ 
+ #define airoha_qdma_rr(qdma, offset)				\
+ 	airoha_rr((qdma)->regs, (offset))
+@@ -630,6 +632,8 @@ u32 airoha_rmw(void __iomem *base, u32 o
+ 	airoha_rmw((qdma)->regs, (offset), 0, (val))
+ #define airoha_qdma_clear(qdma, offset, val)			\
+ 	airoha_rmw((qdma)->regs, (offset), (val), 0)
++#define airoha_qdma_get(qdma, offset, mask)			\
++	FIELD_GET((mask), airoha_qdma_rr((qdma), (offset)))
+ 
+ static inline u16 airoha_qdma_get_txq(struct airoha_qdma *qdma, u16 qid)
+ {
+--- a/drivers/net/ethernet/airoha/airoha_ppe.c
++++ b/drivers/net/ethernet/airoha/airoha_ppe.c
+@@ -80,9 +80,8 @@ bool airoha_ppe_is_enabled(struct airoha
+ 
+ static u32 airoha_ppe_get_timestamp(struct airoha_ppe *ppe)
+ {
+-	u16 timestamp = airoha_fe_rr(ppe->eth, REG_FE_FOE_TS);
+-
+-	return FIELD_GET(AIROHA_FOE_IB1_BIND_TIMESTAMP, timestamp);
++	return airoha_fe_get(ppe->eth, REG_FE_FOE_TS,
++			     AIROHA_FOE_IB1_BIND_TIMESTAMP);
+ }
+ 
+ void airoha_ppe_set_cpu_port(struct airoha_gdm_port *port, u8 ppe_id, u8 fport)

--- a/target/linux/airoha/patches-6.6/160-v7.2-net-airoha-Reserve-RX-headroom-to-avoid-skb-realloca.patch
+++ b/target/linux/airoha/patches-6.6/160-v7.2-net-airoha-Reserve-RX-headroom-to-avoid-skb-realloca.patch
@@ -1,0 +1,73 @@
+From bbfb1983944f2eaa8ee192e0f7b59ecc0fda9981 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Wed, 13 May 2026 17:03:59 +0200
+Subject: [PATCH] net: airoha: Reserve RX headroom to avoid skb reallocation
+
+Reserve NET_SKB_PAD + NET_IP_ALIGN bytes of headroom for received packets
+to avoid skb head reallocation when pushing protocol headers into the skb.
+
+Tested-by: Xuegang Lu <xuegang.lu@airoha.com>
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260513-airoha-rx-headroom-v1-1-bd87798e422d@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 14 ++++++++------
+ drivers/net/ethernet/airoha/airoha_eth.h |  2 ++
+ 2 files changed, 10 insertions(+), 6 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -543,9 +543,10 @@ static int airoha_qdma_fill_rx_queue(str
+ 		q->queued++;
+ 		nframes++;
+ 
++		offset += AIROHA_RX_HEADROOM;
+ 		e->buf = page_address(page) + offset;
+ 		e->dma_addr = page_pool_get_dma_addr(page) + offset;
+-		e->dma_len = SKB_WITH_OVERHEAD(q->buf_size);
++		e->dma_len = SKB_WITH_OVERHEAD(AIROHA_RX_LEN(q->buf_size));
+ 
+ 		val = FIELD_PREP(QDMA_DESC_LEN_MASK, e->dma_len);
+ 		WRITE_ONCE(desc->ctrl, cpu_to_le32(val));
+@@ -611,13 +612,12 @@ static int airoha_qdma_rx_process(struct
+ 		q->tail = (q->tail + 1) % q->ndesc;
+ 		q->queued--;
+ 
+-		dma_sync_single_for_cpu(eth->dev, e->dma_addr,
+-					SKB_WITH_OVERHEAD(q->buf_size), dir);
++		dma_sync_single_for_cpu(eth->dev, e->dma_addr, e->dma_len,
++					dir);
+ 
+ 		page = virt_to_head_page(e->buf);
+ 		len = FIELD_GET(QDMA_DESC_LEN_MASK, desc_ctrl);
+-		data_len = q->skb ? q->buf_size
+-				  : SKB_WITH_OVERHEAD(q->buf_size);
++		data_len = q->skb ? AIROHA_RX_LEN(q->buf_size) : e->dma_len;
+ 		if (!len || data_len < len)
+ 			goto free_frag;
+ 
+@@ -627,10 +627,12 @@ static int airoha_qdma_rx_process(struct
+ 
+ 		port = eth->ports[p];
+ 		if (!q->skb) { /* first buffer */
+-			q->skb = napi_build_skb(e->buf, q->buf_size);
++			q->skb = napi_build_skb(e->buf - AIROHA_RX_HEADROOM,
++						q->buf_size);
+ 			if (!q->skb)
+ 				goto free_frag;
+ 
++			skb_reserve(q->skb, AIROHA_RX_HEADROOM);
+ 			__skb_put(q->skb, len);
+ 			skb_mark_for_recycle(q->skb);
+ 			q->skb->dev = port->dev;
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -32,6 +32,8 @@
+ #define AIROHA_FE_MC_MAX_VLAN_TABLE	64
+ #define AIROHA_FE_MC_MAX_VLAN_PORT	16
+ #define AIROHA_NUM_TX_IRQ		2
++#define AIROHA_RX_HEADROOM		(NET_SKB_PAD + NET_IP_ALIGN)
++#define AIROHA_RX_LEN(_n)		((_n) - AIROHA_RX_HEADROOM)
+ #define HW_DSCP_NUM			2048
+ #define IRQ_QUEUE_LEN(_n)		((_n) ? 1024 : 2048)
+ #define TX_DSCP_NUM			1024

--- a/target/linux/airoha/patches-6.6/161-v7.2-net-airoha-Disable-GDM2-forwarding-before-configurin.patch
+++ b/target/linux/airoha/patches-6.6/161-v7.2-net-airoha-Disable-GDM2-forwarding-before-configurin.patch
@@ -1,0 +1,45 @@
+From 985d4a55e64e43bd86eeb896b81ceba453301989 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Wed, 20 May 2026 15:12:02 +0200
+Subject: [PATCH] net: airoha: Disable GDM2 forwarding before configuring GDM2
+ loopback
+
+Hw design requires to disable GDM2 forwarding before configuring GDM2
+loopback in airoha_set_gdm2_loopback routine.
+
+Fixes: 9cd451d414f6e ("net: airoha: Add loopback support for GDM2")
+Tested-by: Madhur Agrawal <madhur.agrawal@airoha.com>
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260520-airoha-disable-gdm2-fwd-v1-1-1eeea5dffc2f@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -1790,11 +1790,8 @@ static int airoha_set_gdm2_loopback(stru
+ 	u32 val, pse_port, chan;
+ 	int i, src_port;
+ 
+-	/* Forward the traffic to the proper GDM port */
+-	pse_port = port->id == AIROHA_GDM3_IDX ? FE_PSE_PORT_GDM3
+-					       : FE_PSE_PORT_GDM4;
+ 	airoha_set_gdm_port_fwd_cfg(eth, REG_GDM_FWD_CFG(AIROHA_GDM2_IDX),
+-				    pse_port);
++				    FE_PSE_PORT_DROP);
+ 	airoha_fe_clear(eth, REG_GDM_FWD_CFG(AIROHA_GDM2_IDX),
+ 			GDM_STRIP_CRC_MASK);
+ 
+@@ -1812,6 +1809,11 @@ static int airoha_set_gdm2_loopback(stru
+ 		      GDM_SHORT_LEN_MASK | GDM_LONG_LEN_MASK,
+ 		      FIELD_PREP(GDM_SHORT_LEN_MASK, 60) |
+ 		      FIELD_PREP(GDM_LONG_LEN_MASK, AIROHA_MAX_MTU));
++	/* Forward the traffic to the proper GDM port */
++	pse_port = port->id == AIROHA_GDM3_IDX ? FE_PSE_PORT_GDM3
++					       : FE_PSE_PORT_GDM4;
++	airoha_set_gdm_port_fwd_cfg(eth, REG_GDM_FWD_CFG(AIROHA_GDM2_IDX),
++				    pse_port);
+ 
+ 	/* Disable VIP and IFC for GDM2 */
+ 	airoha_fe_clear(eth, REG_FE_VIP_PORT_EN, BIT(AIROHA_GDM2_IDX));

--- a/target/linux/airoha/patches-6.6/310-02-net-airoha-deassert-XSI-line-on-hw-init.patch
+++ b/target/linux/airoha/patches-6.6/310-02-net-airoha-deassert-XSI-line-on-hw-init.patch
@@ -13,7 +13,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1409,6 +1409,10 @@ static int airoha_hw_init(struct platfor
+@@ -1425,6 +1425,10 @@ static int airoha_hw_init(struct platfor
  	if (err)
  		return err;
  

--- a/target/linux/airoha/patches-6.6/310-02-net-airoha-deassert-XSI-line-on-hw-init.patch
+++ b/target/linux/airoha/patches-6.6/310-02-net-airoha-deassert-XSI-line-on-hw-init.patch
@@ -13,7 +13,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1423,6 +1423,10 @@ static int airoha_hw_init(struct platfor
+@@ -1490,6 +1490,10 @@ static int airoha_hw_init(struct platfor
  	if (err)
  		return err;
  

--- a/target/linux/airoha/patches-6.6/310-02-net-airoha-deassert-XSI-line-on-hw-init.patch
+++ b/target/linux/airoha/patches-6.6/310-02-net-airoha-deassert-XSI-line-on-hw-init.patch
@@ -13,7 +13,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1425,6 +1425,10 @@ static int airoha_hw_init(struct platfor
+@@ -1422,6 +1422,10 @@ static int airoha_hw_init(struct platfor
  	if (err)
  		return err;
  

--- a/target/linux/airoha/patches-6.6/310-02-net-airoha-deassert-XSI-line-on-hw-init.patch
+++ b/target/linux/airoha/patches-6.6/310-02-net-airoha-deassert-XSI-line-on-hw-init.patch
@@ -13,7 +13,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1490,6 +1490,10 @@ static int airoha_hw_init(struct platfor
+@@ -1487,6 +1487,10 @@ static int airoha_hw_init(struct platfor
  	if (err)
  		return err;
  

--- a/target/linux/airoha/patches-6.6/310-02-net-airoha-deassert-XSI-line-on-hw-init.patch
+++ b/target/linux/airoha/patches-6.6/310-02-net-airoha-deassert-XSI-line-on-hw-init.patch
@@ -13,7 +13,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1422,6 +1422,10 @@ static int airoha_hw_init(struct platfor
+@@ -1423,6 +1423,10 @@ static int airoha_hw_init(struct platfor
  	if (err)
  		return err;
  

--- a/target/linux/airoha/patches-6.6/310-02-net-airoha-deassert-XSI-line-on-hw-init.patch
+++ b/target/linux/airoha/patches-6.6/310-02-net-airoha-deassert-XSI-line-on-hw-init.patch
@@ -13,7 +13,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1383,6 +1383,10 @@ static int airoha_hw_init(struct platfor
+@@ -1409,6 +1409,10 @@ static int airoha_hw_init(struct platfor
  	if (err)
  		return err;
  

--- a/target/linux/airoha/patches-6.6/310-03-net-airoha-add-reference-for-SPORT-GDM4-in-qdma_get_.patch
+++ b/target/linux/airoha/patches-6.6/310-03-net-airoha-add-reference-for-SPORT-GDM4-in-qdma_get_.patch
@@ -16,7 +16,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -578,8 +578,11 @@ static int airoha_qdma_get_gdm_port(stru
+@@ -574,8 +574,11 @@ static int airoha_qdma_get_gdm_port(stru
  
  	sport = FIELD_GET(QDMA_ETH_RXMSG_SPORT_MASK, msg1);
  	switch (sport) {

--- a/target/linux/airoha/patches-6.6/310-03-net-airoha-add-reference-for-SPORT-GDM4-in-qdma_get_.patch
+++ b/target/linux/airoha/patches-6.6/310-03-net-airoha-add-reference-for-SPORT-GDM4-in-qdma_get_.patch
@@ -16,7 +16,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -577,8 +577,11 @@ static int airoha_qdma_get_gdm_port(stru
+@@ -578,8 +578,11 @@ static int airoha_qdma_get_gdm_port(stru
  
  	sport = FIELD_GET(QDMA_ETH_RXMSG_SPORT_MASK, msg1);
  	switch (sport) {

--- a/target/linux/airoha/patches-6.6/310-03-net-airoha-add-reference-for-SPORT-GDM4-in-qdma_get_.patch
+++ b/target/linux/airoha/patches-6.6/310-03-net-airoha-add-reference-for-SPORT-GDM4-in-qdma_get_.patch
@@ -16,7 +16,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -588,8 +588,11 @@ static int airoha_qdma_get_gdm_port(stru
+@@ -577,8 +577,11 @@ static int airoha_qdma_get_gdm_port(stru
  
  	sport = FIELD_GET(QDMA_ETH_RXMSG_SPORT_MASK, msg1);
  	switch (sport) {

--- a/target/linux/airoha/patches-6.6/310-06-net-airoha-add-initial-fixup-for-GDM3-4-port-support.patch
+++ b/target/linux/airoha/patches-6.6/310-06-net-airoha-add-initial-fixup-for-GDM3-4-port-support.patch
@@ -28,7 +28,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
  	airoha_fe_crsn_qsel_init(eth);
  
-@@ -1655,7 +1657,8 @@ static int airoha_dev_open(struct net_de
+@@ -1722,7 +1724,8 @@ static int airoha_dev_open(struct net_de
  	if (err)
  		return err;
  

--- a/target/linux/airoha/patches-6.6/310-06-net-airoha-add-initial-fixup-for-GDM3-4-port-support.patch
+++ b/target/linux/airoha/patches-6.6/310-06-net-airoha-add-initial-fixup-for-GDM3-4-port-support.patch
@@ -28,7 +28,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
  	airoha_fe_crsn_qsel_init(eth);
  
-@@ -1641,7 +1643,8 @@ static int airoha_dev_open(struct net_de
+@@ -1657,7 +1659,8 @@ static int airoha_dev_open(struct net_de
  	if (err)
  		return err;
  

--- a/target/linux/airoha/patches-6.6/310-06-net-airoha-add-initial-fixup-for-GDM3-4-port-support.patch
+++ b/target/linux/airoha/patches-6.6/310-06-net-airoha-add-initial-fixup-for-GDM3-4-port-support.patch
@@ -15,7 +15,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -514,8 +514,10 @@ static int airoha_fe_init(struct airoha_
+@@ -503,8 +503,10 @@ static int airoha_fe_init(struct airoha_
  		      FIELD_PREP(IP_ASSEMBLE_PORT_MASK, 0) |
  		      FIELD_PREP(IP_ASSEMBLE_NBQ_MASK, 22));
  
@@ -28,7 +28,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
  	airoha_fe_crsn_qsel_init(eth);
  
-@@ -1657,7 +1659,8 @@ static int airoha_dev_open(struct net_de
+@@ -1654,7 +1656,8 @@ static int airoha_dev_open(struct net_de
  	if (err)
  		return err;
  

--- a/target/linux/airoha/patches-6.6/310-06-net-airoha-add-initial-fixup-for-GDM3-4-port-support.patch
+++ b/target/linux/airoha/patches-6.6/310-06-net-airoha-add-initial-fixup-for-GDM3-4-port-support.patch
@@ -28,7 +28,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
  	airoha_fe_crsn_qsel_init(eth);
  
-@@ -1654,7 +1656,8 @@ static int airoha_dev_open(struct net_de
+@@ -1655,7 +1657,8 @@ static int airoha_dev_open(struct net_de
  	if (err)
  		return err;
  

--- a/target/linux/airoha/patches-6.6/310-06-net-airoha-add-initial-fixup-for-GDM3-4-port-support.patch
+++ b/target/linux/airoha/patches-6.6/310-06-net-airoha-add-initial-fixup-for-GDM3-4-port-support.patch
@@ -15,7 +15,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -503,8 +503,10 @@ static int airoha_fe_init(struct airoha_
+@@ -498,8 +498,10 @@ static int airoha_fe_init(struct airoha_
  		      FIELD_PREP(IP_ASSEMBLE_PORT_MASK, 0) |
  		      FIELD_PREP(IP_ASSEMBLE_NBQ_MASK, 22));
  
@@ -28,7 +28,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
  	airoha_fe_crsn_qsel_init(eth);
  
-@@ -1722,7 +1724,8 @@ static int airoha_dev_open(struct net_de
+@@ -1719,7 +1721,8 @@ static int airoha_dev_open(struct net_de
  	if (err)
  		return err;
  

--- a/target/linux/airoha/patches-6.6/310-06-net-airoha-add-initial-fixup-for-GDM3-4-port-support.patch
+++ b/target/linux/airoha/patches-6.6/310-06-net-airoha-add-initial-fixup-for-GDM3-4-port-support.patch
@@ -28,7 +28,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
  	airoha_fe_crsn_qsel_init(eth);
  
-@@ -1626,7 +1628,8 @@ static int airoha_dev_open(struct net_de
+@@ -1641,7 +1643,8 @@ static int airoha_dev_open(struct net_de
  	if (err)
  		return err;
  

--- a/target/linux/airoha/patches-6.6/310-07-airoha-ethernet-drop-xsi-mac-reset.patch
+++ b/target/linux/airoha/patches-6.6/310-07-airoha-ethernet-drop-xsi-mac-reset.patch
@@ -15,7 +15,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -3109,7 +3109,6 @@ static void airoha_remove(struct platfor
+@@ -3127,7 +3127,6 @@ static void airoha_remove(struct platfor
  }
  
  static const char * const en7581_xsi_rsts_names[] = {
@@ -23,7 +23,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	"hsi0-mac",
  	"hsi1-mac",
  	"hsi-mac",
-@@ -3141,7 +3140,6 @@ static int airoha_en7581_get_src_port_id
+@@ -3159,7 +3158,6 @@ static int airoha_en7581_get_src_port_id
  }
  
  static const char * const an7583_xsi_rsts_names[] = {

--- a/target/linux/airoha/patches-6.6/310-07-airoha-ethernet-drop-xsi-mac-reset.patch
+++ b/target/linux/airoha/patches-6.6/310-07-airoha-ethernet-drop-xsi-mac-reset.patch
@@ -15,7 +15,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -3126,7 +3126,6 @@ static void airoha_remove(struct platfor
+@@ -3202,7 +3202,6 @@ static void airoha_remove(struct platfor
  }
  
  static const char * const en7581_xsi_rsts_names[] = {
@@ -23,7 +23,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	"hsi0-mac",
  	"hsi1-mac",
  	"hsi-mac",
-@@ -3180,7 +3179,6 @@ static u32 airoha_en7581_get_vip_port(st
+@@ -3256,7 +3255,6 @@ static u32 airoha_en7581_get_vip_port(st
  }
  
  static const char * const an7583_xsi_rsts_names[] = {

--- a/target/linux/airoha/patches-6.6/310-07-airoha-ethernet-drop-xsi-mac-reset.patch
+++ b/target/linux/airoha/patches-6.6/310-07-airoha-ethernet-drop-xsi-mac-reset.patch
@@ -15,7 +15,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -3127,7 +3127,6 @@ static void airoha_remove(struct platfor
+@@ -3125,7 +3125,6 @@ static void airoha_remove(struct platfor
  }
  
  static const char * const en7581_xsi_rsts_names[] = {
@@ -23,7 +23,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	"hsi0-mac",
  	"hsi1-mac",
  	"hsi-mac",
-@@ -3159,7 +3158,6 @@ static int airoha_en7581_get_src_port_id
+@@ -3179,7 +3178,6 @@ static u32 airoha_en7581_get_vip_port(st
  }
  
  static const char * const an7583_xsi_rsts_names[] = {

--- a/target/linux/airoha/patches-6.6/310-07-airoha-ethernet-drop-xsi-mac-reset.patch
+++ b/target/linux/airoha/patches-6.6/310-07-airoha-ethernet-drop-xsi-mac-reset.patch
@@ -15,7 +15,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -3202,7 +3202,6 @@ static void airoha_remove(struct platfor
+@@ -3194,7 +3194,6 @@ static void airoha_remove(struct platfor
  }
  
  static const char * const en7581_xsi_rsts_names[] = {
@@ -23,7 +23,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	"hsi0-mac",
  	"hsi1-mac",
  	"hsi-mac",
-@@ -3256,7 +3255,6 @@ static u32 airoha_en7581_get_vip_port(st
+@@ -3248,7 +3247,6 @@ static u32 airoha_en7581_get_vip_port(st
  }
  
  static const char * const an7583_xsi_rsts_names[] = {

--- a/target/linux/airoha/patches-6.6/310-07-airoha-ethernet-drop-xsi-mac-reset.patch
+++ b/target/linux/airoha/patches-6.6/310-07-airoha-ethernet-drop-xsi-mac-reset.patch
@@ -15,7 +15,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -3125,7 +3125,6 @@ static void airoha_remove(struct platfor
+@@ -3126,7 +3126,6 @@ static void airoha_remove(struct platfor
  }
  
  static const char * const en7581_xsi_rsts_names[] = {
@@ -23,7 +23,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	"hsi0-mac",
  	"hsi1-mac",
  	"hsi-mac",
-@@ -3179,7 +3178,6 @@ static u32 airoha_en7581_get_vip_port(st
+@@ -3180,7 +3179,6 @@ static u32 airoha_en7581_get_vip_port(st
  }
  
  static const char * const an7583_xsi_rsts_names[] = {

--- a/target/linux/airoha/patches-6.6/310-07-airoha-ethernet-drop-xsi-mac-reset.patch
+++ b/target/linux/airoha/patches-6.6/310-07-airoha-ethernet-drop-xsi-mac-reset.patch
@@ -15,7 +15,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -3194,7 +3194,6 @@ static void airoha_remove(struct platfor
+@@ -3196,7 +3196,6 @@ static void airoha_remove(struct platfor
  }
  
  static const char * const en7581_xsi_rsts_names[] = {
@@ -23,7 +23,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	"hsi0-mac",
  	"hsi1-mac",
  	"hsi-mac",
-@@ -3248,7 +3247,6 @@ static u32 airoha_en7581_get_vip_port(st
+@@ -3250,7 +3249,6 @@ static u32 airoha_en7581_get_vip_port(st
  }
  
  static const char * const an7583_xsi_rsts_names[] = {

--- a/target/linux/airoha/patches-6.6/310-07-airoha-ethernet-drop-xsi-mac-reset.patch
+++ b/target/linux/airoha/patches-6.6/310-07-airoha-ethernet-drop-xsi-mac-reset.patch
@@ -15,7 +15,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -3114,7 +3114,6 @@ static void airoha_remove(struct platfor
+@@ -3109,7 +3109,6 @@ static void airoha_remove(struct platfor
  }
  
  static const char * const en7581_xsi_rsts_names[] = {
@@ -23,7 +23,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	"hsi0-mac",
  	"hsi1-mac",
  	"hsi-mac",
-@@ -3146,7 +3145,6 @@ static int airoha_en7581_get_src_port_id
+@@ -3141,7 +3140,6 @@ static int airoha_en7581_get_src_port_id
  }
  
  static const char * const an7583_xsi_rsts_names[] = {

--- a/target/linux/airoha/patches-6.6/310-10-net-airoha-add-phylink-support-for-GDM2-4.patch
+++ b/target/linux/airoha/patches-6.6/310-10-net-airoha-add-phylink-support-for-GDM2-4.patch
@@ -35,7 +35,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static void airoha_set_macaddr(struct airoha_gdm_port *port, const u8 *addr)
  {
  	struct airoha_eth *eth = port->qdma->eth;
-@@ -1652,6 +1658,17 @@ static int airoha_dev_open(struct net_de
+@@ -1719,6 +1725,17 @@ static int airoha_dev_open(struct net_de
  	struct airoha_qdma *qdma = port->qdma;
  	u32 pse_port = FE_PSE_PORT_PPE1;
  
@@ -53,7 +53,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	netif_tx_start_all_queues(dev);
  	err = airoha_set_vip_for_gdm_port(port, true);
  	if (err)
-@@ -1716,6 +1733,11 @@ static int airoha_dev_stop(struct net_de
+@@ -1783,6 +1800,11 @@ static int airoha_dev_stop(struct net_de
  		}
  	}
  
@@ -65,7 +65,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	return 0;
  }
  
-@@ -2846,6 +2868,20 @@ static const struct ethtool_ops airoha_e
+@@ -2922,6 +2944,20 @@ static const struct ethtool_ops airoha_e
  	.get_link		= ethtool_op_get_link,
  };
  
@@ -86,7 +86,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static int airoha_metadata_dst_alloc(struct airoha_gdm_port *port)
  {
  	int i;
-@@ -2890,6 +2926,99 @@ bool airoha_is_valid_gdm_port(struct air
+@@ -2966,6 +3002,99 @@ bool airoha_is_valid_gdm_port(struct air
  	return false;
  }
  
@@ -186,7 +186,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static int airoha_alloc_gdm_port(struct airoha_eth *eth,
  				 struct device_node *np)
  {
-@@ -2963,6 +3092,12 @@ static int airoha_alloc_gdm_port(struct
+@@ -3039,6 +3168,12 @@ static int airoha_alloc_gdm_port(struct
  	port->nbq = id == AIROHA_GDM3_IDX && airoha_is_7581(eth) ? 4 : 0;
  	eth->ports[p] = port;
  
@@ -199,7 +199,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	return airoha_metadata_dst_alloc(port);
  }
  
-@@ -3092,6 +3227,10 @@ error_napi_stop:
+@@ -3168,6 +3303,10 @@ error_napi_stop:
  
  		if (port->dev->reg_state == NETREG_REGISTERED)
  			unregister_netdev(port->dev);
@@ -210,7 +210,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  		airoha_metadata_dst_free(port);
  	}
  	airoha_hw_cleanup(eth);
-@@ -3118,6 +3257,10 @@ static void airoha_remove(struct platfor
+@@ -3194,6 +3333,10 @@ static void airoha_remove(struct platfor
  
  		unregister_netdev(port->dev);
  		airoha_metadata_dst_free(port);
@@ -223,7 +223,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
-@@ -539,6 +539,10 @@ struct airoha_gdm_port {
+@@ -540,6 +540,10 @@ struct airoha_gdm_port {
  	int id;
  	int nbq;
  

--- a/target/linux/airoha/patches-6.6/310-10-net-airoha-add-phylink-support-for-GDM2-4.patch
+++ b/target/linux/airoha/patches-6.6/310-10-net-airoha-add-phylink-support-for-GDM2-4.patch
@@ -35,7 +35,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static void airoha_set_macaddr(struct airoha_gdm_port *port, const u8 *addr)
  {
  	struct airoha_eth *eth = port->qdma->eth;
-@@ -1654,6 +1660,17 @@ static int airoha_dev_open(struct net_de
+@@ -1651,6 +1657,17 @@ static int airoha_dev_open(struct net_de
  	struct airoha_qdma *qdma = port->qdma;
  	u32 pse_port = FE_PSE_PORT_PPE1;
  
@@ -53,7 +53,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	netif_tx_start_all_queues(dev);
  	err = airoha_set_vip_for_gdm_port(port, true);
  	if (err)
-@@ -1718,6 +1735,11 @@ static int airoha_dev_stop(struct net_de
+@@ -1715,6 +1732,11 @@ static int airoha_dev_stop(struct net_de
  		}
  	}
  
@@ -65,7 +65,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	return 0;
  }
  
-@@ -2849,6 +2871,20 @@ static const struct ethtool_ops airoha_e
+@@ -2845,6 +2867,20 @@ static const struct ethtool_ops airoha_e
  	.get_link		= ethtool_op_get_link,
  };
  
@@ -86,7 +86,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static int airoha_metadata_dst_alloc(struct airoha_gdm_port *port)
  {
  	int i;
-@@ -2893,6 +2929,99 @@ bool airoha_is_valid_gdm_port(struct air
+@@ -2889,6 +2925,99 @@ bool airoha_is_valid_gdm_port(struct air
  	return false;
  }
  
@@ -186,8 +186,8 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static int airoha_alloc_gdm_port(struct airoha_eth *eth,
  				 struct device_node *np)
  {
-@@ -2964,6 +3093,12 @@ static int airoha_alloc_gdm_port(struct
- 	port->id = id;
+@@ -2962,6 +3091,12 @@ static int airoha_alloc_gdm_port(struct
+ 	port->nbq = id == AIROHA_GDM3_IDX && airoha_is_7581(eth) ? 4 : 0;
  	eth->ports[p] = port;
  
 +	if (airhoa_is_phy_external(port)) {
@@ -199,7 +199,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	return airoha_metadata_dst_alloc(port);
  }
  
-@@ -3093,6 +3228,10 @@ error_napi_stop:
+@@ -3091,6 +3226,10 @@ error_napi_stop:
  
  		if (port->dev->reg_state == NETREG_REGISTERED)
  			unregister_netdev(port->dev);
@@ -210,7 +210,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  		airoha_metadata_dst_free(port);
  	}
  	airoha_hw_cleanup(eth);
-@@ -3119,6 +3258,10 @@ static void airoha_remove(struct platfor
+@@ -3117,6 +3256,10 @@ static void airoha_remove(struct platfor
  
  		unregister_netdev(port->dev);
  		airoha_metadata_dst_free(port);
@@ -223,9 +223,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
-@@ -538,6 +538,10 @@ struct airoha_gdm_port {
- 	struct net_device *dev;
+@@ -539,6 +539,10 @@ struct airoha_gdm_port {
  	int id;
+ 	int nbq;
  
 +	struct phylink *phylink;
 +	struct phylink_config phylink_config;

--- a/target/linux/airoha/patches-6.6/310-10-net-airoha-add-phylink-support-for-GDM2-4.patch
+++ b/target/linux/airoha/patches-6.6/310-10-net-airoha-add-phylink-support-for-GDM2-4.patch
@@ -35,7 +35,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static void airoha_set_macaddr(struct airoha_gdm_port *port, const u8 *addr)
  {
  	struct airoha_eth *eth = port->qdma->eth;
-@@ -1651,6 +1657,17 @@ static int airoha_dev_open(struct net_de
+@@ -1652,6 +1658,17 @@ static int airoha_dev_open(struct net_de
  	struct airoha_qdma *qdma = port->qdma;
  	u32 pse_port = FE_PSE_PORT_PPE1;
  
@@ -53,7 +53,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	netif_tx_start_all_queues(dev);
  	err = airoha_set_vip_for_gdm_port(port, true);
  	if (err)
-@@ -1715,6 +1732,11 @@ static int airoha_dev_stop(struct net_de
+@@ -1716,6 +1733,11 @@ static int airoha_dev_stop(struct net_de
  		}
  	}
  
@@ -65,7 +65,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	return 0;
  }
  
-@@ -2845,6 +2867,20 @@ static const struct ethtool_ops airoha_e
+@@ -2846,6 +2868,20 @@ static const struct ethtool_ops airoha_e
  	.get_link		= ethtool_op_get_link,
  };
  
@@ -86,7 +86,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static int airoha_metadata_dst_alloc(struct airoha_gdm_port *port)
  {
  	int i;
-@@ -2889,6 +2925,99 @@ bool airoha_is_valid_gdm_port(struct air
+@@ -2890,6 +2926,99 @@ bool airoha_is_valid_gdm_port(struct air
  	return false;
  }
  
@@ -186,7 +186,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static int airoha_alloc_gdm_port(struct airoha_eth *eth,
  				 struct device_node *np)
  {
-@@ -2962,6 +3091,12 @@ static int airoha_alloc_gdm_port(struct
+@@ -2963,6 +3092,12 @@ static int airoha_alloc_gdm_port(struct
  	port->nbq = id == AIROHA_GDM3_IDX && airoha_is_7581(eth) ? 4 : 0;
  	eth->ports[p] = port;
  
@@ -199,7 +199,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	return airoha_metadata_dst_alloc(port);
  }
  
-@@ -3091,6 +3226,10 @@ error_napi_stop:
+@@ -3092,6 +3227,10 @@ error_napi_stop:
  
  		if (port->dev->reg_state == NETREG_REGISTERED)
  			unregister_netdev(port->dev);
@@ -210,7 +210,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  		airoha_metadata_dst_free(port);
  	}
  	airoha_hw_cleanup(eth);
-@@ -3117,6 +3256,10 @@ static void airoha_remove(struct platfor
+@@ -3118,6 +3257,10 @@ static void airoha_remove(struct platfor
  
  		unregister_netdev(port->dev);
  		airoha_metadata_dst_free(port);

--- a/target/linux/airoha/patches-6.6/310-10-net-airoha-add-phylink-support-for-GDM2-4.patch
+++ b/target/linux/airoha/patches-6.6/310-10-net-airoha-add-phylink-support-for-GDM2-4.patch
@@ -35,7 +35,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static void airoha_set_macaddr(struct airoha_gdm_port *port, const u8 *addr)
  {
  	struct airoha_eth *eth = port->qdma->eth;
-@@ -1638,6 +1644,17 @@ static int airoha_dev_open(struct net_de
+@@ -1654,6 +1660,17 @@ static int airoha_dev_open(struct net_de
  	struct airoha_qdma *qdma = port->qdma;
  	u32 pse_port = FE_PSE_PORT_PPE1;
  
@@ -53,7 +53,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	netif_tx_start_all_queues(dev);
  	err = airoha_set_vip_for_gdm_port(port, true);
  	if (err)
-@@ -1702,6 +1719,11 @@ static int airoha_dev_stop(struct net_de
+@@ -1718,6 +1735,11 @@ static int airoha_dev_stop(struct net_de
  		}
  	}
  
@@ -65,7 +65,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	return 0;
  }
  
-@@ -2834,6 +2856,20 @@ static const struct ethtool_ops airoha_e
+@@ -2849,6 +2871,20 @@ static const struct ethtool_ops airoha_e
  	.get_link		= ethtool_op_get_link,
  };
  
@@ -86,7 +86,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static int airoha_metadata_dst_alloc(struct airoha_gdm_port *port)
  {
  	int i;
-@@ -2878,6 +2914,99 @@ bool airoha_is_valid_gdm_port(struct air
+@@ -2893,6 +2929,99 @@ bool airoha_is_valid_gdm_port(struct air
  	return false;
  }
  
@@ -186,7 +186,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static int airoha_alloc_gdm_port(struct airoha_eth *eth,
  				 struct device_node *np)
  {
-@@ -2949,6 +3078,12 @@ static int airoha_alloc_gdm_port(struct
+@@ -2964,6 +3093,12 @@ static int airoha_alloc_gdm_port(struct
  	port->id = id;
  	eth->ports[p] = port;
  
@@ -199,7 +199,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	return airoha_metadata_dst_alloc(port);
  }
  
-@@ -3075,6 +3210,10 @@ error_napi_stop:
+@@ -3093,6 +3228,10 @@ error_napi_stop:
  
  		if (port->dev->reg_state == NETREG_REGISTERED)
  			unregister_netdev(port->dev);
@@ -210,7 +210,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  		airoha_metadata_dst_free(port);
  	}
  	airoha_hw_cleanup(eth);
-@@ -3101,6 +3240,10 @@ static void airoha_remove(struct platfor
+@@ -3119,6 +3258,10 @@ static void airoha_remove(struct platfor
  
  		unregister_netdev(port->dev);
  		airoha_metadata_dst_free(port);
@@ -223,7 +223,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
-@@ -537,6 +537,10 @@ struct airoha_gdm_port {
+@@ -538,6 +538,10 @@ struct airoha_gdm_port {
  	struct net_device *dev;
  	int id;
  

--- a/target/linux/airoha/patches-6.6/310-10-net-airoha-add-phylink-support-for-GDM2-4.patch
+++ b/target/linux/airoha/patches-6.6/310-10-net-airoha-add-phylink-support-for-GDM2-4.patch
@@ -65,7 +65,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	return 0;
  }
  
-@@ -2834,6 +2856,20 @@ static const struct ethtool_ops airoha_e
+@@ -2916,6 +2938,11 @@ static const struct ethtool_ops airoha_e
  	.get_link		= ethtool_op_get_link,
  };
  
@@ -86,7 +86,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static int airoha_metadata_dst_alloc(struct airoha_gdm_port *port)
  {
  	int i;
-@@ -2878,6 +2914,99 @@ bool airoha_is_valid_gdm_port(struct air
+@@ -2960,6 +2987,119 @@ bool airoha_is_valid_gdm_port(struct air
  	return false;
  }
  
@@ -186,8 +186,8 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static int airoha_alloc_gdm_port(struct airoha_eth *eth,
  				 struct device_node *np)
  {
-@@ -2949,6 +3078,12 @@ static int airoha_alloc_gdm_port(struct
- 	port->id = id;
+@@ -3033,6 +3173,12 @@ static int airoha_alloc_gdm_port(struct
+ 	port->nbq = id == AIROHA_GDM3_IDX && airoha_is_7581(eth) ? 4 : 0;
  	eth->ports[p] = port;
  
 +	if (airhoa_is_phy_external(port)) {
@@ -199,7 +199,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	return airoha_metadata_dst_alloc(port);
  }
  
-@@ -3075,6 +3210,10 @@ error_napi_stop:
+@@ -3160,8 +3306,11 @@ error_napi_stop:
+ 		if (!port)
+ 			continue;
  
  		if (port->dev->reg_state == NETREG_REGISTERED)
  			unregister_netdev(port->dev);
@@ -210,7 +212,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  		airoha_metadata_dst_free(port);
  	}
  	airoha_hw_cleanup(eth);
-@@ -3101,6 +3240,10 @@ static void airoha_remove(struct platfor
+@@ -3186,6 +3335,8 @@ static void airoha_remove(struct platfor
+ 		if (!port)
+ 			continue;
  
  		unregister_netdev(port->dev);
  		airoha_metadata_dst_free(port);

--- a/target/linux/airoha/patches-6.6/310-10-net-airoha-add-phylink-support-for-GDM2-4.patch
+++ b/target/linux/airoha/patches-6.6/310-10-net-airoha-add-phylink-support-for-GDM2-4.patch
@@ -35,7 +35,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static void airoha_set_macaddr(struct airoha_gdm_port *port, const u8 *addr)
  {
  	struct airoha_eth *eth = port->qdma->eth;
-@@ -1623,6 +1629,17 @@ static int airoha_dev_open(struct net_de
+@@ -1638,6 +1644,17 @@ static int airoha_dev_open(struct net_de
  	struct airoha_qdma *qdma = port->qdma;
  	u32 pse_port = FE_PSE_PORT_PPE1;
  
@@ -53,7 +53,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	netif_tx_start_all_queues(dev);
  	err = airoha_set_vip_for_gdm_port(port, true);
  	if (err)
-@@ -1687,6 +1704,11 @@ static int airoha_dev_stop(struct net_de
+@@ -1702,6 +1719,11 @@ static int airoha_dev_stop(struct net_de
  		}
  	}
  
@@ -199,7 +199,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	return airoha_metadata_dst_alloc(port);
  }
  
-@@ -3080,6 +3215,10 @@ error_hw_cleanup:
+@@ -3075,6 +3210,10 @@ error_napi_stop:
  
  		if (port->dev->reg_state == NETREG_REGISTERED)
  			unregister_netdev(port->dev);
@@ -209,8 +209,8 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 +		}
  		airoha_metadata_dst_free(port);
  	}
- 	free_netdev(eth->napi_dev);
-@@ -3106,6 +3245,10 @@ static void airoha_remove(struct platfor
+ 	airoha_hw_cleanup(eth);
+@@ -3101,6 +3240,10 @@ static void airoha_remove(struct platfor
  
  		unregister_netdev(port->dev);
  		airoha_metadata_dst_free(port);
@@ -219,7 +219,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 +			airoha_pcs_destroy(port->pcs);
 +		}
  	}
- 	free_netdev(eth->napi_dev);
+ 	airoha_hw_cleanup(eth);
  
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
@@ -236,7 +236,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	DECLARE_BITMAP(qos_sq_bmap, AIROHA_NUM_QOS_CHANNELS);
 --- a/drivers/net/ethernet/airoha/airoha_regs.h
 +++ b/drivers/net/ethernet/airoha/airoha_regs.h
-@@ -359,6 +359,18 @@
+@@ -358,6 +358,18 @@
  #define IP_FRAGMENT_PORT_MASK		GENMASK(8, 5)
  #define IP_FRAGMENT_NBQ_MASK		GENMASK(4, 0)
  

--- a/target/linux/airoha/patches-6.6/310-10-net-airoha-add-phylink-support-for-GDM2-4.patch
+++ b/target/linux/airoha/patches-6.6/310-10-net-airoha-add-phylink-support-for-GDM2-4.patch
@@ -35,7 +35,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static void airoha_set_macaddr(struct airoha_gdm_port *port, const u8 *addr)
  {
  	struct airoha_eth *eth = port->qdma->eth;
-@@ -1719,6 +1725,17 @@ static int airoha_dev_open(struct net_de
+@@ -1638,6 +1644,17 @@ static int airoha_dev_open(struct net_de
  	struct airoha_qdma *qdma = port->qdma;
  	u32 pse_port = FE_PSE_PORT_PPE1;
  
@@ -53,7 +53,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	netif_tx_start_all_queues(dev);
  	err = airoha_set_vip_for_gdm_port(port, true);
  	if (err)
-@@ -1783,6 +1800,11 @@ static int airoha_dev_stop(struct net_de
+@@ -1702,6 +1719,11 @@ static int airoha_dev_stop(struct net_de
  		}
  	}
  
@@ -65,7 +65,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	return 0;
  }
  
-@@ -2922,6 +2944,20 @@ static const struct ethtool_ops airoha_e
+@@ -2834,6 +2856,20 @@ static const struct ethtool_ops airoha_e
  	.get_link		= ethtool_op_get_link,
  };
  
@@ -86,7 +86,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static int airoha_metadata_dst_alloc(struct airoha_gdm_port *port)
  {
  	int i;
-@@ -2966,6 +3002,99 @@ bool airoha_is_valid_gdm_port(struct air
+@@ -2878,6 +2914,99 @@ bool airoha_is_valid_gdm_port(struct air
  	return false;
  }
  
@@ -186,8 +186,8 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static int airoha_alloc_gdm_port(struct airoha_eth *eth,
  				 struct device_node *np)
  {
-@@ -3039,6 +3168,12 @@ static int airoha_alloc_gdm_port(struct
- 	port->nbq = id == AIROHA_GDM3_IDX && airoha_is_7581(eth) ? 4 : 0;
+@@ -2949,6 +3078,12 @@ static int airoha_alloc_gdm_port(struct
+ 	port->id = id;
  	eth->ports[p] = port;
  
 +	if (airhoa_is_phy_external(port)) {
@@ -199,7 +199,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	return airoha_metadata_dst_alloc(port);
  }
  
-@@ -3168,6 +3303,10 @@ error_napi_stop:
+@@ -3075,6 +3210,10 @@ error_napi_stop:
  
  		if (port->dev->reg_state == NETREG_REGISTERED)
  			unregister_netdev(port->dev);
@@ -210,7 +210,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  		airoha_metadata_dst_free(port);
  	}
  	airoha_hw_cleanup(eth);
-@@ -3194,6 +3333,10 @@ static void airoha_remove(struct platfor
+@@ -3101,6 +3240,10 @@ static void airoha_remove(struct platfor
  
  		unregister_netdev(port->dev);
  		airoha_metadata_dst_free(port);
@@ -223,9 +223,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
-@@ -540,6 +540,10 @@ struct airoha_gdm_port {
+@@ -537,6 +537,10 @@ struct airoha_gdm_port {
+ 	struct net_device *dev;
  	int id;
- 	int nbq;
  
 +	struct phylink *phylink;
 +	struct phylink_config phylink_config;

--- a/target/linux/airoha/patches-6.6/604-02-net-ethernet-airoha-define-sport-value-for-GDM3.patch
+++ b/target/linux/airoha/patches-6.6/604-02-net-ethernet-airoha-define-sport-value-for-GDM3.patch
@@ -14,7 +14,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -588,6 +588,9 @@ static int airoha_qdma_get_gdm_port(stru
+@@ -589,6 +589,9 @@ static int airoha_qdma_get_gdm_port(stru
  	case 0x18:
  		port = 3; /* GDM4 */
  		break;

--- a/target/linux/airoha/patches-6.6/604-02-net-ethernet-airoha-define-sport-value-for-GDM3.patch
+++ b/target/linux/airoha/patches-6.6/604-02-net-ethernet-airoha-define-sport-value-for-GDM3.patch
@@ -14,7 +14,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -589,6 +589,9 @@ static int airoha_qdma_get_gdm_port(stru
+@@ -585,6 +585,9 @@ static int airoha_qdma_get_gdm_port(stru
  	case 0x18:
  		port = 3; /* GDM4 */
  		break;

--- a/target/linux/airoha/patches-6.6/604-02-net-ethernet-airoha-define-sport-value-for-GDM3.patch
+++ b/target/linux/airoha/patches-6.6/604-02-net-ethernet-airoha-define-sport-value-for-GDM3.patch
@@ -14,7 +14,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -599,6 +599,9 @@ static int airoha_qdma_get_gdm_port(stru
+@@ -588,6 +588,9 @@ static int airoha_qdma_get_gdm_port(stru
  	case 0x18:
  		port = 3; /* GDM4 */
  		break;

--- a/target/linux/airoha/patches-6.6/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
+++ b/target/linux/airoha/patches-6.6/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
@@ -28,7 +28,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  static void airoha_set_macaddr(struct airoha_gdm_port *port, const u8 *addr)
  {
-@@ -1661,6 +1663,7 @@ static int airoha_dev_open(struct net_de
+@@ -1728,6 +1730,7 @@ static int airoha_dev_open(struct net_de
  	struct airoha_qdma *qdma = port->qdma;
  	u32 pse_port = FE_PSE_PORT_PPE1;
  
@@ -36,7 +36,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  	if (airhoa_is_phy_external(port)) {
  		err = phylink_of_phy_connect(port->phylink, dev->dev.of_node, 0);
  		if (err) {
-@@ -1671,6 +1674,7 @@ static int airoha_dev_open(struct net_de
+@@ -1738,6 +1741,7 @@ static int airoha_dev_open(struct net_de
  
  		phylink_start(port->phylink);
  	}
@@ -44,7 +44,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  	netif_tx_start_all_queues(dev);
  	err = airoha_set_vip_for_gdm_port(port, true);
-@@ -1736,10 +1740,12 @@ static int airoha_dev_stop(struct net_de
+@@ -1803,10 +1807,12 @@ static int airoha_dev_stop(struct net_de
  		}
  	}
  
@@ -57,7 +57,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  	return 0;
  }
-@@ -2871,6 +2877,7 @@ static const struct ethtool_ops airoha_e
+@@ -2947,6 +2953,7 @@ static const struct ethtool_ops airoha_e
  	.get_link		= ethtool_op_get_link,
  };
  
@@ -65,7 +65,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  static struct phylink_pcs *airoha_phylink_mac_select_pcs(struct phylink_config *config,
  							 phy_interface_t interface)
  {
-@@ -2884,6 +2891,7 @@ static void airoha_mac_config(struct phy
+@@ -2960,6 +2967,7 @@ static void airoha_mac_config(struct phy
  			      const struct phylink_link_state *state)
  {
  }
@@ -73,7 +73,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  static int airoha_metadata_dst_alloc(struct airoha_gdm_port *port)
  {
-@@ -2929,6 +2937,7 @@ bool airoha_is_valid_gdm_port(struct air
+@@ -3005,6 +3013,7 @@ bool airoha_is_valid_gdm_port(struct air
  	return false;
  }
  
@@ -81,7 +81,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  static void airoha_mac_link_up(struct phylink_config *config, struct phy_device *phy,
  			       unsigned int mode, phy_interface_t interface,
  			       int speed, int duplex, bool tx_pause, bool rx_pause)
-@@ -3021,6 +3030,7 @@ static int airoha_setup_phylink(struct n
+@@ -3097,6 +3106,7 @@ static int airoha_setup_phylink(struct n
  
  	return 0;
  }
@@ -89,7 +89,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  static int airoha_alloc_gdm_port(struct airoha_eth *eth,
  				 struct device_node *np)
-@@ -3095,11 +3105,13 @@ static int airoha_alloc_gdm_port(struct
+@@ -3171,11 +3181,13 @@ static int airoha_alloc_gdm_port(struct
  	port->nbq = id == AIROHA_GDM3_IDX && airoha_is_7581(eth) ? 4 : 0;
  	eth->ports[p] = port;
  
@@ -103,7 +103,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  	return airoha_metadata_dst_alloc(port);
  }
-@@ -3230,10 +3242,12 @@ error_napi_stop:
+@@ -3306,10 +3318,12 @@ error_napi_stop:
  
  		if (port->dev->reg_state == NETREG_REGISTERED)
  			unregister_netdev(port->dev);
@@ -116,7 +116,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  		airoha_metadata_dst_free(port);
  	}
  	airoha_hw_cleanup(eth);
-@@ -3260,10 +3274,12 @@ static void airoha_remove(struct platfor
+@@ -3336,10 +3350,12 @@ static void airoha_remove(struct platfor
  
  		unregister_netdev(port->dev);
  		airoha_metadata_dst_free(port);
@@ -131,7 +131,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
-@@ -539,9 +539,11 @@ struct airoha_gdm_port {
+@@ -540,9 +540,11 @@ struct airoha_gdm_port {
  	int id;
  	int nbq;
  

--- a/target/linux/airoha/patches-6.6/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
+++ b/target/linux/airoha/patches-6.6/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
@@ -28,7 +28,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  static void airoha_set_macaddr(struct airoha_gdm_port *port, const u8 *addr)
  {
-@@ -1660,6 +1662,7 @@ static int airoha_dev_open(struct net_de
+@@ -1661,6 +1663,7 @@ static int airoha_dev_open(struct net_de
  	struct airoha_qdma *qdma = port->qdma;
  	u32 pse_port = FE_PSE_PORT_PPE1;
  
@@ -36,7 +36,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  	if (airhoa_is_phy_external(port)) {
  		err = phylink_of_phy_connect(port->phylink, dev->dev.of_node, 0);
  		if (err) {
-@@ -1670,6 +1673,7 @@ static int airoha_dev_open(struct net_de
+@@ -1671,6 +1674,7 @@ static int airoha_dev_open(struct net_de
  
  		phylink_start(port->phylink);
  	}
@@ -44,7 +44,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  	netif_tx_start_all_queues(dev);
  	err = airoha_set_vip_for_gdm_port(port, true);
-@@ -1735,10 +1739,12 @@ static int airoha_dev_stop(struct net_de
+@@ -1736,10 +1740,12 @@ static int airoha_dev_stop(struct net_de
  		}
  	}
  
@@ -57,7 +57,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  	return 0;
  }
-@@ -2870,6 +2876,7 @@ static const struct ethtool_ops airoha_e
+@@ -2871,6 +2877,7 @@ static const struct ethtool_ops airoha_e
  	.get_link		= ethtool_op_get_link,
  };
  
@@ -65,7 +65,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  static struct phylink_pcs *airoha_phylink_mac_select_pcs(struct phylink_config *config,
  							 phy_interface_t interface)
  {
-@@ -2883,6 +2890,7 @@ static void airoha_mac_config(struct phy
+@@ -2884,6 +2891,7 @@ static void airoha_mac_config(struct phy
  			      const struct phylink_link_state *state)
  {
  }
@@ -73,7 +73,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  static int airoha_metadata_dst_alloc(struct airoha_gdm_port *port)
  {
-@@ -2928,6 +2936,7 @@ bool airoha_is_valid_gdm_port(struct air
+@@ -2929,6 +2937,7 @@ bool airoha_is_valid_gdm_port(struct air
  	return false;
  }
  
@@ -81,7 +81,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  static void airoha_mac_link_up(struct phylink_config *config, struct phy_device *phy,
  			       unsigned int mode, phy_interface_t interface,
  			       int speed, int duplex, bool tx_pause, bool rx_pause)
-@@ -3020,6 +3029,7 @@ static int airoha_setup_phylink(struct n
+@@ -3021,6 +3030,7 @@ static int airoha_setup_phylink(struct n
  
  	return 0;
  }
@@ -89,7 +89,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  static int airoha_alloc_gdm_port(struct airoha_eth *eth,
  				 struct device_node *np)
-@@ -3094,11 +3104,13 @@ static int airoha_alloc_gdm_port(struct
+@@ -3095,11 +3105,13 @@ static int airoha_alloc_gdm_port(struct
  	port->nbq = id == AIROHA_GDM3_IDX && airoha_is_7581(eth) ? 4 : 0;
  	eth->ports[p] = port;
  
@@ -103,7 +103,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  	return airoha_metadata_dst_alloc(port);
  }
-@@ -3229,10 +3241,12 @@ error_napi_stop:
+@@ -3230,10 +3242,12 @@ error_napi_stop:
  
  		if (port->dev->reg_state == NETREG_REGISTERED)
  			unregister_netdev(port->dev);
@@ -116,7 +116,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  		airoha_metadata_dst_free(port);
  	}
  	airoha_hw_cleanup(eth);
-@@ -3259,10 +3273,12 @@ static void airoha_remove(struct platfor
+@@ -3260,10 +3274,12 @@ static void airoha_remove(struct platfor
  
  		unregister_netdev(port->dev);
  		airoha_metadata_dst_free(port);

--- a/target/linux/airoha/patches-6.6/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
+++ b/target/linux/airoha/patches-6.6/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
@@ -28,7 +28,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  static void airoha_set_macaddr(struct airoha_gdm_port *port, const u8 *addr)
  {
-@@ -1663,6 +1665,7 @@ static int airoha_dev_open(struct net_de
+@@ -1660,6 +1662,7 @@ static int airoha_dev_open(struct net_de
  	struct airoha_qdma *qdma = port->qdma;
  	u32 pse_port = FE_PSE_PORT_PPE1;
  
@@ -36,7 +36,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  	if (airhoa_is_phy_external(port)) {
  		err = phylink_of_phy_connect(port->phylink, dev->dev.of_node, 0);
  		if (err) {
-@@ -1673,6 +1676,7 @@ static int airoha_dev_open(struct net_de
+@@ -1670,6 +1673,7 @@ static int airoha_dev_open(struct net_de
  
  		phylink_start(port->phylink);
  	}
@@ -44,7 +44,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  	netif_tx_start_all_queues(dev);
  	err = airoha_set_vip_for_gdm_port(port, true);
-@@ -1738,10 +1742,12 @@ static int airoha_dev_stop(struct net_de
+@@ -1735,10 +1739,12 @@ static int airoha_dev_stop(struct net_de
  		}
  	}
  
@@ -57,7 +57,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  	return 0;
  }
-@@ -2874,6 +2880,7 @@ static const struct ethtool_ops airoha_e
+@@ -2870,6 +2876,7 @@ static const struct ethtool_ops airoha_e
  	.get_link		= ethtool_op_get_link,
  };
  
@@ -65,7 +65,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  static struct phylink_pcs *airoha_phylink_mac_select_pcs(struct phylink_config *config,
  							 phy_interface_t interface)
  {
-@@ -2887,6 +2894,7 @@ static void airoha_mac_config(struct phy
+@@ -2883,6 +2890,7 @@ static void airoha_mac_config(struct phy
  			      const struct phylink_link_state *state)
  {
  }
@@ -73,7 +73,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  static int airoha_metadata_dst_alloc(struct airoha_gdm_port *port)
  {
-@@ -2932,6 +2940,7 @@ bool airoha_is_valid_gdm_port(struct air
+@@ -2928,6 +2936,7 @@ bool airoha_is_valid_gdm_port(struct air
  	return false;
  }
  
@@ -81,7 +81,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  static void airoha_mac_link_up(struct phylink_config *config, struct phy_device *phy,
  			       unsigned int mode, phy_interface_t interface,
  			       int speed, int duplex, bool tx_pause, bool rx_pause)
-@@ -3024,6 +3033,7 @@ static int airoha_setup_phylink(struct n
+@@ -3020,6 +3029,7 @@ static int airoha_setup_phylink(struct n
  
  	return 0;
  }
@@ -89,8 +89,8 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  static int airoha_alloc_gdm_port(struct airoha_eth *eth,
  				 struct device_node *np)
-@@ -3096,11 +3106,13 @@ static int airoha_alloc_gdm_port(struct
- 	port->id = id;
+@@ -3094,11 +3104,13 @@ static int airoha_alloc_gdm_port(struct
+ 	port->nbq = id == AIROHA_GDM3_IDX && airoha_is_7581(eth) ? 4 : 0;
  	eth->ports[p] = port;
  
 +#if defined(CONFIG_PCS_AIROHA)
@@ -103,7 +103,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  	return airoha_metadata_dst_alloc(port);
  }
-@@ -3231,10 +3243,12 @@ error_napi_stop:
+@@ -3229,10 +3241,12 @@ error_napi_stop:
  
  		if (port->dev->reg_state == NETREG_REGISTERED)
  			unregister_netdev(port->dev);
@@ -116,7 +116,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  		airoha_metadata_dst_free(port);
  	}
  	airoha_hw_cleanup(eth);
-@@ -3261,10 +3275,12 @@ static void airoha_remove(struct platfor
+@@ -3259,10 +3273,12 @@ static void airoha_remove(struct platfor
  
  		unregister_netdev(port->dev);
  		airoha_metadata_dst_free(port);
@@ -131,9 +131,9 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
-@@ -538,9 +538,11 @@ struct airoha_gdm_port {
- 	struct net_device *dev;
+@@ -539,9 +539,11 @@ struct airoha_gdm_port {
  	int id;
+ 	int nbq;
  
 +#if defined(CONFIG_PCS_AIROHA)
  	struct phylink *phylink;

--- a/target/linux/airoha/patches-6.6/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
+++ b/target/linux/airoha/patches-6.6/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
@@ -28,7 +28,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  static void airoha_set_macaddr(struct airoha_gdm_port *port, const u8 *addr)
  {
-@@ -1728,6 +1730,7 @@ static int airoha_dev_open(struct net_de
+@@ -1725,6 +1727,7 @@ static int airoha_dev_open(struct net_de
  	struct airoha_qdma *qdma = port->qdma;
  	u32 pse_port = FE_PSE_PORT_PPE1;
  
@@ -36,7 +36,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  	if (airhoa_is_phy_external(port)) {
  		err = phylink_of_phy_connect(port->phylink, dev->dev.of_node, 0);
  		if (err) {
-@@ -1738,6 +1741,7 @@ static int airoha_dev_open(struct net_de
+@@ -1735,6 +1738,7 @@ static int airoha_dev_open(struct net_de
  
  		phylink_start(port->phylink);
  	}
@@ -44,7 +44,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  	netif_tx_start_all_queues(dev);
  	err = airoha_set_vip_for_gdm_port(port, true);
-@@ -1803,10 +1807,12 @@ static int airoha_dev_stop(struct net_de
+@@ -1797,10 +1801,12 @@ static int airoha_dev_stop(struct net_de
  		}
  	}
  

--- a/target/linux/airoha/patches-6.6/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
+++ b/target/linux/airoha/patches-6.6/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
@@ -57,6 +57,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  	return 0;
  }
+<<<<<<< HEAD:target/linux/airoha/patches-6.6/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
 @@ -2947,6 +2953,7 @@ static const struct ethtool_ops airoha_e
  	.get_link		= ethtool_op_get_link,
  };
@@ -74,6 +75,9 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  static int airoha_metadata_dst_alloc(struct airoha_gdm_port *port)
  {
 @@ -3005,6 +3013,7 @@ bool airoha_is_valid_gdm_port(struct air
+=======
+@@ -2990,6 +2996,7 @@ bool airoha_is_valid_gdm_port(struct air
+>>>>>>> 5b25d4235d23 (airoha: backport GDM2 loopback fixup for Ethernet driver):target/linux/airoha/patches-6.12/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
  	return false;
  }
  
@@ -81,7 +85,11 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  static void airoha_mac_link_up(struct phylink_config *config, struct phy_device *phy,
  			       unsigned int mode, phy_interface_t interface,
  			       int speed, int duplex, bool tx_pause, bool rx_pause)
+<<<<<<< HEAD:target/linux/airoha/patches-6.6/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
 @@ -3097,6 +3106,7 @@ static int airoha_setup_phylink(struct n
+=======
+@@ -3102,6 +3109,7 @@ static int airoha_setup_phylink(struct n
+>>>>>>> 5b25d4235d23 (airoha: backport GDM2 loopback fixup for Ethernet driver):target/linux/airoha/patches-6.12/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
  
  	return 0;
  }
@@ -89,7 +97,11 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  static int airoha_alloc_gdm_port(struct airoha_eth *eth,
  				 struct device_node *np)
+<<<<<<< HEAD:target/linux/airoha/patches-6.6/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
 @@ -3171,11 +3181,13 @@ static int airoha_alloc_gdm_port(struct
+=======
+@@ -3176,11 +3184,13 @@ static int airoha_alloc_gdm_port(struct
+>>>>>>> 5b25d4235d23 (airoha: backport GDM2 loopback fixup for Ethernet driver):target/linux/airoha/patches-6.12/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
  	port->nbq = id == AIROHA_GDM3_IDX && airoha_is_7581(eth) ? 4 : 0;
  	eth->ports[p] = port;
  
@@ -103,10 +115,24 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  	return airoha_metadata_dst_alloc(port);
  }
+<<<<<<< HEAD:target/linux/airoha/patches-6.6/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
 @@ -3306,10 +3318,12 @@ error_napi_stop:
+=======
+@@ -3310,8 +3320,10 @@ error_napi_stop:
+ 			continue;
+>>>>>>> 5b25d4235d23 (airoha: backport GDM2 loopback fixup for Ethernet driver):target/linux/airoha/patches-6.12/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
  
  		if (port->dev->reg_state == NETREG_REGISTERED)
  			unregister_netdev(port->dev);
+<<<<<<< HEAD:target/linux/airoha/patches-6.6/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
+=======
+ 		}
+ 		airoha_metadata_dst_free(port);
+@@ -3338,8 +3350,10 @@ static void airoha_remove(struct platfor
+ 		if (!port)
+ 			continue;
+ 
+>>>>>>> 5b25d4235d23 (airoha: backport GDM2 loopback fixup for Ethernet driver):target/linux/airoha/patches-6.12/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
 +#if defined(CONFIG_PCS_AIROHA)
  		if (airhoa_is_phy_external(port)) {
  			phylink_destroy(port->phylink);

--- a/target/linux/airoha/patches-6.6/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
+++ b/target/linux/airoha/patches-6.6/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
@@ -28,7 +28,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  static void airoha_set_macaddr(struct airoha_gdm_port *port, const u8 *addr)
  {
-@@ -1647,6 +1649,7 @@ static int airoha_dev_open(struct net_de
+@@ -1663,6 +1665,7 @@ static int airoha_dev_open(struct net_de
  	struct airoha_qdma *qdma = port->qdma;
  	u32 pse_port = FE_PSE_PORT_PPE1;
  
@@ -36,7 +36,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  	if (airhoa_is_phy_external(port)) {
  		err = phylink_of_phy_connect(port->phylink, dev->dev.of_node, 0);
  		if (err) {
-@@ -1657,6 +1660,7 @@ static int airoha_dev_open(struct net_de
+@@ -1673,6 +1676,7 @@ static int airoha_dev_open(struct net_de
  
  		phylink_start(port->phylink);
  	}
@@ -44,7 +44,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  	netif_tx_start_all_queues(dev);
  	err = airoha_set_vip_for_gdm_port(port, true);
-@@ -1722,10 +1726,12 @@ static int airoha_dev_stop(struct net_de
+@@ -1738,10 +1742,12 @@ static int airoha_dev_stop(struct net_de
  		}
  	}
  
@@ -57,7 +57,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  	return 0;
  }
-@@ -2859,6 +2865,7 @@ static const struct ethtool_ops airoha_e
+@@ -2874,6 +2880,7 @@ static const struct ethtool_ops airoha_e
  	.get_link		= ethtool_op_get_link,
  };
  
@@ -65,7 +65,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  static struct phylink_pcs *airoha_phylink_mac_select_pcs(struct phylink_config *config,
  							 phy_interface_t interface)
  {
-@@ -2872,6 +2879,7 @@ static void airoha_mac_config(struct phy
+@@ -2887,6 +2894,7 @@ static void airoha_mac_config(struct phy
  			      const struct phylink_link_state *state)
  {
  }
@@ -73,7 +73,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  static int airoha_metadata_dst_alloc(struct airoha_gdm_port *port)
  {
-@@ -2917,6 +2925,7 @@ bool airoha_is_valid_gdm_port(struct air
+@@ -2932,6 +2940,7 @@ bool airoha_is_valid_gdm_port(struct air
  	return false;
  }
  
@@ -81,7 +81,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  static void airoha_mac_link_up(struct phylink_config *config, struct phy_device *phy,
  			       unsigned int mode, phy_interface_t interface,
  			       int speed, int duplex, bool tx_pause, bool rx_pause)
-@@ -3009,6 +3018,7 @@ static int airoha_setup_phylink(struct n
+@@ -3024,6 +3033,7 @@ static int airoha_setup_phylink(struct n
  
  	return 0;
  }
@@ -89,7 +89,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  static int airoha_alloc_gdm_port(struct airoha_eth *eth,
  				 struct device_node *np)
-@@ -3081,11 +3091,13 @@ static int airoha_alloc_gdm_port(struct
+@@ -3096,11 +3106,13 @@ static int airoha_alloc_gdm_port(struct
  	port->id = id;
  	eth->ports[p] = port;
  
@@ -103,7 +103,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  	return airoha_metadata_dst_alloc(port);
  }
-@@ -3213,10 +3225,12 @@ error_napi_stop:
+@@ -3231,10 +3243,12 @@ error_napi_stop:
  
  		if (port->dev->reg_state == NETREG_REGISTERED)
  			unregister_netdev(port->dev);
@@ -116,7 +116,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  		airoha_metadata_dst_free(port);
  	}
  	airoha_hw_cleanup(eth);
-@@ -3243,10 +3257,12 @@ static void airoha_remove(struct platfor
+@@ -3261,10 +3275,12 @@ static void airoha_remove(struct platfor
  
  		unregister_netdev(port->dev);
  		airoha_metadata_dst_free(port);
@@ -131,7 +131,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
-@@ -537,9 +537,11 @@ struct airoha_gdm_port {
+@@ -538,9 +538,11 @@ struct airoha_gdm_port {
  	struct net_device *dev;
  	int id;
  

--- a/target/linux/airoha/patches-6.6/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
+++ b/target/linux/airoha/patches-6.6/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
@@ -28,7 +28,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  static void airoha_set_macaddr(struct airoha_gdm_port *port, const u8 *addr)
  {
-@@ -1632,6 +1634,7 @@ static int airoha_dev_open(struct net_de
+@@ -1647,6 +1649,7 @@ static int airoha_dev_open(struct net_de
  	struct airoha_qdma *qdma = port->qdma;
  	u32 pse_port = FE_PSE_PORT_PPE1;
  
@@ -36,7 +36,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  	if (airhoa_is_phy_external(port)) {
  		err = phylink_of_phy_connect(port->phylink, dev->dev.of_node, 0);
  		if (err) {
-@@ -1642,6 +1645,7 @@ static int airoha_dev_open(struct net_de
+@@ -1657,6 +1660,7 @@ static int airoha_dev_open(struct net_de
  
  		phylink_start(port->phylink);
  	}
@@ -44,7 +44,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  	netif_tx_start_all_queues(dev);
  	err = airoha_set_vip_for_gdm_port(port, true);
-@@ -1707,10 +1711,12 @@ static int airoha_dev_stop(struct net_de
+@@ -1722,10 +1726,12 @@ static int airoha_dev_stop(struct net_de
  		}
  	}
  
@@ -103,7 +103,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  	return airoha_metadata_dst_alloc(port);
  }
-@@ -3218,10 +3230,12 @@ error_hw_cleanup:
+@@ -3213,10 +3225,12 @@ error_napi_stop:
  
  		if (port->dev->reg_state == NETREG_REGISTERED)
  			unregister_netdev(port->dev);
@@ -115,8 +115,8 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
 +#endif
  		airoha_metadata_dst_free(port);
  	}
- 	free_netdev(eth->napi_dev);
-@@ -3248,10 +3262,12 @@ static void airoha_remove(struct platfor
+ 	airoha_hw_cleanup(eth);
+@@ -3243,10 +3257,12 @@ static void airoha_remove(struct platfor
  
  		unregister_netdev(port->dev);
  		airoha_metadata_dst_free(port);
@@ -127,7 +127,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  		}
 +#endif
  	}
- 	free_netdev(eth->napi_dev);
+ 	airoha_hw_cleanup(eth);
  
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h

--- a/target/linux/airoha/patches-6.6/916-net-airoha-Implement-LRO-TCP-support.patch
+++ b/target/linux/airoha/patches-6.6/916-net-airoha-Implement-LRO-TCP-support.patch
@@ -1,0 +1,357 @@
+From 598e1ddfe85ad0f4778eeadd5d878209dd931280 Mon Sep 17 00:00:00 2001
+Message-ID: <598e1ddfe85ad0f4778eeadd5d878209dd931280.1779112628.git.lorenzo@kernel.org>
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Thu, 14 May 2026 20:25:19 +0200
+Subject: [PATCH] net: airoha: Implement LRO TCP support
+
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c  | 178 ++++++++++++++++++++--
+ drivers/net/ethernet/airoha/airoha_eth.h  |  23 +++
+ drivers/net/ethernet/airoha/airoha_regs.h |  22 ++-
+ 3 files changed, 208 insertions(+), 15 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -13,6 +13,7 @@
+ #include <net/dst_metadata.h>
+ #include <net/page_pool/helpers.h>
+ #include <net/pkt_cls.h>
++#include <net/tcp.h>
+ #include <uapi/linux/ppp_defs.h>
+ 
+ #include "airoha_regs.h"
+@@ -439,6 +440,41 @@ static void airoha_fe_crsn_qsel_init(str
+ 				 CDM_CRSN_QSEL_Q1));
+ }
+ 
++static void airoha_fe_lro_init_rx_queue(struct airoha_eth *eth, int qdma_id,
++					int lro_queue_index, int qid,
++					int nbuf, int buf_size)
++{
++	int id = qdma_id + 1;
++
++	airoha_fe_rmw(eth, REG_CDM_LRO_LIMIT(id),
++		      CDM_LRO_AGG_NUM_MASK | CDM_LRO_AGG_SIZE_MASK,
++		      FIELD_PREP(CDM_LRO_AGG_NUM_MASK, nbuf) |
++		      FIELD_PREP(CDM_LRO_AGG_SIZE_MASK, buf_size));
++	airoha_fe_rmw(eth, REG_CDM_LRO_AGE_TIME(id),
++		      CDM_LRO_AGE_TIME_MASK | CDM_LRO_AGG_TIME_MASK,
++		      FIELD_PREP(CDM_LRO_AGE_TIME_MASK,
++				 AIROHA_RXQ_LRO_MAX_AGE_TIME) |
++		      FIELD_PREP(CDM_LRO_AGG_TIME_MASK,
++				 AIROHA_RXQ_LRO_MAX_AGG_TIME));
++	airoha_fe_rmw(eth, REG_CDM_LRO_RXQ(id, lro_queue_index),
++		      LRO_RXQ_MASK(lro_queue_index),
++		      __field_prep(LRO_RXQ_MASK(lro_queue_index), qid));
++	airoha_fe_set(eth, REG_CDM_LRO_EN(id), BIT(lro_queue_index));
++}
++
++static void airoha_fe_lro_disable(struct airoha_eth *eth, int qdma_id)
++{
++	int i, id = qdma_id + 1;
++
++	airoha_fe_clear(eth, REG_CDM_LRO_LIMIT(id),
++			CDM_LRO_AGG_NUM_MASK | CDM_LRO_AGG_SIZE_MASK);
++	airoha_fe_clear(eth, REG_CDM_LRO_AGE_TIME(id),
++			CDM_LRO_AGE_TIME_MASK | CDM_LRO_AGG_TIME_MASK);
++	airoha_fe_clear(eth, REG_CDM_LRO_EN(id), LRO_RXQ_EN_MASK);
++	for (i = 0; i < AIROHA_MAX_NUM_LRO_QUEUES; i++)
++		airoha_fe_clear(eth, REG_CDM_LRO_RXQ(id, i), LRO_RXQ_MASK(i));
++}
++
+ static int airoha_fe_init(struct airoha_eth *eth)
+ {
+ 	airoha_fe_maccr_init(eth);
+@@ -603,9 +639,78 @@ static int airoha_qdma_get_gdm_port(stru
+ 	return port >= ARRAY_SIZE(eth->ports) ? -EINVAL : port;
+ }
+ 
++static int airoha_qdma_lro_rx_process(struct airoha_queue *q,
++				      struct airoha_qdma_desc *desc)
++{
++	u32 msg1 = le32_to_cpu(READ_ONCE(desc->msg1));
++	u32 msg2 = le32_to_cpu(READ_ONCE(desc->msg2));
++	u32 msg3 = le32_to_cpu(READ_ONCE(desc->msg3));
++	bool ipv4 = FIELD_GET(QDMA_ETH_RXMSG_IP4_MASK, msg1);
++	bool ipv6 = FIELD_GET(QDMA_ETH_RXMSG_IP6_MASK, msg1);
++	struct sk_buff *skb = q->skb;
++	u32 th_off, tcp_ack_seq;
++	u16 tcp_win, l2_len;
++	struct tcphdr *th;
++
++	if (FIELD_GET(QDMA_ETH_RXMSG_AGG_COUNT_MASK, msg2) <= 1)
++		return 0;
++
++	if (!ipv4 && !ipv6)
++		return -EOPNOTSUPP;
++
++	l2_len = FIELD_GET(QDMA_ETH_RXMSG_L2_LEN_MASK, msg2);
++	if (ipv4) {
++		u16 agg_len = FIELD_GET(QDMA_ETH_RXMSG_AGG_LEN_MASK, msg3);
++		struct iphdr *iph = (struct iphdr *)(skb->data + l2_len);
++
++		if (iph->protocol != IPPROTO_TCP)
++			return -EOPNOTSUPP;
++
++		iph->tot_len = cpu_to_be16(agg_len);
++		iph->check = 0;
++		iph->check = ip_fast_csum((void *)iph, iph->ihl);
++		th_off = l2_len + (iph->ihl << 2);
++	} else {
++		struct ipv6hdr *ip6h = (struct ipv6hdr *)(skb->data + l2_len);
++		u32 len, desc_ctrl = le32_to_cpu(READ_ONCE(desc->ctrl));
++
++		if (ip6h->nexthdr != NEXTHDR_TCP)
++			return -EOPNOTSUPP;
++
++		len = FIELD_GET(QDMA_DESC_LEN_MASK, desc_ctrl);
++		ip6h->payload_len = cpu_to_be16(len - l2_len - sizeof(*ip6h));
++		th_off = l2_len + sizeof(*ip6h);
++	}
++
++	tcp_win = FIELD_GET(QDMA_ETH_RXMSG_TCP_WIN_MASK, msg3);
++	tcp_ack_seq = le32_to_cpu(READ_ONCE(desc->data));
++
++	th = (struct tcphdr *)(skb->data + th_off);
++	th->ack_seq = cpu_to_be32(tcp_ack_seq);
++	th->window = cpu_to_be16(tcp_win);
++
++	/* Check tcp timestamp option */
++	if (th->doff == (sizeof(*th) + TCPOLEN_TSTAMP_ALIGNED) / 4) {
++		__be32 *topt = (__be32 *)(th + 1);
++
++		if (*topt == cpu_to_be32((TCPOPT_NOP << 24) |
++					 (TCPOPT_NOP << 16) |
++					 (TCPOPT_TIMESTAMP << 8) |
++					 TCPOLEN_TIMESTAMP)) {
++			__le32 tcp_ts_reply = READ_ONCE(desc->tcp_ts_reply);
++
++			put_unaligned_be32(le32_to_cpu(tcp_ts_reply),
++					   topt + 2);
++		}
++	}
++
++	return 0;
++}
++
+ static int airoha_qdma_rx_process(struct airoha_queue *q, int budget)
+ {
+ 	enum dma_data_direction dir = page_pool_get_dma_dir(q->page_pool);
++	bool lro_q = airoha_qdma_is_lro_queue(q);
+ 	struct airoha_qdma *qdma = q->qdma;
+ 	struct airoha_eth *eth = qdma->eth;
+ 	int qid = q - &qdma->q_rx[0];
+@@ -652,9 +757,14 @@ static int airoha_qdma_rx_process(struct
+ 			__skb_put(q->skb, len);
+ 			skb_mark_for_recycle(q->skb);
+ 			q->skb->dev = port->dev;
+-			q->skb->protocol = eth_type_trans(q->skb, port->dev);
+ 			q->skb->ip_summed = CHECKSUM_UNNECESSARY;
+ 			skb_record_rx_queue(q->skb, qid);
++
++			if (lro_q && (port->dev->features & NETIF_F_LRO) &&
++			    airoha_qdma_lro_rx_process(q, desc) < 0)
++				goto free_frag;
++
++			q->skb->protocol = eth_type_trans(q->skb, port->dev);
+ 		} else { /* scattered frame */
+ 			struct skb_shared_info *shinfo = skb_shinfo(q->skb);
+ 			int nr_frags = shinfo->nr_frags;
+@@ -743,23 +853,19 @@ static int airoha_qdma_rx_napi_poll(stru
+ static int airoha_qdma_init_rx_queue(struct airoha_queue *q,
+ 				     struct airoha_qdma *qdma, int ndesc)
+ {
+-	const struct page_pool_params pp_params = {
+-		.order = 0,
+-		.pool_size = 256,
++	struct page_pool_params pp_params = {
+ 		.flags = PP_FLAG_DMA_MAP | PP_FLAG_DMA_SYNC_DEV,
+ 		.dma_dir = DMA_FROM_DEVICE,
+-		.max_len = PAGE_SIZE,
+ 		.nid = NUMA_NO_NODE,
+ 		.dev = qdma->eth->dev,
+ 		.napi = &q->napi,
+ 	};
++	int pp_order, qid = q - &qdma->q_rx[0], thr;
+ 	struct airoha_eth *eth = qdma->eth;
+-	int qid = q - &qdma->q_rx[0], thr;
+ 	dma_addr_t dma_addr;
++	bool lro_q;
+ 
+-	q->buf_size = PAGE_SIZE / 2;
+ 	q->qdma = qdma;
+-
+ 	q->entry = devm_kzalloc(eth->dev, ndesc * sizeof(*q->entry),
+ 				GFP_KERNEL);
+ 	if (!q->entry)
+@@ -770,6 +876,12 @@ static int airoha_qdma_init_rx_queue(str
+ 	if (!q->desc)
+ 		return -ENOMEM;
+ 
++	lro_q = airoha_qdma_is_lro_queue(q);
++	pp_order = lro_q ? AIROHA_LRO_PAGE_ORDER : 0;
++	pp_params.order = pp_order;
++	pp_params.pool_size = 256 >> pp_order;
++	pp_params.max_len = PAGE_SIZE << pp_order;
++
+ 	q->page_pool = page_pool_create(&pp_params);
+ 	if (IS_ERR(q->page_pool)) {
+ 		int err = PTR_ERR(q->page_pool);
+@@ -778,6 +890,7 @@ static int airoha_qdma_init_rx_queue(str
+ 		return err;
+ 	}
+ 
++	q->buf_size = pp_params.max_len / (2 * (1 + lro_q));
+ 	q->ndesc = ndesc;
+ 	netif_napi_add(eth->napi_dev, &q->napi, airoha_qdma_rx_napi_poll);
+ 
+@@ -2032,6 +2145,45 @@ int airoha_get_fe_port(struct airoha_gdm
+ 	}
+ }
+ 
++static int airoha_dev_set_features(struct net_device *dev,
++				   netdev_features_t features)
++{
++
++	netdev_features_t diff = dev->features ^ features;
++	struct airoha_gdm_port *port = netdev_priv(dev);
++	struct airoha_qdma *qdma = port->qdma;
++	struct airoha_eth *eth = qdma->eth;
++	int qdma_id = qdma - &eth->qdma[0];
++
++	if (!(diff & NETIF_F_LRO))
++		return 0;
++
++	/* reset LRO configuration */
++	if (features & NETIF_F_LRO) {
++		int i, lro_queue_index = 0;
++
++		for (i = 0; i < ARRAY_SIZE(qdma->q_rx); i++) {
++			struct airoha_queue *q = &qdma->q_rx[i];
++
++			if (!q->ndesc)
++				continue;
++
++			if (!airoha_qdma_is_lro_queue(q))
++				continue;
++
++			airoha_fe_lro_init_rx_queue(eth, qdma_id,
++						    lro_queue_index, i,
++						    q->page_pool->p.pool_size,
++						    q->buf_size);
++			lro_queue_index++;
++		}
++	} else {
++		airoha_fe_lro_disable(eth, qdma_id);
++	}
++
++	return 0;
++}
++
+ static netdev_tx_t airoha_dev_xmit(struct sk_buff *skb,
+ 				   struct net_device *dev)
+ {
+@@ -2931,6 +3083,7 @@ static const struct net_device_ops airoh
+ 	.ndo_stop		= airoha_dev_stop,
+ 	.ndo_change_mtu		= airoha_dev_change_mtu,
+ 	.ndo_select_queue	= airoha_dev_select_queue,
++	.ndo_set_features	= airoha_dev_set_features,
+ 	.ndo_start_xmit		= airoha_dev_xmit,
+ 	.ndo_get_stats64        = airoha_dev_get_stats64,
+ 	.ndo_set_mac_address	= airoha_dev_set_macaddr,
+@@ -3153,12 +3306,9 @@ static int airoha_alloc_gdm_port(struct
+ 	dev->ethtool_ops = &airoha_ethtool_ops;
+ 	dev->max_mtu = AIROHA_MAX_MTU;
+ 	dev->watchdog_timeo = 5 * HZ;
+-	dev->hw_features = NETIF_F_IP_CSUM | NETIF_F_RXCSUM |
+-			   NETIF_F_TSO6 | NETIF_F_IPV6_CSUM |
+-			   NETIF_F_SG | NETIF_F_TSO |
+-			   NETIF_F_HW_TC;
+-	dev->features |= dev->hw_features;
+-	dev->vlan_features = dev->hw_features;
++	dev->hw_features = AIROHA_HW_FEATURES | NETIF_F_LRO;
++	dev->features |= AIROHA_HW_FEATURES;
++	dev->vlan_features = AIROHA_HW_FEATURES;
+ 	dev->dev.of_node = np;
+ 	SET_NETDEV_DEV(dev, eth->dev);
+ 
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -43,6 +43,17 @@
+ 	 (_n) == 15 ? 128 :		\
+ 	 (_n) ==  0 ? 1024 : 16)
+ 
++#define AIROHA_LRO_PAGE_ORDER		2
++#define AIROHA_MAX_NUM_LRO_QUEUES	8
++#define AIROHA_RXQ_LRO_EN_MASK		0xff000
++#define AIROHA_RXQ_LRO_MAX_AGG_TIME	100
++#define AIROHA_RXQ_LRO_MAX_AGE_TIME	2000 /* 1ms */
++
++#define AIROHA_HW_FEATURES			\
++	(NETIF_F_IP_CSUM | NETIF_F_RXCSUM |	\
++	 NETIF_F_TSO6 | NETIF_F_IPV6_CSUM |	\
++	 NETIF_F_SG | NETIF_F_TSO | NETIF_F_HW_TC)
++
+ #define PSE_RSV_PAGES			128
+ #define PSE_QUEUE_RSV_PAGES		64
+ 
+@@ -666,6 +677,18 @@ static inline bool airoha_is_7583(struct
+ 	return eth->soc->version == 0x7583;
+ }
+ 
++static inline bool airoha_qdma_is_lro_queue(struct airoha_queue *q)
++{
++	struct airoha_qdma *qdma = q->qdma;
++	int qid = q - &qdma->q_rx[0];
++
++	/* EN7581 SoC supports at most 8 LRO rx queues */
++	BUILD_BUG_ON(hweight32(AIROHA_RXQ_LRO_EN_MASK) >
++		     AIROHA_MAX_NUM_LRO_QUEUES);
++
++	return !!(AIROHA_RXQ_LRO_EN_MASK & BIT(qid));
++}
++
+ int airoha_get_fe_port(struct airoha_gdm_port *port);
+ bool airoha_is_valid_gdm_port(struct airoha_eth *eth,
+ 			      struct airoha_gdm_port *port);
+--- a/drivers/net/ethernet/airoha/airoha_regs.h
++++ b/drivers/net/ethernet/airoha/airoha_regs.h
+@@ -122,6 +122,20 @@
+ #define CDM_CRSN_QSEL_REASON_MASK(_n)	\
+ 	GENMASK(4 + (((_n) % 4) << 3),	(((_n) % 4) << 3))
+ 
++#define REG_CDM_LRO_RXQ(_n, _m)		(CDM_BASE(_n) + 0x78 + ((_m) & 0x4))
++#define LRO_RXQ_MASK(_n)		GENMASK(4 + (((_n) & 0x3) << 3), ((_n) & 0x3) << 3)
++
++#define REG_CDM_LRO_EN(_n)		(CDM_BASE(_n) + 0x80)
++#define LRO_RXQ_EN_MASK			GENMASK(7, 0)
++
++#define REG_CDM_LRO_LIMIT(_n)		(CDM_BASE(_n) + 0x84)
++#define CDM_LRO_AGG_NUM_MASK		GENMASK(23, 16)
++#define CDM_LRO_AGG_SIZE_MASK		GENMASK(15, 0)
++
++#define REG_CDM_LRO_AGE_TIME(_n)	(CDM_BASE(_n) + 0x88)
++#define CDM_LRO_AGE_TIME_MASK		GENMASK(31, 16)
++#define CDM_LRO_AGG_TIME_MASK		GENMASK(15, 0)
++
+ #define REG_GDM_FWD_CFG(_n)		GDM_BASE(_n)
+ #define GDM_PAD_EN_MASK			BIT(28)
+ #define GDM_DROP_CRC_ERR_MASK		BIT(23)
+@@ -895,9 +909,15 @@
+ #define QDMA_ETH_RXMSG_SPORT_MASK	GENMASK(25, 21)
+ #define QDMA_ETH_RXMSG_CRSN_MASK	GENMASK(20, 16)
+ #define QDMA_ETH_RXMSG_PPE_ENTRY_MASK	GENMASK(15, 0)
++/* RX MSG2 */
++#define QDMA_ETH_RXMSG_AGG_COUNT_MASK	GENMASK(31, 24)
++#define QDMA_ETH_RXMSG_L2_LEN_MASK	GENMASK(6, 0)
++/* RX MSG3 */
++#define QDMA_ETH_RXMSG_AGG_LEN_MASK	GENMASK(31, 16)
++#define QDMA_ETH_RXMSG_TCP_WIN_MASK	GENMASK(15, 0)
+ 
+ struct airoha_qdma_desc {
+-	__le32 rsv;
++	__le32 tcp_ts_reply;
+ 	__le32 ctrl;
+ 	__le32 addr;
+ 	__le32 data;

--- a/target/linux/airoha/patches-6.6/916-net-airoha-Implement-LRO-TCP-support.patch
+++ b/target/linux/airoha/patches-6.6/916-net-airoha-Implement-LRO-TCP-support.patch
@@ -212,7 +212,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	q->ndesc = ndesc;
  	netif_napi_add(eth->napi_dev, &q->napi, airoha_qdma_rx_napi_poll);
  
-@@ -2032,6 +2151,64 @@ int airoha_get_fe_port(struct airoha_gdm
+@@ -2034,6 +2153,64 @@ int airoha_get_fe_port(struct airoha_gdm
  	}
  }
  
@@ -277,7 +277,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  static netdev_tx_t airoha_dev_xmit(struct sk_buff *skb,
  				   struct net_device *dev)
  {
-@@ -2931,6 +3108,7 @@ static const struct net_device_ops airoh
+@@ -2933,6 +3110,7 @@ static const struct net_device_ops airoh
  	.ndo_stop		= airoha_dev_stop,
  	.ndo_change_mtu		= airoha_dev_change_mtu,
  	.ndo_select_queue	= airoha_dev_select_queue,
@@ -285,7 +285,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	.ndo_start_xmit		= airoha_dev_xmit,
  	.ndo_get_stats64        = airoha_dev_get_stats64,
  	.ndo_set_mac_address	= airoha_dev_set_macaddr,
-@@ -3148,12 +3326,9 @@ static int airoha_alloc_gdm_port(struct
+@@ -3150,12 +3328,9 @@ static int airoha_alloc_gdm_port(struct
  	dev->ethtool_ops = &airoha_ethtool_ops;
  	dev->max_mtu = AIROHA_MAX_MTU;
  	dev->watchdog_timeo = 5 * HZ;

--- a/target/linux/airoha/patches-6.6/916-net-airoha-Implement-LRO-TCP-support.patch
+++ b/target/linux/airoha/patches-6.6/916-net-airoha-Implement-LRO-TCP-support.patch
@@ -21,7 +21,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  #include <uapi/linux/ppp_defs.h>
  
  #include "airoha_regs.h"
-@@ -439,6 +440,41 @@ static void airoha_fe_crsn_qsel_init(str
+@@ -439,6 +440,47 @@ static void airoha_fe_crsn_qsel_init(str
  				 CDM_CRSN_QSEL_Q1));
  }
  
@@ -60,10 +60,16 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 +		airoha_fe_clear(eth, REG_CDM_LRO_RXQ(id, i), LRO_RXQ_MASK(i));
 +}
 +
++static bool airoha_fe_lro_is_enabled(struct airoha_eth *eth, int qdma_id)
++{
++	return airoha_fe_get(eth, REG_CDM_LRO_EN(qdma_id + 1),
++			     LRO_RXQ_EN_MASK);
++}
++
  static int airoha_fe_init(struct airoha_eth *eth)
  {
  	airoha_fe_maccr_init(eth);
-@@ -603,9 +639,78 @@ static int airoha_qdma_get_gdm_port(stru
+@@ -603,9 +645,78 @@ static int airoha_qdma_get_gdm_port(stru
  	return port >= ARRAY_SIZE(eth->ports) ? -EINVAL : port;
  }
  
@@ -142,7 +148,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	struct airoha_qdma *qdma = q->qdma;
  	struct airoha_eth *eth = qdma->eth;
  	int qid = q - &qdma->q_rx[0];
-@@ -652,9 +757,14 @@ static int airoha_qdma_rx_process(struct
+@@ -652,9 +763,14 @@ static int airoha_qdma_rx_process(struct
  			__skb_put(q->skb, len);
  			skb_mark_for_recycle(q->skb);
  			q->skb->dev = port->dev;
@@ -158,7 +164,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		} else { /* scattered frame */
  			struct skb_shared_info *shinfo = skb_shinfo(q->skb);
  			int nr_frags = shinfo->nr_frags;
-@@ -743,23 +853,19 @@ static int airoha_qdma_rx_napi_poll(stru
+@@ -743,23 +859,19 @@ static int airoha_qdma_rx_napi_poll(stru
  static int airoha_qdma_init_rx_queue(struct airoha_queue *q,
  				     struct airoha_qdma *qdma, int ndesc)
  {
@@ -185,7 +191,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	q->entry = devm_kzalloc(eth->dev, ndesc * sizeof(*q->entry),
  				GFP_KERNEL);
  	if (!q->entry)
-@@ -770,6 +876,12 @@ static int airoha_qdma_init_rx_queue(str
+@@ -770,6 +882,12 @@ static int airoha_qdma_init_rx_queue(str
  	if (!q->desc)
  		return -ENOMEM;
  
@@ -198,7 +204,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	q->page_pool = page_pool_create(&pp_params);
  	if (IS_ERR(q->page_pool)) {
  		int err = PTR_ERR(q->page_pool);
-@@ -778,6 +890,7 @@ static int airoha_qdma_init_rx_queue(str
+@@ -778,6 +896,7 @@ static int airoha_qdma_init_rx_queue(str
  		return err;
  	}
  
@@ -206,7 +212,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	q->ndesc = ndesc;
  	netif_napi_add(eth->napi_dev, &q->napi, airoha_qdma_rx_napi_poll);
  
-@@ -2032,6 +2145,45 @@ int airoha_get_fe_port(struct airoha_gdm
+@@ -2032,6 +2151,64 @@ int airoha_get_fe_port(struct airoha_gdm
  	}
  }
  
@@ -219,13 +225,17 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 +	struct airoha_qdma *qdma = port->qdma;
 +	struct airoha_eth *eth = qdma->eth;
 +	int qdma_id = qdma - &eth->qdma[0];
++	int i;
 +
 +	if (!(diff & NETIF_F_LRO))
 +		return 0;
 +
 +	/* reset LRO configuration */
 +	if (features & NETIF_F_LRO) {
-+		int i, lro_queue_index = 0;
++		int lro_queue_index = 0;
++
++		if (airoha_fe_lro_is_enabled(eth, qdma_id))
++			return 0;
 +
 +		for (i = 0; i < ARRAY_SIZE(qdma->q_rx); i++) {
 +			struct airoha_queue *q = &qdma->q_rx[i];
@@ -243,6 +253,21 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 +			lro_queue_index++;
 +		}
 +	} else {
++		for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
++			struct airoha_gdm_port *p = eth->ports[i];
++
++			if (!p)
++				continue;
++
++			if (p->qdma != qdma)
++				continue;
++
++			if (p->dev == dev)
++				continue;
++
++			if (p->dev->features & NETIF_F_LRO)
++				return 0;
++		}
 +		airoha_fe_lro_disable(eth, qdma_id);
 +	}
 +
@@ -252,7 +277,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  static netdev_tx_t airoha_dev_xmit(struct sk_buff *skb,
  				   struct net_device *dev)
  {
-@@ -2931,6 +3083,7 @@ static const struct net_device_ops airoh
+@@ -2931,6 +3108,7 @@ static const struct net_device_ops airoh
  	.ndo_stop		= airoha_dev_stop,
  	.ndo_change_mtu		= airoha_dev_change_mtu,
  	.ndo_select_queue	= airoha_dev_select_queue,
@@ -260,7 +285,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	.ndo_start_xmit		= airoha_dev_xmit,
  	.ndo_get_stats64        = airoha_dev_get_stats64,
  	.ndo_set_mac_address	= airoha_dev_set_macaddr,
-@@ -3153,12 +3306,9 @@ static int airoha_alloc_gdm_port(struct
+@@ -3148,12 +3326,9 @@ static int airoha_alloc_gdm_port(struct
  	dev->ethtool_ops = &airoha_ethtool_ops;
  	dev->max_mtu = AIROHA_MAX_MTU;
  	dev->watchdog_timeo = 5 * HZ;

--- a/target/linux/airoha/patches-6.6/920-01-net-airoha-Introduce-airoha_gdm_dev-struct.patch
+++ b/target/linux/airoha/patches-6.6/920-01-net-airoha-Introduce-airoha_gdm_dev-struct.patch
@@ -1,0 +1,1012 @@
+From e15783f7c987e199ecf80b3d858ed5a86d33c508 Mon Sep 17 00:00:00 2001
+Message-ID: <e15783f7c987e199ecf80b3d858ed5a86d33c508.1779348625.git.lorenzo@kernel.org>
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Sat, 1 Nov 2025 11:25:52 +0100
+Subject: [PATCH 01/13] net: airoha: Introduce airoha_gdm_dev struct
+
+EN7581 and AN7583 SoCs support connecting multiple external SerDes to GDM3
+or GDM4 ports via a hw arbiter that manages the traffic in a TDM manner.
+As a result multiple net_devices can connect to the same GDM{3,4} port
+and there is a theoretical "1:n" relation between GDM port and
+net_devices.
+Introduce airoha_gdm_dev struct to collect net_device related info (e.g.
+net_device and external phy pointer). Please note this is just a
+preliminary patch and we are still supporting a single net_device for
+each GDM port. Subsequent patches will add support for multiple net_devices
+connected to the same GDM port.
+
+Tested-by: Xuegang Lu <xuegang.lu@airoha.com>
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 312 ++++++++++++++---------
+ drivers/net/ethernet/airoha/airoha_eth.h |  13 +-
+ drivers/net/ethernet/airoha/airoha_ppe.c |  17 +-
+ 3 files changed, 206 insertions(+), 136 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -727,6 +727,7 @@ static int airoha_qdma_rx_process(struct
+ 		struct airoha_qdma_desc *desc = &q->desc[q->tail];
+ 		u32 hash, reason, msg1, desc_ctrl;
+ 		struct airoha_gdm_port *port;
++		struct net_device *netdev;
+ 		int data_len, len, p;
+ 		struct page *page;
+ 
+@@ -753,6 +754,10 @@ static int airoha_qdma_rx_process(struct
+ 			goto free_frag;
+ 
+ 		port = eth->ports[p];
++		if (!port->dev)
++			goto free_frag;
++
++		netdev = port->dev->dev;
+ 		if (!q->skb) { /* first buffer */
+ 			q->skb = napi_build_skb(e->buf - AIROHA_RX_HEADROOM,
+ 						q->buf_size);
+@@ -762,15 +767,15 @@ static int airoha_qdma_rx_process(struct
+ 			skb_reserve(q->skb, AIROHA_RX_HEADROOM);
+ 			__skb_put(q->skb, len);
+ 			skb_mark_for_recycle(q->skb);
+-			q->skb->dev = port->dev;
++			q->skb->dev = netdev;
+ 			q->skb->ip_summed = CHECKSUM_UNNECESSARY;
+ 			skb_record_rx_queue(q->skb, qid);
+ 
+-			if (lro_q && (port->dev->features & NETIF_F_LRO) &&
++			if (lro_q && (netdev->features & NETIF_F_LRO) &&
+ 			    airoha_qdma_lro_rx_process(q, desc) < 0)
+ 				goto free_frag;
+ 
+-			q->skb->protocol = eth_type_trans(q->skb, port->dev);
++			q->skb->protocol = eth_type_trans(q->skb, netdev);
+ 		} else { /* scattered frame */
+ 			struct skb_shared_info *shinfo = skb_shinfo(q->skb);
+ 			int nr_frags = shinfo->nr_frags;
+@@ -786,7 +791,7 @@ static int airoha_qdma_rx_process(struct
+ 		if (FIELD_GET(QDMA_DESC_MORE_MASK, desc_ctrl))
+ 			continue;
+ 
+-		if (netdev_uses_dsa(port->dev)) {
++		if (netdev_uses_dsa(netdev)) {
+ 			/* PPE module requires untagged packets to work
+ 			 * properly and it provides DSA port index via the
+ 			 * DMA descriptor. Report DSA tag to the DSA stack
+@@ -983,6 +988,7 @@ static void airoha_qdma_wake_netdev_txqs
+ 
+ 	for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
+ 		struct airoha_gdm_port *port = eth->ports[i];
++		struct airoha_gdm_dev *dev;
+ 		int j;
+ 
+ 		if (!port)
+@@ -991,11 +997,12 @@ static void airoha_qdma_wake_netdev_txqs
+ 		if (port->qdma != qdma)
+ 			continue;
+ 
+-		for (j = 0; j < port->dev->num_tx_queues; j++) {
++		dev = port->dev;
++		for (j = 0; j < dev->dev->num_tx_queues; j++) {
+ 			if (airoha_qdma_get_txq(qdma, j) != qid)
+ 				continue;
+ 
+-			netif_wake_subqueue(port->dev, j);
++			netif_wake_subqueue(dev->dev, j);
+ 		}
+ 	}
+ 	q->txq_stopped = false;
+@@ -1839,33 +1846,34 @@ static void airoha_update_hw_stats(struc
+ 	spin_unlock(&port->stats.lock);
+ }
+ 
+-static int airoha_dev_open(struct net_device *dev)
++static int airoha_dev_open(struct net_device *netdev)
+ {
+-	int err, len = ETH_HLEN + dev->mtu + ETH_FCS_LEN;
+-	struct airoha_gdm_port *port = netdev_priv(dev);
++	int err, len = ETH_HLEN + netdev->mtu + ETH_FCS_LEN;
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
+ 	struct airoha_qdma *qdma = port->qdma;
+ 	u32 pse_port = FE_PSE_PORT_PPE1;
+ 
+ #if defined(CONFIG_PCS_AIROHA)
+ 	if (airhoa_is_phy_external(port)) {
+-		err = phylink_of_phy_connect(port->phylink, dev->dev.of_node, 0);
++		err = phylink_of_phy_connect(dev->phylink, netdev->dev.of_node, 0);
+ 		if (err) {
+-			netdev_err(dev, "%s: could not attach PHY: %d\n", __func__,
++			netdev_err(netdev, "%s: could not attach PHY: %d\n", __func__,
+ 				   err);
+ 			return err;
+ 		}
+ 
+-		phylink_start(port->phylink);
++		phylink_start(dev->phylink);
+ 	}
+ #endif
+ 
+-	netif_tx_start_all_queues(dev);
++	netif_tx_start_all_queues(netdev);
+ 	err = airoha_set_vip_for_gdm_port(port, true);
+ 	if (err)
+ 		return err;
+ 
+ 	/* It seems GDM3 and GDM4 needs SPORT enabled to correctly work */
+-	if (netdev_uses_dsa(dev) || port->id > 2)
++	if (netdev_uses_dsa(netdev) || port->id > 2)
+ 		airoha_fe_set(qdma->eth, REG_GDM_INGRESS_CFG(port->id),
+ 			      GDM_STAG_EN_MASK);
+ 	else
+@@ -1893,16 +1901,17 @@ static int airoha_dev_open(struct net_de
+ 	return 0;
+ }
+ 
+-static int airoha_dev_stop(struct net_device *dev)
++static int airoha_dev_stop(struct net_device *netdev)
+ {
+-	struct airoha_gdm_port *port = netdev_priv(dev);
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
+ 	struct airoha_qdma *qdma = port->qdma;
+ 	int i;
+ 
+-	netif_tx_disable(dev);
++	netif_tx_disable(netdev);
+ 	airoha_set_vip_for_gdm_port(port, false);
+-	for (i = 0; i < dev->num_tx_queues; i++)
+-		netdev_tx_reset_subqueue(dev, i);
++	for (i = 0; i < netdev->num_tx_queues; i++)
++		netdev_tx_reset_subqueue(netdev, i);
+ 
+ 	airoha_set_gdm_port_fwd_cfg(qdma->eth, REG_GDM_FWD_CFG(port->id),
+ 				    FE_PSE_PORT_DROP);
+@@ -1922,24 +1931,25 @@ static int airoha_dev_stop(struct net_de
+ 
+ #if defined(CONFIG_PCS_AIROHA)
+ 	if (airhoa_is_phy_external(port)) {
+-		phylink_stop(port->phylink);
+-		phylink_disconnect_phy(port->phylink);
++		phylink_stop(dev->phylink);
++		phylink_disconnect_phy(dev->phylink);
+ 	}
+ #endif
+ 
+ 	return 0;
+ }
+ 
+-static int airoha_dev_set_macaddr(struct net_device *dev, void *p)
++static int airoha_dev_set_macaddr(struct net_device *netdev, void *p)
+ {
+-	struct airoha_gdm_port *port = netdev_priv(dev);
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
+ 	int err;
+ 
+-	err = eth_mac_addr(dev, p);
++	err = eth_mac_addr(netdev, p);
+ 	if (err)
+ 		return err;
+ 
+-	airoha_set_macaddr(port, dev->dev_addr);
++	airoha_set_macaddr(port, netdev->dev_addr);
+ 
+ 	return 0;
+ }
+@@ -2005,16 +2015,17 @@ static int airoha_set_gdm2_loopback(stru
+ 	return 0;
+ }
+ 
+-static int airoha_dev_init(struct net_device *dev)
++static int airoha_dev_init(struct net_device *netdev)
+ {
+-	struct airoha_gdm_port *port = netdev_priv(dev);
+-	struct airoha_eth *eth = port->eth;
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
++	struct airoha_eth *eth = dev->eth;
+ 	int i;
+ 
+ 	/* QDMA0 is used for lan ports while QDMA1 is used for WAN ports */
+ 	port->qdma = &eth->qdma[!airoha_is_lan_gdm_port(port)];
+-	port->dev->irq = port->qdma->irq_banks[0].irq;
+-	airoha_set_macaddr(port, dev->dev_addr);
++	dev->dev->irq = port->qdma->irq_banks[0].irq;
++	airoha_set_macaddr(port, netdev->dev_addr);
+ 
+ 	switch (port->id) {
+ 	case AIROHA_GDM3_IDX:
+@@ -2039,10 +2050,11 @@ static int airoha_dev_init(struct net_de
+ 	return 0;
+ }
+ 
+-static void airoha_dev_get_stats64(struct net_device *dev,
++static void airoha_dev_get_stats64(struct net_device *netdev,
+ 				   struct rtnl_link_stats64 *storage)
+ {
+-	struct airoha_gdm_port *port = netdev_priv(dev);
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
+ 	unsigned int start;
+ 
+ 	airoha_update_hw_stats(port);
+@@ -2061,36 +2073,39 @@ static void airoha_dev_get_stats64(struc
+ 	} while (u64_stats_fetch_retry(&port->stats.syncp, start));
+ }
+ 
+-static int airoha_dev_change_mtu(struct net_device *dev, int mtu)
++static int airoha_dev_change_mtu(struct net_device *netdev, int mtu)
+ {
+-	struct airoha_gdm_port *port = netdev_priv(dev);
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
+ 	struct airoha_eth *eth = port->qdma->eth;
+ 	u32 len = ETH_HLEN + mtu + ETH_FCS_LEN;
+ 
+ 	airoha_fe_rmw(eth, REG_GDM_LEN_CFG(port->id),
+ 		      GDM_LONG_LEN_MASK,
+ 		      FIELD_PREP(GDM_LONG_LEN_MASK, len));
+-	WRITE_ONCE(dev->mtu, mtu);
++	WRITE_ONCE(netdev->mtu, mtu);
+ 
+ 	return 0;
+ }
+ 
+-static u16 airoha_dev_select_queue(struct net_device *dev, struct sk_buff *skb,
++static u16 airoha_dev_select_queue(struct net_device *netdev,
++				   struct sk_buff *skb,
+ 				   struct net_device *sb_dev)
+ {
+-	struct airoha_gdm_port *port = netdev_priv(dev);
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
+ 	int queue, channel;
+ 
+ 	/* For dsa device select QoS channel according to the dsa user port
+ 	 * index, rely on port id otherwise. Select QoS queue based on the
+ 	 * skb priority.
+ 	 */
+-	channel = netdev_uses_dsa(dev) ? skb_get_queue_mapping(skb) : port->id;
++	channel = netdev_uses_dsa(netdev) ? skb_get_queue_mapping(skb) : port->id;
+ 	channel = channel % AIROHA_NUM_QOS_CHANNELS;
+ 	queue = (skb->priority - 1) % AIROHA_NUM_QOS_QUEUES; /* QoS queue */
+ 	queue = channel * AIROHA_NUM_QOS_QUEUES + queue;
+ 
+-	return queue < dev->num_tx_queues ? queue : 0;
++	return queue < netdev->num_tx_queues ? queue : 0;
+ }
+ 
+ static u32 airoha_get_dsa_tag(struct sk_buff *skb, struct net_device *dev)
+@@ -2153,12 +2168,13 @@ int airoha_get_fe_port(struct airoha_gdm
+ 	}
+ }
+ 
+-static int airoha_dev_set_features(struct net_device *dev,
++static int airoha_dev_set_features(struct net_device *netdev,
+ 				   netdev_features_t features)
+ {
+ 
+-	netdev_features_t diff = dev->features ^ features;
+-	struct airoha_gdm_port *port = netdev_priv(dev);
++	netdev_features_t diff = netdev->features ^ features;
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
+ 	struct airoha_qdma *qdma = port->qdma;
+ 	struct airoha_eth *eth = qdma->eth;
+ 	int qdma_id = qdma - &eth->qdma[0];
+@@ -2192,6 +2208,7 @@ static int airoha_dev_set_features(struc
+ 	} else {
+ 		for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
+ 			struct airoha_gdm_port *p = eth->ports[i];
++			struct airoha_gdm_dev *d;
+ 
+ 			if (!p)
+ 				continue;
+@@ -2199,10 +2216,11 @@ static int airoha_dev_set_features(struc
+ 			if (p->qdma != qdma)
+ 				continue;
+ 
+-			if (p->dev == dev)
++			d = p->dev;
++			if (d->dev == netdev)
+ 				continue;
+ 
+-			if (p->dev->features & NETIF_F_LRO)
++			if (d->dev->features & NETIF_F_LRO)
+ 				return 0;
+ 		}
+ 		airoha_fe_lro_disable(eth, qdma_id);
+@@ -2212,9 +2230,10 @@ static int airoha_dev_set_features(struc
+ }
+ 
+ static netdev_tx_t airoha_dev_xmit(struct sk_buff *skb,
+-				   struct net_device *dev)
++				   struct net_device *netdev)
+ {
+-	struct airoha_gdm_port *port = netdev_priv(dev);
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
+ 	struct airoha_qdma *qdma = port->qdma;
+ 	u32 nr_frags, tag, msg0, msg1, len;
+ 	struct airoha_queue_entry *e;
+@@ -2227,7 +2246,7 @@ static netdev_tx_t airoha_dev_xmit(struc
+ 	u8 fport;
+ 
+ 	qid = airoha_qdma_get_txq(qdma, skb_get_queue_mapping(skb));
+-	tag = airoha_get_dsa_tag(skb, dev);
++	tag = airoha_get_dsa_tag(skb, netdev);
+ 
+ 	msg0 = FIELD_PREP(QDMA_ETH_TXMSG_CHAN_MASK,
+ 			  qid / AIROHA_NUM_QOS_QUEUES) |
+@@ -2263,7 +2282,7 @@ static netdev_tx_t airoha_dev_xmit(struc
+ 
+ 	spin_lock_bh(&q->lock);
+ 
+-	txq = skb_get_tx_queue(dev, skb);
++	txq = skb_get_tx_queue(netdev, skb);
+ 	nr_frags = 1 + skb_shinfo(skb)->nr_frags;
+ 
+ 	if (q->queued + nr_frags >= q->ndesc) {
+@@ -2287,9 +2306,9 @@ static netdev_tx_t airoha_dev_xmit(struc
+ 		dma_addr_t addr;
+ 		u32 val;
+ 
+-		addr = dma_map_single(dev->dev.parent, data, len,
++		addr = dma_map_single(netdev->dev.parent, data, len,
+ 				      DMA_TO_DEVICE);
+-		if (unlikely(dma_mapping_error(dev->dev.parent, addr)))
++		if (unlikely(dma_mapping_error(netdev->dev.parent, addr)))
+ 			goto error_unmap;
+ 
+ 		list_move_tail(&e->list, &tx_list);
+@@ -2338,7 +2357,7 @@ static netdev_tx_t airoha_dev_xmit(struc
+ 
+ error_unmap:
+ 	list_for_each_entry(e, &tx_list, list) {
+-		dma_unmap_single(dev->dev.parent, e->dma_addr, e->dma_len,
++		dma_unmap_single(netdev->dev.parent, e->dma_addr, e->dma_len,
+ 				 DMA_TO_DEVICE);
+ 		e->dma_addr = 0;
+ 	}
+@@ -2347,25 +2366,27 @@ error_unmap:
+ 	spin_unlock_bh(&q->lock);
+ error:
+ 	dev_kfree_skb_any(skb);
+-	dev->stats.tx_dropped++;
++	netdev->stats.tx_dropped++;
+ 
+ 	return NETDEV_TX_OK;
+ }
+ 
+-static void airoha_ethtool_get_drvinfo(struct net_device *dev,
++static void airoha_ethtool_get_drvinfo(struct net_device *netdev,
+ 				       struct ethtool_drvinfo *info)
+ {
+-	struct airoha_gdm_port *port = netdev_priv(dev);
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
+ 	struct airoha_eth *eth = port->qdma->eth;
+ 
+ 	strscpy(info->driver, eth->dev->driver->name, sizeof(info->driver));
+ 	strscpy(info->bus_info, dev_name(eth->dev), sizeof(info->bus_info));
+ }
+ 
+-static void airoha_ethtool_get_mac_stats(struct net_device *dev,
++static void airoha_ethtool_get_mac_stats(struct net_device *netdev,
+ 					 struct ethtool_eth_mac_stats *stats)
+ {
+-	struct airoha_gdm_port *port = netdev_priv(dev);
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
+ 	unsigned int start;
+ 
+ 	airoha_update_hw_stats(port);
+@@ -2393,11 +2414,12 @@ static const struct ethtool_rmon_hist_ra
+ };
+ 
+ static void
+-airoha_ethtool_get_rmon_stats(struct net_device *dev,
++airoha_ethtool_get_rmon_stats(struct net_device *netdev,
+ 			      struct ethtool_rmon_stats *stats,
+ 			      const struct ethtool_rmon_hist_range **ranges)
+ {
+-	struct airoha_gdm_port *port = netdev_priv(dev);
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
+ 	struct airoha_hw_stats *hw_stats = &port->stats;
+ 	unsigned int start;
+ 
+@@ -2422,11 +2444,12 @@ airoha_ethtool_get_rmon_stats(struct net
+ 	} while (u64_stats_fetch_retry(&port->stats.syncp, start));
+ }
+ 
+-static int airoha_qdma_set_chan_tx_sched(struct net_device *dev,
++static int airoha_qdma_set_chan_tx_sched(struct net_device *netdev,
+ 					 int channel, enum tx_sched_mode mode,
+ 					 const u16 *weights, u8 n_weights)
+ {
+-	struct airoha_gdm_port *port = netdev_priv(dev);
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
+ 	int i;
+ 
+ 	for (i = 0; i < AIROHA_NUM_TX_RING; i++)
+@@ -2511,10 +2534,12 @@ static int airoha_qdma_set_tx_ets_sched(
+ 					     ARRAY_SIZE(w));
+ }
+ 
+-static int airoha_qdma_get_tx_ets_stats(struct net_device *dev, int channel,
++static int airoha_qdma_get_tx_ets_stats(struct net_device *netdev, int channel,
+ 					struct tc_ets_qopt_offload *opt)
+ {
+-	struct airoha_gdm_port *port = netdev_priv(dev);
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
++
+ 	u64 cpu_tx_packets = airoha_qdma_rr(port->qdma,
+ 					    REG_CNTR_VAL(channel << 1));
+ 	u64 fwd_tx_packets = airoha_qdma_rr(port->qdma,
+@@ -2776,11 +2801,12 @@ static int airoha_qdma_set_trtcm_token_b
+ 					   mode, val);
+ }
+ 
+-static int airoha_qdma_set_tx_rate_limit(struct net_device *dev,
++static int airoha_qdma_set_tx_rate_limit(struct net_device *netdev,
+ 					 int channel, u32 rate,
+ 					 u32 bucket_size)
+ {
+-	struct airoha_gdm_port *port = netdev_priv(dev);
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
+ 	int i, err;
+ 
+ 	for (i = 0; i <= TRTCM_PEAK_MODE; i++) {
+@@ -2800,20 +2826,22 @@ static int airoha_qdma_set_tx_rate_limit
+ 	return 0;
+ }
+ 
+-static int airoha_tc_htb_alloc_leaf_queue(struct net_device *dev,
++static int airoha_tc_htb_alloc_leaf_queue(struct net_device *netdev,
+ 					  struct tc_htb_qopt_offload *opt)
+ {
+ 	u32 channel = TC_H_MIN(opt->classid) % AIROHA_NUM_QOS_CHANNELS;
+ 	u32 rate = div_u64(opt->rate, 1000) << 3; /* kbps */
+-	int err, num_tx_queues = dev->real_num_tx_queues;
+-	struct airoha_gdm_port *port = netdev_priv(dev);
++	int err, num_tx_queues = netdev->real_num_tx_queues;
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
+ 
+ 	if (opt->parent_classid != TC_HTB_CLASSID_ROOT) {
+ 		NL_SET_ERR_MSG_MOD(opt->extack, "invalid parent classid");
+ 		return -EINVAL;
+ 	}
+ 
+-	err = airoha_qdma_set_tx_rate_limit(dev, channel, rate, opt->quantum);
++	err = airoha_qdma_set_tx_rate_limit(netdev, channel, rate,
++					    opt->quantum);
+ 	if (err) {
+ 		NL_SET_ERR_MSG_MOD(opt->extack,
+ 				   "failed configuring htb offload");
+@@ -2823,9 +2851,10 @@ static int airoha_tc_htb_alloc_leaf_queu
+ 	if (opt->command == TC_HTB_NODE_MODIFY)
+ 		return 0;
+ 
+-	err = netif_set_real_num_tx_queues(dev, num_tx_queues + 1);
++	err = netif_set_real_num_tx_queues(netdev, num_tx_queues + 1);
+ 	if (err) {
+-		airoha_qdma_set_tx_rate_limit(dev, channel, 0, opt->quantum);
++		airoha_qdma_set_tx_rate_limit(netdev, channel, 0,
++					      opt->quantum);
+ 		NL_SET_ERR_MSG_MOD(opt->extack,
+ 				   "failed setting real_num_tx_queues");
+ 		return err;
+@@ -2915,11 +2944,12 @@ static int airoha_tc_matchall_act_valida
+ 	return 0;
+ }
+ 
+-static int airoha_dev_tc_matchall(struct net_device *dev,
++static int airoha_dev_tc_matchall(struct net_device *netdev,
+ 				  struct tc_cls_matchall_offload *f)
+ {
+ 	enum trtcm_unit_type unit_type = TRTCM_BYTE_UNIT;
+-	struct airoha_gdm_port *port = netdev_priv(dev);
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
+ 	u32 rate = 0, bucket_size = 0;
+ 
+ 	switch (f->command) {
+@@ -2954,18 +2984,19 @@ static int airoha_dev_tc_matchall(struct
+ static int airoha_dev_setup_tc_block_cb(enum tc_setup_type type,
+ 					void *type_data, void *cb_priv)
+ {
+-	struct net_device *dev = cb_priv;
+-	struct airoha_gdm_port *port = netdev_priv(dev);
++	struct net_device *netdev = cb_priv;
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
+ 	struct airoha_eth *eth = port->qdma->eth;
+ 
+-	if (!tc_can_offload(dev))
++	if (!tc_can_offload(netdev))
+ 		return -EOPNOTSUPP;
+ 
+ 	switch (type) {
+ 	case TC_SETUP_CLSFLOWER:
+ 		return airoha_ppe_setup_tc_block_cb(&eth->ppe->dev, type_data);
+ 	case TC_SETUP_CLSMATCHALL:
+-		return airoha_dev_tc_matchall(dev, type_data);
++		return airoha_dev_tc_matchall(netdev, type_data);
+ 	default:
+ 		return -EOPNOTSUPP;
+ 	}
+@@ -3012,47 +3043,51 @@ static int airoha_dev_setup_tc_block(str
+ 	}
+ }
+ 
+-static void airoha_tc_remove_htb_queue(struct net_device *dev, int queue)
++static void airoha_tc_remove_htb_queue(struct net_device *netdev, int queue)
+ {
+-	struct airoha_gdm_port *port = netdev_priv(dev);
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
+ 
+-	netif_set_real_num_tx_queues(dev, dev->real_num_tx_queues - 1);
+-	airoha_qdma_set_tx_rate_limit(dev, queue + 1, 0, 0);
++	netif_set_real_num_tx_queues(netdev, netdev->real_num_tx_queues - 1);
++	airoha_qdma_set_tx_rate_limit(netdev, queue + 1, 0, 0);
+ 	clear_bit(queue, port->qos_sq_bmap);
+ }
+ 
+-static int airoha_tc_htb_delete_leaf_queue(struct net_device *dev,
++static int airoha_tc_htb_delete_leaf_queue(struct net_device *netdev,
+ 					   struct tc_htb_qopt_offload *opt)
+ {
+ 	u32 channel = TC_H_MIN(opt->classid) % AIROHA_NUM_QOS_CHANNELS;
+-	struct airoha_gdm_port *port = netdev_priv(dev);
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
+ 
+ 	if (!test_bit(channel, port->qos_sq_bmap)) {
+ 		NL_SET_ERR_MSG_MOD(opt->extack, "invalid queue id");
+ 		return -EINVAL;
+ 	}
+ 
+-	airoha_tc_remove_htb_queue(dev, channel);
++	airoha_tc_remove_htb_queue(netdev, channel);
+ 
+ 	return 0;
+ }
+ 
+-static int airoha_tc_htb_destroy(struct net_device *dev)
++static int airoha_tc_htb_destroy(struct net_device *netdev)
+ {
+-	struct airoha_gdm_port *port = netdev_priv(dev);
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
+ 	int q;
+ 
+ 	for_each_set_bit(q, port->qos_sq_bmap, AIROHA_NUM_QOS_CHANNELS)
+-		airoha_tc_remove_htb_queue(dev, q);
++		airoha_tc_remove_htb_queue(netdev, q);
+ 
+ 	return 0;
+ }
+ 
+-static int airoha_tc_get_htb_get_leaf_queue(struct net_device *dev,
++static int airoha_tc_get_htb_get_leaf_queue(struct net_device *netdev,
+ 					    struct tc_htb_qopt_offload *opt)
+ {
+ 	u32 channel = TC_H_MIN(opt->classid) % AIROHA_NUM_QOS_CHANNELS;
+-	struct airoha_gdm_port *port = netdev_priv(dev);
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
+ 
+ 	if (!test_bit(channel, port->qos_sq_bmap)) {
+ 		NL_SET_ERR_MSG_MOD(opt->extack, "invalid queue id");
+@@ -3088,8 +3123,8 @@ static int airoha_tc_setup_qdisc_htb(str
+ 	return 0;
+ }
+ 
+-static int airoha_dev_tc_setup(struct net_device *dev, enum tc_setup_type type,
+-			       void *type_data)
++static int airoha_dev_tc_setup(struct net_device *dev,
++			       enum tc_setup_type type, void *type_data)
+ {
+ 	switch (type) {
+ 	case TC_SETUP_QDISC_ETS:
+@@ -3161,13 +3196,18 @@ static void airoha_metadata_dst_free(str
+ 	}
+ }
+ 
+-bool airoha_is_valid_gdm_port(struct airoha_eth *eth,
+-			      struct airoha_gdm_port *port)
++bool airoha_is_valid_gdm_dev(struct airoha_eth *eth,
++			     struct airoha_gdm_dev *dev)
+ {
+ 	int i;
+ 
+ 	for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
+-		if (eth->ports[i] == port)
++		struct airoha_gdm_port *port = eth->ports[i];
++
++		if (!port)
++			continue;
++
++		if (port->dev == dev)
+ 			return true;
+ 	}
+ 
+@@ -3179,8 +3219,9 @@ static void airoha_mac_link_up(struct ph
+ 			       unsigned int mode, phy_interface_t interface,
+ 			       int speed, int duplex, bool tx_pause, bool rx_pause)
+ {
+-	struct airoha_gdm_port *port = container_of(config, struct airoha_gdm_port,
+-						    phylink_config);
++	struct airoha_gdm_dev *dev = container_of(config, struct airoha_gdm_dev,
++						  phylink_config);
++	struct airoha_gdm_port *port = dev->port;
+ 	struct airoha_qdma *qdma = port->qdma;
+ 	struct airoha_eth *eth = qdma->eth;
+ 	u32 frag_size_tx, frag_size_rx;
+@@ -3236,65 +3277,122 @@ static int airoha_fill_available_pcs(str
+ 				        &num_available_pcs);
+ }
+ 
+-static int airoha_setup_phylink(struct net_device *dev)
++static int airoha_setup_phylink(struct net_device *netdev)
+ {
+-	struct airoha_gdm_port *port = netdev_priv(dev);
+-	struct device_node *np = dev->dev.of_node;
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct device_node *np = netdev->dev.of_node;
+ 	phy_interface_t phy_mode;
+ 	struct phylink *phylink;
+ 	int err;
+ 
+ 	err = of_get_phy_mode(np, &phy_mode);
+ 	if (err) {
+-		dev_err(&dev->dev, "incorrect phy-mode\n");
++		dev_err(&netdev->dev, "incorrect phy-mode\n");
+ 		return err;
+ 	}
+ 
+-	port->phylink_config.dev = &dev->dev;
+-	port->phylink_config.type = PHYLINK_NETDEV;
+-	port->phylink_config.mac_capabilities = MAC_ASYM_PAUSE | MAC_SYM_PAUSE |
+-						MAC_10 | MAC_100 | MAC_1000 | MAC_2500FD |
+-						MAC_5000FD | MAC_10000FD;
++	dev->phylink_config.dev = &netdev->dev;
++	dev->phylink_config.type = PHYLINK_NETDEV;
++	dev->phylink_config.mac_capabilities = MAC_ASYM_PAUSE | MAC_SYM_PAUSE |
++					       MAC_10 | MAC_100 | MAC_1000 | MAC_2500FD |
++					       MAC_5000FD | MAC_10000FD;
+ 
+-	err = fwnode_phylink_pcs_parse(dev_fwnode(&dev->dev), NULL,
+-				       &port->phylink_config.num_available_pcs);
++	err = fwnode_phylink_pcs_parse(dev_fwnode(&netdev->dev), NULL,
++				       &dev->phylink_config.num_available_pcs);
+ 	if (err)
+ 		return err;
+ 
+-	port->phylink_config.fill_available_pcs = airoha_fill_available_pcs;
++	dev->phylink_config.fill_available_pcs = airoha_fill_available_pcs;
+ 
+ 	__set_bit(PHY_INTERFACE_MODE_SGMII,
+-		  port->phylink_config.supported_interfaces);
++		  dev->phylink_config.supported_interfaces);
+ 	__set_bit(PHY_INTERFACE_MODE_1000BASEX,
+-		  port->phylink_config.supported_interfaces);
++		  dev->phylink_config.supported_interfaces);
+ 	__set_bit(PHY_INTERFACE_MODE_2500BASEX,
+-		  port->phylink_config.supported_interfaces);
++		  dev->phylink_config.supported_interfaces);
+ 	__set_bit(PHY_INTERFACE_MODE_10GBASER,
+-		  port->phylink_config.supported_interfaces);
++		  dev->phylink_config.supported_interfaces);
+ 	__set_bit(PHY_INTERFACE_MODE_USXGMII,
+-		  port->phylink_config.supported_interfaces);
++		  dev->phylink_config.supported_interfaces);
+ 
+-	phy_interface_copy(port->phylink_config.pcs_interfaces,
+-			   port->phylink_config.supported_interfaces);
++	phy_interface_copy(dev->phylink_config.pcs_interfaces,
++			   dev->phylink_config.supported_interfaces);
+ 
+-	phylink = phylink_create(&port->phylink_config,
++	phylink = phylink_create(&dev->phylink_config,
+ 				 of_fwnode_handle(np),
+ 				 phy_mode, &airoha_phylink_ops);
+ 	if (IS_ERR(phylink))
+ 		return PTR_ERR(phylink);
+ 
+-	port->phylink = phylink;
++	dev->phylink = phylink;
+ 
+ 	return err;
+ }
+ #endif
+ 
++static int airoha_alloc_gdm_device(struct airoha_eth *eth,
++				   struct airoha_gdm_port *port,
++				   struct device_node *np)
++{
++	struct airoha_gdm_dev *dev;
++	struct net_device *netdev;
++	int err;
++
++	netdev = devm_alloc_etherdev_mqs(eth->dev, sizeof(*dev),
++					 AIROHA_NUM_NETDEV_TX_RINGS,
++					 AIROHA_NUM_RX_RING);
++	if (!netdev) {
++		dev_err(eth->dev, "alloc_etherdev failed\n");
++		return -ENOMEM;
++	}
++
++	netdev->netdev_ops = &airoha_netdev_ops;
++	netdev->ethtool_ops = &airoha_ethtool_ops;
++	netdev->max_mtu = AIROHA_MAX_MTU;
++	netdev->watchdog_timeo = 5 * HZ;
++	netdev->hw_features = AIROHA_HW_FEATURES | NETIF_F_LRO;
++	netdev->features |= AIROHA_HW_FEATURES;
++	netdev->vlan_features = AIROHA_HW_FEATURES;
++	netdev->dev.of_node = np;
++	SET_NETDEV_DEV(netdev, eth->dev);
++
++	/* reserve hw queues for HTB offloading */
++	err = netif_set_real_num_tx_queues(netdev, AIROHA_NUM_TX_RING);
++	if (err)
++		return err;
++
++	err = of_get_ethdev_address(np, netdev);
++	if (err) {
++		if (err == -EPROBE_DEFER)
++			return err;
++
++		eth_hw_addr_random(netdev);
++		dev_info(eth->dev, "generated random MAC address %pM\n",
++			 netdev->dev_addr);
++	}
++
++	dev = netdev_priv(netdev);
++	dev->dev = netdev;
++	dev->port = port;
++	port->dev = dev;
++	dev->eth = eth;
++
++#if defined(CONFIG_PCS_AIROHA)
++	if (airhoa_is_phy_external(port)) {
++		err = airoha_setup_phylink(netdev);
++		if (err)
++			return err;
++	}
++#endif
++
++	return 0;
++}
++
+ static int airoha_alloc_gdm_port(struct airoha_eth *eth,
+ 				 struct device_node *np)
+ {
+ 	const __be32 *id_ptr = of_get_property(np, "reg", NULL);
+ 	struct airoha_gdm_port *port;
+-	struct net_device *dev;
+ 	int err, p;
+ 	u32 id;
+ 
+@@ -3316,58 +3414,22 @@ static int airoha_alloc_gdm_port(struct
+ 		return -EINVAL;
+ 	}
+ 
+-	dev = devm_alloc_etherdev_mqs(eth->dev, sizeof(*port),
+-				      AIROHA_NUM_NETDEV_TX_RINGS,
+-				      AIROHA_NUM_RX_RING);
+-	if (!dev) {
+-		dev_err(eth->dev, "alloc_etherdev failed\n");
++	port = devm_kzalloc(eth->dev, sizeof(*port), GFP_KERNEL);
++	if (!port)
+ 		return -ENOMEM;
+-	}
+-
+-	dev->netdev_ops = &airoha_netdev_ops;
+-	dev->ethtool_ops = &airoha_ethtool_ops;
+-	dev->max_mtu = AIROHA_MAX_MTU;
+-	dev->watchdog_timeo = 5 * HZ;
+-	dev->hw_features = AIROHA_HW_FEATURES | NETIF_F_LRO;
+-	dev->features |= AIROHA_HW_FEATURES;
+-	dev->vlan_features = AIROHA_HW_FEATURES;
+-	dev->dev.of_node = np;
+-	SET_NETDEV_DEV(dev, eth->dev);
+-
+-	/* reserve hw queues for HTB offloading */
+-	err = netif_set_real_num_tx_queues(dev, AIROHA_NUM_TX_RING);
+-	if (err)
+-		return err;
+ 
+-	err = of_get_ethdev_address(np, dev);
+-	if (err) {
+-		if (err == -EPROBE_DEFER)
+-			return err;
+-
+-		eth_hw_addr_random(dev);
+-		dev_info(eth->dev, "generated random MAC address %pM\n",
+-			 dev->dev_addr);
+-	}
+-
+-	port = netdev_priv(dev);
+ 	u64_stats_init(&port->stats.syncp);
+ 	spin_lock_init(&port->stats.lock);
+-	port->eth = eth;
+-	port->dev = dev;
+ 	port->id = id;
+ 	/* XXX: Read nbq from DTS */
+ 	port->nbq = id == AIROHA_GDM3_IDX && airoha_is_7581(eth) ? 4 : 0;
+ 	eth->ports[p] = port;
+ 
+-#if defined(CONFIG_PCS_AIROHA)
+-	if (airhoa_is_phy_external(port)) {
+-		err = airoha_setup_phylink(dev);
+-		if (err)
+-			return err;
+-	}
+-#endif
++	err = airoha_metadata_dst_alloc(port);
++	if (err)
++		return err;
+ 
+-	return airoha_metadata_dst_alloc(port);
++	return airoha_alloc_gdm_device(eth, port, np);
+ }
+ 
+ static int airoha_register_gdm_devices(struct airoha_eth *eth)
+@@ -3381,7 +3443,7 @@ static int airoha_register_gdm_devices(s
+ 		if (!port)
+ 			continue;
+ 
+-		err = register_netdev(port->dev);
++		err = register_netdev(port->dev->dev);
+ 		if (err)
+ 			return err;
+ 	}
+@@ -3490,16 +3552,18 @@ error_napi_stop:
+ 
+ 	for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
+ 		struct airoha_gdm_port *port = eth->ports[i];
++		struct airoha_gdm_dev *dev;
+ 
+ 		if (!port)
+ 			continue;
+ 
+-		if (port->dev->reg_state == NETREG_REGISTERED) {
++		dev = port->dev;
++		if (dev && dev->dev->reg_state == NETREG_REGISTERED) {
+ #if defined(CONFIG_PCS_AIROHA)
+ 			if (airhoa_is_phy_external(port))
+-				phylink_destroy(port->phylink);
++				phylink_destroy(dev->phylink);
+ #endif
+-			unregister_netdev(port->dev);
++			unregister_netdev(dev->dev);
+ 		}
+ 		airoha_metadata_dst_free(port);
+ 	}
+@@ -3521,15 +3585,19 @@ static void airoha_remove(struct platfor
+ 
+ 	for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
+ 		struct airoha_gdm_port *port = eth->ports[i];
++		struct airoha_gdm_dev *dev;
+ 
+ 		if (!port)
+ 			continue;
+ 
+ #if defined(CONFIG_PCS_AIROHA)
+ 		if (airhoa_is_phy_external(port))
+-			phylink_destroy(port->phylink);
++			phylink_destroy(dev->phylink);
+ #endif
+-		unregister_netdev(port->dev);
++
++		dev = port->dev;
++		if (dev)
++			unregister_netdev(dev->dev);
+ 		airoha_metadata_dst_free(port);
+ 	}
+ 	airoha_hw_cleanup(eth);
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -546,17 +546,22 @@ struct airoha_qdma {
+ 	struct airoha_queue q_rx[AIROHA_NUM_RX_RING];
+ };
+ 
+-struct airoha_gdm_port {
+-	struct airoha_qdma *qdma;
+-	struct airoha_eth *eth;
++struct airoha_gdm_dev {
++	struct airoha_gdm_port *port;
+ 	struct net_device *dev;
+-	int id;
+-	int nbq;
++	struct airoha_eth *eth;
+ 
+ #if defined(CONFIG_PCS_AIROHA)
+ 	struct phylink *phylink;
+ 	struct phylink_config phylink_config;
+ #endif
++};
++
++struct airoha_gdm_port {
++	struct airoha_qdma *qdma;
++	struct airoha_gdm_dev *dev;
++	int id;
++	int nbq;
+ 
+ 	struct airoha_hw_stats stats;
+ 
+@@ -690,8 +695,8 @@ static inline bool airoha_qdma_is_lro_qu
+ }
+ 
+ int airoha_get_fe_port(struct airoha_gdm_port *port);
+-bool airoha_is_valid_gdm_port(struct airoha_eth *eth,
+-			      struct airoha_gdm_port *port);
++bool airoha_is_valid_gdm_dev(struct airoha_eth *eth,
++			     struct airoha_gdm_dev *dev);
+ 
+ void airoha_ppe_set_cpu_port(struct airoha_gdm_port *port, u8 ppe_id,
+ 			     u8 fport);
+--- a/drivers/net/ethernet/airoha/airoha_ppe.c
++++ b/drivers/net/ethernet/airoha/airoha_ppe.c
+@@ -297,12 +297,12 @@ static void airoha_ppe_foe_set_bridge_ad
+ 
+ static int airoha_ppe_foe_entry_prepare(struct airoha_eth *eth,
+ 					struct airoha_foe_entry *hwe,
+-					struct net_device *dev, int type,
++					struct net_device *netdev, int type,
+ 					struct airoha_flow_data *data,
+ 					int l4proto, u8 dsfield)
+ {
+ 	u32 qdata = FIELD_PREP(AIROHA_FOE_SHAPER_ID, 0x7f), ports_pad, val;
+-	int wlan_etype = -EINVAL, dsa_port = airoha_get_dsa_port(&dev);
++	int wlan_etype = -EINVAL, dsa_port = airoha_get_dsa_port(&netdev);
+ 	struct airoha_foe_mac_info_common *l2;
+ 	u8 smac_id = 0xf;
+ 
+@@ -318,10 +318,11 @@ static int airoha_ppe_foe_entry_prepare(
+ 	hwe->ib1 = val;
+ 
+ 	val = FIELD_PREP(AIROHA_FOE_IB2_PORT_AG, 0x1f);
+-	if (dev) {
++	if (netdev) {
+ 		struct airoha_wdma_info info = {};
+ 
+-		if (!airoha_ppe_get_wdma_info(dev, data->eth.h_dest, &info)) {
++		if (!airoha_ppe_get_wdma_info(netdev, data->eth.h_dest,
++					      &info)) {
+ 			val |= FIELD_PREP(AIROHA_FOE_IB2_NBQ, info.idx) |
+ 			       FIELD_PREP(AIROHA_FOE_IB2_PSE_PORT,
+ 					  FE_PSE_PORT_CDM4);
+@@ -331,12 +332,14 @@ static int airoha_ppe_foe_entry_prepare(
+ 				     FIELD_PREP(AIROHA_FOE_MAC_WDMA_WCID,
+ 						info.wcid);
+ 		} else {
+-			struct airoha_gdm_port *port = netdev_priv(dev);
++			struct airoha_gdm_dev *dev = netdev_priv(netdev);
+ 			u8 pse_port, channel, priority;
++			struct airoha_gdm_port *port;
+ 
+-			if (!airoha_is_valid_gdm_port(eth, port))
++			if (!airoha_is_valid_gdm_dev(eth, dev))
+ 				return -EINVAL;
+ 
++			port = dev->port;
+ 			if (dsa_port >= 0 || eth->ports[1])
+ 				pse_port = port->id == 4 ? FE_PSE_PORT_GDM4
+ 							 : port->id;
+@@ -1483,7 +1486,7 @@ void airoha_ppe_check_skb(struct airoha_
+ void airoha_ppe_init_upd_mem(struct airoha_gdm_port *port)
+ {
+ 	struct airoha_eth *eth = port->qdma->eth;
+-	struct net_device *dev = port->dev;
++	struct net_device *dev = port->dev->dev;
+ 	const u8 *addr = dev->dev_addr;
+ 	u32 val;
+ 

--- a/target/linux/airoha/patches-6.6/920-02-net-airoha-Move-airoha_qdma-pointer-in-airoha_gdm_de.patch
+++ b/target/linux/airoha/patches-6.6/920-02-net-airoha-Move-airoha_qdma-pointer-in-airoha_gdm_de.patch
@@ -1,0 +1,495 @@
+From f62cea6483cc55360863d66300790a5fb9de5f7c Mon Sep 17 00:00:00 2001
+Message-ID: <f62cea6483cc55360863d66300790a5fb9de5f7c.1779348625.git.lorenzo@kernel.org>
+In-Reply-To: <e15783f7c987e199ecf80b3d858ed5a86d33c508.1779348625.git.lorenzo@kernel.org>
+References: <e15783f7c987e199ecf80b3d858ed5a86d33c508.1779348625.git.lorenzo@kernel.org>
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Tue, 24 Feb 2026 18:43:05 +0100
+Subject: [PATCH 02/13] net: airoha: Move airoha_qdma pointer in airoha_gdm_dev
+ struct
+
+Move airoha_qdma pointer from airoha_gdm_port struct to airoha_gdm_dev
+one since the QDMA block used depends on the particular net_device
+WAN/LAN configuration and in the current codebase net_device pointer is
+associated to airoha_gdm_dev struct.
+This is a preliminary patch to support multiple net_devices connected
+to the same GDM{3,4} port via an external hw arbiter.
+
+Tested-by: Xuegang Lu <xuegang.lu@airoha.com>
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 105 +++++++++++------------
+ drivers/net/ethernet/airoha/airoha_eth.h |   9 +-
+ drivers/net/ethernet/airoha/airoha_ppe.c |  17 ++--
+ 3 files changed, 64 insertions(+), 67 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -80,9 +80,10 @@ static bool airhoa_is_phy_external(struc
+ }
+ #endif
+ 
+-static void airoha_set_macaddr(struct airoha_gdm_port *port, const u8 *addr)
++static void airoha_set_macaddr(struct airoha_gdm_dev *dev, const u8 *addr)
+ {
+-	struct airoha_eth *eth = port->qdma->eth;
++	struct airoha_gdm_port *port = dev->port;
++	struct airoha_eth *eth = dev->eth;
+ 	u32 val, reg;
+ 
+ 	reg = airoha_is_lan_gdm_port(port) ? REG_FE_LAN_MAC_H
+@@ -94,7 +95,7 @@ static void airoha_set_macaddr(struct ai
+ 	airoha_fe_wr(eth, REG_FE_MAC_LMIN(reg), val);
+ 	airoha_fe_wr(eth, REG_FE_MAC_LMAX(reg), val);
+ 
+-	airoha_ppe_init_upd_mem(port);
++	airoha_ppe_init_upd_mem(dev);
+ }
+ 
+ static void airoha_set_gdm_port_fwd_cfg(struct airoha_eth *eth, u32 addr,
+@@ -110,10 +111,10 @@ static void airoha_set_gdm_port_fwd_cfg(
+ 		      FIELD_PREP(GDM_UCFQ_MASK, val));
+ }
+ 
+-static int airoha_set_vip_for_gdm_port(struct airoha_gdm_port *port,
+-				       bool enable)
++static int airoha_set_vip_for_gdm_port(struct airoha_gdm_dev *dev, bool enable)
+ {
+-	struct airoha_eth *eth = port->qdma->eth;
++	struct airoha_gdm_port *port = dev->port;
++	struct airoha_eth *eth = dev->eth;
+ 	u32 vip_port;
+ 
+ 	vip_port = eth->soc->ops.get_vip_port(port, port->nbq);
+@@ -994,10 +995,13 @@ static void airoha_qdma_wake_netdev_txqs
+ 		if (!port)
+ 			continue;
+ 
+-		if (port->qdma != qdma)
++		dev = port->dev;
++		if (!dev)
++			continue;
++
++		if (dev->qdma != qdma)
+ 			continue;
+ 
+-		dev = port->dev;
+ 		for (j = 0; j < dev->dev->num_tx_queues; j++) {
+ 			if (airoha_qdma_get_txq(qdma, j) != qid)
+ 				continue;
+@@ -1702,9 +1706,10 @@ static void airoha_qdma_stop_napi(struct
+ 	}
+ }
+ 
+-static void airoha_update_hw_stats(struct airoha_gdm_port *port)
++static void airoha_update_hw_stats(struct airoha_gdm_dev *dev)
+ {
+-	struct airoha_eth *eth = port->qdma->eth;
++	struct airoha_gdm_port *port = dev->port;
++	struct airoha_eth *eth = dev->eth;
+ 	u32 val, i = 0;
+ 
+ 	spin_lock(&port->stats.lock);
+@@ -1851,7 +1856,7 @@ static int airoha_dev_open(struct net_de
+ 	int err, len = ETH_HLEN + netdev->mtu + ETH_FCS_LEN;
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+ 	struct airoha_gdm_port *port = dev->port;
+-	struct airoha_qdma *qdma = port->qdma;
++	struct airoha_qdma *qdma = dev->qdma;
+ 	u32 pse_port = FE_PSE_PORT_PPE1;
+ 
+ #if defined(CONFIG_PCS_AIROHA)
+@@ -1868,7 +1873,7 @@ static int airoha_dev_open(struct net_de
+ #endif
+ 
+ 	netif_tx_start_all_queues(netdev);
+-	err = airoha_set_vip_for_gdm_port(port, true);
++	err = airoha_set_vip_for_gdm_port(dev, true);
+ 	if (err)
+ 		return err;
+ 
+@@ -1905,11 +1910,11 @@ static int airoha_dev_stop(struct net_de
+ {
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+ 	struct airoha_gdm_port *port = dev->port;
+-	struct airoha_qdma *qdma = port->qdma;
++	struct airoha_qdma *qdma = dev->qdma;
+ 	int i;
+ 
+ 	netif_tx_disable(netdev);
+-	airoha_set_vip_for_gdm_port(port, false);
++	airoha_set_vip_for_gdm_port(dev, false);
+ 	for (i = 0; i < netdev->num_tx_queues; i++)
+ 		netdev_tx_reset_subqueue(netdev, i);
+ 
+@@ -1942,21 +1947,21 @@ static int airoha_dev_stop(struct net_de
+ static int airoha_dev_set_macaddr(struct net_device *netdev, void *p)
+ {
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+-	struct airoha_gdm_port *port = dev->port;
+ 	int err;
+ 
+ 	err = eth_mac_addr(netdev, p);
+ 	if (err)
+ 		return err;
+ 
+-	airoha_set_macaddr(port, netdev->dev_addr);
++	airoha_set_macaddr(dev, netdev->dev_addr);
+ 
+ 	return 0;
+ }
+ 
+-static int airoha_set_gdm2_loopback(struct airoha_gdm_port *port)
++static int airoha_set_gdm2_loopback(struct airoha_gdm_dev *dev)
+ {
+-	struct airoha_eth *eth = port->qdma->eth;
++	struct airoha_gdm_port *port = dev->port;
++	struct airoha_eth *eth = dev->eth;
+ 	u32 val, pse_port, chan;
+ 	int i, src_port;
+ 
+@@ -2003,7 +2008,7 @@ static int airoha_set_gdm2_loopback(stru
+ 		      __field_prep(SP_CPORT_MASK(val), FE_PSE_PORT_CDM2));
+ 
+ 	for (i = 0; i < eth->soc->num_ppe; i++)
+-		airoha_ppe_set_cpu_port(port, i, AIROHA_GDM2_IDX);
++		airoha_ppe_set_cpu_port(dev, i, AIROHA_GDM2_IDX);
+ 
+ 	if (port->id == AIROHA_GDM4_IDX && airoha_is_7581(eth)) {
+ 		u32 mask = FC_ID_OF_SRC_PORT_MASK(port->nbq);
+@@ -2023,9 +2028,9 @@ static int airoha_dev_init(struct net_de
+ 	int i;
+ 
+ 	/* QDMA0 is used for lan ports while QDMA1 is used for WAN ports */
+-	port->qdma = &eth->qdma[!airoha_is_lan_gdm_port(port)];
+-	dev->dev->irq = port->qdma->irq_banks[0].irq;
+-	airoha_set_macaddr(port, netdev->dev_addr);
++	dev->qdma = &eth->qdma[!airoha_is_lan_gdm_port(port)];
++	dev->dev->irq = dev->qdma->irq_banks[0].irq;
++	airoha_set_macaddr(dev, netdev->dev_addr);
+ 
+ 	switch (port->id) {
+ 	case AIROHA_GDM3_IDX:
+@@ -2034,7 +2039,7 @@ static int airoha_dev_init(struct net_de
+ 		if (!eth->ports[1]) {
+ 			int err;
+ 
+-			err = airoha_set_gdm2_loopback(port);
++			err = airoha_set_gdm2_loopback(dev);
+ 			if (err)
+ 				return err;
+ 		}
+@@ -2044,8 +2049,7 @@ static int airoha_dev_init(struct net_de
+ 	}
+ 
+ 	for (i = 0; i < eth->soc->num_ppe; i++)
+-		airoha_ppe_set_cpu_port(port, i,
+-					airoha_get_fe_port(port));
++		airoha_ppe_set_cpu_port(dev, i, airoha_get_fe_port(dev));
+ 
+ 	return 0;
+ }
+@@ -2057,7 +2061,7 @@ static void airoha_dev_get_stats64(struc
+ 	struct airoha_gdm_port *port = dev->port;
+ 	unsigned int start;
+ 
+-	airoha_update_hw_stats(port);
++	airoha_update_hw_stats(dev);
+ 	do {
+ 		start = u64_stats_fetch_begin(&port->stats.syncp);
+ 		storage->rx_packets = port->stats.rx_ok_pkts;
+@@ -2077,8 +2081,8 @@ static int airoha_dev_change_mtu(struct
+ {
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+ 	struct airoha_gdm_port *port = dev->port;
+-	struct airoha_eth *eth = port->qdma->eth;
+ 	u32 len = ETH_HLEN + mtu + ETH_FCS_LEN;
++	struct airoha_eth *eth = dev->eth;
+ 
+ 	airoha_fe_rmw(eth, REG_GDM_LEN_CFG(port->id),
+ 		      GDM_LONG_LEN_MASK,
+@@ -2152,10 +2156,10 @@ static u32 airoha_get_dsa_tag(struct sk_
+ #endif
+ }
+ 
+-int airoha_get_fe_port(struct airoha_gdm_port *port)
++int airoha_get_fe_port(struct airoha_gdm_dev *dev)
+ {
+-	struct airoha_qdma *qdma = port->qdma;
+-	struct airoha_eth *eth = qdma->eth;
++	struct airoha_gdm_port *port = dev->port;
++	struct airoha_eth *eth = dev->eth;
+ 
+ 	switch (eth->soc->version) {
+ 	case 0x7583:
+@@ -2174,8 +2178,7 @@ static int airoha_dev_set_features(struc
+ 
+ 	netdev_features_t diff = netdev->features ^ features;
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+-	struct airoha_gdm_port *port = dev->port;
+-	struct airoha_qdma *qdma = port->qdma;
++	struct airoha_qdma *qdma = dev->qdma;
+ 	struct airoha_eth *eth = qdma->eth;
+ 	int qdma_id = qdma - &eth->qdma[0];
+ 	int i;
+@@ -2213,10 +2216,10 @@ static int airoha_dev_set_features(struc
+ 			if (!p)
+ 				continue;
+ 
+-			if (p->qdma != qdma)
++			d = p->dev;
++			if (d->qdma != qdma)
+ 				continue;
+ 
+-			d = p->dev;
+ 			if (d->dev == netdev)
+ 				continue;
+ 
+@@ -2233,8 +2236,7 @@ static netdev_tx_t airoha_dev_xmit(struc
+ 				   struct net_device *netdev)
+ {
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+-	struct airoha_gdm_port *port = dev->port;
+-	struct airoha_qdma *qdma = port->qdma;
++	struct airoha_qdma *qdma = dev->qdma;
+ 	u32 nr_frags, tag, msg0, msg1, len;
+ 	struct airoha_queue_entry *e;
+ 	struct netdev_queue *txq;
+@@ -2272,7 +2274,7 @@ static netdev_tx_t airoha_dev_xmit(struc
+ 		}
+ 	}
+ 
+-	fport = airoha_get_fe_port(port);
++	fport = airoha_get_fe_port(dev);
+ 	msg1 = FIELD_PREP(QDMA_ETH_TXMSG_FPORT_MASK, fport) |
+ 	       FIELD_PREP(QDMA_ETH_TXMSG_METER_MASK, 0x7f);
+ 
+@@ -2375,8 +2377,7 @@ static void airoha_ethtool_get_drvinfo(s
+ 				       struct ethtool_drvinfo *info)
+ {
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+-	struct airoha_gdm_port *port = dev->port;
+-	struct airoha_eth *eth = port->qdma->eth;
++	struct airoha_eth *eth = dev->eth;
+ 
+ 	strscpy(info->driver, eth->dev->driver->name, sizeof(info->driver));
+ 	strscpy(info->bus_info, dev_name(eth->dev), sizeof(info->bus_info));
+@@ -2389,7 +2390,7 @@ static void airoha_ethtool_get_mac_stats
+ 	struct airoha_gdm_port *port = dev->port;
+ 	unsigned int start;
+ 
+-	airoha_update_hw_stats(port);
++	airoha_update_hw_stats(dev);
+ 	do {
+ 		start = u64_stats_fetch_begin(&port->stats.syncp);
+ 		stats->FramesTransmittedOK = port->stats.tx_ok_pkts;
+@@ -2429,7 +2430,7 @@ airoha_ethtool_get_rmon_stats(struct net
+ 		     ARRAY_SIZE(hw_stats->rx_len) + 1);
+ 
+ 	*ranges = airoha_ethtool_rmon_ranges;
+-	airoha_update_hw_stats(port);
++	airoha_update_hw_stats(dev);
+ 	do {
+ 		int i;
+ 
+@@ -2449,18 +2450,17 @@ static int airoha_qdma_set_chan_tx_sched
+ 					 const u16 *weights, u8 n_weights)
+ {
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+-	struct airoha_gdm_port *port = dev->port;
+ 	int i;
+ 
+ 	for (i = 0; i < AIROHA_NUM_TX_RING; i++)
+-		airoha_qdma_clear(port->qdma, REG_QUEUE_CLOSE_CFG(channel),
++		airoha_qdma_clear(dev->qdma, REG_QUEUE_CLOSE_CFG(channel),
+ 				  TXQ_DISABLE_CHAN_QUEUE_MASK(channel, i));
+ 
+ 	for (i = 0; i < n_weights; i++) {
+ 		u32 status;
+ 		int err;
+ 
+-		airoha_qdma_wr(port->qdma, REG_TXWRR_WEIGHT_CFG,
++		airoha_qdma_wr(dev->qdma, REG_TXWRR_WEIGHT_CFG,
+ 			       TWRR_RW_CMD_MASK |
+ 			       FIELD_PREP(TWRR_CHAN_IDX_MASK, channel) |
+ 			       FIELD_PREP(TWRR_QUEUE_IDX_MASK, i) |
+@@ -2468,13 +2468,12 @@ static int airoha_qdma_set_chan_tx_sched
+ 		err = read_poll_timeout(airoha_qdma_rr, status,
+ 					status & TWRR_RW_CMD_DONE,
+ 					USEC_PER_MSEC, 10 * USEC_PER_MSEC,
+-					true, port->qdma,
+-					REG_TXWRR_WEIGHT_CFG);
++					true, dev->qdma, REG_TXWRR_WEIGHT_CFG);
+ 		if (err)
+ 			return err;
+ 	}
+ 
+-	airoha_qdma_rmw(port->qdma, REG_CHAN_QOS_MODE(channel >> 3),
++	airoha_qdma_rmw(dev->qdma, REG_CHAN_QOS_MODE(channel >> 3),
+ 			CHAN_QOS_MODE_MASK(channel),
+ 			__field_prep(CHAN_QOS_MODE_MASK(channel), mode));
+ 
+@@ -2540,9 +2539,9 @@ static int airoha_qdma_get_tx_ets_stats(
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+ 	struct airoha_gdm_port *port = dev->port;
+ 
+-	u64 cpu_tx_packets = airoha_qdma_rr(port->qdma,
++	u64 cpu_tx_packets = airoha_qdma_rr(dev->qdma,
+ 					    REG_CNTR_VAL(channel << 1));
+-	u64 fwd_tx_packets = airoha_qdma_rr(port->qdma,
++	u64 fwd_tx_packets = airoha_qdma_rr(dev->qdma,
+ 					    REG_CNTR_VAL((channel << 1) + 1));
+ 	u64 tx_packets = (cpu_tx_packets - port->cpu_tx_packets) +
+ 			 (fwd_tx_packets - port->fwd_tx_packets);
+@@ -2806,17 +2805,16 @@ static int airoha_qdma_set_tx_rate_limit
+ 					 u32 bucket_size)
+ {
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+-	struct airoha_gdm_port *port = dev->port;
+ 	int i, err;
+ 
+ 	for (i = 0; i <= TRTCM_PEAK_MODE; i++) {
+-		err = airoha_qdma_set_trtcm_config(port->qdma, channel,
++		err = airoha_qdma_set_trtcm_config(dev->qdma, channel,
+ 						   REG_EGRESS_TRTCM_CFG, i,
+ 						   !!rate, TRTCM_METER_MODE);
+ 		if (err)
+ 			return err;
+ 
+-		err = airoha_qdma_set_trtcm_token_bucket(port->qdma, channel,
++		err = airoha_qdma_set_trtcm_token_bucket(dev->qdma, channel,
+ 							 REG_EGRESS_TRTCM_CFG,
+ 							 i, rate, bucket_size);
+ 		if (err)
+@@ -2866,11 +2864,11 @@ static int airoha_tc_htb_alloc_leaf_queu
+ 	return 0;
+ }
+ 
+-static int airoha_qdma_set_rx_meter(struct airoha_gdm_port *port,
++static int airoha_qdma_set_rx_meter(struct airoha_gdm_dev *dev,
+ 				    u32 rate, u32 bucket_size,
+ 				    enum trtcm_unit_type unit_type)
+ {
+-	struct airoha_qdma *qdma = port->qdma;
++	struct airoha_qdma *qdma = dev->qdma;
+ 	int i;
+ 
+ 	for (i = 0; i < ARRAY_SIZE(qdma->q_rx); i++) {
+@@ -2949,7 +2947,6 @@ static int airoha_dev_tc_matchall(struct
+ {
+ 	enum trtcm_unit_type unit_type = TRTCM_BYTE_UNIT;
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+-	struct airoha_gdm_port *port = dev->port;
+ 	u32 rate = 0, bucket_size = 0;
+ 
+ 	switch (f->command) {
+@@ -2974,7 +2971,7 @@ static int airoha_dev_tc_matchall(struct
+ 		fallthrough;
+ 	}
+ 	case TC_CLSMATCHALL_DESTROY:
+-		return airoha_qdma_set_rx_meter(port, rate, bucket_size,
++		return airoha_qdma_set_rx_meter(dev, rate, bucket_size,
+ 						unit_type);
+ 	default:
+ 		return -EOPNOTSUPP;
+@@ -2986,8 +2983,7 @@ static int airoha_dev_setup_tc_block_cb(
+ {
+ 	struct net_device *netdev = cb_priv;
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+-	struct airoha_gdm_port *port = dev->port;
+-	struct airoha_eth *eth = port->qdma->eth;
++	struct airoha_eth *eth = dev->eth;
+ 
+ 	if (!tc_can_offload(netdev))
+ 		return -EOPNOTSUPP;
+@@ -3222,7 +3218,7 @@ static void airoha_mac_link_up(struct ph
+ 	struct airoha_gdm_dev *dev = container_of(config, struct airoha_gdm_dev,
+ 						  phylink_config);
+ 	struct airoha_gdm_port *port = dev->port;
+-	struct airoha_qdma *qdma = port->qdma;
++	struct airoha_qdma *qdma = dev->qdma;
+ 	struct airoha_eth *eth = qdma->eth;
+ 	u32 frag_size_tx, frag_size_rx;
+ 
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -548,6 +548,7 @@ struct airoha_qdma {
+ 
+ struct airoha_gdm_dev {
+ 	struct airoha_gdm_port *port;
++	struct airoha_qdma *qdma;
+ 	struct net_device *dev;
+ 	struct airoha_eth *eth;
+ 
+@@ -558,7 +559,6 @@ struct airoha_gdm_dev {
+ };
+ 
+ struct airoha_gdm_port {
+-	struct airoha_qdma *qdma;
+ 	struct airoha_gdm_dev *dev;
+ 	int id;
+ 	int nbq;
+@@ -694,19 +694,18 @@ static inline bool airoha_qdma_is_lro_qu
+ 	return !!(AIROHA_RXQ_LRO_EN_MASK & BIT(qid));
+ }
+ 
+-int airoha_get_fe_port(struct airoha_gdm_port *port);
++int airoha_get_fe_port(struct airoha_gdm_dev *dev);
+ bool airoha_is_valid_gdm_dev(struct airoha_eth *eth,
+ 			     struct airoha_gdm_dev *dev);
+ 
+-void airoha_ppe_set_cpu_port(struct airoha_gdm_port *port, u8 ppe_id,
+-			     u8 fport);
++void airoha_ppe_set_cpu_port(struct airoha_gdm_dev *dev, u8 ppe_id, u8 fport);
+ bool airoha_ppe_is_enabled(struct airoha_eth *eth, int index);
+ void airoha_ppe_check_skb(struct airoha_ppe_dev *dev, struct sk_buff *skb,
+ 			  u16 hash, bool rx_wlan);
+ int airoha_ppe_setup_tc_block_cb(struct airoha_ppe_dev *dev, void *type_data);
+ int airoha_ppe_init(struct airoha_eth *eth);
+ void airoha_ppe_deinit(struct airoha_eth *eth);
+-void airoha_ppe_init_upd_mem(struct airoha_gdm_port *port);
++void airoha_ppe_init_upd_mem(struct airoha_gdm_dev *dev);
+ u32 airoha_ppe_get_total_num_entries(struct airoha_ppe *ppe);
+ struct airoha_foe_entry *airoha_ppe_foe_get_entry(struct airoha_ppe *ppe,
+ 						  u32 hash);
+--- a/drivers/net/ethernet/airoha/airoha_ppe.c
++++ b/drivers/net/ethernet/airoha/airoha_ppe.c
+@@ -85,9 +85,9 @@ static u32 airoha_ppe_get_timestamp(stru
+ 			     AIROHA_FOE_IB1_BIND_TIMESTAMP);
+ }
+ 
+-void airoha_ppe_set_cpu_port(struct airoha_gdm_port *port, u8 ppe_id, u8 fport)
++void airoha_ppe_set_cpu_port(struct airoha_gdm_dev *dev, u8 ppe_id, u8 fport)
+ {
+-	struct airoha_qdma *qdma = port->qdma;
++	struct airoha_qdma *qdma = dev->qdma;
+ 	struct airoha_eth *eth = qdma->eth;
+ 	u8 qdma_id = qdma - &eth->qdma[0];
+ 	u32 fe_cpu_port;
+@@ -181,8 +181,8 @@ static void airoha_ppe_hw_init(struct ai
+ 			if (!port)
+ 				continue;
+ 
+-			airoha_ppe_set_cpu_port(port, i,
+-						airoha_get_fe_port(port));
++			airoha_ppe_set_cpu_port(port->dev, i,
++						airoha_get_fe_port(port->dev));
+ 		}
+ 	}
+ }
+@@ -1483,11 +1483,12 @@ void airoha_ppe_check_skb(struct airoha_
+ 	airoha_ppe_foe_insert_entry(ppe, skb, hash, rx_wlan);
+ }
+ 
+-void airoha_ppe_init_upd_mem(struct airoha_gdm_port *port)
++void airoha_ppe_init_upd_mem(struct airoha_gdm_dev *dev)
+ {
+-	struct airoha_eth *eth = port->qdma->eth;
+-	struct net_device *dev = port->dev->dev;
+-	const u8 *addr = dev->dev_addr;
++	struct airoha_gdm_port *port = dev->port;
++	struct net_device *netdev = dev->dev;
++	struct airoha_eth *eth = dev->eth;
++	const u8 *addr = netdev->dev_addr;
+ 	u32 val;
+ 
+ 	val = (addr[2] << 24) | (addr[3] << 16) | (addr[4] << 8) | addr[5];

--- a/target/linux/airoha/patches-6.6/920-03-net-airoha-Rely-on-airoha_gdm_dev-pointer-in-airoha_.patch
+++ b/target/linux/airoha/patches-6.6/920-03-net-airoha-Rely-on-airoha_gdm_dev-pointer-in-airoha_.patch
@@ -1,0 +1,73 @@
+From 32bfd008c19f9ad55514181d8cd02e14bf384475 Mon Sep 17 00:00:00 2001
+Message-ID: <32bfd008c19f9ad55514181d8cd02e14bf384475.1779348625.git.lorenzo@kernel.org>
+In-Reply-To: <e15783f7c987e199ecf80b3d858ed5a86d33c508.1779348625.git.lorenzo@kernel.org>
+References: <e15783f7c987e199ecf80b3d858ed5a86d33c508.1779348625.git.lorenzo@kernel.org>
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Sat, 13 Dec 2025 10:06:45 +0100
+Subject: [PATCH 03/13] net: airoha: Rely on airoha_gdm_dev pointer in
+ airoha_is_lan_gdm_port()
+
+Rename airoha_is_lan_gdm_port in airoha_is_lan_gdm_dev. Moreover, rely
+on airoha_gdm_dev pointer in airoha_is_lan_gdm_dev() instead of
+airoha_gdm_port one.
+This is a preliminary patch to support multiple net_devices connected to
+the same GDM{3,4} port via an external hw arbiter.
+
+Tested-by: Xuegang Lu <xuegang.lu@airoha.com>
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 6 ++----
+ drivers/net/ethernet/airoha/airoha_eth.h | 4 +++-
+ drivers/net/ethernet/airoha/airoha_ppe.c | 2 +-
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -82,12 +82,10 @@ static bool airhoa_is_phy_external(struc
+ 
+ static void airoha_set_macaddr(struct airoha_gdm_dev *dev, const u8 *addr)
+ {
+-	struct airoha_gdm_port *port = dev->port;
+ 	struct airoha_eth *eth = dev->eth;
+ 	u32 val, reg;
+ 
+-	reg = airoha_is_lan_gdm_port(port) ? REG_FE_LAN_MAC_H
+-					   : REG_FE_WAN_MAC_H;
++	reg = airoha_is_lan_gdm_dev(dev) ? REG_FE_LAN_MAC_H : REG_FE_WAN_MAC_H;
+ 	val = (addr[0] << 16) | (addr[1] << 8) | addr[2];
+ 	airoha_fe_wr(eth, reg, val);
+ 
+@@ -2028,7 +2026,7 @@ static int airoha_dev_init(struct net_de
+ 	int i;
+ 
+ 	/* QDMA0 is used for lan ports while QDMA1 is used for WAN ports */
+-	dev->qdma = &eth->qdma[!airoha_is_lan_gdm_port(port)];
++	dev->qdma = &eth->qdma[!airoha_is_lan_gdm_dev(dev)];
+ 	dev->dev->irq = dev->qdma->irq_banks[0].irq;
+ 	airoha_set_macaddr(dev, netdev->dev_addr);
+ 
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -663,8 +663,10 @@ static inline u16 airoha_qdma_get_txq(st
+ 	return qid % ARRAY_SIZE(qdma->q_tx);
+ }
+ 
+-static inline bool airoha_is_lan_gdm_port(struct airoha_gdm_port *port)
++static inline bool airoha_is_lan_gdm_dev(struct airoha_gdm_dev *dev)
+ {
++	struct airoha_gdm_port *port = dev->port;
++
+ 	/* GDM1 port on EN7581 SoC is connected to the lan dsa switch.
+ 	 * GDM{2,3,4} can be used as wan port connected to an external
+ 	 * phy module.
+--- a/drivers/net/ethernet/airoha/airoha_ppe.c
++++ b/drivers/net/ethernet/airoha/airoha_ppe.c
+@@ -365,7 +365,7 @@ static int airoha_ppe_foe_entry_prepare(
+ 			/* For downlink traffic consume SRAM memory for hw
+ 			 * forwarding descriptors queue.
+ 			 */
+-			if (airoha_is_lan_gdm_port(port))
++			if (airoha_is_lan_gdm_dev(dev))
+ 				val |= AIROHA_FOE_IB2_FAST_PATH;
+ 			if (dsa_port >= 0)
+ 				val |= FIELD_PREP(AIROHA_FOE_IB2_NBQ,

--- a/target/linux/airoha/patches-6.6/920-04-net-airoha-Move-qos_sq_bmap-in-airoha_gdm_dev-struct.patch
+++ b/target/linux/airoha/patches-6.6/920-04-net-airoha-Move-qos_sq_bmap-in-airoha_gdm_dev-struct.patch
@@ -1,0 +1,184 @@
+From 634d75285db77f3385aa85a1bf2b185396225100 Mon Sep 17 00:00:00 2001
+Message-ID: <634d75285db77f3385aa85a1bf2b185396225100.1779348625.git.lorenzo@kernel.org>
+In-Reply-To: <e15783f7c987e199ecf80b3d858ed5a86d33c508.1779348625.git.lorenzo@kernel.org>
+References: <e15783f7c987e199ecf80b3d858ed5a86d33c508.1779348625.git.lorenzo@kernel.org>
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Fri, 10 Apr 2026 14:35:32 +0200
+Subject: [PATCH 04/13] net: airoha: Move qos_sq_bmap in airoha_gdm_dev struct
+
+Since now multiple net_devices connected to different QDMA blocks can
+share the same GDM port, qos_sq_bmap field can be overwritten with the
+configuration obtained from a net_device connected to a different QDMA
+block. In order to fix the issue move qos_sq_bmap field from
+airoha_gdm_port struct to airoha_gdm_dev one.
+Add qos_channel_map bitmap in airoha_qdma struct to track if a shared
+QDMA channel is already in use by another net_device.
+
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 58 +++++++++++++++---------
+ drivers/net/ethernet/airoha/airoha_eth.h |  6 ++-
+ 2 files changed, 40 insertions(+), 24 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -2822,30 +2822,40 @@ static int airoha_qdma_set_tx_rate_limit
+ 	return 0;
+ }
+ 
+-static int airoha_tc_htb_alloc_leaf_queue(struct net_device *netdev,
+-					  struct tc_htb_qopt_offload *opt)
++static int airoha_tc_htb_modify_queue(struct net_device *dev,
++				      struct tc_htb_qopt_offload *opt)
+ {
+ 	u32 channel = TC_H_MIN(opt->classid) % AIROHA_NUM_QOS_CHANNELS;
+ 	u32 rate = div_u64(opt->rate, 1000) << 3; /* kbps */
+-	int err, num_tx_queues = netdev->real_num_tx_queues;
+-	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+-	struct airoha_gdm_port *port = dev->port;
+ 
+ 	if (opt->parent_classid != TC_HTB_CLASSID_ROOT) {
+ 		NL_SET_ERR_MSG_MOD(opt->extack, "invalid parent classid");
+ 		return -EINVAL;
+ 	}
+ 
+-	err = airoha_qdma_set_tx_rate_limit(netdev, channel, rate,
+-					    opt->quantum);
+-	if (err) {
++	return airoha_qdma_set_tx_rate_limit(dev, channel, rate, opt->quantum);
++}
++
++static int airoha_tc_htb_alloc_leaf_queue(struct net_device *netdev,
++					  struct tc_htb_qopt_offload *opt)
++{
++	u32 channel = TC_H_MIN(opt->classid) % AIROHA_NUM_QOS_CHANNELS;
++	int err, num_tx_queues = netdev->real_num_tx_queues;
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_qdma *qdma = dev->qdma;
++
++	/* Here we need to check the requested QDMA channel is not already
++	 * in use by another net_device running on the same QDMA block.
++	 */
++	if (test_and_set_bit(channel, qdma->qos_channel_map)) {
+ 		NL_SET_ERR_MSG_MOD(opt->extack,
+-				   "failed configuring htb offload");
+-		return err;
++				   "qdma qos channel already in use");
++		return -EBUSY;
+ 	}
+ 
+-	if (opt->command == TC_HTB_NODE_MODIFY)
+-		return 0;
++	err = airoha_tc_htb_modify_queue(netdev, opt);
++	if (err)
++		goto error;
+ 
+ 	err = netif_set_real_num_tx_queues(netdev, num_tx_queues + 1);
+ 	if (err) {
+@@ -2853,13 +2863,17 @@ static int airoha_tc_htb_alloc_leaf_queu
+ 					      opt->quantum);
+ 		NL_SET_ERR_MSG_MOD(opt->extack,
+ 				   "failed setting real_num_tx_queues");
+-		return err;
++		goto error;
+ 	}
+ 
+-	set_bit(channel, port->qos_sq_bmap);
++	set_bit(channel, dev->qos_sq_bmap);
+ 	opt->qid = AIROHA_NUM_TX_RING + channel;
+ 
+ 	return 0;
++error:
++	clear_bit(channel, qdma->qos_channel_map);
++
++	return err;
+ }
+ 
+ static int airoha_qdma_set_rx_meter(struct airoha_gdm_dev *dev,
+@@ -3040,11 +3054,13 @@ static int airoha_dev_setup_tc_block(str
+ static void airoha_tc_remove_htb_queue(struct net_device *netdev, int queue)
+ {
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+-	struct airoha_gdm_port *port = dev->port;
++	struct airoha_qdma *qdma = dev->qdma;
+ 
+ 	netif_set_real_num_tx_queues(netdev, netdev->real_num_tx_queues - 1);
+ 	airoha_qdma_set_tx_rate_limit(netdev, queue + 1, 0, 0);
+-	clear_bit(queue, port->qos_sq_bmap);
++
++	clear_bit(queue, qdma->qos_channel_map);
++	clear_bit(queue, dev->qos_sq_bmap);
+ }
+ 
+ static int airoha_tc_htb_delete_leaf_queue(struct net_device *netdev,
+@@ -3052,9 +3068,8 @@ static int airoha_tc_htb_delete_leaf_que
+ {
+ 	u32 channel = TC_H_MIN(opt->classid) % AIROHA_NUM_QOS_CHANNELS;
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+-	struct airoha_gdm_port *port = dev->port;
+ 
+-	if (!test_bit(channel, port->qos_sq_bmap)) {
++	if (!test_bit(channel, dev->qos_sq_bmap)) {
+ 		NL_SET_ERR_MSG_MOD(opt->extack, "invalid queue id");
+ 		return -EINVAL;
+ 	}
+@@ -3067,10 +3082,9 @@ static int airoha_tc_htb_delete_leaf_que
+ static int airoha_tc_htb_destroy(struct net_device *netdev)
+ {
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+-	struct airoha_gdm_port *port = dev->port;
+ 	int q;
+ 
+-	for_each_set_bit(q, port->qos_sq_bmap, AIROHA_NUM_QOS_CHANNELS)
++	for_each_set_bit(q, dev->qos_sq_bmap, AIROHA_NUM_QOS_CHANNELS)
+ 		airoha_tc_remove_htb_queue(netdev, q);
+ 
+ 	return 0;
+@@ -3081,9 +3095,8 @@ static int airoha_tc_get_htb_get_leaf_qu
+ {
+ 	u32 channel = TC_H_MIN(opt->classid) % AIROHA_NUM_QOS_CHANNELS;
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+-	struct airoha_gdm_port *port = dev->port;
+ 
+-	if (!test_bit(channel, port->qos_sq_bmap)) {
++	if (!test_bit(channel, dev->qos_sq_bmap)) {
+ 		NL_SET_ERR_MSG_MOD(opt->extack, "invalid queue id");
+ 		return -EINVAL;
+ 	}
+@@ -3102,6 +3115,7 @@ static int airoha_tc_setup_qdisc_htb(str
+ 	case TC_HTB_DESTROY:
+ 		return airoha_tc_htb_destroy(dev);
+ 	case TC_HTB_NODE_MODIFY:
++		return airoha_tc_htb_modify_queue(dev, opt);
+ 	case TC_HTB_LEAF_ALLOC_QUEUE:
+ 		return airoha_tc_htb_alloc_leaf_queue(dev, opt);
+ 	case TC_HTB_LEAF_DEL:
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -544,6 +544,8 @@ struct airoha_qdma {
+ 
+ 	struct airoha_queue q_tx[AIROHA_NUM_TX_RING];
+ 	struct airoha_queue q_rx[AIROHA_NUM_RX_RING];
++
++	DECLARE_BITMAP(qos_channel_map, AIROHA_NUM_QOS_CHANNELS);
+ };
+ 
+ struct airoha_gdm_dev {
+@@ -556,6 +558,8 @@ struct airoha_gdm_dev {
+ 	struct phylink *phylink;
+ 	struct phylink_config phylink_config;
+ #endif
++
++	DECLARE_BITMAP(qos_sq_bmap, AIROHA_NUM_QOS_CHANNELS);
+ };
+ 
+ struct airoha_gdm_port {
+@@ -565,8 +569,6 @@ struct airoha_gdm_port {
+ 
+ 	struct airoha_hw_stats stats;
+ 
+-	DECLARE_BITMAP(qos_sq_bmap, AIROHA_NUM_QOS_CHANNELS);
+-
+ 	/* qos stats counters */
+ 	u64 cpu_tx_packets;
+ 	u64 fwd_tx_packets;

--- a/target/linux/airoha/patches-6.6/920-05-net-airoha-Move-cpu-fwd-_tx_packets-in-airoha_gdm_de.patch
+++ b/target/linux/airoha/patches-6.6/920-05-net-airoha-Move-cpu-fwd-_tx_packets-in-airoha_gdm_de.patch
@@ -1,0 +1,73 @@
+From 00272dbf6a52241a21145631f22dc5f03891078b Mon Sep 17 00:00:00 2001
+Message-ID: <00272dbf6a52241a21145631f22dc5f03891078b.1779348625.git.lorenzo@kernel.org>
+In-Reply-To: <e15783f7c987e199ecf80b3d858ed5a86d33c508.1779348625.git.lorenzo@kernel.org>
+References: <e15783f7c987e199ecf80b3d858ed5a86d33c508.1779348625.git.lorenzo@kernel.org>
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Fri, 10 Apr 2026 14:47:08 +0200
+Subject: [PATCH 05/13] net: airoha: Move {cpu,fwd}_tx_packets in
+ airoha_gdm_dev struct
+
+Since now multiple net_devices connected to different QDMA blocks can
+share the same GDM port, cpu_tx_packets and fwd_tx_packets fields can
+be overwritten with the value from a different QDMA block. In order to
+fix the issue move cpu_tx_packets and fwd_tx_packets fields from
+airoha_gdm_port struct to airoha_gdm_dev one.
+
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 16 +++++++---------
+ drivers/net/ethernet/airoha/airoha_eth.h |  7 +++----
+ 2 files changed, 10 insertions(+), 13 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -2535,19 +2535,17 @@ static int airoha_qdma_get_tx_ets_stats(
+ 					struct tc_ets_qopt_offload *opt)
+ {
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+-	struct airoha_gdm_port *port = dev->port;
++	struct airoha_qdma *qdma = dev->qdma;
+ 
+-	u64 cpu_tx_packets = airoha_qdma_rr(dev->qdma,
+-					    REG_CNTR_VAL(channel << 1));
+-	u64 fwd_tx_packets = airoha_qdma_rr(dev->qdma,
++	u64 cpu_tx_packets = airoha_qdma_rr(qdma, REG_CNTR_VAL(channel << 1));
++	u64 fwd_tx_packets = airoha_qdma_rr(qdma,
+ 					    REG_CNTR_VAL((channel << 1) + 1));
+-	u64 tx_packets = (cpu_tx_packets - port->cpu_tx_packets) +
+-			 (fwd_tx_packets - port->fwd_tx_packets);
++	u64 tx_packets = (cpu_tx_packets - dev->cpu_tx_packets) +
++			 (fwd_tx_packets - dev->fwd_tx_packets);
+ 
+ 	_bstats_update(opt->stats.bstats, 0, tx_packets);
+-
+-	port->cpu_tx_packets = cpu_tx_packets;
+-	port->fwd_tx_packets = fwd_tx_packets;
++	dev->cpu_tx_packets = cpu_tx_packets;
++	dev->fwd_tx_packets = fwd_tx_packets;
+ 
+ 	return 0;
+ }
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -560,6 +560,9 @@ struct airoha_gdm_dev {
+ #endif
+ 
+ 	DECLARE_BITMAP(qos_sq_bmap, AIROHA_NUM_QOS_CHANNELS);
++	/* qos stats counters */
++	u64 cpu_tx_packets;
++	u64 fwd_tx_packets;
+ };
+ 
+ struct airoha_gdm_port {
+@@ -569,10 +572,6 @@ struct airoha_gdm_port {
+ 
+ 	struct airoha_hw_stats stats;
+ 
+-	/* qos stats counters */
+-	u64 cpu_tx_packets;
+-	u64 fwd_tx_packets;
+-
+ 	struct metadata_dst *dsa_meta[AIROHA_MAX_DSA_PORTS];
+ };
+ 

--- a/target/linux/airoha/patches-6.6/920-06-net-airoha-Support-multiple-net_devices-for-a-single.patch
+++ b/target/linux/airoha/patches-6.6/920-06-net-airoha-Support-multiple-net_devices-for-a-single.patch
@@ -1,0 +1,714 @@
+From 8eb0a71bfbe92b6fbc668c5d9ebdcbf6523a89ad Mon Sep 17 00:00:00 2001
+Message-ID: <8eb0a71bfbe92b6fbc668c5d9ebdcbf6523a89ad.1779348625.git.lorenzo@kernel.org>
+In-Reply-To: <e15783f7c987e199ecf80b3d858ed5a86d33c508.1779348625.git.lorenzo@kernel.org>
+References: <e15783f7c987e199ecf80b3d858ed5a86d33c508.1779348625.git.lorenzo@kernel.org>
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Sat, 1 Nov 2025 11:27:48 +0100
+Subject: [PATCH 06/13] net: airoha: Support multiple net_devices for a single
+ FE GDM port
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+EN7581 or AN7583 SoCs support connecting multiple external SerDes (e.g.
+Ethernet or USB SerDes) to GDM3 or GDM4 ports via a hw arbiter that
+manages the traffic in a TDM manner. As a result multiple net_devices can
+connect to the same GDM{3,4} port and there is a theoretical "1:n"
+relation between GDM ports and net_devices.
+
+           ┌─────────────────────────────────┐
+           │                                 │    ┌──────┐
+           │                         P1 GDM1 ├────►MT7530│
+           │                                 │    └──────┘
+           │                                 │      ETH0 (DSA conduit)
+           │                                 │
+           │              PSE/FE             │
+           │                                 │
+           │                                 │
+           │                                 │    ┌─────┐
+           │                         P0 CDM1 ├────►QDMA0│
+           │  P4                     P9 GDM4 │    └─────┘
+           └──┬─────────────────────────┬────┘
+              │                         │
+           ┌──▼──┐                 ┌────▼────┐
+           │ PPE │                 │   ARB   │
+           └─────┘                 └─┬─────┬─┘
+                                     │     │
+                                  ┌──▼──┐┌─▼───┐
+                                  │ ETH ││ USB │
+                                  └─────┘└─────┘
+                                   ETH1   ETH2
+
+Introduce support for multiple net_devices connected to the same Frame
+Engine (FE) GDM port (GDM3 or GDM4) via an external hw arbiter.
+Please note GDM1 or GDM2 does not support the connection with the external
+arbiter.
+Add get_dev_from_sport callback since EN7581 and AN7583 have different
+logics for the net_device type connected to GDM3 or GDM4.
+
+Tested-by: Xuegang Lu <xuegang.lu@airoha.com>
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 274 +++++++++++++++++------
+ drivers/net/ethernet/airoha/airoha_eth.h |  10 +-
+ drivers/net/ethernet/airoha/airoha_ppe.c |  13 +-
+ 3 files changed, 228 insertions(+), 69 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -115,7 +115,7 @@ static int airoha_set_vip_for_gdm_port(s
+ 	struct airoha_eth *eth = dev->eth;
+ 	u32 vip_port;
+ 
+-	vip_port = eth->soc->ops.get_vip_port(port, port->nbq);
++	vip_port = eth->soc->ops.get_vip_port(port, dev->nbq);
+ 	if (enable) {
+ 		airoha_fe_set(eth, REG_FE_VIP_PORT_EN, vip_port);
+ 		airoha_fe_set(eth, REG_FE_IFC_PORT_EN, vip_port);
+@@ -618,30 +618,26 @@ static int airoha_qdma_fill_rx_queue(str
+ 	return nframes;
+ }
+ 
+-static int airoha_qdma_get_gdm_port(struct airoha_eth *eth,
+-				    struct airoha_qdma_desc *desc)
++static struct airoha_gdm_dev *
++airoha_qdma_get_gdm_dev(struct airoha_eth *eth, struct airoha_qdma_desc *desc)
+ {
+-	u32 port, sport, msg1 = le32_to_cpu(READ_ONCE(desc->msg1));
++	struct airoha_gdm_port *port;
++	u16 p, d;
+ 
+-	sport = FIELD_GET(QDMA_ETH_RXMSG_SPORT_MASK, msg1);
+-	switch (sport) {
+-	case 0x18:
+-		port = 3; /* GDM4 */
+-		break;
+-	case 0x16:
+-		port = 2; /* GDM3 */
+-		break;
+-	case 0x10 ... 0x14:
+-		port = 0; /* GDM1 */
+-		break;
+-	case 0x2 ... 0x4:
+-		port = sport - 1;
+-		break;
+-	default:
+-		return -EINVAL;
+-	}
++	if (eth->soc->ops.get_dev_from_sport(desc, &p, &d))
++		return ERR_PTR(-ENODEV);
++
++	if (p >= ARRAY_SIZE(eth->ports))
++		return ERR_PTR(-ENODEV);
++
++	port = eth->ports[p];
++	if (!port)
++		return ERR_PTR(-ENODEV);
++
++	if (d >= ARRAY_SIZE(port->devs))
++		return ERR_PTR(-ENODEV);
+ 
+-	return port >= ARRAY_SIZE(eth->ports) ? -EINVAL : port;
++	return port->devs[d] ? port->devs[d] : ERR_PTR(-ENODEV);
+ }
+ 
+ static int airoha_qdma_lro_rx_process(struct airoha_queue *q,
+@@ -725,9 +721,8 @@ static int airoha_qdma_rx_process(struct
+ 		struct airoha_queue_entry *e = &q->entry[q->tail];
+ 		struct airoha_qdma_desc *desc = &q->desc[q->tail];
+ 		u32 hash, reason, msg1, desc_ctrl;
+-		struct airoha_gdm_port *port;
+-		struct net_device *netdev;
+-		int data_len, len, p;
++		struct airoha_gdm_dev *dev;
++		int data_len, len;
+ 		struct page *page;
+ 
+ 		desc_ctrl = le32_to_cpu(READ_ONCE(desc->ctrl));
+@@ -748,15 +743,10 @@ static int airoha_qdma_rx_process(struct
+ 		if (!len || data_len < len)
+ 			goto free_frag;
+ 
+-		p = airoha_qdma_get_gdm_port(eth, desc);
+-		if (p < 0 || !eth->ports[p])
+-			goto free_frag;
+-
+-		port = eth->ports[p];
+-		if (!port->dev)
++		dev = airoha_qdma_get_gdm_dev(eth, desc);
++		if (IS_ERR(dev))
+ 			goto free_frag;
+ 
+-		netdev = port->dev->dev;
+ 		if (!q->skb) { /* first buffer */
+ 			q->skb = napi_build_skb(e->buf - AIROHA_RX_HEADROOM,
+ 						q->buf_size);
+@@ -766,15 +756,15 @@ static int airoha_qdma_rx_process(struct
+ 			skb_reserve(q->skb, AIROHA_RX_HEADROOM);
+ 			__skb_put(q->skb, len);
+ 			skb_mark_for_recycle(q->skb);
+-			q->skb->dev = netdev;
++			q->skb->dev = dev->dev;
+ 			q->skb->ip_summed = CHECKSUM_UNNECESSARY;
+ 			skb_record_rx_queue(q->skb, qid);
+ 
+-			if (lro_q && (netdev->features & NETIF_F_LRO) &&
++			if (lro_q && (dev->dev->features & NETIF_F_LRO) &&
+ 			    airoha_qdma_lro_rx_process(q, desc) < 0)
+ 				goto free_frag;
+ 
+-			q->skb->protocol = eth_type_trans(q->skb, netdev);
++			q->skb->protocol = eth_type_trans(q->skb, dev->dev);
+ 		} else { /* scattered frame */
+ 			struct skb_shared_info *shinfo = skb_shinfo(q->skb);
+ 			int nr_frags = shinfo->nr_frags;
+@@ -790,7 +780,9 @@ static int airoha_qdma_rx_process(struct
+ 		if (FIELD_GET(QDMA_DESC_MORE_MASK, desc_ctrl))
+ 			continue;
+ 
+-		if (netdev_uses_dsa(netdev)) {
++		if (netdev_uses_dsa(dev->dev)) {
++			struct airoha_gdm_port *port = dev->port;
++
+ 			/* PPE module requires untagged packets to work
+ 			 * properly and it provides DSA port index via the
+ 			 * DMA descriptor. Report DSA tag to the DSA stack
+@@ -987,24 +979,27 @@ static void airoha_qdma_wake_netdev_txqs
+ 
+ 	for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
+ 		struct airoha_gdm_port *port = eth->ports[i];
+-		struct airoha_gdm_dev *dev;
+-		int j;
++		int d;
+ 
+ 		if (!port)
+ 			continue;
+ 
+-		dev = port->dev;
+-		if (!dev)
+-			continue;
++		for (d = 0; d < ARRAY_SIZE(port->devs); d++) {
++			struct airoha_gdm_dev *dev = port->devs[d];
++			int j;
+ 
+-		if (dev->qdma != qdma)
+-			continue;
++			if (!dev)
++				continue;
+ 
+-		for (j = 0; j < dev->dev->num_tx_queues; j++) {
+-			if (airoha_qdma_get_txq(qdma, j) != qid)
++			if (dev->qdma != qdma)
+ 				continue;
+ 
+-			netif_wake_subqueue(dev->dev, j);
++			for (j = 0; j < dev->dev->num_tx_queues; j++) {
++				if (airoha_qdma_get_txq(qdma, j) != qid)
++					continue;
++
++				netif_wake_subqueue(dev->dev, j);
++			}
+ 		}
+ 	}
+ 	q->txq_stopped = false;
+@@ -1893,11 +1888,9 @@ static int airoha_dev_open(struct net_de
+ 			GLOBAL_CFG_RX_DMA_EN_MASK);
+ 	atomic_inc(&qdma->users);
+ 
+-	if (port->id == AIROHA_GDM2_IDX &&
+-	    airoha_ppe_is_enabled(qdma->eth, 1)) {
+-		/* For PPE2 always use secondary cpu port. */
++	if (!airoha_is_lan_gdm_dev(dev) &&
++	    airoha_ppe_is_enabled(qdma->eth, 1))
+ 		pse_port = FE_PSE_PORT_PPE2;
+-	}
+ 	airoha_set_gdm_port_fwd_cfg(qdma->eth, REG_GDM_FWD_CFG(port->id),
+ 				    pse_port);
+ 
+@@ -1992,7 +1985,7 @@ static int airoha_set_gdm2_loopback(stru
+ 	airoha_fe_clear(eth, REG_FE_VIP_PORT_EN, BIT(AIROHA_GDM2_IDX));
+ 	airoha_fe_clear(eth, REG_FE_IFC_PORT_EN, BIT(AIROHA_GDM2_IDX));
+ 
+-	src_port = eth->soc->ops.get_sport(port, port->nbq);
++	src_port = eth->soc->ops.get_sport(port, dev->nbq);
+ 	if (src_port < 0)
+ 		return src_port;
+ 
+@@ -2009,7 +2002,7 @@ static int airoha_set_gdm2_loopback(stru
+ 		airoha_ppe_set_cpu_port(dev, i, AIROHA_GDM2_IDX);
+ 
+ 	if (port->id == AIROHA_GDM4_IDX && airoha_is_7581(eth)) {
+-		u32 mask = FC_ID_OF_SRC_PORT_MASK(port->nbq);
++		u32 mask = FC_ID_OF_SRC_PORT_MASK(dev->nbq);
+ 
+ 		airoha_fe_rmw(eth, REG_SRC_PORT_FC_MAP6, mask,
+ 			      __field_prep(mask, AIROHA_GDM2_IDX));
+@@ -2023,7 +2016,7 @@ static int airoha_dev_init(struct net_de
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+ 	struct airoha_gdm_port *port = dev->port;
+ 	struct airoha_eth *eth = dev->eth;
+-	int i;
++	int ppe_id;
+ 
+ 	/* QDMA0 is used for lan ports while QDMA1 is used for WAN ports */
+ 	dev->qdma = &eth->qdma[!airoha_is_lan_gdm_dev(dev)];
+@@ -2046,8 +2039,8 @@ static int airoha_dev_init(struct net_de
+ 		break;
+ 	}
+ 
+-	for (i = 0; i < eth->soc->num_ppe; i++)
+-		airoha_ppe_set_cpu_port(dev, i, airoha_get_fe_port(dev));
++	ppe_id = !airoha_is_lan_gdm_dev(dev) && airoha_ppe_is_enabled(eth, 1);
++	airoha_ppe_set_cpu_port(dev, ppe_id, airoha_get_fe_port(dev));
+ 
+ 	return 0;
+ }
+@@ -2209,20 +2202,26 @@ static int airoha_dev_set_features(struc
+ 	} else {
+ 		for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
+ 			struct airoha_gdm_port *p = eth->ports[i];
+-			struct airoha_gdm_dev *d;
++			int j;
+ 
+ 			if (!p)
+ 				continue;
+ 
+-			d = p->dev;
+-			if (d->qdma != qdma)
+-				continue;
++			for (j = 0; j < ARRAY_SIZE(p->devs); j++) {
++				struct airoha_gdm_dev *d = p->devs[j];
+ 
+-			if (d->dev == netdev)
+-				continue;
++				if (!d)
++					continue;
+ 
+-			if (d->dev->features & NETIF_F_LRO)
+-				return 0;
++				if (d->qdma != qdma)
++					continue;
++
++				if (d->dev == netdev)
++					continue;
++
++				if (d->dev->features & NETIF_F_LRO)
++					return 0;
++			}
+ 		}
+ 		airoha_fe_lro_disable(eth, qdma_id);
+ 	}
+@@ -2273,7 +2272,8 @@ static netdev_tx_t airoha_dev_xmit(struc
+ 	}
+ 
+ 	fport = airoha_get_fe_port(dev);
+-	msg1 = FIELD_PREP(QDMA_ETH_TXMSG_FPORT_MASK, fport) |
++	msg1 = FIELD_PREP(QDMA_ETH_TXMSG_NBOQ_MASK, dev->nbq) |
++	       FIELD_PREP(QDMA_ETH_TXMSG_FPORT_MASK, fport) |
+ 	       FIELD_PREP(QDMA_ETH_TXMSG_METER_MASK, 0x7f);
+ 
+ 	q = &qdma->q_tx[qid];
+@@ -3209,12 +3209,15 @@ bool airoha_is_valid_gdm_dev(struct airo
+ 
+ 	for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
+ 		struct airoha_gdm_port *port = eth->ports[i];
++		int j;
+ 
+ 		if (!port)
+ 			continue;
+ 
+-		if (port->dev == dev)
+-			return true;
++		for (j = 0; j < ARRAY_SIZE(port->devs); j++) {
++			if (port->devs[j] == dev)
++				return true;
++		}
+ 	}
+ 
+ 	return false;
+@@ -3338,10 +3341,11 @@ static int airoha_setup_phylink(struct n
+ 
+ static int airoha_alloc_gdm_device(struct airoha_eth *eth,
+ 				   struct airoha_gdm_port *port,
+-				   struct device_node *np)
++				   int nbq, struct device_node *np)
+ {
+-	struct airoha_gdm_dev *dev;
+ 	struct net_device *netdev;
++	struct airoha_gdm_dev *dev;
++	u8 index;
+ 	int err;
+ 
+ 	netdev = devm_alloc_etherdev_mqs(eth->dev, sizeof(*dev),
+@@ -3359,7 +3363,6 @@ static int airoha_alloc_gdm_device(struc
+ 	netdev->hw_features = AIROHA_HW_FEATURES | NETIF_F_LRO;
+ 	netdev->features |= AIROHA_HW_FEATURES;
+ 	netdev->vlan_features = AIROHA_HW_FEATURES;
+-	netdev->dev.of_node = np;
+ 	SET_NETDEV_DEV(netdev, eth->dev);
+ 
+ 	/* reserve hw queues for HTB offloading */
+@@ -3377,11 +3380,25 @@ static int airoha_alloc_gdm_device(struc
+ 			 netdev->dev_addr);
+ 	}
+ 
++	/* Allowed nbq for EN7581 on GDM3 port are 4 and 5 for PCIE0
++	 * and PCIE1 respectively.
++	 */
++	index = nbq;
++	if (index && airoha_is_7581(eth) && port->id == AIROHA_GDM3_IDX)
++		index -= 4;
++
++	if (index >= ARRAY_SIZE(port->devs) || port->devs[index]) {
++		dev_err(eth->dev, "invalid nbq id: %d\n", nbq);
++		return -EINVAL;
++	}
++
++	netdev->dev.of_node = of_node_get(np);
+ 	dev = netdev_priv(netdev);
+ 	dev->dev = netdev;
+ 	dev->port = port;
+-	port->dev = dev;
+ 	dev->eth = eth;
++	dev->nbq = nbq;
++	port->devs[index] = dev;
+ 
+ #if defined(CONFIG_PCS_AIROHA)
+ 	if (airhoa_is_phy_external(port)) {
+@@ -3399,7 +3416,8 @@ static int airoha_alloc_gdm_port(struct
+ {
+ 	const __be32 *id_ptr = of_get_property(np, "reg", NULL);
+ 	struct airoha_gdm_port *port;
+-	int err, p;
++	struct device_node *node;
++	int err, nbq, p, d = 0;
+ 	u32 id;
+ 
+ 	if (!id_ptr) {
+@@ -3427,15 +3445,51 @@ static int airoha_alloc_gdm_port(struct
+ 	u64_stats_init(&port->stats.syncp);
+ 	spin_lock_init(&port->stats.lock);
+ 	port->id = id;
+-	/* XXX: Read nbq from DTS */
+-	port->nbq = id == AIROHA_GDM3_IDX && airoha_is_7581(eth) ? 4 : 0;
+ 	eth->ports[p] = port;
+ 
+ 	err = airoha_metadata_dst_alloc(port);
+ 	if (err)
+ 		return err;
+ 
+-	return airoha_alloc_gdm_device(eth, port, np);
++	/* Default nbq value to ensure backward compatibility */
++	nbq = id == AIROHA_GDM3_IDX && airoha_is_7581(eth) ? 4 : 0;
++
++	for_each_child_of_node(np, node) {
++		/* Multiple external serdes connected to the FE GDM port via an
++		 * external arbiter.
++		 */
++		const __be32 *nbq_ptr;
++
++		if (!of_device_is_compatible(node, "airoha,eth-port"))
++			continue;
++
++		d++;
++		if (!of_device_is_available(node))
++			continue;
++
++		nbq_ptr = of_get_property(node, "reg", NULL);
++		if (!nbq_ptr) {
++			dev_err(eth->dev, "missing nbq id\n");
++			of_node_put(node);
++			return -EINVAL;
++		}
++
++		/* Verify the provided nbq parameter is valid */
++		nbq = be32_to_cpup(nbq_ptr);
++		err = eth->soc->ops.get_sport(port, nbq);
++		if (err < 0) {
++			of_node_put(node);
++			return err;
++		}
++
++		err = airoha_alloc_gdm_device(eth, port, nbq, node);
++		if (err) {
++			of_node_put(node);
++			return err;
++		}
++	}
++
++	return !d ? airoha_alloc_gdm_device(eth, port, nbq, np) : 0;
+ }
+ 
+ static int airoha_register_gdm_devices(struct airoha_eth *eth)
+@@ -3444,14 +3498,22 @@ static int airoha_register_gdm_devices(s
+ 
+ 	for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
+ 		struct airoha_gdm_port *port = eth->ports[i];
+-		int err;
++		int j;
+ 
+ 		if (!port)
+ 			continue;
+ 
+-		err = register_netdev(port->dev->dev);
+-		if (err)
+-			return err;
++		for (j = 0; j < ARRAY_SIZE(port->devs); j++) {
++			struct airoha_gdm_dev *dev = port->devs[j];
++			int err;
++
++			if (!dev)
++				continue;
++
++			err = register_netdev(dev->dev);
++			if (err)
++				return err;
++		}
+ 	}
+ 
+ 	set_bit(DEV_STATE_REGISTERED, &eth->state);
+@@ -3558,18 +3620,27 @@ error_napi_stop:
+ 
+ 	for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
+ 		struct airoha_gdm_port *port = eth->ports[i];
+-		struct airoha_gdm_dev *dev;
++		int j;
+ 
+ 		if (!port)
+ 			continue;
+ 
+-		dev = port->dev;
+-		if (dev && dev->dev->reg_state == NETREG_REGISTERED) {
++		for (j = 0; j < ARRAY_SIZE(port->devs); j++) {
++			struct airoha_gdm_dev *dev = port->devs[j];
++			struct net_device *netdev;
++
++			if (!dev)
++				continue;
++
++			netdev = dev->dev;
++			if (netdev->reg_state == NETREG_REGISTERED) {
+ #if defined(CONFIG_PCS_AIROHA)
+-			if (airhoa_is_phy_external(port))
+-				phylink_destroy(dev->phylink);
++				if (airhoa_is_phy_external(port))
++					phylink_destroy(dev->phylink);
+ #endif
+-			unregister_netdev(dev->dev);
++				unregister_netdev(netdev);
++			}
++			of_node_put(netdev->dev.of_node);
+ 		}
+ 		airoha_metadata_dst_free(port);
+ 	}
+@@ -3591,19 +3662,26 @@ static void airoha_remove(struct platfor
+ 
+ 	for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
+ 		struct airoha_gdm_port *port = eth->ports[i];
+-		struct airoha_gdm_dev *dev;
++		int j;
+ 
+ 		if (!port)
+ 			continue;
+ 
++		for (j = 0; j < ARRAY_SIZE(port->devs); j++) {
++			struct airoha_gdm_dev *dev = port->devs[j];
++			struct net_device *netdev;
++
++			if (!dev)
++				continue;
++
+ #if defined(CONFIG_PCS_AIROHA)
+ 		if (airhoa_is_phy_external(port))
+ 			phylink_destroy(dev->phylink);
+ #endif
+-
+-		dev = port->dev;
+-		if (dev)
+-			unregister_netdev(dev->dev);
++			netdev = dev->dev;
++			unregister_netdev(netdev);
++			of_node_put(netdev->dev.of_node);
++		}
+ 		airoha_metadata_dst_free(port);
+ 	}
+ 	airoha_hw_cleanup(eth);
+@@ -3665,6 +3743,39 @@ static u32 airoha_en7581_get_vip_port(st
+ 	return 0;
+ }
+ 
++static int airoha_en7581_get_dev_from_sport(struct airoha_qdma_desc *desc,
++					    u16 *port, u16 *dev)
++{
++	u32 sport = FIELD_GET(QDMA_ETH_RXMSG_SPORT_MASK,
++			      le32_to_cpu(READ_ONCE(desc->msg1)));
++
++	*dev = 0;
++	switch (sport) {
++	case 0x10 ... 0x14:
++		*port = 0; /* GDM1 */
++		break;
++	case 0x2 ... 0x4:
++		*port = sport - 1;
++		break;
++	case HSGMII_LAN_7581_PCIE1_SRCPORT:
++		*dev = 1;
++		fallthrough;
++	case HSGMII_LAN_7581_PCIE0_SRCPORT:
++		*port = 2; /* GDM3 */
++		break;
++	case HSGMII_LAN_7581_USB_SRCPORT:
++		*dev = 1;
++		fallthrough;
++	case HSGMII_LAN_7581_ETH_SRCPORT:
++		*port = 3; /* GDM4 */
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	return 0;
++}
++
+ static const char * const an7583_xsi_rsts_names[] = {
+ 	"hsi0-mac",
+ 	"hsi1-mac",
+@@ -3713,6 +3824,36 @@ static u32 airoha_an7583_get_vip_port(st
+ 	return 0;
+ }
+ 
++static int airoha_an7583_get_dev_from_sport(struct airoha_qdma_desc *desc,
++					    u16 *port, u16 *dev)
++{
++	u32 sport = FIELD_GET(QDMA_ETH_RXMSG_SPORT_MASK,
++			      le32_to_cpu(READ_ONCE(desc->msg1)));
++
++	*dev = 0;
++	switch (sport) {
++	case 0x10 ... 0x14:
++		*port = 0; /* GDM1 */
++		break;
++	case 0x2 ... 0x4:
++		*port = sport - 1;
++		break;
++	case HSGMII_LAN_7583_ETH_SRCPORT:
++		*port = 2; /* GDM3 */
++		break;
++	case HSGMII_LAN_7583_USB_SRCPORT:
++		*dev = 1;
++		fallthrough;
++	case HSGMII_LAN_7583_PCIE_SRCPORT:
++		*port = 3; /* GDM4 */
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	return 0;
++}
++
+ static const struct airoha_eth_soc_data en7581_soc_data = {
+ 	.version = 0x7581,
+ 	.xsi_rsts_names = en7581_xsi_rsts_names,
+@@ -3721,6 +3862,7 @@ static const struct airoha_eth_soc_data
+ 	.ops = {
+ 		.get_sport = airoha_en7581_get_sport,
+ 		.get_vip_port = airoha_en7581_get_vip_port,
++		.get_dev_from_sport = airoha_en7581_get_dev_from_sport,
+ 	},
+ };
+ 
+@@ -3732,6 +3874,7 @@ static const struct airoha_eth_soc_data
+ 	.ops = {
+ 		.get_sport = airoha_an7583_get_sport,
+ 		.get_vip_port = airoha_an7583_get_vip_port,
++		.get_dev_from_sport = airoha_an7583_get_dev_from_sport,
+ 	},
+ };
+ 
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -17,6 +17,7 @@
+ #include <net/dsa.h>
+ 
+ #define AIROHA_MAX_NUM_GDM_PORTS	4
++#define AIROHA_MAX_NUM_GDM_DEVS		2
+ #define AIROHA_MAX_NUM_QDMA		2
+ #define AIROHA_MAX_NUM_IRQ_BANKS	4
+ #define AIROHA_MAX_DSA_PORTS		7
+@@ -551,8 +552,8 @@ struct airoha_qdma {
+ struct airoha_gdm_dev {
+ 	struct airoha_gdm_port *port;
+ 	struct airoha_qdma *qdma;
+-	struct net_device *dev;
+ 	struct airoha_eth *eth;
++	struct net_device *dev;
+ 
+ #if defined(CONFIG_PCS_AIROHA)
+ 	struct phylink *phylink;
+@@ -563,12 +564,13 @@ struct airoha_gdm_dev {
+ 	/* qos stats counters */
+ 	u64 cpu_tx_packets;
+ 	u64 fwd_tx_packets;
++
++	int nbq;
+ };
+ 
+ struct airoha_gdm_port {
+-	struct airoha_gdm_dev *dev;
++	struct airoha_gdm_dev *devs[AIROHA_MAX_NUM_GDM_DEVS];
+ 	int id;
+-	int nbq;
+ 
+ 	struct airoha_hw_stats stats;
+ 
+@@ -604,6 +606,8 @@ struct airoha_eth_soc_data {
+ 	struct {
+ 		int (*get_sport)(struct airoha_gdm_port *port, int nbq);
+ 		u32 (*get_vip_port)(struct airoha_gdm_port *port, int nbq);
++		int (*get_dev_from_sport)(struct airoha_qdma_desc *desc,
++					  u16 *port, u16 *dev);
+ 	} ops;
+ };
+ 
+--- a/drivers/net/ethernet/airoha/airoha_ppe.c
++++ b/drivers/net/ethernet/airoha/airoha_ppe.c
+@@ -168,9 +168,7 @@ static void airoha_ppe_hw_init(struct ai
+ 		airoha_fe_clear(eth, REG_PPE_PPE_FLOW_CFG(i),
+ 				PPE_FLOW_CFG_IP6_6RD_MASK);
+ 
+-		for (p = 0; p < ARRAY_SIZE(eth->ports); p++) {
+-			struct airoha_gdm_port *port = eth->ports[p];
+-
++		for (p = 0; p < ARRAY_SIZE(eth->ports); p++)
+ 			airoha_fe_rmw(eth, REG_PPE_MTU(i, p),
+ 				      FP0_EGRESS_MTU_MASK |
+ 				      FP1_EGRESS_MTU_MASK,
+@@ -178,11 +176,24 @@ static void airoha_ppe_hw_init(struct ai
+ 						 AIROHA_MAX_MTU) |
+ 				      FIELD_PREP(FP1_EGRESS_MTU_MASK,
+ 						 AIROHA_MAX_MTU));
+-			if (!port)
++	}
++
++	for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
++		struct airoha_gdm_port *port = eth->ports[i];
++		int j;
++
++		if (!port)
++			continue;
++
++		for (j = 0; j < ARRAY_SIZE(port->devs); j++) {
++			struct airoha_gdm_dev *dev = port->devs[j];
++			u8 fport;
++
++			if (!dev)
+ 				continue;
+ 
+-			airoha_ppe_set_cpu_port(port->dev, i,
+-						airoha_get_fe_port(port->dev));
++			fport = airoha_get_fe_port(dev);
++			airoha_ppe_set_cpu_port(dev, i, fport);
+ 		}
+ 	}
+ }

--- a/target/linux/airoha/patches-6.6/920-07-net-airoha-Do-not-stop-GDM-port-if-it-is-shared.patch
+++ b/target/linux/airoha/patches-6.6/920-07-net-airoha-Do-not-stop-GDM-port-if-it-is-shared.patch
@@ -1,0 +1,132 @@
+From de856a5b802cf030c8e242e98df3bc88446a4ea1 Mon Sep 17 00:00:00 2001
+Message-ID: <de856a5b802cf030c8e242e98df3bc88446a4ea1.1779348625.git.lorenzo@kernel.org>
+In-Reply-To: <e15783f7c987e199ecf80b3d858ed5a86d33c508.1779348625.git.lorenzo@kernel.org>
+References: <e15783f7c987e199ecf80b3d858ed5a86d33c508.1779348625.git.lorenzo@kernel.org>
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Fri, 20 Mar 2026 11:09:40 +0100
+Subject: [PATCH 07/13] net: airoha: Do not stop GDM port if it is shared
+
+Theoretically, in the current codebase, two independent net_devices can
+be connected to the same GDM port so we need to check the GDM port is not
+used by any other running net_device before setting the forward
+configuration to FE_PSE_PORT_DROP.
+Moreover, always set in GDM_LONG_LEN_MASK field of REG_GDM_LEN_CFG
+register the maximum MTU of all running net_devices connected to the same
+GDM port.
+
+Tested-by: Xuegang Lu <xuegang.lu@airoha.com>
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 59 +++++++++++++++++++-----
+ drivers/net/ethernet/airoha/airoha_eth.h |  1 +
+ 2 files changed, 48 insertions(+), 12 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -1849,8 +1849,8 @@ static int airoha_dev_open(struct net_de
+ 	int err, len = ETH_HLEN + netdev->mtu + ETH_FCS_LEN;
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+ 	struct airoha_gdm_port *port = dev->port;
++	u32 cur_len, pse_port = FE_PSE_PORT_PPE1;
+ 	struct airoha_qdma *qdma = dev->qdma;
+-	u32 pse_port = FE_PSE_PORT_PPE1;
+ 
+ #if defined(CONFIG_PCS_AIROHA)
+ 	if (airhoa_is_phy_external(port)) {
+@@ -1878,10 +1878,20 @@ static int airoha_dev_open(struct net_de
+ 		airoha_fe_clear(qdma->eth, REG_GDM_INGRESS_CFG(port->id),
+ 				GDM_STAG_EN_MASK);
+ 
+-	airoha_fe_rmw(qdma->eth, REG_GDM_LEN_CFG(port->id),
+-		      GDM_SHORT_LEN_MASK | GDM_LONG_LEN_MASK,
+-		      FIELD_PREP(GDM_SHORT_LEN_MASK, 60) |
+-		      FIELD_PREP(GDM_LONG_LEN_MASK, len));
++	cur_len = airoha_fe_get(qdma->eth, REG_GDM_LEN_CFG(port->id),
++				GDM_LONG_LEN_MASK);
++	if (!port->users || len > cur_len) {
++		/* Opening a sibling net_device with a larger MTU updates the
++		 * MTU of already running devices. This is required to allow
++		 * multiple net_devices with different MTUs to share the same
++		 * GDM port.
++		 */
++		airoha_fe_rmw(qdma->eth, REG_GDM_LEN_CFG(port->id),
++			      GDM_SHORT_LEN_MASK | GDM_LONG_LEN_MASK,
++			      FIELD_PREP(GDM_SHORT_LEN_MASK, 60) |
++			      FIELD_PREP(GDM_LONG_LEN_MASK, len));
++	}
++	port->users++;
+ 
+ 	airoha_qdma_set(qdma, REG_QDMA_GLOBAL_CFG,
+ 			GLOBAL_CFG_TX_DMA_EN_MASK |
+@@ -1897,6 +1907,30 @@ static int airoha_dev_open(struct net_de
+ 	return 0;
+ }
+ 
++static void airoha_set_port_mtu(struct airoha_eth *eth,
++				struct airoha_gdm_port *port)
++{
++	u32 len = 0;
++	int i;
++
++	for (i = 0; i < ARRAY_SIZE(port->devs); i++) {
++		struct airoha_gdm_dev *dev = port->devs[i];
++		struct net_device *netdev;
++
++		if (!dev)
++			continue;
++
++		netdev = dev->dev;
++		if (netif_running(netdev))
++			len = max_t(u32, len, netdev->mtu);
++	}
++	len += ETH_HLEN + ETH_FCS_LEN;
++
++	airoha_fe_rmw(eth, REG_GDM_LEN_CFG(port->id),
++		      GDM_LONG_LEN_MASK,
++		      FIELD_PREP(GDM_LONG_LEN_MASK, len));
++}
++
+ static int airoha_dev_stop(struct net_device *netdev)
+ {
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+@@ -1909,8 +1943,12 @@ static int airoha_dev_stop(struct net_de
+ 	for (i = 0; i < netdev->num_tx_queues; i++)
+ 		netdev_tx_reset_subqueue(netdev, i);
+ 
+-	airoha_set_gdm_port_fwd_cfg(qdma->eth, REG_GDM_FWD_CFG(port->id),
+-				    FE_PSE_PORT_DROP);
++	if (--port->users)
++		airoha_set_port_mtu(dev->eth, port);
++	else
++		airoha_set_gdm_port_fwd_cfg(qdma->eth,
++					    REG_GDM_FWD_CFG(port->id),
++					    FE_PSE_PORT_DROP);
+ 
+ 	if (atomic_dec_and_test(&qdma->users)) {
+ 		airoha_qdma_clear(qdma, REG_QDMA_GLOBAL_CFG,
+@@ -2072,13 +2110,10 @@ static int airoha_dev_change_mtu(struct
+ {
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+ 	struct airoha_gdm_port *port = dev->port;
+-	u32 len = ETH_HLEN + mtu + ETH_FCS_LEN;
+-	struct airoha_eth *eth = dev->eth;
+ 
+-	airoha_fe_rmw(eth, REG_GDM_LEN_CFG(port->id),
+-		      GDM_LONG_LEN_MASK,
+-		      FIELD_PREP(GDM_LONG_LEN_MASK, len));
+ 	WRITE_ONCE(netdev->mtu, mtu);
++	if (port->users)
++		airoha_set_port_mtu(dev->eth, port);
+ 
+ 	return 0;
+ }
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -571,6 +571,7 @@ struct airoha_gdm_dev {
+ struct airoha_gdm_port {
+ 	struct airoha_gdm_dev *devs[AIROHA_MAX_NUM_GDM_DEVS];
+ 	int id;
++	int users;
+ 
+ 	struct airoha_hw_stats stats;
+ 

--- a/target/linux/airoha/patches-6.6/920-08-net-airoha-Introduce-WAN-device-flag.patch
+++ b/target/linux/airoha/patches-6.6/920-08-net-airoha-Introduce-WAN-device-flag.patch
@@ -1,0 +1,174 @@
+From c4f3077948eda05a6b9d1a11304d82c3e0300151 Mon Sep 17 00:00:00 2001
+Message-ID: <c4f3077948eda05a6b9d1a11304d82c3e0300151.1779348625.git.lorenzo@kernel.org>
+In-Reply-To: <e15783f7c987e199ecf80b3d858ed5a86d33c508.1779348625.git.lorenzo@kernel.org>
+References: <e15783f7c987e199ecf80b3d858ed5a86d33c508.1779348625.git.lorenzo@kernel.org>
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Fri, 3 Apr 2026 12:07:27 +0200
+Subject: [PATCH 08/13] net: airoha: Introduce WAN device flag
+
+Introduce WAN flag to specify if a given device is used to transmit/receive
+WAN or LAN traffic. Current codebase supports specifying LAN/WAN device
+configuration in ndo_init() callback during device bootstrap.
+In order to consider setups where LAN configuration is used even for
+GDM3/GDM4 devices, check airoha_is_lan_gdm_dev() to select pse_port in
+airoha_ppe_foe_entry_prepare().
+Please note after this patch, it will be possible to specify multiple LAN
+devices but just a single WAN one. Please note this change is not visible
+to the user since airoha_eth driver currently supports just the internal
+phy available via the MT7530 DSA switch and there are no WAN interfaces
+officially supported since PCS/external phy is not merged mainline yet
+(it will be posted with following patches).
+
+Tested-by: Xuegang Lu <xuegang.lu@airoha.com>
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 72 +++++++++++++++++++-----
+ drivers/net/ethernet/airoha/airoha_eth.h | 13 ++---
+ drivers/net/ethernet/airoha/airoha_ppe.c |  2 +-
+ 3 files changed, 65 insertions(+), 22 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -2049,36 +2049,80 @@ static int airoha_set_gdm2_loopback(stru
+ 	return 0;
+ }
+ 
+-static int airoha_dev_init(struct net_device *netdev)
++static struct airoha_gdm_dev *
++airoha_get_wan_gdm_dev(struct airoha_eth *eth)
++{
++	int i;
++
++	for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
++		struct airoha_gdm_port *port = eth->ports[i];
++		int j;
++
++		if (!port)
++			continue;
++
++		for (j = 0; j < ARRAY_SIZE(port->devs); j++) {
++			struct airoha_gdm_dev *dev = port->devs[j];
++
++			if (dev && !airoha_is_lan_gdm_dev(dev))
++				return dev;
++		}
++	}
++
++	return NULL;
++}
++
++static void airoha_dev_set_qdma(struct airoha_gdm_dev *dev)
+ {
+-	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+-	struct airoha_gdm_port *port = dev->port;
+ 	struct airoha_eth *eth = dev->eth;
+ 	int ppe_id;
+ 
+ 	/* QDMA0 is used for lan ports while QDMA1 is used for WAN ports */
+ 	dev->qdma = &eth->qdma[!airoha_is_lan_gdm_dev(dev)];
+ 	dev->dev->irq = dev->qdma->irq_banks[0].irq;
+-	airoha_set_macaddr(dev, netdev->dev_addr);
++
++	ppe_id = !airoha_is_lan_gdm_dev(dev) && airoha_ppe_is_enabled(eth, 1);
++	airoha_ppe_set_cpu_port(dev, ppe_id, airoha_get_fe_port(dev));
++}
++
++static int airoha_dev_init(struct net_device *netdev)
++{
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
+ 
+ 	switch (port->id) {
+ 	case AIROHA_GDM3_IDX:
+-	case AIROHA_GDM4_IDX:
+-		/* If GDM2 is active we can't enable loopback */
+-		if (!eth->ports[1]) {
+-			int err;
+-
+-			err = airoha_set_gdm2_loopback(dev);
+-			if (err)
+-				return err;
+-		}
++	case AIROHA_GDM4_IDX: {
++		struct airoha_eth *eth = dev->eth;
++
++		/* GDM2 supports a single net_device */
++		if (eth->ports[1] && eth->ports[1]->devs[0])
++			break;
++
++		if (airoha_get_wan_gdm_dev(eth))
++			break;
++
++		fallthrough;
++	}
++	case AIROHA_GDM2_IDX:
++		/* GDM2 is always used as wan */
++		dev->flags |= AIROHA_PRIV_F_WAN;
+ 		break;
+ 	default:
+ 		break;
+ 	}
+ 
+-	ppe_id = !airoha_is_lan_gdm_dev(dev) && airoha_ppe_is_enabled(eth, 1);
+-	airoha_ppe_set_cpu_port(dev, ppe_id, airoha_get_fe_port(dev));
++	airoha_dev_set_qdma(dev);
++	airoha_set_macaddr(dev, netdev->dev_addr);
++
++	if (!airoha_is_lan_gdm_dev(dev) &&
++	    (port->id == AIROHA_GDM3_IDX || port->id == AIROHA_GDM4_IDX)) {
++		int err;
++
++		err = airoha_set_gdm2_loopback(dev);
++		if (err)
++			return err;
++	}
+ 
+ 	return 0;
+ }
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -549,6 +549,10 @@ struct airoha_qdma {
+ 	DECLARE_BITMAP(qos_channel_map, AIROHA_NUM_QOS_CHANNELS);
+ };
+ 
++enum airoha_priv_flags {
++	AIROHA_PRIV_F_WAN = BIT(0),
++};
++
+ struct airoha_gdm_dev {
+ 	struct airoha_gdm_port *port;
+ 	struct airoha_qdma *qdma;
+@@ -565,6 +569,7 @@ struct airoha_gdm_dev {
+ 	u64 cpu_tx_packets;
+ 	u64 fwd_tx_packets;
+ 
++	u32 flags;
+ 	int nbq;
+ };
+ 
+@@ -671,13 +676,7 @@ static inline u16 airoha_qdma_get_txq(st
+ 
+ static inline bool airoha_is_lan_gdm_dev(struct airoha_gdm_dev *dev)
+ {
+-	struct airoha_gdm_port *port = dev->port;
+-
+-	/* GDM1 port on EN7581 SoC is connected to the lan dsa switch.
+-	 * GDM{2,3,4} can be used as wan port connected to an external
+-	 * phy module.
+-	 */
+-	return port->id == 1;
++	return !(dev->flags & AIROHA_PRIV_F_WAN);
+ }
+ 
+ static inline bool airoha_is_7581(struct airoha_eth *eth)
+--- a/drivers/net/ethernet/airoha/airoha_ppe.c
++++ b/drivers/net/ethernet/airoha/airoha_ppe.c
+@@ -351,7 +351,7 @@ static int airoha_ppe_foe_entry_prepare(
+ 				return -EINVAL;
+ 
+ 			port = dev->port;
+-			if (dsa_port >= 0 || eth->ports[1])
++			if (dsa_port >= 0 || airoha_is_lan_gdm_dev(dev))
+ 				pse_port = port->id == 4 ? FE_PSE_PORT_GDM4
+ 							 : port->id;
+ 			else

--- a/target/linux/airoha/patches-6.6/920-09-net-airoha-Support-multiple-LAN-WAN-interfaces-for-h.patch
+++ b/target/linux/airoha/patches-6.6/920-09-net-airoha-Support-multiple-LAN-WAN-interfaces-for-h.patch
@@ -1,0 +1,161 @@
+From 144f0e6e55896625e3411aad02399a5ebb48d8f9 Mon Sep 17 00:00:00 2001
+Message-ID: <144f0e6e55896625e3411aad02399a5ebb48d8f9.1779348625.git.lorenzo@kernel.org>
+In-Reply-To: <e15783f7c987e199ecf80b3d858ed5a86d33c508.1779348625.git.lorenzo@kernel.org>
+References: <e15783f7c987e199ecf80b3d858ed5a86d33c508.1779348625.git.lorenzo@kernel.org>
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Mon, 13 Apr 2026 17:38:51 +0200
+Subject: [PATCH 09/13] net: airoha: Support multiple LAN/WAN interfaces for hw
+ MAC address configuration
+
+The EN7581 and AN7583 SoCs provide registers to configure hardware LAN/WAN
+MAC addresses, used to determine whether received traffic is destined for
+this host or should be forwarded to another device.
+The SoC hardware design assumes all interfaces configured as LAN (or WAN)
+share a common upper MAC address, which is programmed into the
+REG_FE_{LAN,WAN}_MAC_H register. The lower bytes of 'local' addresses can
+be expressed as a range via the REG_FE_MAC_LMIN and REG_FE_MAC_LMAX
+registers.
+Previously, only a single interface was considered when programming these
+registers. Extend the logic to derive the correct minimum and maximum
+values for REG_FE_MAC_LMIN/REG_FE_MAC_LMAX when two or more interfaces are
+configured as LAN or WAN.
+
+Tested-by: Madhur Agrawal <madhur.agrawal@airoha.com>
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 77 ++++++++++++++++++++----
+ drivers/net/ethernet/airoha/airoha_eth.h |  2 +-
+ drivers/net/ethernet/airoha/airoha_ppe.c |  4 +-
+ 3 files changed, 68 insertions(+), 15 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -80,20 +80,74 @@ static bool airhoa_is_phy_external(struc
+ }
+ #endif
+ 
+-static void airoha_set_macaddr(struct airoha_gdm_dev *dev, const u8 *addr)
++static int airoha_set_macaddr(struct airoha_gdm_dev *dev, const u8 *addr)
+ {
++	u8 ref_addr[ETH_ALEN] __aligned(2);
+ 	struct airoha_eth *eth = dev->eth;
+-	u32 val, reg;
++	u32 reg, val, lmin, lmax;
++	int i;
++
++	eth_zero_addr(ref_addr);
++	lmin = (addr[3] << 16) | (addr[4] << 8) | addr[5];
++	lmax = lmin;
++
++	for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
++		struct airoha_gdm_port *port = eth->ports[i];
++		int j;
++
++		if (!port)
++			continue;
++
++		for (j = 0; j < ARRAY_SIZE(port->devs); j++) {
++			struct airoha_gdm_dev *iter_dev;
++			struct net_device *netdev;
++
++			iter_dev = port->devs[j];
++			if (!iter_dev || iter_dev == dev)
++				continue;
++
++			if (airoha_is_lan_gdm_dev(iter_dev) !=
++			    airoha_is_lan_gdm_dev(dev))
++				continue;
++
++			netdev = iter_dev->dev;
++			if (netdev->reg_state != NETREG_REGISTERED)
++				continue;
++
++			ether_addr_copy(ref_addr, netdev->dev_addr);
++			val = (netdev->dev_addr[3] << 16) |
++			      (netdev->dev_addr[4] << 8) | netdev->dev_addr[5];
++			if (val < lmin)
++				lmin = val;
++			if (val > lmax)
++				lmax = val;
++		}
++	}
++
++	if (!is_zero_ether_addr(ref_addr) && memcmp(ref_addr, addr, 3)) {
++		/* According to the HW design, hw mac address MSBs must be
++		 * the same for each net_device with the same LAN/WAN
++		 * configuration.
++		 */
++		dev_warn(eth->dev,
++			 "%s: wrong mac addr, MSBs must be %02x:%02x:%02x\n",
++			 dev->dev->name, ref_addr[0], ref_addr[1],
++			 ref_addr[2]);
++		dev_warn(eth->dev, "FE hw forwarding won't work properly\n");
++
++		return -EINVAL;
++	}
+ 
+ 	reg = airoha_is_lan_gdm_dev(dev) ? REG_FE_LAN_MAC_H : REG_FE_WAN_MAC_H;
+ 	val = (addr[0] << 16) | (addr[1] << 8) | addr[2];
+ 	airoha_fe_wr(eth, reg, val);
+ 
+-	val = (addr[3] << 16) | (addr[4] << 8) | addr[5];
+-	airoha_fe_wr(eth, REG_FE_MAC_LMIN(reg), val);
+-	airoha_fe_wr(eth, REG_FE_MAC_LMAX(reg), val);
++	airoha_fe_wr(eth, REG_FE_MAC_LMIN(reg), lmin);
++	airoha_fe_wr(eth, REG_FE_MAC_LMAX(reg), lmax);
++
++	airoha_ppe_init_upd_mem(dev, addr);
+ 
+-	airoha_ppe_init_upd_mem(dev);
++	return 0;
+ }
+ 
+ static void airoha_set_gdm_port_fwd_cfg(struct airoha_eth *eth, u32 addr,
+@@ -1976,13 +2030,18 @@ static int airoha_dev_stop(struct net_de
+ static int airoha_dev_set_macaddr(struct net_device *netdev, void *p)
+ {
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct sockaddr *addr = p;
+ 	int err;
+ 
+-	err = eth_mac_addr(netdev, p);
++	err = eth_prepare_mac_addr_change(netdev, p);
++	if (err)
++		return err;
++
++	err = airoha_set_macaddr(dev, addr->sa_data);
+ 	if (err)
+ 		return err;
+ 
+-	airoha_set_macaddr(dev, netdev->dev_addr);
++	eth_commit_mac_addr_change(netdev, p);
+ 
+ 	return 0;
+ }
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -712,7 +712,7 @@ void airoha_ppe_check_skb(struct airoha_
+ int airoha_ppe_setup_tc_block_cb(struct airoha_ppe_dev *dev, void *type_data);
+ int airoha_ppe_init(struct airoha_eth *eth);
+ void airoha_ppe_deinit(struct airoha_eth *eth);
+-void airoha_ppe_init_upd_mem(struct airoha_gdm_dev *dev);
++void airoha_ppe_init_upd_mem(struct airoha_gdm_dev *dev, const u8 *addr);
+ u32 airoha_ppe_get_total_num_entries(struct airoha_ppe *ppe);
+ struct airoha_foe_entry *airoha_ppe_foe_get_entry(struct airoha_ppe *ppe,
+ 						  u32 hash);
+--- a/drivers/net/ethernet/airoha/airoha_ppe.c
++++ b/drivers/net/ethernet/airoha/airoha_ppe.c
+@@ -1494,12 +1494,10 @@ void airoha_ppe_check_skb(struct airoha_
+ 	airoha_ppe_foe_insert_entry(ppe, skb, hash, rx_wlan);
+ }
+ 
+-void airoha_ppe_init_upd_mem(struct airoha_gdm_dev *dev)
++void airoha_ppe_init_upd_mem(struct airoha_gdm_dev *dev, const u8 *addr)
+ {
+ 	struct airoha_gdm_port *port = dev->port;
+-	struct net_device *netdev = dev->dev;
+ 	struct airoha_eth *eth = dev->eth;
+-	const u8 *addr = netdev->dev_addr;
+ 	u32 val;
+ 
+ 	val = (addr[2] << 24) | (addr[3] << 16) | (addr[4] << 8) | addr[5];

--- a/target/linux/airoha/patches-6.6/920-10-net-airoha-Rename-airoha_set_gdm2_loopback-in-airoha.patch
+++ b/target/linux/airoha/patches-6.6/920-10-net-airoha-Rename-airoha_set_gdm2_loopback-in-airoha.patch
@@ -1,0 +1,37 @@
+From 917f959d54efd09719bd5047aa4b9543615e131e Mon Sep 17 00:00:00 2001
+Message-ID: <917f959d54efd09719bd5047aa4b9543615e131e.1779348625.git.lorenzo@kernel.org>
+In-Reply-To: <e15783f7c987e199ecf80b3d858ed5a86d33c508.1779348625.git.lorenzo@kernel.org>
+References: <e15783f7c987e199ecf80b3d858ed5a86d33c508.1779348625.git.lorenzo@kernel.org>
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Fri, 19 Dec 2025 23:12:32 +0100
+Subject: [PATCH 10/13] net: airoha: Rename airoha_set_gdm2_loopback in
+ airoha_enable_gdm2_loopback
+
+This is a preliminary patch in order to allow the user to select if the
+configured device will be used as hw lan or wan.
+
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -2046,7 +2046,7 @@ static int airoha_dev_set_macaddr(struct
+ 	return 0;
+ }
+ 
+-static int airoha_set_gdm2_loopback(struct airoha_gdm_dev *dev)
++static int airoha_enable_gdm2_loopback(struct airoha_gdm_dev *dev)
+ {
+ 	struct airoha_gdm_port *port = dev->port;
+ 	struct airoha_eth *eth = dev->eth;
+@@ -2178,7 +2178,7 @@ static int airoha_dev_init(struct net_de
+ 	    (port->id == AIROHA_GDM3_IDX || port->id == AIROHA_GDM4_IDX)) {
+ 		int err;
+ 
+-		err = airoha_set_gdm2_loopback(dev);
++		err = airoha_enable_gdm2_loopback(dev);
+ 		if (err)
+ 			return err;
+ 	}

--- a/target/linux/airoha/patches-6.6/920-12-net-airoha-Add-ethtool-priv_flags-callbacks.patch
+++ b/target/linux/airoha/patches-6.6/920-12-net-airoha-Add-ethtool-priv_flags-callbacks.patch
@@ -1,0 +1,246 @@
+From e928621a0bbd010b75624c77105ce31f2b8d2faf Mon Sep 17 00:00:00 2001
+Message-ID: <e928621a0bbd010b75624c77105ce31f2b8d2faf.1779348625.git.lorenzo@kernel.org>
+In-Reply-To: <e15783f7c987e199ecf80b3d858ed5a86d33c508.1779348625.git.lorenzo@kernel.org>
+References: <e15783f7c987e199ecf80b3d858ed5a86d33c508.1779348625.git.lorenzo@kernel.org>
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Sat, 13 Dec 2025 09:45:09 +0100
+Subject: [PATCH 12/13] net: airoha: Add ethtool priv_flags callbacks
+
+Introduce ethtool priv_flags callbacks in order to allow the user to
+select if the configured device will be used as hw lan or wan and enable
+or disable gdm2 loopback (used for hw QoS).
+
+Tested-by: Madhur Agrawal <madhur.agrawal@airoha.com>
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c  | 173 ++++++++++++++++++++++
+ drivers/net/ethernet/airoha/airoha_regs.h |   1 +
+ 2 files changed, 174 insertions(+)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -1906,6 +1906,11 @@ static int airoha_dev_open(struct net_de
+ 	u32 cur_len, pse_port = FE_PSE_PORT_PPE1;
+ 	struct airoha_qdma *qdma = dev->qdma;
+ 
++	if (port->id == AIROHA_GDM2_IDX && airoha_is_lan_gdm_dev(dev)) {
++		/* GDM2 can be used just as wan */
++		return -EBUSY;
++	}
++
+ #if defined(CONFIG_PCS_AIROHA)
+ 	if (airhoa_is_phy_external(port)) {
+ 		err = phylink_of_phy_connect(dev->phylink, netdev->dev.of_node, 0);
+@@ -2108,6 +2113,45 @@ static int airoha_enable_gdm2_loopback(s
+ 	return 0;
+ }
+ 
++static int airoha_disable_gdm2_loopback(struct airoha_gdm_dev *dev)
++{
++	struct airoha_eth *eth = dev->eth;
++	int i, src_port;
++	u32 pse_port;
++
++	src_port = eth->soc->ops.get_sport(dev->port, dev->nbq);
++	if (src_port < 0)
++		return src_port;
++
++	airoha_fe_clear(eth,
++			REG_SP_DFT_CPORT(src_port >> fls(SP_CPORT_DFT_MASK)),
++			SP_CPORT_MASK(src_port & SP_CPORT_DFT_MASK));
++
++	airoha_set_gdm_port_fwd_cfg(eth, REG_GDM_FWD_CFG(AIROHA_GDM2_IDX),
++				    FE_PSE_PORT_DROP);
++	airoha_fe_clear(eth, REG_GDM_LPBK_CFG(AIROHA_GDM2_IDX),
++			LPBK_CHAN_MASK | LPBK_MODE_MASK | LPBK_EN_MASK);
++	pse_port = airoha_ppe_is_enabled(eth, 1) ? FE_PSE_PORT_PPE2
++						 : FE_PSE_PORT_PPE1;
++	airoha_set_gdm_port_fwd_cfg(eth, REG_GDM_FWD_CFG(AIROHA_GDM2_IDX),
++				    pse_port);
++
++	airoha_fe_rmw(eth, REG_FE_WAN_PORT, WAN0_MASK,
++		      FIELD_PREP(WAN0_MASK, AIROHA_GDM2_IDX));
++
++	for (i = 0; i < eth->soc->num_ppe; i++)
++		airoha_fe_clear(eth, REG_PPE_DFT_CPORT(i, AIROHA_GDM2_IDX),
++				DFT_CPORT_MASK(AIROHA_GDM2_IDX));
++
++	/* Enable VIP and IFC for GDM2 */
++	airoha_fe_set(eth, REG_FE_VIP_PORT_EN, BIT(AIROHA_GDM2_IDX));
++	airoha_fe_set(eth, REG_FE_IFC_PORT_EN, BIT(AIROHA_GDM2_IDX));
++
++	airoha_fe_wr(eth, REG_SRC_PORT_FC_MAP6, FC_MAP6_DEF_VALUE);
++
++	return 0;
++}
++
+ static struct airoha_gdm_dev *
+ airoha_get_wan_gdm_dev(struct airoha_eth *eth)
+ {
+@@ -2509,6 +2553,80 @@ error:
+ 	return NETDEV_TX_OK;
+ }
+ 
++struct airoha_ethool_priv_flags {
++	char name[ETH_GSTRING_LEN];
++	int (*handler)(struct net_device *netdev, u32 flags);
++};
++
++static int airoha_dev_set_wan_flag(struct net_device *netdev, u32 flags)
++{
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
++	struct airoha_eth *eth = dev->eth;
++
++	if (!((dev->flags ^ flags) & AIROHA_PRIV_F_WAN))
++		return 0;
++
++	if (netif_running(netdev))
++		return -EBUSY;
++
++	if (flags & AIROHA_PRIV_F_WAN) {
++		struct airoha_gdm_dev *wan_dev;
++
++		/* Verify the wan device is not already configured */
++		wan_dev = airoha_get_wan_gdm_dev(eth);
++		if (wan_dev && wan_dev != dev)
++			return -EBUSY;
++
++		switch (port->id) {
++		case AIROHA_GDM2_IDX:
++			dev->flags |= AIROHA_PRIV_F_WAN;
++			airoha_dev_set_qdma(dev);
++			break;
++		case AIROHA_GDM3_IDX:
++		case AIROHA_GDM4_IDX: {
++			int err;
++
++			dev->flags |= AIROHA_PRIV_F_WAN;
++			airoha_dev_set_qdma(dev);
++
++			err = airoha_enable_gdm2_loopback(dev);
++			if (err) {
++				dev->flags &= ~AIROHA_PRIV_F_WAN;
++				return err;
++			}
++			break;
++		}
++		default:
++			return -EOPNOTSUPP;
++		}
++	} else {
++		switch (port->id) {
++		case AIROHA_GDM3_IDX:
++		case AIROHA_GDM4_IDX: {
++			int err;
++
++			err = airoha_disable_gdm2_loopback(dev);
++			if (err)
++				return err;
++			break;
++		}
++		default:
++			break;
++		}
++
++		dev->flags &= ~AIROHA_PRIV_F_WAN;
++		airoha_dev_set_qdma(dev);
++	}
++
++	return airoha_set_macaddr(dev, netdev->dev_addr);
++}
++
++static const struct airoha_ethool_priv_flags airoha_eth_priv_flags[] = {
++	{ "wan", airoha_dev_set_wan_flag },
++};
++#define AIROHA_PRIV_FLAGS_STR_LEN	ARRAY_SIZE(airoha_eth_priv_flags)
++
+ static void airoha_ethtool_get_drvinfo(struct net_device *netdev,
+ 				       struct ethtool_drvinfo *info)
+ {
+@@ -2517,6 +2635,7 @@ static void airoha_ethtool_get_drvinfo(s
+ 
+ 	strscpy(info->driver, eth->dev->driver->name, sizeof(info->driver));
+ 	strscpy(info->bus_info, dev_name(eth->dev), sizeof(info->bus_info));
++	info->n_priv_flags = AIROHA_PRIV_FLAGS_STR_LEN;
+ }
+ 
+ static void airoha_ethtool_get_mac_stats(struct net_device *netdev,
+@@ -2581,6 +2700,56 @@ airoha_ethtool_get_rmon_stats(struct net
+ 	} while (u64_stats_fetch_retry(&port->stats.syncp, start));
+ }
+ 
++static int airoha_ethtool_set_priv_flags(struct net_device *netdev, u32 flags)
++{
++	int i;
++
++	for (i = 0; i < AIROHA_PRIV_FLAGS_STR_LEN; i++) {
++		int err;
++
++		if (!airoha_eth_priv_flags[i].handler)
++			continue;
++
++		err = airoha_eth_priv_flags[i].handler(netdev, flags);
++		if (err)
++			return err;
++	}
++
++	return 0;
++}
++
++static u32 airoha_ethtool_get_priv_flags(struct net_device *netdev)
++{
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++
++	return dev->flags;
++}
++
++static int airoha_ethtool_get_sset_count(struct net_device *netdev, int sset)
++{
++	switch (sset) {
++	case ETH_SS_PRIV_FLAGS:
++		return AIROHA_PRIV_FLAGS_STR_LEN;
++	default:
++		return -EOPNOTSUPP;
++	}
++}
++
++static void airoha_ethtool_get_strings(struct net_device *netdev,
++				       u32 stringset, u8 *data)
++{
++	int i;
++
++	switch (stringset) {
++	case ETH_SS_PRIV_FLAGS:
++		for (i = 0; i < AIROHA_PRIV_FLAGS_STR_LEN; i++)
++			ethtool_puts(&data, airoha_eth_priv_flags[i].name);
++		break;
++	default:
++		break;
++	}
++}
++
+ static int airoha_qdma_set_chan_tx_sched(struct net_device *netdev,
+ 					 int channel, enum tx_sched_mode mode,
+ 					 const u16 *weights, u8 n_weights)
+@@ -3302,6 +3471,10 @@ static const struct ethtool_ops airoha_e
+ 	.get_rmon_stats		= airoha_ethtool_get_rmon_stats,
+ 	.get_link_ksettings	= phy_ethtool_get_link_ksettings,
+ 	.get_link		= ethtool_op_get_link,
++	.set_priv_flags		= airoha_ethtool_set_priv_flags,
++	.get_priv_flags		= airoha_ethtool_get_priv_flags,
++	.get_sset_count		= airoha_ethtool_get_sset_count,
++	.get_strings		= airoha_ethtool_get_strings,
+ };
+ 
+ static void airoha_mac_config(struct phylink_config *config, unsigned int mode,
+--- a/drivers/net/ethernet/airoha/airoha_regs.h
++++ b/drivers/net/ethernet/airoha/airoha_regs.h
+@@ -402,6 +402,7 @@
+ 
+ #define REG_SRC_PORT_FC_MAP6		0x2298
+ #define FC_ID_OF_SRC_PORT_MASK(_n)	GENMASK(4 + ((_n) << 3), ((_n) << 3))
++#define FC_MAP6_DEF_VALUE		0x1b1a1918
+ 
+ #define REG_CDM5_RX_OQ1_DROP_CNT	0x29d4
+ 

--- a/target/linux/airoha/patches-6.6/920-13-net-airoha-Rework-MTU-configuration.patch
+++ b/target/linux/airoha/patches-6.6/920-13-net-airoha-Rework-MTU-configuration.patch
@@ -1,0 +1,223 @@
+From 99e204d255c9b47a188dd79762b9406d9c5fed9b Mon Sep 17 00:00:00 2001
+Message-ID: <99e204d255c9b47a188dd79762b9406d9c5fed9b.1779348625.git.lorenzo@kernel.org>
+In-Reply-To: <e15783f7c987e199ecf80b3d858ed5a86d33c508.1779348625.git.lorenzo@kernel.org>
+References: <e15783f7c987e199ecf80b3d858ed5a86d33c508.1779348625.git.lorenzo@kernel.org>
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Wed, 20 May 2026 17:16:39 +0200
+Subject: [PATCH 13/13] net: airoha: Rework MTU configuration
+
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c  | 85 +++++++++++------------
+ drivers/net/ethernet/airoha/airoha_eth.h  |  1 +
+ drivers/net/ethernet/airoha/airoha_ppe.c  |  8 +--
+ drivers/net/ethernet/airoha/airoha_regs.h |  9 ++-
+ 4 files changed, 49 insertions(+), 54 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -185,10 +185,15 @@ static void airoha_fe_maccr_init(struct
+ {
+ 	int p;
+ 
+-	for (p = 1; p <= ARRAY_SIZE(eth->ports); p++)
++	for (p = 1; p <= ARRAY_SIZE(eth->ports); p++) {
+ 		airoha_fe_set(eth, REG_GDM_FWD_CFG(p),
+ 			      GDM_TCP_CKSUM_MASK | GDM_UDP_CKSUM_MASK |
+ 			      GDM_IP4_CKSUM_MASK | GDM_DROP_CRC_ERR_MASK);
++		airoha_fe_rmw(eth, REG_GDM_LEN_CFG(p),
++			      GDM_SHORT_LEN_MASK | GDM_LONG_LEN_MASK,
++			      FIELD_PREP(GDM_SHORT_LEN_MASK, 60) |
++			      FIELD_PREP(GDM_LONG_LEN_MASK, AIROHA_MAX_MTU));
++	}
+ 
+ 	airoha_fe_rmw(eth, REG_CDM_VLAN_CTRL(1), CDM_VLAN_MASK,
+ 		      FIELD_PREP(CDM_VLAN_MASK, 0x8100));
+@@ -1898,13 +1903,37 @@ static void airoha_update_hw_stats(struc
+ 	spin_unlock(&port->stats.lock);
+ }
+ 
++void airoha_set_port_mtu(struct airoha_eth *eth, struct airoha_gdm_port *port)
++{
++	u32 mtu = 0, index;
++	int i;
++
++	for (i = 0; i < ARRAY_SIZE(port->devs); i++) {
++		struct airoha_gdm_dev *dev = port->devs[i];
++		struct net_device *netdev;
++
++		if (!dev)
++			continue;
++
++		netdev = dev->dev;
++		if (netif_running(netdev))
++			mtu = max_t(u32, mtu, netdev->mtu);
++	}
++
++	index = port->id == AIROHA_GDM4_IDX ? 7 : port->id;
++	for (i = 0; i < eth->soc->num_ppe; i++)
++		airoha_fe_rmw(eth, REG_PPE_MTU(i, index),
++			      FP_EGRESS_MTU_MASK(index),
++			      __field_prep(FP_EGRESS_MTU_MASK(index), mtu));
++}
++
+ static int airoha_dev_open(struct net_device *netdev)
+ {
+-	int err, len = ETH_HLEN + netdev->mtu + ETH_FCS_LEN;
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+ 	struct airoha_gdm_port *port = dev->port;
+-	u32 cur_len, pse_port = FE_PSE_PORT_PPE1;
+ 	struct airoha_qdma *qdma = dev->qdma;
++	u32 pse_port = FE_PSE_PORT_PPE1;
++	int err;
+ 
+ 	if (port->id == AIROHA_GDM2_IDX && airoha_is_lan_gdm_dev(dev)) {
+ 		/* GDM2 can be used just as wan */
+@@ -1937,19 +1966,12 @@ static int airoha_dev_open(struct net_de
+ 		airoha_fe_clear(qdma->eth, REG_GDM_INGRESS_CFG(port->id),
+ 				GDM_STAG_EN_MASK);
+ 
+-	cur_len = airoha_fe_get(qdma->eth, REG_GDM_LEN_CFG(port->id),
+-				GDM_LONG_LEN_MASK);
+-	if (!port->users || len > cur_len) {
+-		/* Opening a sibling net_device with a larger MTU updates the
+-		 * MTU of already running devices. This is required to allow
+-		 * multiple net_devices with different MTUs to share the same
+-		 * GDM port.
+-		 */
+-		airoha_fe_rmw(qdma->eth, REG_GDM_LEN_CFG(port->id),
+-			      GDM_SHORT_LEN_MASK | GDM_LONG_LEN_MASK,
+-			      FIELD_PREP(GDM_SHORT_LEN_MASK, 60) |
+-			      FIELD_PREP(GDM_LONG_LEN_MASK, len));
+-	}
++	airoha_set_port_mtu(qdma->eth, port);
++	if (!airoha_is_lan_gdm_dev(dev))
++		airoha_fe_rmw(qdma->eth, REG_WAN_MTU0,
++			      WAN_MTU0_MASK,
++			      FIELD_PREP(WAN_MTU0_MASK, netdev->mtu));
++
+ 	port->users++;
+ 
+ 	airoha_qdma_set(qdma, REG_QDMA_GLOBAL_CFG,
+@@ -1966,30 +1988,6 @@ static int airoha_dev_open(struct net_de
+ 	return 0;
+ }
+ 
+-static void airoha_set_port_mtu(struct airoha_eth *eth,
+-				struct airoha_gdm_port *port)
+-{
+-	u32 len = 0;
+-	int i;
+-
+-	for (i = 0; i < ARRAY_SIZE(port->devs); i++) {
+-		struct airoha_gdm_dev *dev = port->devs[i];
+-		struct net_device *netdev;
+-
+-		if (!dev)
+-			continue;
+-
+-		netdev = dev->dev;
+-		if (netif_running(netdev))
+-			len = max_t(u32, len, netdev->mtu);
+-	}
+-	len += ETH_HLEN + ETH_FCS_LEN;
+-
+-	airoha_fe_rmw(eth, REG_GDM_LEN_CFG(port->id),
+-		      GDM_LONG_LEN_MASK,
+-		      FIELD_PREP(GDM_LONG_LEN_MASK, len));
+-}
+-
+ static int airoha_dev_stop(struct net_device *netdev)
+ {
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+@@ -2073,10 +2071,6 @@ static int airoha_enable_gdm2_loopback(s
+ 		      FIELD_PREP(LPBK_CHAN_MASK, chan) |
+ 		      LBK_GAP_MODE_MASK | LBK_LEN_MODE_MASK |
+ 		      LBK_CHAN_MODE_MASK | LPBK_EN_MASK);
+-	airoha_fe_rmw(eth, REG_GDM_LEN_CFG(AIROHA_GDM2_IDX),
+-		      GDM_SHORT_LEN_MASK | GDM_LONG_LEN_MASK,
+-		      FIELD_PREP(GDM_SHORT_LEN_MASK, 60) |
+-		      FIELD_PREP(GDM_LONG_LEN_MASK, AIROHA_MAX_MTU));
+ 	/* Forward the traffic to the proper GDM port */
+ 	pse_port = port->id == AIROHA_GDM3_IDX ? FE_PSE_PORT_GDM3
+ 					       : FE_PSE_PORT_GDM4;
+@@ -2600,6 +2594,9 @@ static int airoha_dev_set_wan_flag(struc
+ 		default:
+ 			return -EOPNOTSUPP;
+ 		}
++		airoha_fe_rmw(eth, REG_WAN_MTU0,
++			      WAN_MTU0_MASK,
++			      FIELD_PREP(WAN_MTU0_MASK, netdev->mtu));
+ 	} else {
+ 		switch (port->id) {
+ 		case AIROHA_GDM3_IDX:
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -705,6 +705,7 @@ int airoha_get_fe_port(struct airoha_gdm
+ bool airoha_is_valid_gdm_dev(struct airoha_eth *eth,
+ 			     struct airoha_gdm_dev *dev);
+ 
++void airoha_set_port_mtu(struct airoha_eth *eth, struct airoha_gdm_port *port);
+ void airoha_ppe_set_cpu_port(struct airoha_gdm_dev *dev, u8 ppe_id, u8 fport);
+ bool airoha_ppe_is_enabled(struct airoha_eth *eth, int index);
+ void airoha_ppe_check_skb(struct airoha_ppe_dev *dev, struct sk_buff *skb,
+--- a/drivers/net/ethernet/airoha/airoha_ppe.c
++++ b/drivers/net/ethernet/airoha/airoha_ppe.c
+@@ -116,8 +116,6 @@ static void airoha_ppe_hw_init(struct ai
+ 		PPE_RAM_NUM_ENTRIES_SHIFT(sram_ppe_num_data_entries);
+ 
+ 	for (i = 0; i < eth->soc->num_ppe; i++) {
+-		int p;
+-
+ 		airoha_fe_wr(eth, REG_PPE_TB_BASE(i),
+ 			     ppe->foe_dma + sram_tb_size);
+ 
+@@ -167,15 +165,6 @@ static void airoha_ppe_hw_init(struct ai
+ 		airoha_fe_wr(eth, REG_PPE_HASH_SEED(i), PPE_HASH_SEED);
+ 		airoha_fe_clear(eth, REG_PPE_PPE_FLOW_CFG(i),
+ 				PPE_FLOW_CFG_IP6_6RD_MASK);
+-
+-		for (p = 0; p < ARRAY_SIZE(eth->ports); p++)
+-			airoha_fe_rmw(eth, REG_PPE_MTU(i, p),
+-				      FP0_EGRESS_MTU_MASK |
+-				      FP1_EGRESS_MTU_MASK,
+-				      FIELD_PREP(FP0_EGRESS_MTU_MASK,
+-						 AIROHA_MAX_MTU) |
+-				      FIELD_PREP(FP1_EGRESS_MTU_MASK,
+-						 AIROHA_MAX_MTU));
+ 	}
+ 
+ 	for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
+@@ -185,6 +174,7 @@ static void airoha_ppe_hw_init(struct ai
+ 		if (!port)
+ 			continue;
+ 
++		airoha_set_port_mtu(eth, port);
+ 		for (j = 0; j < ARRAY_SIZE(port->devs); j++) {
+ 			struct airoha_gdm_dev *dev = port->devs[j];
+ 			u8 fport;
+--- a/drivers/net/ethernet/airoha/airoha_regs.h
++++ b/drivers/net/ethernet/airoha/airoha_regs.h
+@@ -341,9 +341,8 @@
+ #define PPE_SRAM_TABLE_EN_MASK			BIT(0)
+ 
+ #define REG_PPE_MTU_BASE(_n)			(((_n) ? PPE2_BASE : PPE1_BASE) + 0x304)
+-#define REG_PPE_MTU(_m, _n)			(REG_PPE_MTU_BASE(_m) + ((_n) << 2))
+-#define FP1_EGRESS_MTU_MASK			GENMASK(29, 16)
+-#define FP0_EGRESS_MTU_MASK			GENMASK(13, 0)
++#define REG_PPE_MTU(_m, _n)			(REG_PPE_MTU_BASE(_m) + (((_n) / 2) << 2))
++#define FP_EGRESS_MTU_MASK(_n)			GENMASK(13 + (((_n) % 2) << 4), ((_n) % 2) << 4)
+ 
+ #define REG_PPE_RAM_CTRL(_n)			(((_n) ? PPE2_BASE : PPE1_BASE) + 0x31c)
+ #define PPE_SRAM_CTRL_ACK_MASK			BIT(31)
+@@ -404,6 +403,10 @@
+ #define FC_ID_OF_SRC_PORT_MASK(_n)	GENMASK(4 + ((_n) << 3), ((_n) << 3))
+ #define FC_MAP6_DEF_VALUE		0x1b1a1918
+ 
++#define REG_WAN_MTU0			0x2300
++#define WAN_MTU1_MASK			GENMASK(29, 16)
++#define WAN_MTU0_MASK			GENMASK(13, 0)
++
+ #define REG_CDM5_RX_OQ1_DROP_CNT	0x29d4
+ 
+ /* QDMA */

--- a/target/linux/airoha/patches-6.6/920-14-net-airoha-Better-handle-MIB-for-GDM-with-multiple-p.patch
+++ b/target/linux/airoha/patches-6.6/920-14-net-airoha-Better-handle-MIB-for-GDM-with-multiple-p.patch
@@ -1,0 +1,415 @@
+From 9652322e0b47eacfef497828f6476a2a3169fd13 Mon Sep 17 00:00:00 2001
+Message-ID: <9652322e0b47eacfef497828f6476a2a3169fd13.1779351672.git.lorenzo@kernel.org>
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Sat, 17 Jan 2026 14:46:12 +0100
+Subject: [PATCH] net: airoha: Better handle MIB for GDM with multiple port
+ attached
+
+In the context of a GDM that can have multiple port attached (GDM3/4)
+the HW counter (MIB) are global for the GDM port. This cause duplicated
+stats reported to the kernel for the related interface.
+
+The SoC supports a split MIB feature where each counter is tracked based
+on the relevant HW channel (NBQ) to account for this scenario and
+provide a way to select the related counter on accessing the MIB
+registers.
+
+Enable this feature for GDM3 and GDM4 and configure the relevant HW
+channel before updating the HW stats to report correct HW counter to the
+kernel for the related interface.
+
+Also move the stats struct from port to dev since HW counter are
+now specific to the network interface instead of the GDM port.
+
+Co-developed-by: Brown Huang <Brown.huang@airoha.com>
+Signed-off-by: Brown Huang <Brown.huang@airoha.com>
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 191 +++++++++++++----------
+ drivers/net/ethernet/airoha/airoha_eth.h |   7 +-
+ 2 files changed, 112 insertions(+), 86 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -611,6 +611,14 @@ static int airoha_fe_init(struct airoha_
+ 	airoha_fe_set(eth, REG_GDM_FWD_CFG(AIROHA_GDM4_IDX),
+ 		      GDM_PAD_EN_MASK | GDM_STRIP_CRC_MASK);
+ 
++	/* Enable split for MIB counters for GDM3 and GDM4 */
++	airoha_fe_set(eth, REG_FE_GDM_MIB_CFG(AIROHA_GDM3_IDX),
++		      FE_GDM_TX_MIB_SPLIT_EN_MASK |
++		      FE_GDM_RX_MIB_SPLIT_EN_MASK);
++	airoha_fe_set(eth, REG_FE_GDM_MIB_CFG(AIROHA_GDM4_IDX),
++		      FE_GDM_TX_MIB_SPLIT_EN_MASK |
++		      FE_GDM_RX_MIB_SPLIT_EN_MASK);
++
+ 	airoha_fe_crsn_qsel_init(eth);
+ 
+ 	airoha_fe_clear(eth, REG_FE_CPORT_CFG, FE_CPORT_QUEUE_XFC_MASK);
+@@ -1758,149 +1766,169 @@ static void airoha_qdma_stop_napi(struct
+ 	}
+ }
+ 
+-static void airoha_update_hw_stats(struct airoha_gdm_dev *dev)
++static void airoha_dev_get_hw_stats(struct airoha_gdm_dev *dev)
+ {
+ 	struct airoha_gdm_port *port = dev->port;
+ 	struct airoha_eth *eth = dev->eth;
+ 	u32 val, i = 0;
+ 
+-	spin_lock(&port->stats.lock);
+-	u64_stats_update_begin(&port->stats.syncp);
++	u64_stats_update_begin(&dev->stats.syncp);
++
++	/* Read relevant MIB for GDM with multiple port attached */
++	if (port->id == AIROHA_GDM3_IDX || port->id == AIROHA_GDM4_IDX)
++		airoha_fe_rmw(eth, REG_FE_GDM_MIB_CFG(port->id),
++			      FE_TX_MIB_ID_MASK | FE_RX_MIB_ID_MASK,
++			      FIELD_PREP(FE_TX_MIB_ID_MASK, dev->nbq) |
++			      FIELD_PREP(FE_RX_MIB_ID_MASK, dev->nbq));
+ 
+ 	/* TX */
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_TX_OK_PKT_CNT_H(port->id));
+-	port->stats.tx_ok_pkts += ((u64)val << 32);
++	dev->stats.tx_ok_pkts += ((u64)val << 32);
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_TX_OK_PKT_CNT_L(port->id));
+-	port->stats.tx_ok_pkts += val;
++	dev->stats.tx_ok_pkts += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_TX_OK_BYTE_CNT_H(port->id));
+-	port->stats.tx_ok_bytes += ((u64)val << 32);
++	dev->stats.tx_ok_bytes += ((u64)val << 32);
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_TX_OK_BYTE_CNT_L(port->id));
+-	port->stats.tx_ok_bytes += val;
++	dev->stats.tx_ok_bytes += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_TX_ETH_DROP_CNT(port->id));
+-	port->stats.tx_drops += val;
++	dev->stats.tx_drops += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_TX_ETH_BC_CNT(port->id));
+-	port->stats.tx_broadcast += val;
++	dev->stats.tx_broadcast += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_TX_ETH_MC_CNT(port->id));
+-	port->stats.tx_multicast += val;
++	dev->stats.tx_multicast += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_TX_ETH_RUNT_CNT(port->id));
+-	port->stats.tx_len[i] += val;
++	dev->stats.tx_len[i] += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_TX_ETH_E64_CNT_H(port->id));
+-	port->stats.tx_len[i] += ((u64)val << 32);
++	dev->stats.tx_len[i] += ((u64)val << 32);
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_TX_ETH_E64_CNT_L(port->id));
+-	port->stats.tx_len[i++] += val;
++	dev->stats.tx_len[i++] += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_TX_ETH_L64_CNT_H(port->id));
+-	port->stats.tx_len[i] += ((u64)val << 32);
++	dev->stats.tx_len[i] += ((u64)val << 32);
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_TX_ETH_L64_CNT_L(port->id));
+-	port->stats.tx_len[i++] += val;
++	dev->stats.tx_len[i++] += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_TX_ETH_L127_CNT_H(port->id));
+-	port->stats.tx_len[i] += ((u64)val << 32);
++	dev->stats.tx_len[i] += ((u64)val << 32);
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_TX_ETH_L127_CNT_L(port->id));
+-	port->stats.tx_len[i++] += val;
++	dev->stats.tx_len[i++] += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_TX_ETH_L255_CNT_H(port->id));
+-	port->stats.tx_len[i] += ((u64)val << 32);
++	dev->stats.tx_len[i] += ((u64)val << 32);
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_TX_ETH_L255_CNT_L(port->id));
+-	port->stats.tx_len[i++] += val;
++	dev->stats.tx_len[i++] += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_TX_ETH_L511_CNT_H(port->id));
+-	port->stats.tx_len[i] += ((u64)val << 32);
++	dev->stats.tx_len[i] += ((u64)val << 32);
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_TX_ETH_L511_CNT_L(port->id));
+-	port->stats.tx_len[i++] += val;
++	dev->stats.tx_len[i++] += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_TX_ETH_L1023_CNT_H(port->id));
+-	port->stats.tx_len[i] += ((u64)val << 32);
++	dev->stats.tx_len[i] += ((u64)val << 32);
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_TX_ETH_L1023_CNT_L(port->id));
+-	port->stats.tx_len[i++] += val;
++	dev->stats.tx_len[i++] += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_TX_ETH_LONG_CNT(port->id));
+-	port->stats.tx_len[i++] += val;
++	dev->stats.tx_len[i++] += val;
+ 
+ 	/* RX */
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_OK_PKT_CNT_H(port->id));
+-	port->stats.rx_ok_pkts += ((u64)val << 32);
++	dev->stats.rx_ok_pkts += ((u64)val << 32);
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_OK_PKT_CNT_L(port->id));
+-	port->stats.rx_ok_pkts += val;
++	dev->stats.rx_ok_pkts += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_OK_BYTE_CNT_H(port->id));
+-	port->stats.rx_ok_bytes += ((u64)val << 32);
++	dev->stats.rx_ok_bytes += ((u64)val << 32);
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_OK_BYTE_CNT_L(port->id));
+-	port->stats.rx_ok_bytes += val;
++	dev->stats.rx_ok_bytes += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_ETH_DROP_CNT(port->id));
+-	port->stats.rx_drops += val;
++	dev->stats.rx_drops += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_ETH_BC_CNT(port->id));
+-	port->stats.rx_broadcast += val;
++	dev->stats.rx_broadcast += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_ETH_MC_CNT(port->id));
+-	port->stats.rx_multicast += val;
++	dev->stats.rx_multicast += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_ERROR_DROP_CNT(port->id));
+-	port->stats.rx_errors += val;
++	dev->stats.rx_errors += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_ETH_CRC_ERR_CNT(port->id));
+-	port->stats.rx_crc_error += val;
++	dev->stats.rx_crc_error += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_OVERFLOW_DROP_CNT(port->id));
+-	port->stats.rx_over_errors += val;
++	dev->stats.rx_over_errors += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_ETH_FRAG_CNT(port->id));
+-	port->stats.rx_fragment += val;
++	dev->stats.rx_fragment += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_ETH_JABBER_CNT(port->id));
+-	port->stats.rx_jabber += val;
++	dev->stats.rx_jabber += val;
+ 
+ 	i = 0;
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_ETH_RUNT_CNT(port->id));
+-	port->stats.rx_len[i] += val;
++	dev->stats.rx_len[i] += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_ETH_E64_CNT_H(port->id));
+-	port->stats.rx_len[i] += ((u64)val << 32);
++	dev->stats.rx_len[i] += ((u64)val << 32);
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_ETH_E64_CNT_L(port->id));
+-	port->stats.rx_len[i++] += val;
++	dev->stats.rx_len[i++] += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_ETH_L64_CNT_H(port->id));
+-	port->stats.rx_len[i] += ((u64)val << 32);
++	dev->stats.rx_len[i] += ((u64)val << 32);
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_ETH_L64_CNT_L(port->id));
+-	port->stats.rx_len[i++] += val;
++	dev->stats.rx_len[i++] += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_ETH_L127_CNT_H(port->id));
+-	port->stats.rx_len[i] += ((u64)val << 32);
++	dev->stats.rx_len[i] += ((u64)val << 32);
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_ETH_L127_CNT_L(port->id));
+-	port->stats.rx_len[i++] += val;
++	dev->stats.rx_len[i++] += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_ETH_L255_CNT_H(port->id));
+-	port->stats.rx_len[i] += ((u64)val << 32);
++	dev->stats.rx_len[i] += ((u64)val << 32);
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_ETH_L255_CNT_L(port->id));
+-	port->stats.rx_len[i++] += val;
++	dev->stats.rx_len[i++] += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_ETH_L511_CNT_H(port->id));
+-	port->stats.rx_len[i] += ((u64)val << 32);
++	dev->stats.rx_len[i] += ((u64)val << 32);
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_ETH_L511_CNT_L(port->id));
+-	port->stats.rx_len[i++] += val;
++	dev->stats.rx_len[i++] += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_ETH_L1023_CNT_H(port->id));
+-	port->stats.rx_len[i] += ((u64)val << 32);
++	dev->stats.rx_len[i] += ((u64)val << 32);
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_ETH_L1023_CNT_L(port->id));
+-	port->stats.rx_len[i++] += val;
++	dev->stats.rx_len[i++] += val;
+ 
+ 	val = airoha_fe_rr(eth, REG_FE_GDM_RX_ETH_LONG_CNT(port->id));
+-	port->stats.rx_len[i++] += val;
++	dev->stats.rx_len[i++] += val;
++
++	u64_stats_update_end(&dev->stats.syncp);
++}
+ 
+-	/* reset mib counters */
+-	airoha_fe_set(eth, REG_FE_GDM_MIB_CLEAR(port->id),
++static void airoha_update_hw_stats(struct airoha_gdm_dev *dev)
++{
++	struct airoha_gdm_port *port = dev->port;
++	int i;
++
++	spin_lock(&port->stats_lock);
++
++	for (i = 0; i < ARRAY_SIZE(port->devs); i++) {
++		if (port->devs[i])
++			airoha_dev_get_hw_stats(port->devs[i]);
++	}
++
++	/* Reset MIB counters */
++	airoha_fe_set(dev->eth, REG_FE_GDM_MIB_CLEAR(port->id),
+ 		      FE_GDM_MIB_RX_CLEAR_MASK | FE_GDM_MIB_TX_CLEAR_MASK);
+ 
+-	u64_stats_update_end(&port->stats.syncp);
+-	spin_unlock(&port->stats.lock);
++	spin_unlock(&port->stats_lock);
+ }
+ 
+ void airoha_set_port_mtu(struct airoha_eth *eth, struct airoha_gdm_port *port)
+@@ -2228,23 +2256,22 @@ static void airoha_dev_get_stats64(struc
+ 				   struct rtnl_link_stats64 *storage)
+ {
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+-	struct airoha_gdm_port *port = dev->port;
+ 	unsigned int start;
+ 
+ 	airoha_update_hw_stats(dev);
+ 	do {
+-		start = u64_stats_fetch_begin(&port->stats.syncp);
+-		storage->rx_packets = port->stats.rx_ok_pkts;
+-		storage->tx_packets = port->stats.tx_ok_pkts;
+-		storage->rx_bytes = port->stats.rx_ok_bytes;
+-		storage->tx_bytes = port->stats.tx_ok_bytes;
+-		storage->multicast = port->stats.rx_multicast;
+-		storage->rx_errors = port->stats.rx_errors;
+-		storage->rx_dropped = port->stats.rx_drops;
+-		storage->tx_dropped = port->stats.tx_drops;
+-		storage->rx_crc_errors = port->stats.rx_crc_error;
+-		storage->rx_over_errors = port->stats.rx_over_errors;
+-	} while (u64_stats_fetch_retry(&port->stats.syncp, start));
++		start = u64_stats_fetch_begin(&dev->stats.syncp);
++		storage->rx_packets = dev->stats.rx_ok_pkts;
++		storage->tx_packets = dev->stats.tx_ok_pkts;
++		storage->rx_bytes = dev->stats.rx_ok_bytes;
++		storage->tx_bytes = dev->stats.tx_ok_bytes;
++		storage->multicast = dev->stats.rx_multicast;
++		storage->rx_errors = dev->stats.rx_errors;
++		storage->rx_dropped = dev->stats.rx_drops;
++		storage->tx_dropped = dev->stats.tx_drops;
++		storage->rx_crc_errors = dev->stats.rx_crc_error;
++		storage->rx_over_errors = dev->stats.rx_over_errors;
++	} while (u64_stats_fetch_retry(&dev->stats.syncp, start));
+ }
+ 
+ static int airoha_dev_change_mtu(struct net_device *netdev, int mtu)
+@@ -2639,20 +2666,19 @@ static void airoha_ethtool_get_mac_stats
+ 					 struct ethtool_eth_mac_stats *stats)
+ {
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+-	struct airoha_gdm_port *port = dev->port;
+ 	unsigned int start;
+ 
+ 	airoha_update_hw_stats(dev);
+ 	do {
+-		start = u64_stats_fetch_begin(&port->stats.syncp);
+-		stats->FramesTransmittedOK = port->stats.tx_ok_pkts;
+-		stats->OctetsTransmittedOK = port->stats.tx_ok_bytes;
+-		stats->MulticastFramesXmittedOK = port->stats.tx_multicast;
+-		stats->BroadcastFramesXmittedOK = port->stats.tx_broadcast;
+-		stats->FramesReceivedOK = port->stats.rx_ok_pkts;
+-		stats->OctetsReceivedOK = port->stats.rx_ok_bytes;
+-		stats->BroadcastFramesReceivedOK = port->stats.rx_broadcast;
+-	} while (u64_stats_fetch_retry(&port->stats.syncp, start));
++		start = u64_stats_fetch_begin(&dev->stats.syncp);
++		stats->FramesTransmittedOK = dev->stats.tx_ok_pkts;
++		stats->OctetsTransmittedOK = dev->stats.tx_ok_bytes;
++		stats->MulticastFramesXmittedOK = dev->stats.tx_multicast;
++		stats->BroadcastFramesXmittedOK = dev->stats.tx_broadcast;
++		stats->FramesReceivedOK = dev->stats.rx_ok_pkts;
++		stats->OctetsReceivedOK = dev->stats.rx_ok_bytes;
++		stats->BroadcastFramesReceivedOK = dev->stats.rx_broadcast;
++	} while (u64_stats_fetch_retry(&dev->stats.syncp, start));
+ }
+ 
+ static const struct ethtool_rmon_hist_range airoha_ethtool_rmon_ranges[] = {
+@@ -2672,8 +2698,7 @@ airoha_ethtool_get_rmon_stats(struct net
+ 			      const struct ethtool_rmon_hist_range **ranges)
+ {
+ 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+-	struct airoha_gdm_port *port = dev->port;
+-	struct airoha_hw_stats *hw_stats = &port->stats;
++	struct airoha_hw_stats *hw_stats = &dev->stats;
+ 	unsigned int start;
+ 
+ 	BUILD_BUG_ON(ARRAY_SIZE(airoha_ethtool_rmon_ranges) !=
+@@ -2686,7 +2711,7 @@ airoha_ethtool_get_rmon_stats(struct net
+ 	do {
+ 		int i;
+ 
+-		start = u64_stats_fetch_begin(&port->stats.syncp);
++		start = u64_stats_fetch_begin(&dev->stats.syncp);
+ 		stats->fragments = hw_stats->rx_fragment;
+ 		stats->jabbers = hw_stats->rx_jabber;
+ 		for (i = 0; i < ARRAY_SIZE(airoha_ethtool_rmon_ranges) - 1;
+@@ -2694,7 +2719,7 @@ airoha_ethtool_get_rmon_stats(struct net
+ 			stats->hist[i] = hw_stats->rx_len[i];
+ 			stats->hist_tx[i] = hw_stats->tx_len[i];
+ 		}
+-	} while (u64_stats_fetch_retry(&port->stats.syncp, start));
++	} while (u64_stats_fetch_retry(&dev->stats.syncp, start));
+ }
+ 
+ static int airoha_ethtool_set_priv_flags(struct net_device *netdev, u32 flags)
+@@ -3702,6 +3727,7 @@ static int airoha_alloc_gdm_device(struc
+ 
+ 	netdev->dev.of_node = of_node_get(np);
+ 	dev = netdev_priv(netdev);
++	u64_stats_init(&dev->stats.syncp);
+ 	dev->dev = netdev;
+ 	dev->port = port;
+ 	dev->eth = eth;
+@@ -3750,9 +3776,8 @@ static int airoha_alloc_gdm_port(struct
+ 	if (!port)
+ 		return -ENOMEM;
+ 
+-	u64_stats_init(&port->stats.syncp);
+-	spin_lock_init(&port->stats.lock);
+ 	port->id = id;
++	spin_lock_init(&port->stats_lock);
+ 	eth->ports[p] = port;
+ 
+ 	err = airoha_metadata_dst_alloc(port);
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -226,8 +226,6 @@ struct airoha_tx_irq_queue {
+ };
+ 
+ struct airoha_hw_stats {
+-	/* protect concurrent hw_stats accesses */
+-	spinlock_t lock;
+ 	struct u64_stats_sync syncp;
+ 
+ 	/* get_stats64 */
+@@ -571,6 +569,8 @@ struct airoha_gdm_dev {
+ 
+ 	u32 flags;
+ 	int nbq;
++
++	struct airoha_hw_stats stats;
+ };
+ 
+ struct airoha_gdm_port {
+@@ -578,7 +578,8 @@ struct airoha_gdm_port {
+ 	int id;
+ 	int users;
+ 
+-	struct airoha_hw_stats stats;
++	/* protect concurrent hw_stats accesses */
++	spinlock_t stats_lock;
+ 
+ 	struct metadata_dst *dsa_meta[AIROHA_MAX_DSA_PORTS];
+ };

--- a/target/linux/airoha/patches-6.6/920-15-net-airoha-fix-wrong-airoha_get_fe_port.patch
+++ b/target/linux/airoha/patches-6.6/920-15-net-airoha-fix-wrong-airoha_get_fe_port.patch
@@ -1,0 +1,40 @@
+From 1e596dac503da44a9fcd3e2654a4963db3e2ee6a Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Wed, 28 Jan 2026 02:38:24 +0100
+Subject: [PATCH] net: airoha: fix wrong airoha_get_fe_port()
+
+It seems the SDK where the airoha_get_fe_port() logic was taken was
+actually wrong and the AN7583 SoC doesn't have such difference. Instead
+it does follow the same port order of AN7581 SoC.
+
+Drop the switch case and apply the same condition on both AN7581 and
+AN7583 SoC.
+
+Fixes: e4e5ce823bdd ("net: airoha: Add AN7583 SoC support")
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 14 ++------------
+ 1 file changed, 2 insertions(+), 12 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -2353,17 +2353,9 @@ static u32 airoha_get_dsa_tag(struct sk_
+ int airoha_get_fe_port(struct airoha_gdm_dev *dev)
+ {
+ 	struct airoha_gdm_port *port = dev->port;
+-	struct airoha_eth *eth = dev->eth;
+ 
+-	switch (eth->soc->version) {
+-	case 0x7583:
+-		return port->id == AIROHA_GDM3_IDX ? FE_PSE_PORT_GDM3
+-						   : port->id;
+-	case 0x7581:
+-	default:
+-		return port->id == AIROHA_GDM4_IDX ? FE_PSE_PORT_GDM4
+-						   : port->id;
+-	}
++	return port->id == AIROHA_GDM4_IDX ? FE_PSE_PORT_GDM4
++					   : port->id;
+ }
+ 
+ static int airoha_dev_set_features(struct net_device *netdev,


### PR DESCRIPTION
This is a major backport of all the cumulative fix for the ethernet driver for 24.10.

All the patch applied directly without having to apply any change.