### PR TITLE
qualcommax: pcs: qca-uniphy: MAC mode and configure-once fixes

### DIFF
--- a/target/linux/qualcommax/files/drivers/net/pcs/pcs-qca-uniphy.c
+++ b/target/linux/qualcommax/files/drivers/net/pcs/pcs-qca-uniphy.c
@@ -482,10 +482,12 @@ static int qca_uniphy_pcs_config_mode(struct phylink_pcs *pcs,
 		break;
 	case PHY_INTERFACE_MODE_QSGMII:
 		mode_ctrl = UNIPHY_CH0_QSGMII_SGMII;
+		mode_ctrl |= FIELD_PREP(UNIPHY_CH0_MODE_CTRL_25M, UNIPHY_CH0_MODE_MAC);
 		misc2_phy_mode = UNIPHY_MISC2_SGMII;
 		break;
 	case PHY_INTERFACE_MODE_PSGMII:
 		mode_ctrl = UNIPHY_CH0_PSGMII_QSGMII;
+		mode_ctrl |= FIELD_PREP(UNIPHY_CH0_MODE_CTRL_25M, UNIPHY_CH0_MODE_MAC);
 		misc2_phy_mode = 0;
 		break;
 	case PHY_INTERFACE_MODE_USXGMII:

--- a/target/linux/qualcommax/files/drivers/net/pcs/pcs-qca-uniphy.c
+++ b/target/linux/qualcommax/files/drivers/net/pcs/pcs-qca-uniphy.c
@@ -10,6 +10,7 @@
  */
 
 #include <linux/bitfield.h>
+#include <linux/cleanup.h>
 #include <linux/clk/clk-conf.h>
 #include <linux/clk-provider.h>
 #include <linux/delay.h>
@@ -469,6 +470,11 @@ static int qca_uniphy_pcs_config_mode(struct phylink_pcs *pcs,
 	dev_dbg(uniphy->dev, "Configuring PCS: chan=%d, interface=%s, neg_mode=0x%x\n",
 		upcs->channel, phy_modes(interface), neg_mode);
 
+	/* Every channel of the instance calls this with its own phylink state
+	 * mutex, so nothing else keeps two of them out of the sequence below.
+	 */
+	guard(mutex)(&uniphy->lock);
+
 	switch (interface) {
 	case PHY_INTERFACE_MODE_1000BASEX:
 		misc2_phy_mode = UNIPHY_MISC2_SGMII;
@@ -518,6 +524,24 @@ static int qca_uniphy_pcs_config_mode(struct phylink_pcs *pcs,
 			clk_prepare_enable(uniphy->ref_clk.hw.clk);
 	}
 
+	/* TODO: Fix for IPQ6018 and IPQ8074 */
+	if (uniphy->data->uniphy_type == UNIPHY_IPQ5018) {
+		//set force mode for fixed link
+		if (neg_mode == PHYLINK_PCS_NEG_OUTBAND && !phylink_expects_phy(pcs->phylink)) {
+			regmap_set_bits(uniphy->regmap,
+					UNIPHY_CH_CTRL(upcs->channel),
+					UNIPHY_CH_FORCE_MODE);
+		}
+	}
+
+	if (uniphy->interface == interface)
+		return 0;
+
+	/* Invalid until the sequence below completes, so that a bail-out
+	 * leaves no cached mode the hardware does not have.
+	 */
+	uniphy->interface = PHY_INTERFACE_MODE_NA;
+
 	/* First update misc2 PHY mode... */
 	regmap_update_bits(uniphy->regmap, UNIPHY_MISC2_PHY_MODE,
 			   UNIPHY_MISC2_PHY_MODE_MASK, misc2_phy_mode);
@@ -531,21 +555,17 @@ static int qca_uniphy_pcs_config_mode(struct phylink_pcs *pcs,
 	msleep(100);
 
 	/* Second assert XPCS... */
-	if (uniphy->rst_xpcs)
-		reset_control_assert(uniphy->rst_xpcs);
+	if (uniphy->rst_xpcs) {
+		ret = reset_control_assert(uniphy->rst_xpcs);
+		if (ret)
+			return ret;
+	}
 
 	/* ...and disable PHY clock */
-	clk_disable(uniphy->clks[port_rx_clk_idx(upcs)].clk);
-	clk_disable(uniphy->clks[port_tx_clk_idx(upcs)].clk);
-
-	/* TODO: Fix for IPQ6018 and IPQ8074 */
-	if (uniphy->data->uniphy_type == UNIPHY_IPQ5018) {
-		//set force mode for fixed link
-		if (neg_mode == PHYLINK_PCS_NEG_OUTBAND && !phylink_expects_phy(pcs->phylink)) {
-			regmap_set_bits(uniphy->regmap,
-					UNIPHY_CH_CTRL(upcs->channel),
-					UNIPHY_CH_FORCE_MODE);
-		}
+	if (upcs->clks_enabled) {
+		clk_bulk_disable(QCA_UNIPHY_PORT_CLKS,
+				 &uniphy->clks[port_rx_clk_idx(upcs)]);
+		upcs->clks_enabled = false;
 	}
 
 	/* Third update the mode ctrl... */
@@ -563,9 +583,13 @@ static int qca_uniphy_pcs_config_mode(struct phylink_pcs *pcs,
 	 * lots of testing it has been verified that operating
 	 * on the single reset is problematic)
 	 */
-	reset_control_assert(uniphy->rst_soft);
+	ret = reset_control_assert(uniphy->rst_soft);
+	if (ret)
+		goto err_clks;
 	msleep(100);
-	reset_control_deassert(uniphy->rst_soft);
+	ret = reset_control_deassert(uniphy->rst_soft);
+	if (ret)
+		goto err_clks;
 
 	/* ...and wait for calibration */
 	ret = regmap_read_poll_timeout(uniphy->regmap, UNIPHY_OFFSET_CALIB_4,
@@ -574,7 +598,8 @@ static int qca_uniphy_pcs_config_mode(struct phylink_pcs *pcs,
 				       UNIPHY_CALIBRATION_TIMEOUT_US);
 	if (ret) {
 		dev_err(uniphy->dev, "PCS calibration timeout\n");
-		return -EINVAL;
+		ret = -EINVAL;
+		goto err_clks;
 	}
 
 	/* Trigger UNIPHY ref clock to recal rate */
@@ -582,24 +607,54 @@ static int qca_uniphy_pcs_config_mode(struct phylink_pcs *pcs,
 	clk_hw_recalc_rate(&uniphy->tx_clk.hw);
 
 	/* As last step enable PHY clock... */
-	clk_enable(uniphy->clks[port_rx_clk_idx(upcs)].clk);
-	clk_enable(uniphy->clks[port_tx_clk_idx(upcs)].clk);
+	ret = clk_bulk_enable(QCA_UNIPHY_PORT_CLKS,
+			      &uniphy->clks[port_rx_clk_idx(upcs)]);
+	if (ret)
+		return ret;
+	upcs->clks_enabled = true;
 
 	if (interface == PHY_INTERFACE_MODE_USXGMII ||
-	    interface == PHY_INTERFACE_MODE_10GBASER)
-		reset_control_deassert(uniphy->rst_xpcs);
+	    interface == PHY_INTERFACE_MODE_10GBASER) {
+		ret = reset_control_deassert(uniphy->rst_xpcs);
+		if (ret)
+			return ret;
+	}
 
-	if (!uniphy->data->ref_clk_enable)
-		return 0;
+	if (uniphy->data->ref_clk_enable) {
+		/* Trigger UNIPHY ref output clock to recalc rate */
+		clk_hw_recalc_rate(&uniphy->ref_clk.hw);
+		/* Trigger assigned-clock-rates in DT to be applied */
+		ret = of_clk_set_defaults(uniphy->dev->of_node, true);
+		if (ret)
+			return ret;
+		if (!qca_uniphy_refclk_is_enabled(&uniphy->ref_clk.hw)) {
+			ret = qca_uniphy_refclk_enable(&uniphy->ref_clk.hw);
+			if (ret)
+				return ret;
+		}
+	}
 
-	/* Trigger UNIPHY ref output clock to recalc rate */
-	clk_hw_recalc_rate(&uniphy->ref_clk.hw);
-	/* Trigger assigned-clock-rates in DT to be applied */
-	of_clk_set_defaults(uniphy->dev->of_node, true);
-	if (!qca_uniphy_refclk_is_enabled(&uniphy->ref_clk.hw))
-		qca_uniphy_refclk_enable(&uniphy->ref_clk.hw);
+	/* Cache the mode last: a bail-out anywhere above leaves the instance
+	 * half configured, and a mode recorded for it would keep the next
+	 * call from finishing the job.
+	 */
+	uniphy->interface = interface;
 
 	return 0;
+
+err_clks:
+	/* Once another channel configures the same mode the sequence is
+	 * skipped, so nothing else re-enables these.
+	 */
+	if (clk_bulk_enable(QCA_UNIPHY_PORT_CLKS,
+			    &uniphy->clks[port_rx_clk_idx(upcs)]))
+		dev_err(uniphy->dev,
+			"Failed to re-enable clocks for channel %d\n",
+			upcs->channel);
+	else
+		upcs->clks_enabled = true;
+
+	return ret;
 }
 
 static int qca_uniphy_pcs_config_usxgmii(struct phylink_pcs *pcs,
@@ -821,8 +876,9 @@ static int qca_uniphy_pcs_validate(struct phylink_pcs *pcs, unsigned long *suppo
 
 /*
  * phylink ignores what pcs_enable() returns and calls pcs_disable() either way,
- * so the reference it holds is tracked on its own: dropping one that was never
- * acquired underflows the clock enable count.
+ * so the reference it holds is tracked separately from the one the mode
+ * sequence takes: dropping a reference that was never acquired underflows the
+ * clock enable count.
  */
 static void qca_uniphy_pcs_disable(struct phylink_pcs *pcs)
 {
@@ -958,6 +1014,10 @@ static int qca_uniphy_probe(struct platform_device *pdev)
 
 	uniphy->dev = dev;
 
+	ret = devm_mutex_init(dev, &uniphy->lock);
+	if (ret)
+		return ret;
+
 	uniphy->data = device_get_match_data(dev);
 	if (!uniphy->data)
 		return -EINVAL;
@@ -1001,6 +1061,8 @@ static int qca_uniphy_probe(struct platform_device *pdev)
 		uniphy->port_pcs[i].pcs.poll = true;
 		uniphy->port_pcs[i].uniphy = uniphy;
 		uniphy->port_pcs[i].channel = i;
+		/* devm_clk_bulk_get_all_enabled() left every clock on */
+		uniphy->port_pcs[i].clks_enabled = true;
 	}
 
 	platform_set_drvdata(pdev, uniphy);

--- a/target/linux/qualcommax/files/drivers/net/pcs/pcs-qca-uniphy.c
+++ b/target/linux/qualcommax/files/drivers/net/pcs/pcs-qca-uniphy.c
@@ -817,15 +817,22 @@ static int qca_uniphy_pcs_validate(struct phylink_pcs *pcs, unsigned long *suppo
 	}
 }
 
+/*
+ * phylink ignores what pcs_enable() returns and calls pcs_disable() either way,
+ * so the reference it holds is tracked on its own: dropping one that was never
+ * acquired underflows the clock enable count.
+ */
 static void qca_uniphy_pcs_disable(struct phylink_pcs *pcs)
 {
 	struct qca_uniphy_pcs *upcs = to_qca_uniphy_pcs(pcs);
 	struct qca_uniphy *uniphy = upcs->uniphy;
 
-	if (uniphy->data->uniphy_type == UNIPHY_IPQ5018) {
-		clk_disable(uniphy->clks[port_rx_clk_idx(upcs)].clk);
-		clk_disable(uniphy->clks[port_tx_clk_idx(upcs)].clk);
-	}
+	if (!upcs->phylink_clks_enabled)
+		return;
+
+	clk_bulk_disable(QCA_UNIPHY_PORT_CLKS,
+			 &uniphy->clks[port_rx_clk_idx(upcs)]);
+	upcs->phylink_clks_enabled = false;
 }
 
 static int qca_uniphy_pcs_enable(struct phylink_pcs *pcs)
@@ -834,20 +841,18 @@ static int qca_uniphy_pcs_enable(struct phylink_pcs *pcs)
 	struct qca_uniphy *uniphy = upcs->uniphy;
 	int ret;
 
-	if (uniphy->data->uniphy_type == UNIPHY_IPQ5018) {
-		ret = clk_enable(uniphy->clks[port_rx_clk_idx(upcs)].clk);
-		if (ret) {
-			dev_err(uniphy->dev, "Failed to enable RX clock for channel %d\n",
-				upcs->channel);
-			return ret;
-		}
-		ret = clk_enable(uniphy->clks[port_tx_clk_idx(upcs)].clk);
-		if (ret) {
-			dev_err(uniphy->dev, "Failed to enable TX clock for channel %d\n",
-				upcs->channel);
-			return ret;
-		}
+	if (uniphy->data->uniphy_type != UNIPHY_IPQ5018)
+		return 0;
+
+	ret = clk_bulk_enable(QCA_UNIPHY_PORT_CLKS,
+			      &uniphy->clks[port_rx_clk_idx(upcs)]);
+	if (ret) {
+		dev_err(uniphy->dev, "Failed to enable clocks for channel %d\n",
+			upcs->channel);
+		return ret;
 	}
+
+	upcs->phylink_clks_enabled = true;
 
 	return 0;
 }

--- a/target/linux/qualcommax/files/include/linux/pcs/pcs-qca-uniphy.h
+++ b/target/linux/qualcommax/files/include/linux/pcs/pcs-qca-uniphy.h
@@ -5,6 +5,7 @@
 #include <linux/bitfield.h>
 #include <linux/clk.h>
 #include <linux/clk-provider.h>
+#include <linux/mutex.h>
 #include <linux/phylink.h>
 #include <linux/reset.h>
 
@@ -118,6 +119,8 @@ struct qca_uniphy_pcs {
 	struct phylink_pcs pcs;
 	struct qca_uniphy *uniphy;
 	int channel;
+	/* Clock pair the mode sequence left enabled on this channel */
+	bool clks_enabled;
 	/* Clock pair phylink's .pcs_enable left enabled on this channel */
 	bool phylink_clks_enabled;
 };
@@ -143,6 +146,8 @@ struct qca_uniphy {
 	struct qca_uniphy_clk tx_clk;
 	struct qca_uniphy_clk ref_clk;
 	const struct qca_uniphy_match_data *data;
+	/* Serializes the instance-wide configuration against the channels */
+	struct mutex lock;
 	phy_interface_t interface;
 };
 

--- a/target/linux/qualcommax/files/include/linux/pcs/pcs-qca-uniphy.h
+++ b/target/linux/qualcommax/files/include/linux/pcs/pcs-qca-uniphy.h
@@ -118,6 +118,8 @@ struct qca_uniphy_pcs {
 	struct phylink_pcs pcs;
 	struct qca_uniphy *uniphy;
 	int channel;
+	/* Clock pair phylink's .pcs_enable left enabled on this channel */
+	bool phylink_clks_enabled;
 };
 
 struct qca_uniphy_match_data {
@@ -146,5 +148,7 @@ struct qca_uniphy {
 
 #define port_rx_clk_idx(upcs)	((upcs)->channel * 2) + 2
 #define port_tx_clk_idx(upcs)	(((upcs)->channel * 2) + 1) + 2
+/* The pair is adjacent, so the bulk ops can take it from the rx index */
+#define QCA_UNIPHY_PORT_CLKS	2
 
 #endif


### PR DESCRIPTION
Three UNIPHY PCS fixes for the qualcommax target, sent together because they touch the same file and the same code path.

* **take a channel's clock pair as a bulk** — `pcs_enable()` leaves the RX clock enabled when the TX clock fails, and nothing rebalances the pair afterwards; `clk_bulk_enable()` unwinds what it enabled.
* **set MAC mode for PSGMII and QSGMII** — the channel mode field was left at its 1000BASE-X value.
* **configure the UNIPHY instance once per mode** — the instance is shared between the ports on it, so reconfiguring it on every link event disturbs the other ports that share it. Skipping a same-mode reconfiguration leaves a genuine mode change still doing the work. The cached mode is cleared before the sequence starts and written back only after its last step, so a bail-out anywhere in between leaves nothing cached that the hardware does not have; the channel's clock pair is restored on the way out, and a per-channel flag keeps a failed re-enable from making the next call disable an already-disabled clock. A per-instance mutex serialises the channels, which otherwise each arrive under their own phylink state lock.

Runtime tested on a Xiaomi AX3600 (IPQ8074, QCA8075 PSGMII, kernel 6.18): three boots, all four ports up with RX and TX counters moving, no clock warnings in `dmesg`, and one port swept 1000 → 100 → 10 Mbps with traffic at each step and the other channels of the instance untouched. Not reachable on that board and not exercised: the calibration bail-out, the XPCS reset paths, and the IPQ5018-only `pcs_enable()` / `pcs_disable()` sites.

Supersedes #24187, which is folded in here.
