### PR TITLE
base-files: sysctl: lower min_free_kbytes on 64 MB systems

### DIFF
--- a/package/base-files/files/etc/init.d/sysctl
+++ b/package/base-files/files/etc/init.d/sysctl
@@ -9,8 +9,6 @@ apply_defaults() {
 
 	if [ "$mem" -gt 65536 ]; then # 128M
 		min_free=16384
-	elif [ "$mem" -gt 32768 ]; then # 64M
-		min_free=8192
 	else
 		min_free=1024
 		frag_low_thresh=393216


### PR DESCRIPTION
Use the low-memory defaults instead of reserving 8 MB. This makes it possible to use OpenWrt on a slimmed down kernel running on Linksys RE6500. Previously, it would OOM and reset.

```
$ ps | grep -Ev '\[.*\]$'
  PID USER       VSZ STAT COMMAND
    1 root      1796 S    /sbin/procd
  612 ubus      1288 S    /sbin/ubusd
  613 root      1128 S    /sbin/askfirst /usr/libexec/login.sh
  648 root      1200 S    /sbin/urngd
  817 logd      2092 S    /sbin/logd -S 128
  871 root      2140 S    /sbin/rpcd -s /var/run/ubus/ubus.sock -t 30
  999 root      1364 S    /usr/sbin/dropbear -F -P /var/run/dropbear.main.pid -p 22 -s -K 300 -T 3
 1066 root      2488 S    /sbin/netifd -l 2
 1265 root      2124 S    /usr/sbin/uhttpd -f -h /www -r OpenWrt -x /cgi-bin -u /ubus -t 60 -T 30 -k 20 -A 1 -n 3 -N 100 -R -p 0.0.0.0:80 -p [::]:80 -C /etc/uhttpd.crt -K /etc/uhttpd.key -s 0.0.0.0:443 -s [::]:443
 1842 root      1388 R    /usr/sbin/dropbear -F -P /var/run/dropbear.main.pid -p 22 -s -K 300 -T 3 -2 9
 1843 root      1456 S    -ash
 1857 root      1456 R    ps
 1858 root      1448 S    grep -Ev \[.*\]$
$ free
              total        used        free      shared  buff/cache   available
Mem:          54908       26052       17708         184       11148       24668
Swap:             0           0           0
$ dmesg |grep Memory:
[    0.343054] Memory: 52512K/65536K available (7910K kernel code, 606K rwdata, 1044K rodata, 1308K init, 201K bss, 11936K reserved, 0K cma-reserved)
$ uname  -a
Linux OpenWrt 6.18.38 #0 SMP Sun Jul 12 22:40:24 2026 mips GNU/Linux
$ lsmod
gpio_button_hotplug    12288  0
leds_gpio              12288  0
netlink_diag           12288  0
```