### PR TITLE
qualcommax: qca_ppe: fix per-port egress wedges

### DIFF
--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -138,6 +138,7 @@
 #define   PPE_XGMAC_CRC_STRIP_TYPE	BIT(2) /* Called CST */
 #define   PPE_XGMAC_GMII_MPLS_LAYER_CK	BIT(6) /* Called GMPSLCE */
 #define   PPE_XGMAC_WATCHDOG_DISABLE	BIT(7) /* Called WD */
+#define   PPE_XGMAC_LOOPBACK		BIT(10) /* Called LM */
 
 #define PPE_XGMAC_PACKET_FILTER(xgmac)	(PPE_MAC_XGMAC_CSR_BASE + (xgmac) * 0x4000 + 0x8)
 #define   PPE_XGMAC_PROMISCUOUS		BIT(0) /* Called PR */

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -981,6 +981,27 @@ static void qca_ppe_mac_config(struct phylink_config *config,
 	}
 }
 
+/* Release what is still in an XGMAC port's egress path by looping the
+ * transmitter back into it, as qca-ssdk does on link-down ("release ppe port
+ * egress packets when link down"). RX goes down in the same write: only the
+ * transmitter has to drain, and the loop would otherwise learn the hosts
+ * behind the other ports onto this one.
+ */
+static void ppe_port_xgmac_loopback_pulse(struct qca_ppe_priv *priv, int port)
+{
+	int xgmac = port - 5;
+
+	if (port < 5 || port >= priv->data->num_ports)
+		return;
+
+	regmap_update_bits(priv->regmap, PPE_XGMAC_RX_CONF(xgmac),
+			   PPE_XGMAC_LOOPBACK | PPE_XGMAC_RX_ENABLE,
+			   PPE_XGMAC_LOOPBACK);
+	usleep_range(1000, 2000);
+	regmap_clear_bits(priv->regmap, PPE_XGMAC_RX_CONF(xgmac),
+			  PPE_XGMAC_LOOPBACK);
+}
+
 static void qca_ppe_mac_link_down(struct phylink_config *config,
 				  unsigned int mode,
 				  phy_interface_t interface)
