### PR TITLE
ath79: add support for Ubiquiti UniFi AP LR v2

### DIFF
--- a/target/linux/ath79/dts/ar9342_ubnt_unifi-ap-lr-v2.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_unifi-ap-lr-v2.dts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9342_ubnt_xw.dtsi"
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "ubnt,unifi-ap-lr-v2", "ubnt,xw", "qca,ar9342";
+	model = "Ubiquiti UniFi AP LR v2";
+
+	aliases {
+		led-boot = &led_dome_green;
+		led-failsafe = &led_dome_orange;
+		led-running = &led_dome_green;
+		led-upgrade = &led_dome_orange;
+		label-mac-device = &eth0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_dome_green: dome-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = "dome";
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_dome_orange: dome-orange {
+			color = <LED_COLOR_ID_ORANGE>;
+			function = "dome";
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&gpio {
+	status = "okay";
+
+	flash-wp-hog {
+		gpio-hog;
+		gpios = <16 GPIO_ACTIVE_LOW>;
+		output-high;
+		line-name = "flash-wp-disable";
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy1: ethernet-phy@1 {
+		reg = <1>;
+		reset-gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-mode = "mii";
+	phy-handle = <&phy1>;
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		partitions {
+			/delete-node/ partition@40000;
+			/delete-node/ partition@50000;
+
+			partition@0 {
+				reg = <0x000000 0x060000>;
+			};
+
+			partition@60000 {
+				label = "u-boot-env";
+				reg = <0x060000 0x010000>;
+				read-only;
+			};
+
+			partition@70000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x070000 0x740000>;
+			};
+		};
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -123,6 +123,7 @@ ath79_setup_interfaces()
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-lr|\
 	ubnt,unifiac-mesh|\
+	ubnt,unifi-ap-lr-v2|\
 	ubnt,unifi|\
 	watchguard,ap100|\
 	watchguard,ap200|\

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -285,6 +285,17 @@ define Device/ubnt_unifi-ap-lr
 endef
 TARGET_DEVICES += ubnt_unifi-ap-lr
 
+define Device/ubnt_unifi-ap-lr-v2
+  $(Device/ubnt)
+  SOC := ar9342
+  DEVICE_MODEL := UniFi AP
+  DEVICE_VARIANT := LR v2
+  IMAGES := sysupgrade.bin
+  IMAGE_SIZE := 7424k
+  DEVICE_PACKAGES += -kmod-usb2
+endef
+TARGET_DEVICES += ubnt_unifi-ap-lr-v2
+
 define Device/ubnt_unifiac-lite
   $(Device/ubnt_unifiac)
   DEVICE_MODEL := UniFi AC Lite


### PR DESCRIPTION
Add support for the Ubiquiti UniFi AP LR v2 access point based
on Atheros AR9342 SoC.

Hardware:
- SoC: Atheros AR9342
- RAM: 64 MB (W9751G6KB-25)
- Flash: 8 MB SPI NOR (MX25L6408EMI-12G)
- Ethernet: 1x 10/100 Mbps (AR8032), 24 V passive PoE in
- 2.4 GHz integrated
- LEDs: 1x green/orange dome
- Buttons: 1x Reset
- UART: TTL 3.3V, 115200 8N1, PCB silkscreen: 3.3V SIN SOUT GND,
use 117200 baud rate if output is garbled

The Ubiquiti UniFi AP LR v2 semes to have similar hardware to 
Ubiquiti UniFi AP v2 #24050

U-Boot ENVs:
bootargs=console=tty0 panic=3
bootcmd=run ubntappinit ubntboot
bootdelay=1
ipaddr=192.168.1.20
serverip=192.168.1.254
ubntappinit=go ${ubntaddr} uappinit;go ${ubntaddr} 
ureset_button;urescue;go ${ubntaddr} uwrite 
mtdparts=mtdparts=ath-nor0:384k(u-boot),64k(u-boot-env),7424k(kernel), 
256k(cfg),64k(EEPROM) ubntboot=bootm 0x9f070000
stdin=serial
stdout=serial
stderr=serial
ethact=eth0
ubntaddr=80200020
mtdids=nor0=ath-nor0
partition=nor0,0
mtddevnum=0
mtddevname=u-boot

MAC address:
There are two MAC addresses stored in the EEPROM partition.
Ethernet MAC and Wi-Fi MAC.

Installation:
Serial access is necessary.
AP needs to be powered off for a few minutes before powering on
and entering U-Boot, otherwise Ethernet in U-Boot doesn't work.
Any modifications of U-Boot ENVs get reset on the next boot.
Modification is not necessary, 
since gpio-hog unlocks flash after U-boot locks it.

1. Interrupt U-Boot by pressing key when countdown shows up.
2. Transfer initramfs image via TFTP and boot it: 
tftpboot 0x82000000 initramfs.bin
bootm 0x82000000
4. From initramfs do sysupgrade: 
sysupgrade -v sysupgrade.bin

Return to stock firmware:
Use Ubiquiti's TFTP recovery to flash original firmware

Tested on one device:
- Ethernet
- 2.4 GHz AP mode
- Dome LEDs
- JFFS2 overlay and persistence after reboot
- Reset button
- UART
- LuCi