### PR TITLE
ramips: fix MT7628/MT7688 SD card support in mtk-mmc driver

### DIFF
--- a/target/linux/ramips/files/drivers/mmc/host/mtk-mmc/sd.c
+++ b/target/linux/ramips/files/drivers/mmc/host/mtk-mmc/sd.c
@@ -2210,6 +2210,12 @@ static int msdc_drv_probe(struct platform_device *pdev)
 	struct msdc_hw *hw;
 	int ret;
 
+	//FIXME: this should be done by pinconf and not by the sd driver
+	if ((ralink_soc == MT762X_SOC_MT7688 ||
+	     ralink_soc == MT762X_SOC_MT7628AN) &&
+	    (!(rt_sysc_r32(0x60) & BIT(15))))
+		rt_sysc_m32(0xf << 17, 0xf << 17, 0x3c);
+
 	hw = &msdc0_hw;
 
 	if (of_property_read_bool(pdev->dev.of_node, "mtk,wp-en"))

--- a/target/linux/ramips/patches-6.18/1001-mmc-core-sd-skip-ext-reg-probe-for-mt7628.patch
+++ b/target/linux/ramips/patches-6.18/1001-mmc-core-sd-skip-ext-reg-probe-for-mt7628.patch
@@ -1,0 +1,36 @@
+From: chris <379716266@qq.com>
+Subject: [PATCH] mmc: core: skip SD ext reg probe for MT7628/MT7688 mtk-mmc
+
+The SD 7.0 extension register probe (sd_read_ext_regs, added in v6.6)
+issues CMD48 with a 512-byte data transfer.  The MT7628/MT7688 vendor
+mtk-mmc DMA engine cannot complete this transfer (xfer_done timeout,
+error -145 / -ETIMEDOUT), which aborts SD card enumeration before
+/dev/mmcblk0 appears.
+
+Clear SD_SCR_CMD48_SUPPORT in mmc_decode_scr() so sd_read_ext_regs()
+returns early via its existing check.  This matches pre-6.6 kernels
+where the probe did not exist; only optional SD 7.0 extension features
+(power management, cache, performance registers) are lost, normal block
+I/O is unaffected.
+
+Signed-off-by: chris <379716266@qq.com>
+---
+ drivers/mmc/core/sd.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+--- a/drivers/mmc/core/sd.c
++++ b/drivers/mmc/core/sd.c
+@@ -241,6 +241,13 @@ int mmc_decode_scr(struct mmc_card *card)
+ 	else if (scr->sda_spec3)
+ 		scr->cmds = unstuff_bits(resp, 32, 2);
+ 
++	/*
++	 * The SD extension register probe (CMD48) issues a 512-byte data transfer
++	 * that the MT7628/MT7688 mtk-mmc DMA engine cannot complete.  Clear CMD48
++	 * support so sd_read_ext_regs() bails out via its existing check; only
++	 * optional SD 7.0 extension features are lost, the card stays usable.
++	 */
++	scr->cmds &= ~SD_SCR_CMD48_SUPPORT;
+ 	/* SD Spec says: any SD Card shall set at least bits 0 and 2 */
+ 	if (!(scr->bus_widths & SD_SCR_BUS_WIDTH_1) ||
+ 	    !(scr->bus_widths & SD_SCR_BUS_WIDTH_4)) {


### PR DESCRIPTION
Fixes SD card support for MT7628/MT7688 in the vendor `mtk-mmc` driver. Two changes:

1. **Restore the AGPIO_CFG EPHY digital-mode setup** in `msdc_drv_probe()`. This block was present in 22.03 and is absent in 24.10 and `main`; without it the SDXC pads never enter digital mode and the SD card returns no response (`RESP0 == 0`).

2. **Skip the SD 7.0 extension-register probe** (added in v6.6) by clearing `SD_SCR_CMD48_SUPPORT` in `mmc_decode_scr()`. The mtk-mmc DMA engine cannot complete the CMD48 512-byte transfer, so enumeration times out (`error -145`) before `mmcblk0` appears.

This fixes the vendor driver that is still shipped via `patches-6.18/830-*`. Whether to make it the default for MT7628/MT7688 (vs the mainline `mtk-sd`, which has a separate CMD-communication regression on this SoC) is intentionally left as a separate decision.

### Verification
Tested on HLK-7688A (MT7688A), OpenWrt 24.10 with both changes applied:
- Full CMD sequence succeeds (CMD8 `0x000001aa`, ACMD41 `0xc0ff8000`, CMD2/3/9/7/51/6)
- Card ramps to 48 MHz high-speed
- `/dev/mmcblk0` (116 GiB SDXC) + `mmcblk0p1` appear
- CMD18 multi-block 512B DMA read succeeds

Closes #24221