@@ -1003,6 +1024,12 @@ static void qca_ppe_mac_link_down(struct phylink_config *config,
 	 */
 	ppe_port_bridge_txmac_set(priv, port, false);
 
+	/* Let the egress path drain before the MAC goes: packets stranded
+	 * there when the link drops wedge the queue manager for good. Same
+	 * 10ms as qca-ssdk.
+	 */
+	msleep(10);
+
 	switch (interface) {
 	case PHY_INTERFACE_MODE_SGMII:
 	case PHY_INTERFACE_MODE_QSGMII:
@@ -1011,13 +1038,16 @@ static void qca_ppe_mac_link_down(struct phylink_config *config,
 		ppe_port_gmac_set(priv, port, false, false);
 		break;
 	case PHY_INTERFACE_MODE_2500BASEX:
-		if (!phylink_autoneg_inband(mode))
+		if (!phylink_autoneg_inband(mode)) {
 			ppe_port_gmac_set(priv, port, false, false);
-		else
+		} else {
+			ppe_port_xgmac_loopback_pulse(priv, port);
 			ppe_port_xgmac_set(priv, port, false, false);
+		}
 		break;
 	case PHY_INTERFACE_MODE_10GBASER:
 	case PHY_INTERFACE_MODE_USXGMII:
+		ppe_port_xgmac_loopback_pulse(priv, port);
 		ppe_port_xgmac_set(priv, port, false, false);
 		break;
 	default:

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -12,6 +12,7 @@
 #include <linux/platform_device.h>
 #include <linux/reset.h>
 #include <linux/if_bridge.h>
+#include <linux/version.h>
 
 #include "qca_ppe.h"
 
@@ -1151,11 +1152,33 @@ static void qca_ppe_mac_link_up(struct phylink_config *config,
 	ppe_port_bridge_txmac_set(priv, port, true);
 }
 
+/* qca_ppe implements no LPI. The stubs exist only to make
+ * phylink_mac_implements_lpi() true with lpi_capabilities left at 0 -
+ * phylink's "EEE always disabled" case, where phylink_bringup_phy() calls
+ * phy_disable_eee(). Without that the PHYs negotiate 802.3az and egress into
+ * a MAC waking from LPI wedges the port. Never called; the ops are 6.14+.
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
+static int qca_ppe_mac_enable_tx_lpi(struct phylink_config *config, u32 timer,
+				     bool tx_clk_stop)
+{
+	return 0;
+}
+
+static void qca_ppe_mac_disable_tx_lpi(struct phylink_config *config)
+{
+}
+#endif
+
 static const struct phylink_mac_ops qca_ppe_phylink_mac_ops = {
 	.mac_prepare	= qca_ppe_mac_prepare,
 	.mac_config	= qca_ppe_mac_config,
 	.mac_link_down	= qca_ppe_mac_link_down,
 	.mac_link_up	= qca_ppe_mac_link_up,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
+	.mac_enable_tx_lpi	= qca_ppe_mac_enable_tx_lpi,
+	.mac_disable_tx_lpi	= qca_ppe_mac_disable_tx_lpi,
+#endif
 };
 
 struct qca_ppe_mib_desc {

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -512,7 +512,13 @@ static int qca_ppe_port_enable(struct dsa_switch *ds, int port,
 {
 	struct qca_ppe_priv *priv = ds_to_priv(ds);
 
-	ppe_port_bridge_txmac_set(priv, port, true);
+	/* A user port's gate is opened by qca_ppe_mac_link_up() once its MAC
+	 * is up. DSA calls this before phylink_start(), so opening it here
+	 * would aim the fabric at a MAC that is still down and about to be
+	 * re-clocked. The CPU port has no MAC of ours to wait for.
+	 */
+	if (dsa_is_cpu_port(ds, port))
+		ppe_port_bridge_txmac_set(priv, port, true);
 
 	return 0;
 }
@@ -982,6 +988,20 @@ static void qca_ppe_mac_link_down(struct phylink_config *config,
 	struct qca_ppe_priv *priv = ds_to_priv(dp->ds);
 	int port = dp->index;
 
+	/* The CPU port is INTERNAL: it falls through the switch below
+	 * without its MAC being touched, and qca_ppe_mac_link_up() would not
+	 * re-open its gate. Leave it alone.
+	 */
+	if (dsa_is_cpu_port(dp->ds, port))
+		return;
+
+	/* Gate the fabric before the MAC is torn down; qca_ppe_mac_link_up()
+	 * turns it back on once the MAC is up. Left on across a flap, the
+	 * fabric dequeues into a MAC that is still being re-clocked and
+	 * latches the port's egress scheduler in a state only a reboot clears.
+	 */
+	ppe_port_bridge_txmac_set(priv, port, false);
+
 	switch (interface) {
 	case PHY_INTERFACE_MODE_SGMII:
 	case PHY_INTERFACE_MODE_QSGMII:
@@ -1124,6 +1144,11 @@ static void qca_ppe_mac_link_up(struct phylink_config *config,
 	default:
 		return;
 	}
+
+	/* MAC is up, so the fabric may feed the port again. The early returns
+	 * above bring no MAC up, so they leave the gate closed on purpose.
+	 */
+	ppe_port_bridge_txmac_set(priv, port, true);
 }
 
 static const struct phylink_mac_ops qca_ppe_phylink_mac_ops = {

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
@@ -691,16 +691,24 @@ static void ppe_l0_scheduler_init(struct qca_ppe_priv *priv)
 		u8 counts[] = { p->ucast_count, p->mcast_count };
 		int k;
 
+		/* Multicast queues take the port's top unicast slots, not
+		 * 0..mcast_count-1: sharing a slot puts two queues on one DRR
+		 * node, whose credit rotation can latch and freeze both until
+		 * the node is rebuilt. The top slots idle unless skb->priority
+		 * selects them, at the cost of sitting on the port's second SP,
+		 * which puts flooding above best-effort unicast.
+		 */
 		for (k = 0; k < 2; k++) {
 			for (j = 0; j < counts[k]; j++) {
+				int slot = k ? p->ucast_count - counts[k] + j : j;
 				struct l0_cfg c = {
 					.queue = bases[k] + j,
 					.port = p->port,
-					.sp = p->sp_base + j / PPE_MAX_SP_PRI,
-					.cpri = j % PPE_MAX_SP_PRI,
-					.cdrr = p->cdrr_base + j,
-					.epri = j % PPE_MAX_SP_PRI,
-					.edrr = p->cdrr_base + j,
+					.sp = p->sp_base + slot / PPE_MAX_SP_PRI,
+					.cpri = slot % PPE_MAX_SP_PRI,
+					.cdrr = p->cdrr_base + slot,
+					.epri = slot % PPE_MAX_SP_PRI,
+					.edrr = p->cdrr_base + slot,
 				};
 
 				ppe_l0_entry_write(priv, &c);


### PR DESCRIPTION
Four fixes for the same failure: a port stops transmitting with its carrier up, and nothing short of a reboot brings it back. They are sent together because they are one fault family in the PPE's egress path, they touch the same file, and the last one depends on the first.

* **gate switch-fabric TX-MAC across carrier flaps** — the fabric otherwise dequeues into a MAC that is still being re-clocked.
* **disable EEE** — an idle port enters low-power idle and egress handed to the waking MAC latches the same way.
* **give multicast queues idle DRR scheduler slots** — sharing a slot puts two queues on one DRR node, and when both cross empty->non-empty together the node's credit rotation latches.
* **drain a port's egress path when its link goes down** — packets left in the egress path when the link drops wedge the queue manager. This one needs the first commit's gate in place, which is why it is stacked here rather than sent separately.

The last commit follows Qualcomm's own driver, whose in-code comment states the mechanism directly: `/* release ppe port egress packets when link down */` (qca-ssdk `30c10e7f`, "enable and disable loopback for xgmac to fix qm stuck issue"). ssdk gates the fabric, waits 10ms, then touches the MAC, and on an XGMAC port pulses MAC loopback. Its loopback is gated on `PORT_XGMAC_TYPE`, which on IPQ8074 is ports 5 and 6 only, so the 10ms wait is what covers ports 1-4.

### Scope, honestly

This is not reproducible on a plain host datapath and I do not expect it to be: the fault needs a link to drop while that port's egress queue is deep, and on the host path the CPU rather than the port is the bottleneck, so the queue stays shallow and there is nothing to strand. The evidence comes from an IPQ8074 offloading in hardware, where forwarding happens inside the fabric at line rate and the queue does back up — a port found dead with one egress queue holding 252 packets whose count never moved, MAC MIB frozen at exactly zero, and the firmware's per-port discard counter climbing one-for-one with what was offered.

Reproducing it needs that depth: with the peer forced to 100M and over-rate UDP into it, the egress queue reaches ~268 packets. With the series applied the link was dropped 55 times with 82-268 packets queued, and the port's queue measured empty while the link was down every time.

Supersedes #24189 and #24252, which are folded in here.
