### PR TITLE
x86, armsr, malta: add metadata to generic targets

### DIFF
--- a/package/base-files/files/lib/upgrade/fwtool.sh
+++ b/package/base-files/files/lib/upgrade/fwtool.sh
@@ -72,7 +72,11 @@ fwtool_check_image() {
 		# so we add the secondary check [ "$dev" = "$oem" ];
 		# If in Step 1 the oem_file was found and valid, the $oem == "b3000" so
 		# [ ("$dev" == "b3000) == ("$oem" == "b3000") ] so firmware is valid oem
-		if [ "$dev" = "$device" ] || [ "$dev" = "$oem" ]; then
+		#
+		# Images built for generic targets (e.g. x86, armsr, malta) may declare the
+		# special device "generic" and run on any board, so treat it as a wildcard
+		# that matches the current device.
+		if [ "$dev" = "$device" ] || [ "$dev" = "$oem" ] || [ "$dev" = "generic" ]; then
 			# major compat version -> no sysupgrade
 			if [ "${devicecompat%.*}" != "${imagecompat%.*}" ]; then
 				v "The device is supported, but this image is incompatible for sysupgrade based on the image version ($devicecompat->$imagecompat)."

--- a/target/linux/armsr/image/Makefile
+++ b/target/linux/armsr/image/Makefile
@@ -90,7 +90,7 @@ define Device/efi-default
   KERNEL_INSTALL := 1
   IMAGES := $$(IMAGES-y)
   ARTIFACTS := $$(ARTIFACTS-y)
-  SUPPORTED_DEVICES :=
+  SUPPORTED_DEVICES := generic
  ifeq ($(CONFIG_arm),y)
   KERNEL_NAME = zImage
  endif

--- a/target/linux/malta/image/Makefile
+++ b/target/linux/malta/image/Makefile
@@ -20,7 +20,7 @@ define Device/Default
   ARTIFACTS := uImage-lzma uImage-gzip
   ARTIFACT/uImage-lzma := kernel-bin | lzma | uImage lzma
   ARTIFACT/uImage-gzip := kernel-bin | gzip | uImage gzip
-  SUPPORTED_DEVICES :=
+  SUPPORTED_DEVICES := generic
 endef
 
 define Device/generic

--- a/target/linux/x86/image/Makefile
+++ b/target/linux/x86/image/Makefile
@@ -172,7 +172,7 @@ define Device/Default
   endif
   IMAGES := $$(IMAGES-y)
   ARTIFACTS := $$(ARTIFACTS-y)
-  SUPPORTED_DEVICES :=
+  SUPPORTED_DEVICES := generic
 endef
 
 include $(SUBTARGET).mk


### PR DESCRIPTION
Add support for adding metadata and signatures to these targets.