### PR TITLE
package(base-files): Fix Makefile syntax error when disabling gpio

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -265,16 +265,16 @@ else
 	$(if $(CONFIG_IPK_FILES_CHECKSUMS),, \
 		rm -f $(1)/sbin/pkg_check)
 endif
-$(if $(CONFIG_TARGET_BUTTON_CUSTOMIZATION_FAILSAFE_DISABLED), \
-	rm -f $(1)/etc/rc.button/failsafe)
-$(if $(CONFIG_TARGET_BUTTON_CUSTOMIZATION_POWER_DISABLED), \
-	rm -f $(1)/etc/rc.button/power)
-$(if $(CONFIG_TARGET_BUTTON_CUSTOMIZATION_REBOOT_DISABLED), \
-	rm -f $(1)/etc/rc.button/reboot)
-$(if $(CONFIG_TARGET_BUTTON_CUSTOMIZATION_RESET_DISABLED), \
-	rm -f $(1)/etc/rc.button/reset)
-$(if $(CONFIG_TARGET_BUTTON_CUSTOMIZATION_RF_KILL_DISABLED), \
-	rm -f $(1)/etc/rc.button/rfkill)
+	$(if $(CONFIG_TARGET_BUTTON_CUSTOMIZATION_FAILSAFE_DISABLED), \
+		rm -f $(1)/etc/rc.button/failsafe)
+	$(if $(CONFIG_TARGET_BUTTON_CUSTOMIZATION_POWER_DISABLED), \
+		rm -f $(1)/etc/rc.button/power)
+	$(if $(CONFIG_TARGET_BUTTON_CUSTOMIZATION_REBOOT_DISABLED), \
+		rm -f $(1)/etc/rc.button/reboot)
+	$(if $(CONFIG_TARGET_BUTTON_CUSTOMIZATION_RESET_DISABLED), \
+		rm -f $(1)/etc/rc.button/reset)
+	$(if $(CONFIG_TARGET_BUTTON_CUSTOMIZATION_RF_KILL_DISABLED), \
+		rm -f $(1)/etc/rc.button/rfkill)
 endef
 
 ifneq ($(DUMP),1)


### PR DESCRIPTION
buttons

Commit 4bdc2ab93ab introduced new options to disable the following button hooks :
 - /etc/rc.button/{reset,reboot,power,failsafe,rfkill}

 Via the new TARGET_BUTTON_CUSTOMIZATION config options.

 The added lines at the end of base-files Makefile :

 ```
 +$(if $(CONFIG_TARGET_BUTTON_CUSTOMIZATION_FAILSAFE_DISABLED), \
+       rm -f $(1)/etc/rc.button/failsafe)
+$(if $(CONFIG_TARGET_BUTTON_CUSTOMIZATION_POWER_DISABLED), \
+       rm -f $(1)/etc/rc.button/power)
+$(if $(CONFIG_TARGET_BUTTON_CUSTOMIZATION_REBOOT_DISABLED), \
+       rm -f $(1)/etc/rc.button/reboot)
+$(if $(CONFIG_TARGET_BUTTON_CUSTOMIZATION_RESET_DISABLED), \
+       rm -f $(1)/etc/rc.button/reset)
+$(if $(CONFIG_TARGET_BUTTON_CUSTOMIZATION_RF_KILL_DISABLED), \
+       rm -f $(1)/etc/rc.button/rfkill)
```

Are missing an indentation.
Thus, when one of the option is enabled (and one of the `rm` line
added), we have a build error because of the syntax error.
