### PR TITLE
qualcommax: qca_ppe: disable EEE to prevent idle-port egress wedge

### DIFF
--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -1126,11 +1126,36 @@ static void qca_ppe_mac_link_up(struct phylink_config *config,
 	}
 }
 
+/*
+ * qca_ppe implements no LPI. These stubs exist only so that
+ * phylink_mac_implements_lpi() is true while config->lpi_capabilities stays 0
+ * - phylink's "MAC has the EEE ops but wants EEE always disabled" case, where
+ * phylink_bringup_phy() calls phy_disable_eee() before autonegotiation.
+ * Without them the PHYs advertise 802.3az, an idle port enters low-power idle,
+ * and egress handed to the waking MAC latches the port's queue-manager egress
+ * scheduler in a state that never drains: the port black-holes its egress
+ * until the box is rebooted (an idle LAN port stops reaching its peer, a WAN
+ * port loses PPPoE PADI across a redial). The vendor ssdk driver clears EEE on
+ * every port at init for the same reason. The stubs themselves are never
+ * called.
+ */
+static int qca_ppe_mac_enable_tx_lpi(struct phylink_config *config, u32 timer,
+				     bool tx_clk_stop)
+{
+	return 0;
+}
+
+static void qca_ppe_mac_disable_tx_lpi(struct phylink_config *config)
+{
+}
+
 static const struct phylink_mac_ops qca_ppe_phylink_mac_ops = {
 	.mac_prepare	= qca_ppe_mac_prepare,
 	.mac_config	= qca_ppe_mac_config,
 	.mac_link_down	= qca_ppe_mac_link_down,
 	.mac_link_up	= qca_ppe_mac_link_up,
+	.mac_enable_tx_lpi	= qca_ppe_mac_enable_tx_lpi,
+	.mac_disable_tx_lpi	= qca_ppe_mac_disable_tx_lpi,
 };
 
 struct qca_ppe_mib_desc {


### PR DESCRIPTION
The `qca_ppe` rewrite dropped the ssdk behaviour of disabling 802.3az EEE at init, so the QCA807x PHYs — which advertise EEE by default — negotiate it. When a port idles the PHY enters low-power idle; egress injected into the MAC as it wakes from LPI latches the port's queue-manager egress scheduler into a non-draining state, and the port's egress is black-holed until reboot. On a LAN port the peer becomes unreachable after the port idles; on WAN the PPPoE PADI can't egress during a redial window, so pppd loops on `Timeout waiting for PADO packets`.

On reproducibility, to be clear about it: I reproduced this on a Xiaomi AX3600 with an out-of-tree NSS data plane driving the port (the firmware is what injects into the waking MAC in that setup) — repeated WAN ifdown/ifup across a PPPoE redial wedges the WAN port on the unfixed image and survives after. I have **not** separately confirmed a wedge on a plain host-forwarding datapath, so treat the reproducer as NSS-driven. The underlying cause is plainer than the reproducer: EEE is left enabled where ssdk disables it (`qca_hppe_interface_mode_init` clears `port_eee_cfg.enable`/`lpi_tx_enable`), and any `qca_ppe` user whose link partner negotiates EEE carries that divergence.

`qca_ppe` doesn't use phylink-managed LPI (it sets no `lpi_capabilities`), so this provides empty `mac_enable_tx_lpi`/`mac_disable_tx_lpi` ops; phylink then takes its "MAC implements LPI but EEE disabled" path in `phylink_bringup_phy()` and calls `phy_disable_eee()` before autoneg, clearing the advertisement on every port device-agnostically. The ops are never invoked.

Note the phylink LPI/EEE-management API (`mac_enable_tx_lpi`/`mac_disable_tx_lpi` + `phy_disable_eee()` in `phylink_bringup_phy()`) landed in 6.14, and qualcommax still builds against 6.12, so this depends on the 6.18 uplift (#24031) and should land after it.

---

### Reproduction

Per the note above the reproducer is **NSS-driven** (NSS data plane armed). Offsets are IPQ807x/AX3600.

Confirm EEE is negotiated before the fix:

```
ethtool --show-eee wan     # before: "EEE status: enabled - active"; after: disabled
```

Hammer the WAN across PPPoE redials (the user-reported trigger):

```
for i in $(seq 1 10); do ifdown wan; sleep 3; ifup wan; done
```

Oracle — the WAN port's queue-manager egress occupancy, plus pppd:

```
devmem 0x3a84ea00 32       # wan AC_UNI queue (q160): low 12 bits, pinned (>20) = wedged, 0 = healthy
logread | grep -i PADO     # unfixed: pppd loops "Timeout waiting for PADO packets"
```

- **Before:** EEE is `enabled - active`; after the hammering the WAN queue occupancy pins, pppd loops on the PADO timeout, and only a reboot recovers.
- **After:** EEE is disabled / `not-active` on every port (advertisement `0x0000`), the WAN queue stays 0 across 10× redials, and the WAN reconnects.

Implemented with AI assistance.
