### PR TITLE
realtek: clocksource: backport upstream patch for __raw reads & writes

### DIFF
--- a/target/linux/realtek/patches-6.18/036-v7.3-clocksource-rtl-otto-change-driver-to-use-__raw-reads-and-writes.patch
+++ b/target/linux/realtek/patches-6.18/036-v7.3-clocksource-rtl-otto-change-driver-to-use-__raw-reads-and-writes.patch
@@ -1,0 +1,74 @@
+From 954a3bfdb64637a485d75c90ae8484fd39de5523 Mon Sep 17 00:00:00 2001
+From: Rustam Adilov <adilov@disroot.org>
+Date: Sat, 25 Jul 2026 22:55:10 +0500
+Subject: clocksource/drivers/rtl-otto: Change driver to use __raw reads and
+ writes
+
+As it stands, the driver uses ioread32 and iowrite32 for register
+access and it works fine. However this stops working when the
+SWAP_IO_SPACE config is enabled as this drivers expects ioread32 and
+iowrite32 to be in native endian (that is big endian for currently
+supported SoCs). RTL9607C is a big endian MIPS SoC that has identical
+timer as the already supported chips but needs to have SWAP_IO_SPACE
+to have a functioning little endian USB host.
+
+Fix this by replacing all instances of ioread32 and iowrite32 with
+__raw_readl and __raw_writel variants. Since they essentially do the
+same register access, this shouldn't affect anything on other
+machines.
+
+Signed-off-by: Rustam Adilov <adilov@disroot.org>
+Signed-off-by: Daniel Lezcano <daniel.lezcano@kernel.org>
+Reviewed-by: Chris Packham <chris.packham@alliedtelesis.co.nz>
+Link: https://patch.msgid.link/20260725175510.77240-1-adilov@disroot.org
+---
+ drivers/clocksource/timer-rtl-otto.c | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+--- a/drivers/clocksource/timer-rtl-otto.c
++++ b/drivers/clocksource/timer-rtl-otto.c
+@@ -56,37 +56,37 @@ struct rttm_cs {
+ /* Simple internal register functions */
+ static inline unsigned int rttm_get_counter(void __iomem *base)
+ {
+-	return ioread32(base + RTTM_CNT);
++	return __raw_readl(base + RTTM_CNT);
+ }
+ 
+ static inline void rttm_set_period(void __iomem *base, unsigned int period)
+ {
+-	iowrite32(period, base + RTTM_DATA);
++	__raw_writel(period, base + RTTM_DATA);
+ }
+ 
+ static inline void rttm_disable_timer(void __iomem *base)
+ {
+-	iowrite32(0, base + RTTM_CTRL);
++	__raw_writel(0, base + RTTM_CTRL);
+ }
+ 
+ static inline void rttm_enable_timer(void __iomem *base, u32 mode, u32 divisor)
+ {
+-	iowrite32(RTTM_CTRL_ENABLE | mode | divisor, base + RTTM_CTRL);
++	__raw_writel(RTTM_CTRL_ENABLE | mode | divisor, base + RTTM_CTRL);
+ }
+ 
+ static inline void rttm_ack_irq(void __iomem *base)
+ {
+-	iowrite32(ioread32(base + RTTM_INT) | RTTM_INT_PENDING, base + RTTM_INT);
++	__raw_writel(__raw_readl(base + RTTM_INT) | RTTM_INT_PENDING, base + RTTM_INT);
+ }
+ 
+ static inline void rttm_enable_irq(void __iomem *base)
+ {
+-	iowrite32(RTTM_INT_ENABLE, base + RTTM_INT);
++	__raw_writel(RTTM_INT_ENABLE, base + RTTM_INT);
+ }
+ 
+ static inline void rttm_disable_irq(void __iomem *base)
+ {
+-	iowrite32(0, base + RTTM_INT);
++	__raw_writel(0, base + RTTM_INT);
+ }
+ 
+ /* Aggregated control functions for kernel clock framework */


### PR DESCRIPTION
One of the many patches that brings SWAP_IO_SPACE support even closer.

~Add the currently ongoing upstream patch from [1] as pending. It has been almost 2 months since i submitted it and still nothing from maintainers so i think it will be quicker to add like this for now.~

Backport an upstream accepted patch, being queued for v7.3.

~[1] https://lore.kernel.org/all/20260511131520.98420-1-adilov@disroot.org/~