### PR TITLE
realtek: watchdog: backport fix patches & regmap patch

### DIFF
--- a/target/linux/realtek/patches-6.18/034-01-v7.2-watchdog-realtek-otto-prevent-PHASE2-underflows.patch
+++ b/target/linux/realtek/patches-6.18/034-01-v7.2-watchdog-realtek-otto-prevent-PHASE2-underflows.patch
@@ -1,0 +1,58 @@
+From 05d871c5194bef01b525ca9289efb736bbfd6ece Mon Sep 17 00:00:00 2001
+From: Sander Vanheule <sander@svanheule.net>
+Date: Fri, 15 May 2026 23:23:50 +0200
+Subject: watchdog: realtek-otto: prevent PHASE2 underflows
+
+For small pretimeout values, ((timeout - pretimeout) / tick) might be
+rounded up to the same value as (timeout / tick). As a result, the
+number of PHASE2 ticks may be zero, causing an underflow when
+subtracting 1 to configure the hardware. While this results in a
+longer-than-expected time to system reset, the duration of PHASE1 and
+minimum ping interval for the watchdog would still be correct.
+
+As the watchdog core ensures pretimeout is strictly less than timeout,
+ceil(timeout / tick) is strictly greater than floor(pretimeout / tick)
+and the number of PHASE1 ticks cannot be 0. So instead of rounding up
+the number of PHASE1 ticks, we can round down the number of PHASE2
+ticks, maintaining the current behavior while avoiding underflows.
+
+The original helper function is now inlined, as it doesn't save any
+duplication anymore.
+
+Signed-off-by: Sander Vanheule <sander@svanheule.net>
+Link: https://lore.kernel.org/r/20260515212351.752054-2-sander@svanheule.net
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+---
+ drivers/watchdog/realtek_otto_wdt.c | 12 +++---------
+ 1 file changed, 3 insertions(+), 9 deletions(-)
+
+(limited to 'drivers/watchdog/realtek_otto_wdt.c')
+
+--- a/drivers/watchdog/realtek_otto_wdt.c
++++ b/drivers/watchdog/realtek_otto_wdt.c
+@@ -114,12 +114,6 @@ static int otto_wdt_tick_ms(struct otto_
+  * the value stored in those fields. This means each phase will run for at least
+  * one tick, so small values need to be clamped to correctly reflect the timeout.
+  */
+-static inline unsigned int div_round_ticks(unsigned int val, unsigned int tick_duration,
+-		unsigned int min_ticks)
+-{
+-	return max(min_ticks, DIV_ROUND_UP(val, tick_duration));
+-}
+-
+ static int otto_wdt_determine_timeouts(struct watchdog_device *wdev, unsigned int timeout,
+ 		unsigned int pretimeout)
+ {
+@@ -140,9 +134,9 @@ static int otto_wdt_determine_timeouts(s
+ 			return -EINVAL;
+ 
+ 		tick_ms = otto_wdt_tick_ms(ctrl, prescale);
+-		total_ticks = div_round_ticks(timeout_ms, tick_ms, 2);
+-		phase1_ticks = div_round_ticks(timeout_ms - pretimeout_ms, tick_ms, 1);
+-		phase2_ticks = total_ticks - phase1_ticks;
++		total_ticks = max(2, DIV_ROUND_UP(timeout_ms, tick_ms));
++		phase2_ticks = max(1, pretimeout_ms / tick_ms);
++		phase1_ticks = total_ticks - phase2_ticks;
+ 
+ 		prescale_next++;
+ 	} while (phase1_ticks > OTTO_WDT_PHASE_TICKS_MAX

--- a/target/linux/realtek/patches-6.18/034-02-v7.2-watchdog-realtek-otto-enable-clock-before-using-IO.patch
+++ b/target/linux/realtek/patches-6.18/034-02-v7.2-watchdog-realtek-otto-enable-clock-before-using-IO.patch
@@ -1,0 +1,41 @@
+From 1147eb0dc29bd33aa3499f9d02777d4165587575 Mon Sep 17 00:00:00 2001
+From: Sander Vanheule <sander@svanheule.net>
+Date: Fri, 15 May 2026 23:23:51 +0200
+Subject: watchdog: realtek-otto: enable clock before using I/O
+
+As the watchdog is normally on the same bus as the UART peripheral, the
+bootloader will have ensured the bus' clock is up and running before the
+watchdog driver is probed. Nevertheless, let's do things the right way
+and enable the watchdog's clock before performing I/O accesses.
+
+Signed-off-by: Sander Vanheule <sander@svanheule.net>
+Link: https://lore.kernel.org/r/20260515212351.752054-3-sander@svanheule.net
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+---
+ drivers/watchdog/realtek_otto_wdt.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+(limited to 'drivers/watchdog/realtek_otto_wdt.c')
+
+--- a/drivers/watchdog/realtek_otto_wdt.c
++++ b/drivers/watchdog/realtek_otto_wdt.c
+@@ -296,15 +296,15 @@ static int otto_wdt_probe(struct platfor
+ 	if (IS_ERR(ctrl->base))
+ 		return PTR_ERR(ctrl->base);
+ 
++	ret = otto_wdt_probe_clk(ctrl);
++	if (ret)
++		return ret;
++
+ 	/* Clear any old interrupts and reset initial state */
+ 	iowrite32(OTTO_WDT_INTR_PHASE_1 | OTTO_WDT_INTR_PHASE_2,
+ 			ctrl->base + OTTO_WDT_REG_INTR);
+ 	iowrite32(OTTO_WDT_CTRL_DEFAULT, ctrl->base + OTTO_WDT_REG_CTRL);
+ 
+-	ret = otto_wdt_probe_clk(ctrl);
+-	if (ret)
+-		return ret;
+-
+ 	ctrl->irq_phase1 = platform_get_irq_byname(pdev, "phase1");
+ 	if (ctrl->irq_phase1 < 0)
+ 		return ctrl->irq_phase1;

--- a/target/linux/realtek/patches-6.18/035-v7.3-watchdog-realtek-otto-change-to-use-regmap-API.patch
+++ b/target/linux/realtek/patches-6.18/035-v7.3-watchdog-realtek-otto-change-to-use-regmap-API.patch
@@ -1,0 +1,206 @@
+From f8b38cdf3c84b60096a99398c1e9b2d5c68714a2 Mon Sep 17 00:00:00 2001
+From: Rustam Adilov <adilov@disroot.org>
+Date: Fri, 10 Jul 2026 12:43:16 +0500
+Subject: watchdog: realtek-otto: Change to use regmap API
+
+To make the realtek watchdog driver functional when SWAP_IO_SPACE
+config is enabled, change all of the register access to be done
+by regmap API which helps us to tweak endianness with big-endian
+or little-endian property from within the device tree node.
+
+Add the REGMAP_MMIO as a select to REALTEK_OTTO_WDT now that the
+regmap is used.
+
+Signed-off-by: Rustam Adilov <adilov@disroot.org>
+Link: https://lore.kernel.org/r/20260710074316.46643-2-adilov@disroot.org
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+---
+ drivers/watchdog/Kconfig            |  1 +
+ drivers/watchdog/realtek_otto_wdt.c | 74 +++++++++++++++++++------------------
+ 2 files changed, 39 insertions(+), 36 deletions(-)
+
+--- a/drivers/watchdog/Kconfig
++++ b/drivers/watchdog/Kconfig
+@@ -1068,6 +1068,7 @@ config REALTEK_OTTO_WDT
+ 	depends on MACH_REALTEK_RTL || COMPILE_TEST
+ 	depends on COMMON_CLK
+ 	select WATCHDOG_CORE
++	select REGMAP_MMIO
+ 	default MACH_REALTEK_RTL
+ 	help
+ 	  Say Y here to include support for the watchdog timer on Realtek
+--- a/drivers/watchdog/realtek_otto_wdt.c
++++ b/drivers/watchdog/realtek_otto_wdt.c
+@@ -28,6 +28,7 @@
+ #include <linux/platform_device.h>
+ #include <linux/property.h>
+ #include <linux/reboot.h>
++#include <linux/regmap.h>
+ #include <linux/watchdog.h>
+ 
+ #define OTTO_WDT_REG_CNTR		0x0
+@@ -66,7 +67,7 @@
+ struct otto_wdt_ctrl {
+ 	struct watchdog_device wdev;
+ 	struct device *dev;
+-	void __iomem *base;
++	struct regmap *regmap;
+ 	unsigned int clk_rate_khz;
+ 	int irq_phase1;
+ };
+@@ -74,24 +75,17 @@ struct otto_wdt_ctrl {
+ static int otto_wdt_start(struct watchdog_device *wdev)
+ {
+ 	struct otto_wdt_ctrl *ctrl = watchdog_get_drvdata(wdev);
+-	u32 v;
+-
+-	v = ioread32(ctrl->base + OTTO_WDT_REG_CTRL);
+-	v |= OTTO_WDT_CTRL_ENABLE;
+-	iowrite32(v, ctrl->base + OTTO_WDT_REG_CTRL);
+ 
++	regmap_set_bits(ctrl->regmap, OTTO_WDT_REG_CTRL, OTTO_WDT_CTRL_ENABLE);
+ 	return 0;
+ }
+ 
+ static int otto_wdt_stop(struct watchdog_device *wdev)
+ {
+ 	struct otto_wdt_ctrl *ctrl = watchdog_get_drvdata(wdev);
+-	u32 v;
+-
+-	v = ioread32(ctrl->base + OTTO_WDT_REG_CTRL);
+-	v &= ~OTTO_WDT_CTRL_ENABLE;
+-	iowrite32(v, ctrl->base + OTTO_WDT_REG_CTRL);
+ 
++	regmap_clear_bits(ctrl->regmap, OTTO_WDT_REG_CTRL,
++			  OTTO_WDT_CTRL_ENABLE);
+ 	return 0;
+ }
+ 
+@@ -99,8 +93,7 @@ static int otto_wdt_ping(struct watchdog
+ {
+ 	struct otto_wdt_ctrl *ctrl = watchdog_get_drvdata(wdev);
+ 
+-	iowrite32(OTTO_WDT_CNTR_PING, ctrl->base + OTTO_WDT_REG_CNTR);
+-
++	regmap_write(ctrl->regmap, OTTO_WDT_REG_CNTR, OTTO_WDT_CNTR_PING);
+ 	return 0;
+ }
+ 
+@@ -126,7 +119,7 @@ static int otto_wdt_determine_timeouts(s
+ 	unsigned int total_ticks;
+ 	unsigned int prescale;
+ 	unsigned int tick_ms;
+-	u32 v;
++	u32 mask, val;
+ 
+ 	do {
+ 		prescale = prescale_next;
+@@ -142,14 +135,11 @@ static int otto_wdt_determine_timeouts(s
+ 	} while (phase1_ticks > OTTO_WDT_PHASE_TICKS_MAX
+ 		|| phase2_ticks > OTTO_WDT_PHASE_TICKS_MAX);
+ 
+-	v = ioread32(ctrl->base + OTTO_WDT_REG_CTRL);
+-
+-	v &= ~(OTTO_WDT_CTRL_PRESCALE | OTTO_WDT_CTRL_PHASE1 | OTTO_WDT_CTRL_PHASE2);
+-	v |= FIELD_PREP(OTTO_WDT_CTRL_PHASE1, phase1_ticks - 1);
+-	v |= FIELD_PREP(OTTO_WDT_CTRL_PHASE2, phase2_ticks - 1);
+-	v |= FIELD_PREP(OTTO_WDT_CTRL_PRESCALE, prescale);
+-
+-	iowrite32(v, ctrl->base + OTTO_WDT_REG_CTRL);
++	mask = OTTO_WDT_CTRL_PRESCALE | OTTO_WDT_CTRL_PHASE1 | OTTO_WDT_CTRL_PHASE2;
++	val = FIELD_PREP(OTTO_WDT_CTRL_PHASE1, phase1_ticks - 1);
++	val |= FIELD_PREP(OTTO_WDT_CTRL_PHASE2, phase2_ticks - 1);
++	val |= FIELD_PREP(OTTO_WDT_CTRL_PRESCALE, prescale);
++	regmap_update_bits(ctrl->regmap, OTTO_WDT_REG_CTRL, mask, val);
+ 
+ 	timeout_ms = total_ticks * tick_ms;
+ 	ctrl->wdev.timeout = timeout_ms / 1000;
+@@ -193,7 +183,7 @@ static int otto_wdt_restart(struct watch
+ 
+ 	/* Configure for shortest timeout and wait for reset to occur */
+ 	v = FIELD_PREP(OTTO_WDT_CTRL_RST_MODE, reset_mode) | OTTO_WDT_CTRL_ENABLE;
+-	iowrite32(v, ctrl->base + OTTO_WDT_REG_CTRL);
++	regmap_write(ctrl->regmap, OTTO_WDT_REG_CTRL, v);
+ 
+ 	mdelay(3 * otto_wdt_tick_ms(ctrl, 0));
+ 
+@@ -204,7 +194,7 @@ static irqreturn_t otto_wdt_phase1_isr(i
+ {
+ 	struct otto_wdt_ctrl *ctrl = dev_id;
+ 
+-	iowrite32(OTTO_WDT_INTR_PHASE_1, ctrl->base + OTTO_WDT_REG_INTR);
++	regmap_write(ctrl->regmap, OTTO_WDT_REG_INTR, OTTO_WDT_INTR_PHASE_1);
+ 	dev_crit(ctrl->dev, "phase 1 timeout\n");
+ 	watchdog_notify_pretimeout(&ctrl->wdev);
+ 
+@@ -250,7 +240,6 @@ static int otto_wdt_probe_reset_mode(str
+ 	const struct fwnode_handle *node = ctrl->dev->fwnode;
+ 	int mode_count;
+ 	u32 mode;
+-	u32 v;
+ 
+ 	if (!node)
+ 		return -ENXIO;
+@@ -272,19 +261,25 @@ static int otto_wdt_probe_reset_mode(str
+ 	else
+ 		return -EINVAL;
+ 
+-	v = ioread32(ctrl->base + OTTO_WDT_REG_CTRL);
+-	v &= ~OTTO_WDT_CTRL_RST_MODE;
+-	v |= FIELD_PREP(OTTO_WDT_CTRL_RST_MODE, mode);
+-	iowrite32(v, ctrl->base + OTTO_WDT_REG_CTRL);
+-
++	regmap_update_bits(ctrl->regmap, OTTO_WDT_REG_CTRL,
++			   OTTO_WDT_CTRL_RST_MODE,
++			   FIELD_PREP(OTTO_WDT_CTRL_RST_MODE, mode));
+ 	return 0;
+ }
+ 
++static const struct regmap_config realtek_otto_wdt_regmap_config = {
++	.reg_bits = 32,
++	.reg_stride = 4,
++	.val_bits = 32,
++	.disable_locking = true,
++};
++
+ static int otto_wdt_probe(struct platform_device *pdev)
+ {
+ 	struct device *dev = &pdev->dev;
+ 	struct otto_wdt_ctrl *ctrl;
+ 	unsigned int max_tick_ms;
++	void __iomem *base;
+ 	int ret;
+ 
+ 	ctrl = devm_kzalloc(dev, sizeof(*ctrl), GFP_KERNEL);
+@@ -292,18 +287,25 @@ static int otto_wdt_probe(struct platfor
+ 		return -ENOMEM;
+ 
+ 	ctrl->dev = dev;
+-	ctrl->base = devm_platform_ioremap_resource(pdev, 0);
+-	if (IS_ERR(ctrl->base))
+-		return PTR_ERR(ctrl->base);
++	base = devm_platform_ioremap_resource(pdev, 0);
++	if (IS_ERR(base))
++		return PTR_ERR(base);
++
++	ctrl->regmap = devm_regmap_init_mmio(dev, base,
++					     &realtek_otto_wdt_regmap_config);
++	if (IS_ERR(ctrl->regmap)) {
++		dev_err(dev, "regmap init failed\n");
++		return PTR_ERR(ctrl->regmap);
++	}
+ 
+ 	ret = otto_wdt_probe_clk(ctrl);
+ 	if (ret)
+ 		return ret;
+ 
+ 	/* Clear any old interrupts and reset initial state */
+-	iowrite32(OTTO_WDT_INTR_PHASE_1 | OTTO_WDT_INTR_PHASE_2,
+-			ctrl->base + OTTO_WDT_REG_INTR);
+-	iowrite32(OTTO_WDT_CTRL_DEFAULT, ctrl->base + OTTO_WDT_REG_CTRL);
++	regmap_write(ctrl->regmap, OTTO_WDT_REG_INTR,
++		     OTTO_WDT_INTR_PHASE_1 | OTTO_WDT_INTR_PHASE_2);
++	regmap_write(ctrl->regmap, OTTO_WDT_REG_CTRL, OTTO_WDT_CTRL_DEFAULT);
+ 
+ 	ctrl->irq_phase1 = platform_get_irq_byname(pdev, "phase1");
+ 	if (ctrl->irq_phase1 < 0)


### PR DESCRIPTION
One of the things that brings SWAP_IO_SPACE even closer.

Backport the accepted fix patches from [1] and my regmap patch from [2].

[1] https://lore.kernel.org/linux-watchdog/20260515212351.752054-1-sander@svanheule.net/
[2] https://lore.kernel.org/linux-watchdog/20260710074316.46643-1-adilov@disroot.org/