### PR TITLE
qualcommax: ipq50xx: enable in-band-status for MXL GPY115C PHY on Linksys MX6200

### DIFF
--- a/target/linux/qualcommax/dts/ipq5018-mx6200.dts
+++ b/target/linux/qualcommax/dts/ipq5018-mx6200.dts
@@ -49,12 +49,13 @@
 	nvmem-cell-names = "mac-address";
 };
 
-// MAC1 ---SGMII---> QCA8337 SerDes
+// MAC1 ---SGMII---> Maxlinear GPY115C
 &gmac1 {
 	status = "okay";
 
 	phy-handle = <&gpy115c>;
 	phy-mode = "sgmii";
+	managed = "in-band-status";
 
 	label = "wan";
 


### PR DESCRIPTION
The MXL GPY115C PHY requires in-band-status to be set properly detect link status and communicate phy capabilities.
So enable in-band-status in the Linksys MX6200 device tree.
