### PR TITLE
package: rtl826x-firmware: make package versions consistent

### DIFF
--- a/package/firmware/rtl826x-firmware/Makefile
+++ b/package/firmware/rtl826x-firmware/Makefile
@@ -33,13 +33,11 @@ endef
 define Package/rtl826x-firmware
   $(call Package/rtl826x-firmware/Default)
   TITLE:=Realtek RTL8251L/RTL8261BE/RTL8261N/RTL8254B/RTL8264/RTL8264B firmware
-  VERSION:=20221115
 endef
 
 define Package/rtl826x-lp-firmware
   $(call Package/rtl826x-firmware/Default)
   TITLE:=Realtek RTL8251L/RTL8261BE/RTL8261N/RTL8254B/RTL8264/RTL8264B low-power firmware
-  VERSION:=20240729
   PROVIDES:=rtl826x-firmware
   CONFLICTS:=rtl826x-firmware
 endef


### PR DESCRIPTION
The two packages rtl826x-firmware and rtl826x-lp-firmware are built from the same source, yet have 'VERSION=xxx' overrides that modify the package name and metadata.  This causes issues with apk, as it always selects the package with the higher version number (the '-lp-' one), irrespective of which package is desired.

Remove the VERSION overrides and use the actual package version so that apk can install the correct package.  The binary contents of the packages remain unaffect, this only changes the package file name and metadata related to versioning.

Before
`  rtl826x-firmware-20221115.apk`
`  rtl826x-lp-firmware-20240729.apk`

After
`  rtl826x-firmware-2026.01.24~0cd4abe2-r4.apk`
`  rtl826x-lp-firmware-2026.01.24~0cd4abe2-r4.apk`

Fixes: https://github.com/openwrt/openwrt/issues/24145
