### PR TITLE
airoha: an7581-evb: fix sysupgrade and add factory image

### DIFF
--- a/target/linux/airoha/image/an7581.mk
+++ b/target/linux/airoha/image/an7581.mk
@@ -52,7 +52,12 @@ define Device/airoha_an7581-evb
   DEVICE_PACKAGES := kmod-leds-pwm kmod-i2c-an7581 kmod-pwm-airoha kmod-input-gpio-keys-polled
   DEVICE_DTS := an7581-evb
   DEVICE_DTS_CONFIG := config@1
-  IMAGE/sysupgrade.bin := append-kernel | pad-to 128k | append-rootfs | pad-rootfs | append-metadata
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_IN_UBI := 1
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to 128k | append-rootfs | pad-rootfs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   ARTIFACT/preloader.bin := an7581-preloader rfb
   ARTIFACT/bl31-uboot.fip := an7581-bl31-uboot rfb
   ARTIFACTS := preloader.bin bl31-uboot.fip


### PR DESCRIPTION
The an7581-evb sysupgrade.bin was generated by concatenating FIT kernel and squashfs rootfs. During sysupgrade, `identify()` reads the first 4 bytes (`d00dfeed` = FIT magic) and calls `nand_upgrade_fit()`, which writes the entire blob to the kernel UBI volume without creating a rootfs volume. After reboot, the kernel waits for `/dev/ubiblock0_5` (rootfs volume) forever.

Fix by switching sysupgrade.bin to the sysupgrade-tar format, which packages kernel and root separately. `identify()` then routes to `nand_upgrade_tar()`, which writes each component to its correct UBI volume.

Also add a factory.bin image using the original concatenated format for U-boot TFTP recovery, where the operator manually splits the blob at the squashfs boundary using the `bin` command.

Add BLOCKSIZE, PAGESIZE, and KERNEL_IN_UBI which are required by the sysupgrade-tar and factory image generation.