### PR TITLE
mediatek: filogic: set eth0 and LAN port MACs on TP-Link BE450

### DIFF
--- a/target/linux/mediatek/dts/mt7988d-tplink-be450.dts
+++ b/target/linux/mediatek/dts/mt7988d-tplink-be450.dts
@@ -19,7 +19,6 @@
 
 	aliases {
 		serial0 = &serial0;
-		label-mac-device = &gmac0;
 		led-boot = &led_status;
 		led-failsafe = &led_status;
 		led-running = &led_status;

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -299,6 +299,7 @@ mediatek_setup_macs()
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\
 	tplink,archer-ax80-v1-eu|\
+	tplink,be450|\
 	tplink,re6000xd)
 		label_mac=$(get_mac_binary "/tmp/tp_data/default-mac" 0)
 		lan_mac=$label_mac

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -37,6 +37,10 @@ preinit_set_mac_address() {
 		;;
 	tplink,be450)
 		addr=$(get_mac_binary "/tmp/tp_data/default-mac" 0)
+		ip link set dev eth0 address "$addr"
+		ip link set dev lan1 address "$addr"
+		ip link set dev lan2 address "$addr"
+		ip link set dev lan3 address "$addr"
 		ip link set dev eth1 address "$(macaddr_add $addr 1)"
 		ip link set dev eth2 address "$(macaddr_add $addr 2)"
 		;;


### PR DESCRIPTION
eth0 (gmac0) is declared label-mac-device, but nothing assigns its MAC, so it and the DSA lan ports come up with a random locally administered address that changes every boot. Assign the base MAC from tp_data default-mac to eth0 and the lan ports, as is already done for eth1 and eth2.

Each lan port needs its own assignment: a DSA user port copies the conduit's MAC once when it is created, at driver probe before preinit runs, and ignores later changes to eth0.

Run-tested on a BE450 on 25.12.5, where the case is identical. Two boots without the fix each came up with a different random address; with the fix applied, eth0 and the lan ports get the label MAC and keep it across reboots.

Candidate for backport to openwrt-25.12: the bug is user-visible there and the patch applies cleanly.