### PR TITLE
qca-edma: fix descriptor overrun during heavy parallel load

### DIFF
--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
@@ -344,12 +344,15 @@ static u32 edma_clean_rx(struct edma_priv *priv, int budget,
 	cons = val & EDMA_RXDESC_CONS_IDX_MASK;
 
 	while (cons != prod && done < budget) {
-		rxdesc = EDMA_RXDESC_DESC(rxdesc_ring, cons);
+		u32 desc_addr, desc_status;
 
-		rxph = phys_to_virt(rxdesc->buffer_addr);
+		rxdesc = EDMA_RXDESC_DESC(rxdesc_ring, cons);
+		desc_addr = le32_to_cpu(rxdesc->buffer_addr);
+		desc_status = le32_to_cpu(rxdesc->status);
+		rxph = phys_to_virt(desc_addr);
 		page = virt_to_head_page(rxph);
 
-		pkt_len = rxdesc->status & EDMA_RXDESC_PACKET_LEN_MASK;
+		pkt_len = desc_status & EDMA_RXDESC_PACKET_LEN_MASK;
 
 		page_pool_dma_sync_for_cpu(priv->page_pool, page, 0,
 					   EDMA_RX_PREHDR_SIZE + pkt_len);
@@ -628,8 +631,11 @@ static void edma_rxdesc_drain(struct edma_priv *priv, struct edma_ring *rxdesc_r
 	prod = val & EDMA_RXDESC_PROD_IDX_MASK;
 
 	while (cons != prod) {
+		u32 desc_addr;
+
 		rxdesc = EDMA_RXDESC_DESC(rxdesc_ring, cons);
-		page = virt_to_head_page(phys_to_virt(rxdesc->buffer_addr));
+		desc_addr = le32_to_cpu(rxdesc->buffer_addr);
+		page = virt_to_head_page(phys_to_virt(desc_addr));
 		page_pool_put_full_page(priv->page_pool, page, false);
 
 		if (++cons == rxdesc_ring->count)

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
@@ -359,11 +359,11 @@ static u32 edma_clean_rx(struct edma_priv *priv, int budget,
 
 		if (EDMA_RXPH_SRC_INFO_TYPE_GET(rxph) !=
 		    EDMA_PREHDR_DSTINFO_PORTID_IND) {
-			dev_warn(
-				&pdev->dev,
-				"rx drop: src_info_type=0x%x src_info=0x%04x dst_info=0x%04x\n",
-				EDMA_RXPH_SRC_INFO_TYPE_GET(rxph),
-				rxph->src_info, rxph->dst_info);
+			dev_warn_ratelimited(&pdev->dev,
+					     "rx drop: src_info_type=%#x src_info=%#06x dst_info=%#06x\n",
+					     EDMA_RXPH_SRC_INFO_TYPE_GET(rxph),
+					     le16_to_cpu(rxph->src_info),
+					     le16_to_cpu(rxph->dst_info));
 			page_pool_put_full_page(priv->page_pool, page, true);
 			goto next;
 		}

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
@@ -1191,6 +1191,10 @@ static int edma_probe(struct platform_device *pdev)
 		goto err_irq;
 	}
 
+	ret = dev_set_threaded(netdev, true);
+	if (ret)
+		dev_warn(dev, "failed to enable threaded NAPI: %d\n", ret);
+
 	platform_set_drvdata(pdev, priv);
 
 	return 0;

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/init.d/smp_affinity
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/init.d/smp_affinity
@@ -1,0 +1,105 @@
+#!/bin/sh /etc/rc.common
+
+START=94
+
+PROG=smp_affinity
+
+log_msg() {
+	local type="$1" id="$2" name="$3" affinity="$4"
+
+	logger -t "$PROG" "Pinning $type($id) $name to CPU $affinity"
+}
+
+get_irq() {
+	awk -v name="$1" '$NF == name {
+		sub(/:$/, "", $1)
+		print $1
+		exit
+	}' /proc/interrupts
+}
+
+get_napi_threads() {
+	local comm comm_path id pid
+
+	TX_NAPI_ID=
+	TX_PID=
+	RX_NAPI_ID=
+	RX_PID=
+
+	for comm_path in /proc/[0-9]*/comm; do
+		read -r comm < "$comm_path"
+		case "$comm" in
+		napi/eth0-[0-9]*)
+			id="${comm##*-}"
+			pid="${comm_path#/proc/}"
+			pid="${pid%/comm}"
+
+			if [ -z "$TX_NAPI_ID" ] || [ "$id" -lt "$TX_NAPI_ID" ]; then
+				TX_NAPI_ID="$id"
+				TX_PID="$pid"
+			fi
+
+			if [ -z "$RX_NAPI_ID" ] || [ "$id" -gt "$RX_NAPI_ID" ]; then
+				RX_NAPI_ID="$id"
+				RX_PID="$pid"
+			fi
+			;;
+		esac
+	done
+}
+
+pin_irq() {
+	local irq="$1" mask="$2" affinity="$3" name="$4"
+
+	[ -n "$irq" ] || return
+	$enable_log && log_msg IRQ "$irq" "$name" "$affinity"
+	echo "$mask" > "/proc/irq/$irq/smp_affinity"
+}
+
+pin_thread() {
+	local pid="$1" mask="$2" affinity="$3" name="$4"
+
+	[ -n "$pid" ] || return
+	$enable_log && log_msg thread "$pid" "$name" "$affinity"
+	taskset -p "$mask" "$pid" >/dev/null
+}
+
+enable_affinity_edma() {
+	local seconds=0 rx_irq tx_irq
+
+	while [ "$seconds" -lt 60 ]; do
+		rx_irq="$(get_irq edma_rxdesc)"
+		tx_irq="$(get_irq edma_txcmpl)"
+		get_napi_threads
+
+		[ -n "$rx_irq" ] && [ -n "$tx_irq" ] &&
+			[ -n "$RX_PID" ] && [ -n "$TX_PID" ] &&
+			[ "$RX_PID" != "$TX_PID" ] && break
+
+		seconds=$((seconds + 1))
+		sleep 1
+	done
+
+	[ -n "$rx_irq" ] && [ -n "$tx_irq" ] &&
+		[ -n "$RX_PID" ] && [ -n "$TX_PID" ] &&
+		[ "$RX_PID" != "$TX_PID" ] || return
+
+	pin_irq "$rx_irq" 2 1 edma_rxdesc
+	pin_thread "$RX_PID" 2 1 "EDMA RX NAPI"
+	pin_irq "$tx_irq" 4 2 edma_txcmpl
+	pin_thread "$TX_PID" 4 2 "EDMA TX NAPI"
+}
+
+boot() {
+	local enable
+
+	config_load smp_affinity
+
+	config_get_bool enable "general" enable 1
+	config_get_bool enable_log "general" enable_log 1
+
+	[ "$enable" -eq 1 ] && enable=true || enable=false
+	[ "$enable_log" -eq 1 ] && enable_log=true || enable_log=false
+
+	$enable && enable_affinity_edma &
+}

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/uci-defaults/15_smp_affinity
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/uci-defaults/15_smp_affinity
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+uci -q get smp_affinity && exit 0
+touch /etc/config/smp_affinity
+
+uci -q batch << EOF
+  set smp_affinity.general=smp_affinity
+  set smp_affinity.general.enable='1'
+  set smp_affinity.general.enable_log='1'
+  commit smp_affinity
+EOF

--- a/target/linux/qualcommax/ipq807x/base-files/etc/init.d/smp_affinity
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/init.d/smp_affinity
@@ -81,6 +81,68 @@ set_affinity() {
     done
 }
 
+get_napi_threads() {
+
+  local comm comm_path id pid
+
+  TX_NAPI_ID=
+  TX_PID=
+  RX_NAPI_ID=
+  RX_PID=
+
+  for comm_path in /proc/[0-9]*/comm; do
+    read -r comm < "$comm_path"
+    case "$comm" in
+      napi/eth0-[0-9]*)
+        id="${comm##*-}"
+        pid="${comm_path#/proc/}"
+        pid="${pid%/comm}"
+
+        if [ -z "$TX_NAPI_ID" ] || [ "$id" -lt "$TX_NAPI_ID" ]; then
+          TX_NAPI_ID="$id"
+          TX_PID="$pid"
+        fi
+
+        if [ -z "$RX_NAPI_ID" ] || [ "$id" -gt "$RX_NAPI_ID" ]; then
+          RX_NAPI_ID="$id"
+          RX_PID="$pid"
+        fi
+        ;;
+    esac
+  done
+}
+
+set_thread_affinity() {
+
+  local pid="$1" affinity="$2" bitmask
+
+  [ -n "$pid" ] || return
+  bitmask=$(cpus_to_bitmask "$affinity") &&
+    taskset -p "$bitmask" "$pid" >/dev/null
+}
+
+enable_affinity_edma() {
+
+  local seconds=0
+
+  while [ "$seconds" -lt 60 ]; do
+    get_napi_threads
+    [ -n "$RX_PID" ] && [ -n "$TX_PID" ] &&
+      [ "$RX_PID" != "$TX_PID" ] && break
+
+    seconds=$((seconds + 1))
+    sleep 1
+  done
+
+  [ -n "$RX_PID" ] && [ -n "$TX_PID" ] &&
+    [ "$RX_PID" != "$TX_PID" ] || return
+
+  set_affinity 'edma_rxdesc' 1
+  set_thread_affinity "$RX_PID" 1
+  set_affinity 'edma_txcmpl' 2
+  set_thread_affinity "$TX_PID" 2
+}
+
 enable_affinity_ipq807x() {
 
   # assign 4 rx interrupts to each core
@@ -99,11 +161,6 @@ enable_affinity_ipq807x() {
   set_affinity 'ppdu-end-interrupts-mac2'      2
   set_affinity 'ppdu-end-interrupts-mac3'      3
 
-  # assign 4 lan/wan to core 4
-  set_affinity 'edma_txcmpl'                   3
-  set_affinity 'edma_rxfill'                   3
-  set_affinity 'edma_rxdesc'                   3
-  set_affinity 'edma_misc'                     3
 }
 
 boot() {
@@ -118,5 +175,8 @@ boot() {
   [ "$enable"     -eq 1 ] && enable=true     || enable=false
   [ "$enable_log" -eq 1 ] && enable_log=true || enable_log=false
 
-  $enable && enable_affinity_ipq807x
+  $enable && {
+    enable_affinity_ipq807x
+    enable_affinity_edma &
+  }
 }


### PR DESCRIPTION
Currently, doing a simple parallel iperf3 test with 4 streams will cause stale descriptors as the RX ring cannot be drained fast enough.
In that scenario HW throws invalid preheaders and will break networking which only a reboot can recover from.

Using threaded NAPI and pinning the IRQ affinity it allows the CPU to keep up to avoid stalls or overruns as well as improves the performance by 600+Mbps.

Other 2 commits clean up the warning for invalid preheader so its rate limited instead of spamming the console, and endianess conversion which is NOP to keep things tidy.