### PR TITLE
ramips: mt7621: add support for Keenetic KN-1010

### DIFF
--- a/target/linux/ramips/dts/mt7621_keenetic_kn-1010.dts
+++ b/target/linux/ramips/dts/mt7621_keenetic_kn-1010.dts
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "keenetic,kn-1010", "mediatek,mt7621-soc";
+	model = "Keenetic KN-1010";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		fn2 {
+			label = "fn2";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_2>;
+		};
+
+		fn1 {
+			label = "fn1";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
+		};
+
+		fn2 {
+			function = LED_FUNCTION_INDICATOR;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <2>;
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		wifi {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		fn1 {
+			function = LED_FUNCTION_INDICATOR;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <1>;
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		internet {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&firmware1 &firmware2 &storage_a &storage_b>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x7540000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart2", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "u-config";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "rf-eeprom";
+			reg = <0x100000 0x80000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					compatible = "mac-base";
+					reg = <0x4 0x6>;
+					#nvmem-cell-cells = <1>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
+			};
+		};
+
+		firmware1: partition@180000 {
+			label = "firmware_1";
+			reg = <0x180000 0x1bc0000>;
+		};
+
+		partition@1d40000 {
+			label = "config_1";
+			reg = <0x1d40000 0x80000>;
+			read-only;
+		};
+
+		partition@1dc0000 {
+			label = "storage_legacy";
+			reg = <0x1dc0000 0x200000>;
+			read-only;
+		};
+
+		partition@1fc0000 {
+			label = "dump";
+			reg = <0x1fc0000 0x40000>;
+			read-only;
+		};
+
+		storage_a: partition@2000000 {
+			label = "storage_a";
+			reg = <0x2000000 0x1fc0000>;
+		};
+
+		partition@3fc0000 {
+			label = "u-state";
+			reg = <0x3fc0000 0x80000>;
+			read-only;
+		};
+
+		partition@4040000 {
+			label = "d-state";
+			reg = <0x4040000 0x80000>;
+			read-only;
+		};
+
+		partition@40c0000 {
+			label = "rf-eeprom_res";
+			reg = <0x40c0000 0x80000>;
+			read-only;
+		};
+
+		firmware2: partition@4140000 {
+			label = "firmware_2";
+			reg = <0x4140000 0x1bc0000>;
+		};
+
+		partition@5d00000 {
+			label = "config_2";
+			reg = <0x5d00000 0x80000>;
+			read-only;
+		};
+
+		storage_b: partition@5d80000 {
+			label = "storage_b";
+			reg = <0x5d80000 0x2200000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		band@1 {
+			reg = <1>;
+			nvmem-cells = <&macaddr_factory_4 2>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&mdio {
+	ethphy5: ethernet-phy@5 {
+		reg = <5>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_4 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-mode = "rgmii";
+	phy-handle = <&ethphy5>;
+
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+};
+
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
+};
+
+&reg_vusb33 {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};

--- a/target/linux/ramips/image/keenetic-kn1010-install/rc.local
+++ b/target/linux/ramips/image/keenetic-kn1010-install/rc.local
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+exec >/dev/console 2>&1
+
+img=/usr/share/kn1010/sysupgrade.bin
+sum=/usr/share/kn1010/sysupgrade.sha256
+
+echo "KN-1010 installer: booted install initramfs"
+
+if [ ! -f "$img" ]; then
+	echo "KN-1010 installer: missing $img"
+	exit 1
+fi
+
+if [ ! -f "$sum" ]; then
+	echo "KN-1010 installer: missing $sum"
+	exit 1
+fi
+
+echo "KN-1010 installer: checking image checksum"
+sha256sum -c "$sum" || exit 1
+
+echo "KN-1010 installer: testing image"
+sysupgrade -T "$img" || exit 1
+
+echo "KN-1010 installer: installing $img"
+sysupgrade -n -v "$img"
+
+exit 0

--- a/target/linux/ramips/image/keenetic-kn1010-install/rc.local
+++ b/target/linux/ramips/image/keenetic-kn1010-install/rc.local
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+exec >/dev/console 2>&1
+
+img=/usr/share/kn1010/sysupgrade.bin
+sum=/usr/share/kn1010/sysupgrade.sha256
+
+echo "KN-1010 installer: booted install initramfs"
+
+if [ ! -f "$img" ]; then
+	echo "KN-1010 installer: missing $img"
+	exit 1
+fi
+
+if [ ! -f "$sum" ]; then
+	echo "KN-1010 installer: missing $sum"
+	exit 1
+fi
+
+echo "KN-1010 installer: checking image checksum"
+(cd "${sum%/*}" && sha256sum -c "${sum##*/}") || exit 1
+
+echo "KN-1010 installer: testing image"
+sysupgrade -T "$img" || exit 1
+
+echo "KN-1010 installer: installing $img"
+sysupgrade -n -v "$img"
+
+exit 0

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -25,6 +25,32 @@ define Build/append-dlink-covr-metadata
 	rm $@metadata.tmp
 endef
 
+define Build/kn1010-install-image
+	rm -rf "$@.kn1010-install-root" "$(LINUX_DIR).kn1010-install"
+	mkdir -p "$@.kn1010-install-root"
+	cp -a "$(TARGET_DIR)/." "$@.kn1010-install-root/"
+	mkdir -p "$@.kn1010-install-root/usr/share/kn1010"
+	install -m 0644 "$(BIN_DIR)/$(DEVICE_IMG_PREFIX)-squashfs-sysupgrade.bin" \
+		"$@.kn1010-install-root/usr/share/kn1010/sysupgrade.bin"
+	printf '%s  %s\n' \
+		"$$($(MKHASH) sha256 "$(BIN_DIR)/$(DEVICE_IMG_PREFIX)-squashfs-sysupgrade.bin")" \
+		"/usr/share/kn1010/sysupgrade.bin" \
+		> "$@.kn1010-install-root/usr/share/kn1010/sysupgrade.sha256"
+	install -m 0755 \
+		"$(TOPDIR)/target/linux/ramips/image/keenetic-kn1010-install/rc.local" \
+		"$@.kn1010-install-root/etc/rc.local"
+	test -x "$@.kn1010-install-root/sbin/init"
+	test -f "$@.kn1010-install-root/usr/share/kn1010/sysupgrade.bin"
+	test -f "$@.kn1010-install-root/usr/share/kn1010/sysupgrade.sha256"
+	$(call Kernel/CompileImage/Initramfs,$@.kn1010-install-root,.kn1010-install)
+	cp "$(KERNEL_BUILD_DIR)/vmlinux-initramfs.kn1010-install" "$@"
+	$(call Build/append-dtb)
+	$(call Build/lzma)
+	$(call Build/loader-kernel)
+	$(call Build/uImage,none)
+	rm -rf "$@.kn1010-install-root" "$(LINUX_DIR).kn1010-install"
+endef
+
 define Build/append-netis-n6-metadata
 	( echo -ne '{ \
 		"up_model": "Netis-N6R", \
@@ -2038,6 +2064,22 @@ define Device/jdcloud_re-sp-01b
 	kmod-mmc-mtk kmod-usb3
 endef
 TARGET_DEVICES += jdcloud_re-sp-01b
+
+define Device/keenetic_kn-1010
+  $(Device/nand)
+  $(Device/uimage-lzma-loader)
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 124160k
+  DEVICE_VENDOR := Keenetic
+  DEVICE_MODEL := KN-1010
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 kmod-phy-realtek \
+	-uboot-envtools
+  IMAGES += factory.bin
+  IMAGE/factory.bin := kn1010-install-image | \
+	zyimage -d 0x801010 -v "KN-1010"
+endef
+TARGET_DEVICES += keenetic_kn-1010
 
 define Device/keenetic_kn-1910
   $(Device/nand)

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -25,6 +25,33 @@ define Build/append-dlink-covr-metadata
 	rm $@metadata.tmp
 endef
 
+define Build/kn1010-install-image
+	rm -rf "$@.kn1010-install-root" "$(LINUX_DIR).kn1010-install"
+	mkdir -p "$@.kn1010-install-root"
+	cp -a "$(TARGET_DIR)/." "$@.kn1010-install-root/"
+	mkdir -p "$@.kn1010-install-root/usr/share/kn1010"
+	install -m 0644 "$(BIN_DIR)/$(DEVICE_IMG_PREFIX)-squashfs-sysupgrade.bin" \
+		"$@.kn1010-install-root/usr/share/kn1010/sysupgrade.bin"
+	printf '%s  %s\n' \
+		"$$($(MKHASH) sha256 "$(BIN_DIR)/$(DEVICE_IMG_PREFIX)-squashfs-sysupgrade.bin")" \
+		"sysupgrade.bin" \
+		> "$@.kn1010-install-root/usr/share/kn1010/sysupgrade.sha256"
+	install -m 0755 \
+		"$(TOPDIR)/target/linux/ramips/image/keenetic-kn1010-install/rc.local" \
+		"$@.kn1010-install-root/etc/rc.local"
+	test -x "$@.kn1010-install-root/sbin/init"
+	test -f "$@.kn1010-install-root/usr/share/kn1010/sysupgrade.bin"
+	test -f "$@.kn1010-install-root/usr/share/kn1010/sysupgrade.sha256"
+	(cd "$@.kn1010-install-root/usr/share/kn1010" && sha256sum -c sysupgrade.sha256)
+	$(call Kernel/CompileImage/Initramfs,$@.kn1010-install-root,.kn1010-install)
+	cp "$(KERNEL_BUILD_DIR)/vmlinux-initramfs.kn1010-install" "$@"
+	$(call Build/append-dtb)
+	$(call Build/lzma)
+	$(call Build/loader-kernel)
+	$(call Build/uImage,none)
+	rm -rf "$@.kn1010-install-root" "$(LINUX_DIR).kn1010-install"
+endef
+
 define Build/append-netis-n6-metadata
 	( echo -ne '{ \
 		"up_model": "Netis-N6R", \
@@ -2050,6 +2077,26 @@ define Device/jdcloud_re-sp-01b
 	kmod-mmc-mtk kmod-usb3
 endef
 TARGET_DEVICES += jdcloud_re-sp-01b
+
+define Device/keenetic_kn-1010
+  $(Device/nand)
+  $(Device/uimage-lzma-loader)
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 124160k
+  DEVICE_VENDOR := Keenetic
+  DEVICE_MODEL := KN-1010
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 kmod-phy-realtek \
+	-uboot-envtools
+ifeq ($(IB),)
+ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
+  ARTIFACTS += initramfs-factory.bin
+  ARTIFACT/initramfs-factory.bin := kn1010-install-image | \
+	zyimage -d 0x801010 -v "KN-1010"
+endif
+endif
+endef
+TARGET_DEVICES += keenetic_kn-1010
 
 define Device/keenetic_kn-1910
   $(Device/nand)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -138,6 +138,9 @@ gnubee,gb-pc2)
 huasifei,ws1208v2)
 	ucidef_set_led_netdev "wwan0" "wwan0" "green:cellular" "wwan0" "link tx rx"
 	;;
+keenetic,kn-1010)
+	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan"
+	;;
 keenetic,kn-1910|\
 keenetic,kn-3010)
 	ucidef_set_led_netdev "internet" "internet" "green:internet" "wan"

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -113,6 +113,7 @@ platform_do_upgrade() {
 	iptime,ax2004m|\
 	iptime,t5004|\
 	jcg,q20|\
+	keenetic,kn-1010|\
 	keenetic,kn-1910|\
 	keenetic,kn-3510|\
 	linksys,e5600|\


### PR DESCRIPTION
This PR adds support for the Keenetic KN-1010 (Giga).

## NAND-safe first install

The KN-1010 has 128 MiB NAND and real hardware contains bad blocks. The
Keenetic U-Boot raw-NAND read path skips bad eraseblocks. A conventional
monolithic factory image contains a kernel followed at a fixed boundary by the
root filesystem / UBI payload; it is therefore not a reliable recovery image
for this layout.

Observed U-Boot evidence:

```text
## Booting image at bfd80000 ...
   Image Name:   MIPS OpenWrt Linux-6.18.38
   Data Size:    3559595 Bytes =  3.4 MB
............................................ranand_read: skip reading a fact bad block 440000 -> 460000
   Verifying Checksum ... OK
OK
No initrd
## Transferring control to Linux (at address 80001000) ...
```

The generated `initramfs-factory.bin` is consequently a Keenetic-compatible
initramfs installer image. It contains the vanilla sysupgrade archive and, on
first boot, verifies its SHA-256 checksum, validates it with `sysupgrade -T`,
then installs it with `sysupgrade -n -v`. The normal sysupgrade path writes the
kernel and UBI targets separately with NAND bad-block handling.

## Artifacts

- `initramfs-kernel.bin`: RAM-only test image.
- `initramfs-factory.bin`: first-stage Keenetic recovery TFTP installer image.
- `squashfs-sysupgrade.bin`: normal OpenWrt upgrade image.

The factory artifact is generated only by a full source build with
`CONFIG_TARGET_ROOTFS_INITRAMFS=y`. It is not available from the ImageBuilder,
because producing it requires compiling a device-specific initramfs.

## First installation

1. Connect a PC to a LAN port and configure it as `192.168.1.2/24`.
2. Serve `initramfs-factory.bin` by TFTP as `KN-1010_recovery.bin`.
3. Hold Reset while powering on the router.
4. Release Reset when the Status LED starts blinking. U-Boot downloads the
   image from the PC; the router uses recovery address `192.168.1.1`.
5. The installer verifies and installs its embedded sysupgrade image, then
   reboots into the NAND-installed system.

## Tested on hardware

- Booted the initramfs image from U-Boot via TFTP.
- Loaded the initramfs factory installer through Keenetic recovery TFTP.
- Verified the embedded sysupgrade archive with `sysupgrade -T`.
- Installed it with `sysupgrade -n -v`.
- Booted the resulting SquashFS rootfs, UBI and UBIFS overlay.
- Confirmed bad-block handling during first-stage boot and the separate
  kernel/UBI sysupgrade.

## Limitations

- SFP support is not tested.
