### PR TITLE
airoha: backport upstream fix for Airoha reported bug for ethernet

### DIFF
--- a/target/linux/airoha/patches-6.12/155-v7.2-net-airoha-Rename-get_src_port_id-callback-in-get_sp.patch
+++ b/target/linux/airoha/patches-6.12/155-v7.2-net-airoha-Rename-get_src_port_id-callback-in-get_sp.patch
@@ -1,0 +1,75 @@
+From c06a2f2903f6fba0a3088ad05fc5cf61a66e5d89 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Tue, 28 Apr 2026 07:23:38 +0200
+Subject: [PATCH] net: airoha: Rename get_src_port_id callback in get_sport
+
+For code consistency, rename get_src_port_id callback in get_sport.
+Please note this patch does not introduce any logical change and it is
+just a cosmetic patch.
+
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260428-airoha-get_src_port_id-callback-v1-1-3f765c91c1e8@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 10 +++++-----
+ drivers/net/ethernet/airoha/airoha_eth.h |  2 +-
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -1823,7 +1823,7 @@ static int airoha_set_gdm2_loopback(stru
+ 	airoha_fe_clear(eth, REG_FE_VIP_PORT_EN, BIT(AIROHA_GDM2_IDX));
+ 	airoha_fe_clear(eth, REG_FE_IFC_PORT_EN, BIT(AIROHA_GDM2_IDX));
+ 
+-	src_port = eth->soc->ops.get_src_port_id(port, port->nbq);
++	src_port = eth->soc->ops.get_sport(port, port->nbq);
+ 	if (src_port < 0)
+ 		return src_port;
+ 
+@@ -3199,7 +3199,7 @@ static const char * const en7581_xsi_rst
+ 	"xfp-mac",
+ };
+ 
+-static int airoha_en7581_get_src_port_id(struct airoha_gdm_port *port, int nbq)
++static int airoha_en7581_get_sport(struct airoha_gdm_port *port, int nbq)
+ {
+ 	switch (port->id) {
+ 	case AIROHA_GDM3_IDX:
+@@ -3252,7 +3252,7 @@ static const char * const an7583_xsi_rst
+ 	"xfp-mac",
+ };
+ 
+-static int airoha_an7583_get_src_port_id(struct airoha_gdm_port *port, int nbq)
++static int airoha_an7583_get_sport(struct airoha_gdm_port *port, int nbq)
+ {
+ 	switch (port->id) {
+ 	case AIROHA_GDM3_IDX:
+@@ -3300,7 +3300,7 @@ static const struct airoha_eth_soc_data
+ 	.num_xsi_rsts = ARRAY_SIZE(en7581_xsi_rsts_names),
+ 	.num_ppe = 2,
+ 	.ops = {
+-		.get_src_port_id = airoha_en7581_get_src_port_id,
++		.get_sport = airoha_en7581_get_sport,
+ 		.get_vip_port = airoha_en7581_get_vip_port,
+ 	},
+ };
+@@ -3311,7 +3311,7 @@ static const struct airoha_eth_soc_data
+ 	.num_xsi_rsts = ARRAY_SIZE(an7583_xsi_rsts_names),
+ 	.num_ppe = 1,
+ 	.ops = {
+-		.get_src_port_id = airoha_an7583_get_src_port_id,
++		.get_sport = airoha_an7583_get_sport,
+ 		.get_vip_port = airoha_an7583_get_vip_port,
+ 	},
+ };
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -578,7 +578,7 @@ struct airoha_eth_soc_data {
+ 	int num_xsi_rsts;
+ 	int num_ppe;
+ 	struct {
+-		int (*get_src_port_id)(struct airoha_gdm_port *port, int nbq);
++		int (*get_sport)(struct airoha_gdm_port *port, int nbq);
+ 		u32 (*get_vip_port)(struct airoha_gdm_port *port, int nbq);
+ 	} ops;
+ };

--- a/target/linux/airoha/patches-6.12/156-v7.2-net-airoha-Do-not-return-err-in-ndo_stop-callback.patch
+++ b/target/linux/airoha/patches-6.12/156-v7.2-net-airoha-Do-not-return-err-in-ndo_stop-callback.patch
@@ -1,0 +1,36 @@
+From 4ca01292ea2f2363660610a65ba0285d7c3309ed Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Tue, 28 Apr 2026 08:53:16 +0200
+Subject: [PATCH] net: airoha: Do not return err in ndo_stop() callback
+
+Always complete the airoha_dev_stop() routine regardless of the
+airoha_set_vip_for_gdm_port() return value, since errors from
+ndo_stop() are ignored by the networking stack and the interface is
+always considered down after the call.
+
+Fixes: 23020f049327 ("net: airoha: Introduce ethernet support for EN7581 SoC")
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260428-airoha-ndo-stop-not-err-v1-1-674506d29a91@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 7 ++-----
+ 1 file changed, 2 insertions(+), 5 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -1747,13 +1747,10 @@ static int airoha_dev_stop(struct net_de
+ {
+ 	struct airoha_gdm_port *port = netdev_priv(dev);
+ 	struct airoha_qdma *qdma = port->qdma;
+-	int i, err;
++	int i;
+ 
+ 	netif_tx_disable(dev);
+-	err = airoha_set_vip_for_gdm_port(port, false);
+-	if (err)
+-		return err;
+-
++	airoha_set_vip_for_gdm_port(port, false);
+ 	for (i = 0; i < dev->num_tx_queues; i++)
+ 		netdev_tx_reset_subqueue(dev, i);
+ 

--- a/target/linux/airoha/patches-6.12/157-v7.2-net-airoha-Move-entries-to-queue-head-in-case-of-DMA.patch
+++ b/target/linux/airoha/patches-6.12/157-v7.2-net-airoha-Move-entries-to-queue-head-in-case-of-DMA.patch
@@ -1,0 +1,38 @@
+From 75df490c9e8457990c8b227650f6491218ce018b Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Wed, 29 Apr 2026 14:02:31 +0200
+Subject: [PATCH] net: airoha: Move entries to queue head in case of DMA
+ mapping failure in airoha_dev_xmit()
+
+In order to respect the original descriptor order and avoid any
+potential IOMMU fault or memory corruption, move pending queue entries
+to the head of hw queue tx_list if the DMA mapping of current inflight
+packet fails in airoha_dev_xmit routine.
+
+Fixes: 3f47e67dff1f7 ("net: airoha: Add the capability to consume out-of-order DMA tx descriptors")
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260429-airoha-xmit-unmap-error-path-v2-1-32e43b7c6d25@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -2120,14 +2120,12 @@ static netdev_tx_t airoha_dev_xmit(struc
+ 	return NETDEV_TX_OK;
+ 
+ error_unmap:
+-	while (!list_empty(&tx_list)) {
+-		e = list_first_entry(&tx_list, struct airoha_queue_entry,
+-				     list);
++	list_for_each_entry(e, &tx_list, list) {
+ 		dma_unmap_single(dev->dev.parent, e->dma_addr, e->dma_len,
+ 				 DMA_TO_DEVICE);
+ 		e->dma_addr = 0;
+-		list_move_tail(&e->list, &q->tx_list);
+ 	}
++	list_splice(&tx_list, &q->tx_list);
+ 
+ 	spin_unlock_bh(&q->lock);
+ error:

--- a/target/linux/airoha/patches-6.12/158-v7.2-net-airoha-configure-QoS-channel-for-HW-accelerated-.patch
+++ b/target/linux/airoha/patches-6.12/158-v7.2-net-airoha-configure-QoS-channel-for-HW-accelerated-.patch
@@ -1,0 +1,44 @@
+From 286efd34d1a1ef5d83f9441b5e59421a26738169 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Thu, 30 Apr 2026 10:47:38 +0200
+Subject: [PATCH] net: airoha: configure QoS channel for HW accelerated
+ flowtable traffic
+
+As done for the SW path, configure the QoS channel for HW accelerated
+traffic according to the user port index when forwarding to a DSA port,
+or rely on the GDM port identifier otherwise. This allows HTB shaping
+to be applied to HW accelerated traffic.
+
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260430-airoha-ppe-qos-channel-v1-1-5ef9221e85c1@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_ppe.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_ppe.c
++++ b/drivers/net/ethernet/airoha/airoha_ppe.c
+@@ -332,7 +332,7 @@ static int airoha_ppe_foe_entry_prepare(
+ 						info.wcid);
+ 		} else {
+ 			struct airoha_gdm_port *port = netdev_priv(dev);
+-			u8 pse_port;
++			u8 pse_port, channel;
+ 
+ 			if (!airoha_is_valid_gdm_port(eth, port))
+ 				return -EINVAL;
+@@ -345,6 +345,14 @@ static int airoha_ppe_foe_entry_prepare(
+ 					       * loopback
+ 					       */
+ 
++			/* For traffic forwarded to DSA devices select QoS
++			 * channel according to the DSA user port index, rely
++			 * on port id otherwise.
++			 */
++			channel = dsa_port >= 0 ? dsa_port : port->id;
++			channel = channel % AIROHA_NUM_QOS_CHANNELS;
++			qdata |= FIELD_PREP(AIROHA_FOE_CHANNEL, channel);
++
+ 			val |= FIELD_PREP(AIROHA_FOE_IB2_PSE_PORT, pse_port) |
+ 			       AIROHA_FOE_IB2_PSE_QOS;
+ 			/* For downlink traffic consume SRAM memory for hw

--- a/target/linux/airoha/patches-6.12/159-v7.2-net-airoha-Introduce-airoha_fe_get-airoha_qdma_get-r.patch
+++ b/target/linux/airoha/patches-6.12/159-v7.2-net-airoha-Introduce-airoha_fe_get-airoha_qdma_get-r.patch
@@ -1,0 +1,95 @@
+From 98e490930de3af9afa0bbb2d1d79d6d5b5513012 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Fri, 1 May 2026 09:49:11 +0200
+Subject: [PATCH] net: airoha: Introduce airoha_fe_get()/airoha_qdma_get()
+ register read helpers
+
+Add airoha_fe_get() and airoha_qdma_get() as utility routines for reading
+a masked field from a specified register.
+This is a non-functional refactor, no logical changes are introduced to
+the existing codebase.
+
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260501-airoha_fe_get-airoha_qdma_get-v3-1-126c6f647ccb@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 13 ++++---------
+ drivers/net/ethernet/airoha/airoha_eth.h |  4 ++++
+ drivers/net/ethernet/airoha/airoha_ppe.c |  5 ++---
+ 3 files changed, 10 insertions(+), 12 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -201,15 +201,13 @@ static void airoha_fe_vip_setup(struct a
+ static u32 airoha_fe_get_pse_queue_rsv_pages(struct airoha_eth *eth,
+ 					     u32 port, u32 queue)
+ {
+-	u32 val;
+-
+ 	airoha_fe_rmw(eth, REG_FE_PSE_QUEUE_CFG_WR,
+ 		      PSE_CFG_PORT_ID_MASK | PSE_CFG_QUEUE_ID_MASK,
+ 		      FIELD_PREP(PSE_CFG_PORT_ID_MASK, port) |
+ 		      FIELD_PREP(PSE_CFG_QUEUE_ID_MASK, queue));
+-	val = airoha_fe_rr(eth, REG_FE_PSE_QUEUE_CFG_VAL);
+ 
+-	return FIELD_GET(PSE_CFG_OQ_RSV_MASK, val);
++	return airoha_fe_get(eth, REG_FE_PSE_QUEUE_CFG_VAL,
++			     PSE_CFG_OQ_RSV_MASK);
+ }
+ 
+ static void airoha_fe_set_pse_queue_rsv_pages(struct airoha_eth *eth,
+@@ -227,9 +225,7 @@ static void airoha_fe_set_pse_queue_rsv_
+ 
+ static u32 airoha_fe_get_pse_all_rsv(struct airoha_eth *eth)
+ {
+-	u32 val = airoha_fe_rr(eth, REG_FE_PSE_BUF_SET);
+-
+-	return FIELD_GET(PSE_ALLRSV_MASK, val);
++	return airoha_fe_get(eth, REG_FE_PSE_BUF_SET, PSE_ALLRSV_MASK);
+ }
+ 
+ static int airoha_fe_set_pse_oq_rsv(struct airoha_eth *eth,
+@@ -247,8 +243,7 @@ static int airoha_fe_set_pse_oq_rsv(stru
+ 		      FIELD_PREP(PSE_ALLRSV_MASK, all_rsv));
+ 
+ 	/* modify hthd */
+-	tmp = airoha_fe_rr(eth, PSE_FQ_CFG);
+-	fq_limit = FIELD_GET(PSE_FQ_LIMIT_MASK, tmp);
++	fq_limit = airoha_fe_get(eth, PSE_FQ_CFG, PSE_FQ_LIMIT_MASK);
+ 	tmp = fq_limit - all_rsv - 0x20;
+ 	airoha_fe_rmw(eth, REG_PSE_SHARE_USED_THD,
+ 		      PSE_SHARE_USED_HTHD_MASK,
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -619,6 +619,8 @@ u32 airoha_rmw(void __iomem *base, u32 o
+ 	airoha_rmw((eth)->fe_regs, (offset), 0, (val))
+ #define airoha_fe_clear(eth, offset, val)			\
+ 	airoha_rmw((eth)->fe_regs, (offset), (val), 0)
++#define airoha_fe_get(eth, offset, mask)			\
++	FIELD_GET((mask), airoha_fe_rr((eth), (offset)))
+ 
+ #define airoha_qdma_rr(qdma, offset)				\
+ 	airoha_rr((qdma)->regs, (offset))
+@@ -630,6 +632,8 @@ u32 airoha_rmw(void __iomem *base, u32 o
+ 	airoha_rmw((qdma)->regs, (offset), 0, (val))
+ #define airoha_qdma_clear(qdma, offset, val)			\
+ 	airoha_rmw((qdma)->regs, (offset), (val), 0)
++#define airoha_qdma_get(qdma, offset, mask)			\
++	FIELD_GET((mask), airoha_qdma_rr((qdma), (offset)))
+ 
+ static inline u16 airoha_qdma_get_txq(struct airoha_qdma *qdma, u16 qid)
+ {
+--- a/drivers/net/ethernet/airoha/airoha_ppe.c
++++ b/drivers/net/ethernet/airoha/airoha_ppe.c
+@@ -80,9 +80,8 @@ bool airoha_ppe_is_enabled(struct airoha
+ 
+ static u32 airoha_ppe_get_timestamp(struct airoha_ppe *ppe)
+ {
+-	u16 timestamp = airoha_fe_rr(ppe->eth, REG_FE_FOE_TS);
+-
+-	return FIELD_GET(AIROHA_FOE_IB1_BIND_TIMESTAMP, timestamp);
++	return airoha_fe_get(ppe->eth, REG_FE_FOE_TS,
++			     AIROHA_FOE_IB1_BIND_TIMESTAMP);
+ }
+ 
+ void airoha_ppe_set_cpu_port(struct airoha_gdm_port *port, u8 ppe_id, u8 fport)

--- a/target/linux/airoha/patches-6.12/160-v7.2-net-airoha-Reserve-RX-headroom-to-avoid-skb-realloca.patch
+++ b/target/linux/airoha/patches-6.12/160-v7.2-net-airoha-Reserve-RX-headroom-to-avoid-skb-realloca.patch
@@ -1,0 +1,73 @@
+From bbfb1983944f2eaa8ee192e0f7b59ecc0fda9981 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Wed, 13 May 2026 17:03:59 +0200
+Subject: [PATCH] net: airoha: Reserve RX headroom to avoid skb reallocation
+
+Reserve NET_SKB_PAD + NET_IP_ALIGN bytes of headroom for received packets
+to avoid skb head reallocation when pushing protocol headers into the skb.
+
+Tested-by: Xuegang Lu <xuegang.lu@airoha.com>
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260513-airoha-rx-headroom-v1-1-bd87798e422d@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 14 ++++++++------
+ drivers/net/ethernet/airoha/airoha_eth.h |  2 ++
+ 2 files changed, 10 insertions(+), 6 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -543,9 +543,10 @@ static int airoha_qdma_fill_rx_queue(str
+ 		q->queued++;
+ 		nframes++;
+ 
++		offset += AIROHA_RX_HEADROOM;
+ 		e->buf = page_address(page) + offset;
+ 		e->dma_addr = page_pool_get_dma_addr(page) + offset;
+-		e->dma_len = SKB_WITH_OVERHEAD(q->buf_size);
++		e->dma_len = SKB_WITH_OVERHEAD(AIROHA_RX_LEN(q->buf_size));
+ 
+ 		val = FIELD_PREP(QDMA_DESC_LEN_MASK, e->dma_len);
+ 		WRITE_ONCE(desc->ctrl, cpu_to_le32(val));
+@@ -611,13 +612,12 @@ static int airoha_qdma_rx_process(struct
+ 		q->tail = (q->tail + 1) % q->ndesc;
+ 		q->queued--;
+ 
+-		dma_sync_single_for_cpu(eth->dev, e->dma_addr,
+-					SKB_WITH_OVERHEAD(q->buf_size), dir);
++		dma_sync_single_for_cpu(eth->dev, e->dma_addr, e->dma_len,
++					dir);
+ 
+ 		page = virt_to_head_page(e->buf);
+ 		len = FIELD_GET(QDMA_DESC_LEN_MASK, desc_ctrl);
+-		data_len = q->skb ? q->buf_size
+-				  : SKB_WITH_OVERHEAD(q->buf_size);
++		data_len = q->skb ? AIROHA_RX_LEN(q->buf_size) : e->dma_len;
+ 		if (!len || data_len < len)
+ 			goto free_frag;
+ 
+@@ -627,10 +627,12 @@ static int airoha_qdma_rx_process(struct
+ 
+ 		port = eth->ports[p];
+ 		if (!q->skb) { /* first buffer */
+-			q->skb = napi_build_skb(e->buf, q->buf_size);
++			q->skb = napi_build_skb(e->buf - AIROHA_RX_HEADROOM,
++						q->buf_size);
+ 			if (!q->skb)
+ 				goto free_frag;
+ 
++			skb_reserve(q->skb, AIROHA_RX_HEADROOM);
+ 			__skb_put(q->skb, len);
+ 			skb_mark_for_recycle(q->skb);
+ 			q->skb->dev = port->dev;
+--- a/drivers/net/ethernet/airoha/airoha_eth.h
++++ b/drivers/net/ethernet/airoha/airoha_eth.h
+@@ -32,6 +32,8 @@
+ #define AIROHA_FE_MC_MAX_VLAN_TABLE	64
+ #define AIROHA_FE_MC_MAX_VLAN_PORT	16
+ #define AIROHA_NUM_TX_IRQ		2
++#define AIROHA_RX_HEADROOM		(NET_SKB_PAD + NET_IP_ALIGN)
++#define AIROHA_RX_LEN(_n)		((_n) - AIROHA_RX_HEADROOM)
+ #define HW_DSCP_NUM			2048
+ #define IRQ_QUEUE_LEN(_n)		((_n) ? 1024 : 2048)
+ #define TX_DSCP_NUM			1024

--- a/target/linux/airoha/patches-6.12/170-v7.2-net-airoha-Fix-register-index-for-Tx-fwd-counter-con.patch
+++ b/target/linux/airoha/patches-6.12/170-v7.2-net-airoha-Fix-register-index-for-Tx-fwd-counter-con.patch
@@ -1,0 +1,37 @@
+From 1402ecccf5630a0b7fa4749d7d2e72abc3f3d73d Mon Sep 17 00:00:00 2001
+Message-ID: <1402ecccf5630a0b7fa4749d7d2e72abc3f3d73d.1782312403.git.lorenzo@kernel.org>
+From: "Wayen.Yan" <win847@gmail.com>
+Date: Fri, 12 Jun 2026 07:09:13 +0800
+Subject: [PATCH 1/2] net: airoha: Fix register index for Tx-fwd counter
+ configuration
+
+In airoha_qdma_init_qos_stats(), the Tx-fwd counter configuration
+register uses the same index (i << 1) as the Tx-cpu counter, which
+overwrites the Tx-cpu configuration. The Tx-fwd counter value register
+correctly uses (i << 1) + 1, so the configuration register should use
+the same index.
+
+Fix the REG_CNTR_CFG index from (i << 1) to ((i << 1) + 1) so that
+the Tx-fwd counter is properly configured instead of clobbering the
+Tx-cpu counter config.
+
+Fixes: 20bf7d07c956 ("net: airoha: Add sched ETS offload support")
+Signed-off-by: Wayen.Yan <win847@gmail.com>
+Acked-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/6a2b40e7.4dd82583.3a5c46.e566@mx.google.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -1250,7 +1250,7 @@ static void airoha_qdma_init_qos_stats(s
+ 			       FIELD_PREP(CNTR_CHAN_MASK, i));
+ 		/* Tx-fwd transferred count */
+ 		airoha_qdma_wr(qdma, REG_CNTR_VAL((i << 1) + 1), 0);
+-		airoha_qdma_wr(qdma, REG_CNTR_CFG(i << 1),
++		airoha_qdma_wr(qdma, REG_CNTR_CFG((i << 1) + 1),
+ 			       CNTR_EN_MASK | CNTR_ALL_QUEUE_EN_MASK |
+ 			       CNTR_ALL_DSCP_RING_EN_MASK |
+ 			       FIELD_PREP(CNTR_SRC_MASK, 1) |

--- a/target/linux/airoha/patches-6.12/171-v7.2-net-airoha-Fix-debugfs-new-tuple-display-for-IPv4-RO.patch
+++ b/target/linux/airoha/patches-6.12/171-v7.2-net-airoha-Fix-debugfs-new-tuple-display-for-IPv4-RO.patch
@@ -1,0 +1,44 @@
+From 1c3a77471afbb3981af28f7f7c8b2487558e4b00 Mon Sep 17 00:00:00 2001
+Message-ID: <1c3a77471afbb3981af28f7f7c8b2487558e4b00.1782312403.git.lorenzo@kernel.org>
+In-Reply-To: <1402ecccf5630a0b7fa4749d7d2e72abc3f3d73d.1782312403.git.lorenzo@kernel.org>
+References: <1402ecccf5630a0b7fa4749d7d2e72abc3f3d73d.1782312403.git.lorenzo@kernel.org>
+From: "Wayen.Yan" <win847@gmail.com>
+Date: Fri, 12 Jun 2026 07:09:56 +0800
+Subject: [PATCH 2/2] net: airoha: Fix debugfs new-tuple display for IPv4 ROUTE
+ entries
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In airoha_ppe_debugfs_foe_show(), the second switch statement falls
+through from PPE_PKT_TYPE_IPV4_HNAPT/DSLITE to PPE_PKT_TYPE_IPV4_ROUTE,
+accessing hwe->ipv4.new_tuple for all three types. However, IPv4 ROUTE
+(3-tuple) entries do not contain a valid new_tuple — this field is only
+meaningful for NATted flows (HNAPT/DSLITE). For ROUTE entries, the
+memory at the new_tuple offset holds routing information, not NAT data,
+so displaying "new=" produces garbage output.
+
+Display new_tuple only for HNAPT and DSLITE, and let IPV4_ROUTE fall
+through to the default case.
+
+Fixes: 3fe15c640f38 ("net: airoha: Introduce PPE debugfs support")
+Link: https://lore.kernel.org/6a2b40ea.4dd82583.3a5c46.e5a2@mx.google.com
+Signed-off-by: Wayen.Yan <win847@gmail.com>
+Acked-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/6a2be54b.ef98c1b2.3c3224.2ed8@mx.google.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_ppe_debugfs.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_ppe_debugfs.c
++++ b/drivers/net/ethernet/airoha/airoha_ppe_debugfs.c
+@@ -121,8 +121,6 @@ static int airoha_ppe_debugfs_foe_show(s
+ 		case PPE_PKT_TYPE_IPV4_DSLITE:
+ 			src_port = &hwe->ipv4.new_tuple.src_port;
+ 			dest_port = &hwe->ipv4.new_tuple.dest_port;
+-			fallthrough;
+-		case PPE_PKT_TYPE_IPV4_ROUTE:
+ 			src_addr = &hwe->ipv4.new_tuple.src_ip;
+ 			dest_addr = &hwe->ipv4.new_tuple.dest_ip;
+ 			seq_puts(m, " new=");

--- a/target/linux/airoha/patches-6.12/172-v7.2-net-airoha-fix-foe_check_time-allocation-size.patch
+++ b/target/linux/airoha/patches-6.12/172-v7.2-net-airoha-fix-foe_check_time-allocation-size.patch
@@ -1,0 +1,34 @@
+From 5c121ee635680c93d7074becf14cfbaac140f80d Mon Sep 17 00:00:00 2001
+Message-ID: <5c121ee635680c93d7074becf14cfbaac140f80d.1782312136.git.lorenzo@kernel.org>
+From: Wayen Yan <win847@gmail.com>
+Date: Tue, 16 Jun 2026 19:52:36 +0800
+Subject: [PATCH] net: airoha: fix foe_check_time allocation size
+
+foe_check_time is declared as u16 pointer but was allocated with
+only ppe_num_entries bytes instead of ppe_num_entries * sizeof(u16).
+
+When airoha_ppe_foe_verify_entry() is called with hash >= ppe_num_entries/2,
+it writes beyond the allocated buffer, causing heap buffer overflow and
+potential kernel crash.
+
+Fixes: 6d5b601d52a2 ("net: airoha: ppe: Dynamically allocate foe_check_time array in airoha_ppe struct")
+Signed-off-by: Wayen Yan <win847@gmail.com>
+Acked-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/178161119471.2163752.14373384830691569758@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_ppe.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_ppe.c
++++ b/drivers/net/ethernet/airoha/airoha_ppe.c
+@@ -1583,7 +1583,8 @@ int airoha_ppe_init(struct airoha_eth *e
+ 			return -ENOMEM;
+ 	}
+ 
+-	ppe->foe_check_time = devm_kzalloc(eth->dev, ppe_num_entries,
++	ppe->foe_check_time = devm_kzalloc(eth->dev,
++					   ppe_num_entries * sizeof(*ppe->foe_check_time),
+ 					   GFP_KERNEL);
+ 	if (!ppe->foe_check_time)
+ 		return -ENOMEM;

--- a/target/linux/airoha/patches-6.12/173-v7.2-net-airoha-Fix-non-standard-return-value-in-airoha_p.patch
+++ b/target/linux/airoha/patches-6.12/173-v7.2-net-airoha-Fix-non-standard-return-value-in-airoha_p.patch
@@ -1,0 +1,31 @@
+From 05173fa30add3787e7ab2e735c4ee00431994259 Mon Sep 17 00:00:00 2001
+Message-ID: <05173fa30add3787e7ab2e735c4ee00431994259.1782312341.git.lorenzo@kernel.org>
+From: "Wayen.Yan" <win847@gmail.com>
+Date: Sat, 13 Jun 2026 08:22:31 +0800
+Subject: [PATCH] net: airoha: Fix non-standard return value in
+ airoha_ppe_get_wdma_info()
+
+airoha_ppe_get_wdma_info() returns -1 when the last path in the
+forwarding path stack is not of type DEV_PATH_MTK_WDMA. This is not
+a standard kernel error code. Replace it with -EINVAL since the
+input path type is invalid from the caller's perspective.
+
+Signed-off-by: Wayen.Yan <win847@gmail.com>
+Acked-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/6a2ca3d9.ad59c0a6.147df9.2a62@mx.google.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_ppe.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_ppe.c
++++ b/drivers/net/ethernet/airoha/airoha_ppe.c
+@@ -261,7 +261,7 @@ static int airoha_ppe_get_wdma_info(stru
+ 
+ 	path = &stack.path[stack.num_paths - 1];
+ 	if (path->type != DEV_PATH_MTK_WDMA)
+-		return -1;
++		return -EINVAL;
+ 
+ 	info->idx = path->mtk_wdma.wdma_idx;
+ 	info->bss = path->mtk_wdma.bss;

--- a/target/linux/airoha/patches-6.12/174-v7.2-net-airoha-Fix-skb-priority-underflow-in-airoha_dev_.patch
+++ b/target/linux/airoha/patches-6.12/174-v7.2-net-airoha-Fix-skb-priority-underflow-in-airoha_dev_.patch
@@ -1,0 +1,52 @@
+From 86e51aa24686cc95bb35613059e8b94b9b81e3f0 Mon Sep 17 00:00:00 2001
+Message-ID: <86e51aa24686cc95bb35613059e8b94b9b81e3f0.1782312099.git.lorenzo@kernel.org>
+From: Wayen Yan <win847@gmail.com>
+Date: Sat, 20 Jun 2026 16:17:44 +0800
+Subject: [PATCH] net: airoha: Fix skb->priority underflow in
+ airoha_dev_select_queue()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In airoha_dev_select_queue(), the expression:
+
+  queue = (skb->priority - 1) % AIROHA_NUM_QOS_QUEUES;
+
+implicitly converts to unsigned arithmetic: when skb->priority is 0
+(the default for unclassified traffic), (0u - 1u) wraps to UINT_MAX,
+and UINT_MAX % 8 = 7, routing default best-effort packets to the
+highest-priority QoS queue. This causes QoS inversion where the
+majority of traffic on a PON gateway starves actual high-priority
+flows (VoIP, gaming, etc.).
+
+The "- 1" offset was a leftover from the ETS offload implementation
+that has since been removed. The correct mapping is a direct modulo:
+
+  queue = skb->priority % AIROHA_NUM_QOS_QUEUES;
+
+This maps priority 0 → queue 0 (lowest), priority 7 → queue 7
+(highest), with higher priorities wrapping around. This is the
+standard Linux sk_prio → HW queue mapping used by other drivers.
+
+Fixes: 2b288b81560b ("net: airoha: Introduce ndo_select_queue callback")
+Link: https://lore.kernel.org/netdev/178185573207.2378135.3729126358670287878@gmail.com/
+Acked-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Reviewed-by: Joe Damato <joe@dama.to>
+Signed-off-by: Wayen Yan <win847@gmail.com>
+Link: https://patch.msgid.link/178194366700.2485734.5368768965976693502@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -1925,7 +1925,7 @@ static u16 airoha_dev_select_queue(struc
+ 	 */
+ 	channel = netdev_uses_dsa(dev) ? skb_get_queue_mapping(skb) : port->id;
+ 	channel = channel % AIROHA_NUM_QOS_CHANNELS;
+-	queue = (skb->priority - 1) % AIROHA_NUM_QOS_QUEUES; /* QoS queue */
++	queue = skb->priority % AIROHA_NUM_QOS_QUEUES;
+ 	queue = channel * AIROHA_NUM_QOS_QUEUES + queue;
+ 
+ 	return queue < dev->num_tx_queues ? queue : 0;

--- a/target/linux/airoha/patches-6.12/175-v7.2-net-airoha-Fix-TX-scheduler-queue-mask-loop-upper-bo.patch
+++ b/target/linux/airoha/patches-6.12/175-v7.2-net-airoha-Fix-TX-scheduler-queue-mask-loop-upper-bo.patch
@@ -1,0 +1,50 @@
+From 245043dfc2101e7dc6268bf123b75305a91e4e00 Mon Sep 17 00:00:00 2001
+Message-ID: <245043dfc2101e7dc6268bf123b75305a91e4e00.1782312080.git.lorenzo@kernel.org>
+From: Wayen Yan <win847@gmail.com>
+Date: Fri, 19 Jun 2026 21:12:06 +0800
+Subject: [PATCH] net: airoha: Fix TX scheduler queue mask loop upper bound
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In airoha_qdma_set_chan_tx_sched(), the loop clearing queue mask was
+using AIROHA_NUM_TX_RING (32) instead of AIROHA_NUM_QOS_QUEUES (8).
+
+Each channel has 8 queues, and TXQ_DISABLE_CHAN_QUEUE_MASK(channel, i)
+computes BIT(i + (channel * 8)). With i ranging 0..31, this causes:
+- channel 0: clears bit 0..31 (all 4 channels) instead of 0..7
+- channel 1: clears bit 8..31 (channels 1-3) instead of 8..15
+- channel 2: clears bit 16..31 (channels 2-3) instead of 16..23
+- channel 3: clears bit 24..31 (channel 3 only) - correct by accident
+
+While BIT(32+) on arm64 produces 64-bit values truncated to 0 in u32
+mask parameter, the loop still incorrectly clears queues within the
+same channel beyond queue 7.
+
+Even though this is functionally harmless (the register resets to 0
+and is only ever cleared, never set — so clearing extra bits is a
+no-op), the loop bound is semantically wrong and should be fixed for
+correctness and clarity.
+
+Fix by using AIROHA_NUM_QOS_QUEUES (8) as the loop upper bound.
+
+Fixes: ef1ca9271313 ("net: airoha: Add sched HTB offload support")
+Acked-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Signed-off-by: Wayen Yan <win847@gmail.com>
+Link: https://patch.msgid.link/178187479434.2400840.1312143943526335838@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -2209,7 +2209,7 @@ static int airoha_qdma_set_chan_tx_sched
+ 	struct airoha_gdm_port *port = netdev_priv(dev);
+ 	int i;
+ 
+-	for (i = 0; i < AIROHA_NUM_TX_RING; i++)
++	for (i = 0; i < AIROHA_NUM_QOS_QUEUES; i++)
+ 		airoha_qdma_clear(port->qdma, REG_QUEUE_CLOSE_CFG(channel),
+ 				  TXQ_DISABLE_CHAN_QUEUE_MASK(channel, i));
+ 

--- a/target/linux/airoha/patches-6.12/176-v7.2-net-airoha-Fix-typos-in-comments-and-Kconfig.patch
+++ b/target/linux/airoha/patches-6.12/176-v7.2-net-airoha-Fix-typos-in-comments-and-Kconfig.patch
@@ -1,0 +1,68 @@
+From a061dfb063fa03ed09cf21145ffff247cf94721a Mon Sep 17 00:00:00 2001
+Message-ID: <a061dfb063fa03ed09cf21145ffff247cf94721a.1782312317.git.lorenzo@kernel.org>
+In-Reply-To: <05173fa30add3787e7ab2e735c4ee00431994259.1782312317.git.lorenzo@kernel.org>
+References: <05173fa30add3787e7ab2e735c4ee00431994259.1782312317.git.lorenzo@kernel.org>
+From: "Wayen.Yan" <win847@gmail.com>
+Date: Sat, 13 Jun 2026 08:41:16 +0800
+Subject: [PATCH 2/2] net: airoha: Fix typos in comments and Kconfig
+
+Fix several typos found during code review:
+- Kconfig: "Aiorha" -> "Airoha" in NET_AIROHA_FLOW_STATS help text
+- Comment: "CMD1" -> "CDM1" (Central DMA, not Command)
+- Comments: "GMD1/2/3/4" -> "GDM1/2/3/4" (Gigabit DMA, not GMD)
+
+These are pure comment and documentation fixes with no functional impact.
+
+Signed-off-by: Wayen.Yan <win847@gmail.com>
+Acked-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/6a2ca74a.c5b1db4e.21a698.01e7@mx.google.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/Kconfig      |  2 +-
+ drivers/net/ethernet/airoha/airoha_eth.c | 10 +++++-----
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+--- a/drivers/net/ethernet/airoha/Kconfig
++++ b/drivers/net/ethernet/airoha/Kconfig
+@@ -29,6 +29,6 @@ config NET_AIROHA_FLOW_STATS
+ 	bool "Airoha flow stats"
+ 	depends on NET_AIROHA && NET_AIROHA_NPU
+ 	help
+-	  Enable Aiorha flowtable statistic counters.
++	  Enable Airoha flowtable statistic counters.
+ 
+ endif #NET_VENDOR_AIROHA
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -289,18 +289,18 @@ static void airoha_fe_pse_ports_init(str
+ 			      FIELD_PREP(PSE_ALLRSV_MASK, all_rsv));
+ 	}
+ 
+-	/* CMD1 */
++	/* CDM1 */
+ 	for (q = 0; q < pse_port_num_queues[FE_PSE_PORT_CDM1]; q++)
+ 		airoha_fe_set_pse_oq_rsv(eth, FE_PSE_PORT_CDM1, q,
+ 					 PSE_QUEUE_RSV_PAGES);
+-	/* GMD1 */
++	/* GDM1 */
+ 	for (q = 0; q < pse_port_num_queues[FE_PSE_PORT_GDM1]; q++)
+ 		airoha_fe_set_pse_oq_rsv(eth, FE_PSE_PORT_GDM1, q,
+ 					 PSE_QUEUE_RSV_PAGES);
+-	/* GMD2 */
++	/* GDM2 */
+ 	for (q = 6; q < pse_port_num_queues[FE_PSE_PORT_GDM2]; q++)
+ 		airoha_fe_set_pse_oq_rsv(eth, FE_PSE_PORT_GDM2, q, 0);
+-	/* GMD3 */
++	/* GDM3 */
+ 	for (q = 0; q < pse_port_num_queues[FE_PSE_PORT_GDM3]; q++)
+ 		airoha_fe_set_pse_oq_rsv(eth, FE_PSE_PORT_GDM3, q,
+ 					 PSE_QUEUE_RSV_PAGES);
+@@ -335,7 +335,7 @@ static void airoha_fe_pse_ports_init(str
+ 							 q, 0);
+ 		}
+ 	}
+-	/* GMD4 */
++	/* GDM4 */
+ 	for (q = 0; q < pse_port_num_queues[FE_PSE_PORT_GDM4]; q++)
+ 		airoha_fe_set_pse_oq_rsv(eth, FE_PSE_PORT_GDM4, q,
+ 					 PSE_QUEUE_RSV_PAGES);

--- a/target/linux/airoha/patches-6.12/177-v7.2-net-airoha-Fix-off-by-one-in-airoha_tc_remove_htb_qu.patch
+++ b/target/linux/airoha/patches-6.12/177-v7.2-net-airoha-Fix-off-by-one-in-airoha_tc_remove_htb_qu.patch
@@ -1,0 +1,34 @@
+From bfcce49c4aaab9339ef7b9a7fa4d8ac5a19cc820 Mon Sep 17 00:00:00 2001
+Message-ID: <bfcce49c4aaab9339ef7b9a7fa4d8ac5a19cc820.1782366471.git.lorenzo@kernel.org>
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Fri, 19 Jun 2026 13:37:13 +0200
+Subject: [PATCH 1/2] net: airoha: Fix off-by-one in
+ airoha_tc_remove_htb_queue()
+
+airoha_tc_htb_alloc_leaf_queue() computes the HTB QoS channel index
+as opt->classid % AIROHA_NUM_QOS_CHANNELS and stores it in qos_sq_bmap.
+However, airoha_tc_remove_htb_queue() clears the HTB configuration
+using queue + 1 as the channel index, causing an off-by-one error.
+Use queue directly as the QoS channel index to match the allocation
+logic.
+
+Fixes: ef1ca9271313b ("net: airoha: Add sched HTB offload support")
+Reviewed-by: Simon Horman <horms@kernel.org>
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260619-airoha-qos-fixes-v2-1-5c43485038f9@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -2797,7 +2797,7 @@ static void airoha_tc_remove_htb_queue(s
+ 	struct airoha_gdm_port *port = netdev_priv(dev);
+ 
+ 	netif_set_real_num_tx_queues(dev, dev->real_num_tx_queues - 1);
+-	airoha_qdma_set_tx_rate_limit(dev, queue + 1, 0, 0);
++	airoha_qdma_set_tx_rate_limit(dev, queue, 0, 0);
+ 	clear_bit(queue, port->qos_sq_bmap);
+ }
+ 

--- a/target/linux/airoha/patches-6.12/310-02-net-airoha-deassert-XSI-line-on-hw-init.patch
+++ b/target/linux/airoha/patches-6.12/310-02-net-airoha-deassert-XSI-line-on-hw-init.patch
@@ -13,7 +13,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1490,6 +1490,10 @@ static int airoha_hw_init(struct platfor
+@@ -1487,6 +1487,10 @@ static int airoha_hw_init(struct platfor
  	if (err)
  		return err;
  

--- a/target/linux/airoha/patches-6.12/310-03-net-airoha-add-reference-for-SPORT-GDM4-in-qdma_get_.patch
+++ b/target/linux/airoha/patches-6.12/310-03-net-airoha-add-reference-for-SPORT-GDM4-in-qdma_get_.patch
@@ -16,7 +16,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -578,8 +578,11 @@ static int airoha_qdma_get_gdm_port(stru
+@@ -574,8 +574,11 @@ static int airoha_qdma_get_gdm_port(stru
  
  	sport = FIELD_GET(QDMA_ETH_RXMSG_SPORT_MASK, msg1);
  	switch (sport) {

--- a/target/linux/airoha/patches-6.12/310-06-net-airoha-add-initial-fixup-for-GDM3-4-port-support.patch
+++ b/target/linux/airoha/patches-6.12/310-06-net-airoha-add-initial-fixup-for-GDM3-4-port-support.patch
@@ -15,7 +15,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -503,8 +503,10 @@ static int airoha_fe_init(struct airoha_
+@@ -498,8 +498,10 @@ static int airoha_fe_init(struct airoha_
  		      FIELD_PREP(IP_ASSEMBLE_PORT_MASK, 0) |
  		      FIELD_PREP(IP_ASSEMBLE_NBQ_MASK, 22));
  
@@ -28,7 +28,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
  	airoha_fe_crsn_qsel_init(eth);
  
-@@ -1722,7 +1724,8 @@ static int airoha_dev_open(struct net_de
+@@ -1719,7 +1721,8 @@ static int airoha_dev_open(struct net_de
  	if (err)
  		return err;
  

--- a/target/linux/airoha/patches-6.12/310-07-airoha-ethernet-drop-xsi-mac-reset.patch
+++ b/target/linux/airoha/patches-6.12/310-07-airoha-ethernet-drop-xsi-mac-reset.patch
@@ -15,7 +15,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -3202,7 +3202,6 @@ static void airoha_remove(struct platfor
+@@ -3194,7 +3194,6 @@ static void airoha_remove(struct platfor
  }
  
  static const char * const en7581_xsi_rsts_names[] = {
@@ -23,7 +23,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	"hsi0-mac",
  	"hsi1-mac",
  	"hsi-mac",
-@@ -3256,7 +3255,6 @@ static u32 airoha_en7581_get_vip_port(st
+@@ -3248,7 +3247,6 @@ static u32 airoha_en7581_get_vip_port(st
  }
  
  static const char * const an7583_xsi_rsts_names[] = {

--- a/target/linux/airoha/patches-6.12/310-10-net-airoha-add-phylink-support-for-GDM2-4.patch
+++ b/target/linux/airoha/patches-6.12/310-10-net-airoha-add-phylink-support-for-GDM2-4.patch
@@ -35,7 +35,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static void airoha_set_macaddr(struct airoha_gdm_port *port, const u8 *addr)
  {
  	struct airoha_eth *eth = port->qdma->eth;
-@@ -1719,6 +1725,17 @@ static int airoha_dev_open(struct net_de
+@@ -1716,6 +1722,17 @@ static int airoha_dev_open(struct net_de
  	struct airoha_qdma *qdma = port->qdma;
  	u32 pse_port = FE_PSE_PORT_PPE1;
  
@@ -53,7 +53,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	netif_tx_start_all_queues(dev);
  	err = airoha_set_vip_for_gdm_port(port, true);
  	if (err)
-@@ -1783,6 +1800,11 @@ static int airoha_dev_stop(struct net_de
+@@ -1777,6 +1794,11 @@ static int airoha_dev_stop(struct net_de
  		}
  	}
  
@@ -65,7 +65,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	return 0;
  }
  
-@@ -2922,6 +2944,20 @@ static const struct ethtool_ops airoha_e
+@@ -2914,6 +2936,20 @@ static const struct ethtool_ops airoha_e
  	.get_link		= ethtool_op_get_link,
  };
  
@@ -86,7 +86,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static int airoha_metadata_dst_alloc(struct airoha_gdm_port *port)
  {
  	int i;
-@@ -2966,6 +3002,99 @@ bool airoha_is_valid_gdm_port(struct air
+@@ -2958,6 +2994,99 @@ bool airoha_is_valid_gdm_port(struct air
  	return false;
  }
  
@@ -186,7 +186,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static int airoha_alloc_gdm_port(struct airoha_eth *eth,
  				 struct device_node *np)
  {
-@@ -3039,6 +3168,12 @@ static int airoha_alloc_gdm_port(struct
+@@ -3031,6 +3160,12 @@ static int airoha_alloc_gdm_port(struct
  	port->nbq = id == AIROHA_GDM3_IDX && airoha_is_7581(eth) ? 4 : 0;
  	eth->ports[p] = port;
  
@@ -199,7 +199,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	return airoha_metadata_dst_alloc(port);
  }
  
-@@ -3168,6 +3303,10 @@ error_napi_stop:
+@@ -3160,6 +3295,10 @@ error_napi_stop:
  
  		if (port->dev->reg_state == NETREG_REGISTERED)
  			unregister_netdev(port->dev);
@@ -210,7 +210,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  		airoha_metadata_dst_free(port);
  	}
  	airoha_hw_cleanup(eth);
-@@ -3194,6 +3333,10 @@ static void airoha_remove(struct platfor
+@@ -3186,6 +3325,10 @@ static void airoha_remove(struct platfor
  
  		unregister_netdev(port->dev);
  		airoha_metadata_dst_free(port);
@@ -223,7 +223,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
-@@ -540,6 +540,10 @@ struct airoha_gdm_port {
+@@ -542,6 +542,10 @@ struct airoha_gdm_port {
  	int id;
  	int nbq;
  

--- a/target/linux/airoha/patches-6.12/604-02-net-ethernet-airoha-define-sport-value-for-GDM3.patch
+++ b/target/linux/airoha/patches-6.12/604-02-net-ethernet-airoha-define-sport-value-for-GDM3.patch
@@ -14,7 +14,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -589,6 +589,9 @@ static int airoha_qdma_get_gdm_port(stru
+@@ -585,6 +585,9 @@ static int airoha_qdma_get_gdm_port(stru
  	case 0x18:
  		port = 3; /* GDM4 */
  		break;

--- a/target/linux/airoha/patches-6.12/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
+++ b/target/linux/airoha/patches-6.12/606-net-airoha-disable-external-phy-code-if-PCS_AIROHA-i.patch
@@ -28,7 +28,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  static void airoha_set_macaddr(struct airoha_gdm_port *port, const u8 *addr)
  {
-@@ -1728,6 +1730,7 @@ static int airoha_dev_open(struct net_de
+@@ -1725,6 +1727,7 @@ static int airoha_dev_open(struct net_de
  	struct airoha_qdma *qdma = port->qdma;
  	u32 pse_port = FE_PSE_PORT_PPE1;
  
@@ -36,7 +36,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  	if (airhoa_is_phy_external(port)) {
  		err = phylink_of_phy_connect(port->phylink, dev->dev.of_node, 0);
  		if (err) {
-@@ -1738,6 +1741,7 @@ static int airoha_dev_open(struct net_de
+@@ -1735,6 +1738,7 @@ static int airoha_dev_open(struct net_de
  
  		phylink_start(port->phylink);
  	}
@@ -44,7 +44,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  	netif_tx_start_all_queues(dev);
  	err = airoha_set_vip_for_gdm_port(port, true);
-@@ -1803,10 +1807,12 @@ static int airoha_dev_stop(struct net_de
+@@ -1797,10 +1801,12 @@ static int airoha_dev_stop(struct net_de
  		}
  	}
  
@@ -57,7 +57,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  	return 0;
  }
-@@ -2947,6 +2953,7 @@ static const struct ethtool_ops airoha_e
+@@ -2939,6 +2945,7 @@ static const struct ethtool_ops airoha_e
  	.get_link		= ethtool_op_get_link,
  };
  
@@ -65,7 +65,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  static struct phylink_pcs *airoha_phylink_mac_select_pcs(struct phylink_config *config,
  							 phy_interface_t interface)
  {
-@@ -2960,6 +2967,7 @@ static void airoha_mac_config(struct phy
+@@ -2952,6 +2959,7 @@ static void airoha_mac_config(struct phy
  			      const struct phylink_link_state *state)
  {
  }
@@ -73,7 +73,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  static int airoha_metadata_dst_alloc(struct airoha_gdm_port *port)
  {
-@@ -3005,6 +3013,7 @@ bool airoha_is_valid_gdm_port(struct air
+@@ -2997,6 +3005,7 @@ bool airoha_is_valid_gdm_port(struct air
  	return false;
  }
  
@@ -81,7 +81,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  static void airoha_mac_link_up(struct phylink_config *config, struct phy_device *phy,
  			       unsigned int mode, phy_interface_t interface,
  			       int speed, int duplex, bool tx_pause, bool rx_pause)
-@@ -3097,6 +3106,7 @@ static int airoha_setup_phylink(struct n
+@@ -3089,6 +3098,7 @@ static int airoha_setup_phylink(struct n
  
  	return 0;
  }
@@ -89,7 +89,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  static int airoha_alloc_gdm_port(struct airoha_eth *eth,
  				 struct device_node *np)
-@@ -3171,11 +3181,13 @@ static int airoha_alloc_gdm_port(struct
+@@ -3163,11 +3173,13 @@ static int airoha_alloc_gdm_port(struct
  	port->nbq = id == AIROHA_GDM3_IDX && airoha_is_7581(eth) ? 4 : 0;
  	eth->ports[p] = port;
  
@@ -103,7 +103,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
  	return airoha_metadata_dst_alloc(port);
  }
-@@ -3306,10 +3318,12 @@ error_napi_stop:
+@@ -3298,10 +3310,12 @@ error_napi_stop:
  
  		if (port->dev->reg_state == NETREG_REGISTERED)
  			unregister_netdev(port->dev);
@@ -116,7 +116,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  		airoha_metadata_dst_free(port);
  	}
  	airoha_hw_cleanup(eth);
-@@ -3336,10 +3350,12 @@ static void airoha_remove(struct platfor
+@@ -3328,10 +3342,12 @@ static void airoha_remove(struct platfor
  
  		unregister_netdev(port->dev);
  		airoha_metadata_dst_free(port);
@@ -131,7 +131,7 @@ Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
  
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
-@@ -540,9 +540,11 @@ struct airoha_gdm_port {
+@@ -542,9 +542,11 @@ struct airoha_gdm_port {
  	int id;
  	int nbq;
  


### PR DESCRIPTION
Airoha reported some additional bug and fixes were pushed for the ethernet driver. Backport the additional patch merged upstream and refresh all affected patch.


(cherry picked from commit dda777dd44726ba70c99a780b5cc4c698563bc65)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
