### PR TITLE
qualcommax: pcs: qca-uniphy: configure the UNIPHY instance once per mode

### DIFF
--- a/target/linux/qualcommax/files/drivers/net/pcs/pcs-qca-uniphy.c
+++ b/target/linux/qualcommax/files/drivers/net/pcs/pcs-qca-uniphy.c
@@ -504,6 +504,19 @@ static int qca_uniphy_pcs_config_mode(struct phylink_pcs *pcs,
 			clk_prepare_enable(uniphy->ref_clk.hw.clk);
 	}
 
+	/* TODO: Fix for IPQ6018 and IPQ8074 */
+	if (uniphy->data->uniphy_type == UNIPHY_IPQ5018) {
+		//set force mode for fixed link
+		if (neg_mode == PHYLINK_PCS_NEG_OUTBAND && !phylink_expects_phy(pcs->phylink)) {
+			regmap_set_bits(uniphy->regmap,
+					UNIPHY_CH_CTRL(upcs->channel),
+					UNIPHY_CH_FORCE_MODE);
+		}
+	}
+
+	if (uniphy->interface == interface)
+		return 0;
+
 	/* First update misc2 PHY mode... */
 	regmap_update_bits(uniphy->regmap, UNIPHY_MISC2_PHY_MODE,
 			   UNIPHY_MISC2_PHY_MODE_MASK, misc2_phy_mode);
@@ -523,16 +536,6 @@ static int qca_uniphy_pcs_config_mode(struct phylink_pcs *pcs,
 	/* ...and disable PHY clock */
 	clk_disable(uniphy->clks[port_rx_clk_idx(upcs)].clk);
 	clk_disable(uniphy->clks[port_tx_clk_idx(upcs)].clk);
-
-	/* TODO: Fix for IPQ6018 and IPQ8074 */
-	if (uniphy->data->uniphy_type == UNIPHY_IPQ5018) {
-		//set force mode for fixed link
-		if (neg_mode == PHYLINK_PCS_NEG_OUTBAND && !phylink_expects_phy(pcs->phylink)) {
-			regmap_set_bits(uniphy->regmap,
-					UNIPHY_CH_CTRL(upcs->channel),
-					UNIPHY_CH_FORCE_MODE);
-		}
-	}
 
 	/* Third update the mode ctrl... */
 	regmap_update_bits(uniphy->regmap, UNIPHY_MODE_CTRL,
@@ -562,6 +565,8 @@ static int qca_uniphy_pcs_config_mode(struct phylink_pcs *pcs,
 		dev_err(uniphy->dev, "PCS calibration timeout\n");
 		return -EINVAL;
 	}
+
+	uniphy->interface = interface;
 
 	/* Trigger UNIPHY ref clock to recal rate */
 	clk_hw_recalc_rate(&uniphy->rx_clk.hw);


### PR DESCRIPTION
On an IPQ8074 board with several QCA8075 PSGMII ports (an AX3600 here: WAN plus three LAN on uniphy0), roughly one cold boot in three brings a random port up link-up at 1 Gbps with working TX but a dead RX path — the GMAC receives ~2 frames since boot, zero rx errors, ARP stays INCOMPLETE. An autoneg restart or a cable replug does not recover it; an admin `ip link set <port> down && up`, or a reboot, does.

This is a real, reproducible bug on a stock qualcommax image — no NSS/offload involved, it reproduces with qca-nss-drv never loaded. It is intermittent because it is a boot-time race: `qca_uniphy_pcs_config_mode()` runs the instance-wide UNIPHY init (PLL reset, MODE_CTRL, soft reset, calibration) on every phylink `pcs_config`, i.e. once per port — up to 5× in ~2 s at boot. Each re-run tears down the channels that already synced, and whether every SerDes lane re-locks against the freshly re-calibrated UNIPHY is timing luck.

The vendor SSDK configures the instance once (`__adpt_hppe_uniphy_psgmii_mode_set`). This records the configured mode in `struct qca_uniphy` (the member already existed, unused) and skips the instance-wide sequence when `pcs_config` repeats for the same mode; a real mode change still runs it. It also drops ~1.5 s of reset sleeps per boot.

Validated on a Xiaomi AX3600: the RX-dead port reproduced within 3 boots before the change; after it, the instance configures once per boot and RX comes up on all ports every boot.

---

### Reproduction

Stock qualcommax image, **no NSS**. Cable the PSGMII ports and cold-boot repeatedly. After each boot, on the router:

```
for p in lan1 lan2 lan3 wan; do
    echo "$p rx_packets=$(cat /sys/class/net/$p/statistics/rx_packets)"
done
ip neigh                          # a cabled peer stuck INCOMPLETE?
dmesg | grep 'configuring for'    # spacing of the per-port PCS lines
```

- **Before:** roughly one boot in three, one port is link-up at 1G with `tx_packets` climbing but `rx_packets` stuck at ~2 and its peer `INCOMPLETE` — recoverable only by `ip link set <port> down && up` or a reboot. The per-port `configuring for ...` lines land ~500 ms apart (the instance-wide sequence runs once per port).
- **After:** every boot, all ports climb `rx_packets`; the `configuring for ...` lines cluster ~180 ms apart (the instance is configured once).

Implemented with AI assistance.
