### PR TITLE
realtek: fix Horaco ZX-SWTGW2C8F sysupgrade operation, 2.5G port LED & add SFP thermal zone/sensors

### DIFF
--- a/target/linux/realtek/dts/rtl9303_horaco_zx-swtgw2c8f.dts
+++ b/target/linux/realtek/dts/rtl9303_horaco_zx-swtgw2c8f.dts
@@ -32,7 +32,7 @@
 		realtek,led-mode = <RTL93XX_LED_MODE_SINGLE_COLOR_SCAN>;
 
 		led_set0 = <RTL93XX_LED_SET_NONE
-		            (RTL93XX_LED_SET_1G | RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+		            (RTL93XX_LED_SET_2P5G | RTL93XX_LED_SET_1G | RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
 		            (RTL93XX_LED_SET_10G | RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)>;
 	};
 
@@ -65,6 +65,7 @@
 		mod-def0-gpio = <&gpio1 1 GPIO_ACTIVE_LOW>;
 		los-gpio = <&gpio1 2 GPIO_ACTIVE_HIGH>;
 		tx-disable-gpio = <&gpio1 0 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
 	};
 
 	sfp1: sfp-p2 {
@@ -73,6 +74,7 @@
 		mod-def0-gpio = <&gpio1 4 GPIO_ACTIVE_LOW>;
 		los-gpio = <&gpio1 5 GPIO_ACTIVE_HIGH>;
 		tx-disable-gpio = <&gpio1 3 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
 	};
 
 	sfp2: sfp-p3 {
@@ -81,6 +83,7 @@
 		mod-def0-gpio = <&gpio1 7 GPIO_ACTIVE_LOW>;
 		los-gpio = <&gpio1 8 GPIO_ACTIVE_HIGH>;
 		tx-disable-gpio = <&gpio1 6 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
 	};
 
 	sfp3: sfp-p4 {
@@ -89,6 +92,7 @@
 		mod-def0-gpio = <&gpio1 10 GPIO_ACTIVE_LOW>;
 		los-gpio = <&gpio1 11 GPIO_ACTIVE_HIGH>;
 		tx-disable-gpio = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
 	};
 
 	sfp4: sfp-p5 {
@@ -97,6 +101,7 @@
 		mod-def0-gpio = <&gpio1 13 GPIO_ACTIVE_LOW>;
 		los-gpio = <&gpio1 14 GPIO_ACTIVE_HIGH>;
 		tx-disable-gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
 	};
 
 	sfp5: sfp-p6 {
@@ -105,6 +110,7 @@
 		mod-def0-gpio = <&gpio1 22 GPIO_ACTIVE_LOW>;
 		los-gpio = <&gpio1 23 GPIO_ACTIVE_HIGH>;
 		tx-disable-gpio = <&gpio1 21 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
 	};
 
 	sfp6: sfp-p7 {
@@ -113,6 +119,7 @@
 		mod-def0-gpio = <&gpio1 25 GPIO_ACTIVE_LOW>;
 		los-gpio = <&gpio1 26 GPIO_ACTIVE_HIGH>;
 		tx-disable-gpio = <&gpio1 24 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
 	};
 
 	sfp7: sfp-p8 {
@@ -121,6 +128,7 @@
 		mod-def0-gpio = <&gpio1 28 GPIO_ACTIVE_LOW>;
 		los-gpio = <&gpio1 29 GPIO_ACTIVE_HIGH>;
 		tx-disable-gpio = <&gpio1 27 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
 	};
 };
 
@@ -231,7 +239,7 @@
 			};
 
 			partition@300000 {
-				label = "runtime";
+				label = "firmware";
 				reg = <0x300000 0xc00000>;
 				compatible = "openwrt,uimage";
 				openwrt,ih-magic = <0x83800000>;
@@ -249,4 +257,19 @@
 &ethernet0 {
 	nvmem-cells = <&macaddr_ubootenv_ethaddr 0>;
 	nvmem-cell-names = "mac-address";
+};
+
+&thermal_zones {
+	sfp-thermal {
+		polling-delay-passive = <10000>;
+		polling-delay = <10000>;
+		thermal-sensors = <&sfp0>, <&sfp1>, <&sfp2>, <&sfp3>, <&sfp4>, <&sfp5>, <&sfp6>, <&sfp7>;
+		trips {
+			sfp-crit {
+				temperature = <110000>;
+				hysteresis = <1000>;
+				type = "critical";
+			};
+		};
+	};
 };

--- a/target/linux/realtek/dts/rtl9303_horaco_zx-swtgw2c8f.dts
+++ b/target/linux/realtek/dts/rtl9303_horaco_zx-swtgw2c8f.dts
@@ -238,10 +238,11 @@
 				read-only;
 			};
 
+			/* stock is 'runtime' */
 			partition@300000 {
 				label = "firmware";
 				reg = <0x300000 0xc00000>;
-				compatible = "openwrt,uimage";
+				compatible = "openwrt,uimage", "denx,uimage";
 				openwrt,ih-magic = <0x83800000>;
 			};
 


### PR DESCRIPTION
1) Corrected name of 'firmware' MTD partition (was 'runtime') to fix sysupgrade
2) Corrected 2.5G port status LED operation
3) Added SFP thermal zone, in line with other RTL9303 devices on OpenWRT

Verified on a clean build of SNAPSHOT r35328-e5c7612b16

Signed-off-by: <dspalu32@gmail.com>