### PR TITLE
qualcommax: ipq8072: assign NVMEM MAC addresses for Linksys MX5300

### DIFF
--- a/target/linux/qualcommax/dts/ipq8072-mx5300.dts
+++ b/target/linux/qualcommax/dts/ipq8072-mx5300.dts
@@ -19,7 +19,7 @@
 		led-running = &led_system_blue;
 		led-failsafe = &led_system_red;
 		led-upgrade = &led_system_green;
-		label-mac-device = &swport2;
+		label-mac-device = &swport5;
 	};
 
 	chosen {
@@ -466,7 +466,7 @@
 			phy-handle = <&qca8075_0>;
 			phy-mode = "psgmii";
 			pcs-handle = <&uniphy0 0>;
-			nvmem-cells = <&hw_mac_addr 0>;
+			nvmem-cells = <&hw_mac_addr 1>;
 			nvmem-cell-names = "mac-address";
 		};
 
@@ -476,7 +476,7 @@
 			phy-handle = <&qca8075_1>;
 			phy-mode = "psgmii";
 			pcs-handle = <&uniphy0 1>;
-			nvmem-cells = <&hw_mac_addr 0>;
+			nvmem-cells = <&hw_mac_addr 1>;
 			nvmem-cell-names = "mac-address";
 		};
 
@@ -486,7 +486,7 @@
 			phy-handle = <&qca8075_2>;
 			phy-mode = "psgmii";
 			pcs-handle = <&uniphy0 2>;
-			nvmem-cells = <&hw_mac_addr 0>;
+			nvmem-cells = <&hw_mac_addr 1>;
 			nvmem-cell-names = "mac-address";
 		};
 
@@ -496,7 +496,7 @@
 			phy-handle = <&qca8075_3>;
 			phy-mode = "psgmii";
 			pcs-handle = <&uniphy0 3>;
-			nvmem-cells = <&hw_mac_addr 0>;
+			nvmem-cells = <&hw_mac_addr 1>;
 			nvmem-cell-names = "mac-address";
 		};
 
@@ -545,8 +545,8 @@
 			reg = <0x00010000 0 0 0 0>;
 
 			qcom,ath10k-calibration-variant = "Linksys-MX5300";
-			nvmem-cell-names = "pre-calibration";
-			nvmem-cells = <&caldata_qca9984>;
+			nvmem-cell-names = "pre-calibration", "mac-address";
+			nvmem-cells = <&caldata_qca9984>, <&hw_mac_addr 2>;
 		};
 	};
 };
@@ -555,4 +555,6 @@
 	status = "okay";
 
 	qcom,ath11k-calibration-variant = "Linksys-MX5300";
+	nvmem-cells = <&hw_mac_addr 3>;
+	nvmem-cell-names = "mac-address";
 };


### PR DESCRIPTION
While the base NVMEM cell (hw_mac_addr) is already defined in the device tree, it was not being utilized by the actual interfaces.

This PR completes the kernel-level MAC assignment by:
1. Correcting the `label-mac-device` alias to point to the WAN port (`&swport5`), ensuring the system reports the sticker MAC address correctly.
2. Assigning the base MAC address (offset 0) to the WAN port (`&swport5`).
3. Assigning the base MAC address (offset 1) to the LAN ports (`&swport1` - `&swport4`).
4. Configuring the proper NVMEM cell references for the PCIe-attached QCA9984 radio (offset 2) and the built-in ATH11K radio (offset 3).

This eliminates the need for post-boot MAC address manipulation and ensures robust, predictable interface initialization.
