### PR TITLE
qualcommax: qca_ppe: report hardware MIB counters in port statistics

### DIFF
--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -7,6 +7,7 @@
 #include <linux/bitmap.h>
 #include <linux/regmap.h>
 #include <linux/spinlock.h>
+#include <linux/workqueue.h>
 #include <linux/types.h>
 #include <linux/io.h>
 #include <net/dsa.h>
@@ -121,6 +122,12 @@
 
 /* --- XGMAC (base 0x003000) --- */
 #define PPE_MAC_XGMAC_CSR_BASE		0x003000
+
+/* MMC block: transmit counters from 0x800, receive from 0x900. Which offset
+ * answers for which GMAC counter is in the MIB table in qca_ppe_main.c.
+ */
+#define PPE_XGMAC_MIB(xgmac, off)	(PPE_MAC_XGMAC_CSR_BASE + \
+					 (xgmac) * 0x4000 + (off))
 
 #define PPE_XGMAC_TX_CONF(xgmac)	(PPE_MAC_XGMAC_CSR_BASE + (xgmac) * 0x4000)
 #define   PPE_XGMAC_TX_ENABLE		BIT(0)
@@ -500,6 +507,9 @@ struct qca_ppe_vlan_entry {
 	int xlt_pvid_idx;
 };
 
+/* Defined beside the MIB table that dimensions it. */
+struct qca_ppe_mib_stats;
+
 struct qca_ppe_priv {
 	struct dsa_switch ds;
 	struct regmap *regmap;
@@ -517,6 +527,15 @@ struct qca_ppe_priv {
 	struct clk *port_rx_clk[QCA_PPE_MAX_PORTS];
 	struct clk *port_tx_clk[QCA_PPE_MAX_PORTS];
 	struct reset_control *port_rst[QCA_PPE_MAX_PORTS];
+	bool port_xgmac[QCA_PPE_MAX_PORTS];
+	bool mib_xgmac[QCA_PPE_MAX_PORTS];
+	bool mib_rebase[QCA_PPE_MAX_PORTS];
+	struct qca_ppe_mib_stats *port_mib;
+	/* Guards port_mib, port_xgmac, mib_xgmac and mib_rebase; get_stats64
+	 * takes it in atomic context, so it is never a mutex.
+	 */
+	spinlock_t mib_lock;
+	struct delayed_work mib_work;
 };
 
 extern const struct psch_tdm_data cppe_psch_tdm_data;

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -17,6 +17,12 @@
 
 #include "qca_ppe.h"
 
+/* A port carrying nothing but minimum-sized frames at 10G wraps a packet
+ * counter in under five minutes, and a total only stays monotonic for as long
+ * as no counter wraps twice unobserved between folds.
+ */
+#define PPE_MIB_FOLD_INTERVAL	(30 * HZ)
+
 static void ppe_port_gmac_set(struct qca_ppe_priv *priv, int port,
 			     bool tx_en, bool rx_en)
 {
@@ -506,6 +512,8 @@ static int qca_ppe_setup(struct dsa_switch *ds)
 	ds->ageing_time_max = (unsigned int)min_t(u64,
 		(u64)PPE_AGE_UNIT_MS * PPE_AGE_TIMER_MASK, U32_MAX);
 	ds->assisted_learning_on_cpu_port = true;
+
+	schedule_delayed_work(&priv->mib_work, PPE_MIB_FOLD_INTERVAL);
 
 	return 0;
 }
@@ -1001,6 +1009,12 @@ static void qca_ppe_xgmac_config(struct qca_ppe_priv *priv, int port)
 			   FIELD_PREP(PPE_XGMAC_PAUSE_TIME, 0xffff));
 }
 
+/* Defined with the MIB table it walks; the port reset and the bank change
+ * below have to bank the counters before the MIB they read stops being the
+ * one they were counted in.
+ */
+static void ppe_mib_fold(struct qca_ppe_priv *priv, int port);
+
 static void qca_ppe_mac_config(struct phylink_config *config,
 				    unsigned int mode,
 				    const struct phylink_link_state *state)
@@ -1017,9 +1031,27 @@ static void qca_ppe_mac_config(struct phylink_config *config,
 	}
 
 	if (priv->port_rst[port]) {
+		/* The reset clears the MIB, so bank what it has counted and
+		 * hold the rebase across the reset: a fold racing the window
+		 * below would otherwise consume it while the counters are
+		 * still running, and leave the drop to zero to be read as a
+		 * wrap. The baseline is taken here rather than left to the
+		 * periodic fold, so that nothing the port counts from
+		 * link-up is discarded.
+		 */
+		spin_lock_bh(&priv->mib_lock);
+		ppe_mib_fold(priv, port);
+		priv->mib_rebase[port] = true;
+		spin_unlock_bh(&priv->mib_lock);
+
 		reset_control_assert(priv->port_rst[port]);
 		msleep(150);
 		reset_control_deassert(priv->port_rst[port]);
+
+		spin_lock_bh(&priv->mib_lock);
+		ppe_mib_fold(priv, port);
+		priv->mib_rebase[port] = false;
+		spin_unlock_bh(&priv->mib_lock);
 	}
 }
 
@@ -1099,6 +1131,19 @@ static void qca_ppe_mac_link_down(struct phylink_config *config,
 	return;
 }
 
+static bool qca_ppe_port_uses_xgmac(unsigned int mode, phy_interface_t interface)
+{
+	switch (interface) {
+	case PHY_INTERFACE_MODE_2500BASEX:
+		return phylink_autoneg_inband(mode);
+	case PHY_INTERFACE_MODE_USXGMII:
+	case PHY_INTERFACE_MODE_10GBASER:
+		return true;
+	default:
+		return false;
+	}
+}
+
 static void qca_ppe_mac_link_up(struct phylink_config *config,
 				     struct phy_device *phydev,
 				     unsigned int mode,
@@ -1117,6 +1162,17 @@ static void qca_ppe_mac_link_up(struct phylink_config *config,
 	     interface == PHY_INTERFACE_MODE_10GBASER) &&
 	     port < 5)
 		return;
+
+	/* Bank what the MAC the port is leaving has counted, then baseline
+	 * the one it arrives on: a rebase left to the periodic fold would
+	 * discard everything the new MAC counted in the meantime. Where the
+	 * bank does not change the second fold adds nothing.
+	 */
+	spin_lock_bh(&priv->mib_lock);
+	ppe_mib_fold(priv, port);
+	priv->port_xgmac[port] = qca_ppe_port_uses_xgmac(mode, interface);
+	ppe_mib_fold(priv, port);
+	spin_unlock_bh(&priv->mib_lock);
 
 	switch (interface) {
 	case PHY_INTERFACE_MODE_SGMII:
@@ -1256,54 +1312,162 @@ static const struct phylink_mac_ops qca_ppe_phylink_mac_ops = {
 struct qca_ppe_mib_desc {
 	unsigned int offset;
 	unsigned int size;
+	unsigned int xgmac;
+	unsigned int xgmac_size;
 	const char name[ETH_GSTRING_LEN];
 };
 
-#define MIB32(_off, _name)	{ .offset = (_off), .size = 1, .name = _name }
-#define MIB64(_off, _name)	{ .offset = (_off), .size = 2, .name = _name }
+#define MIB_ROW(_off, _sz, _xoff, _xsz, _name)				\
+	{ .offset = (_off), .size = (_sz), .xgmac = (_xoff),		\
+	  .xgmac_size = (_xsz), .name = _name }
 
+/* Each counter as both MACs express it: the GMAC offset and word count, then
+ * the XGMAC MMC offset and word count, or 0 where the XGMAC has no
+ * equivalent. The XGMAC lumps 1519-and-up into its 1024-to-max bin and counts
+ * no collisions, no alignment error and no bad receive bytes.
+ */
 static const struct qca_ppe_mib_desc qca_ppe_mib[] = {
-	MIB32(PPE_MIB_RXBROAD,		"rx_broadcast"),
-	MIB32(PPE_MIB_RXPAUSE,		"rx_pause"),
-	MIB32(PPE_MIB_RXMULTI,		"rx_multicast"),
-	MIB32(PPE_MIB_RXFCSERR,		"rx_fcs_error"),
-	MIB32(PPE_MIB_RXALIGNERR,	"rx_align_error"),
-	MIB32(PPE_MIB_RXRUNT,		"rx_runt"),
-	MIB32(PPE_MIB_RXFRAG,		"rx_fragment"),
-	MIB32(PPE_MIB_RXJUMBOFCSERR,	"rx_jumbo_fcs_error"),
-	MIB32(PPE_MIB_RXJUMBOALIGNERR,	"rx_jumbo_align_error"),
-	MIB32(PPE_MIB_RXPKT64,		"rx_64byte"),
-	MIB32(PPE_MIB_RXPKT65TO127,	"rx_65_127byte"),
-	MIB32(PPE_MIB_RXPKT128TO255,	"rx_128_255byte"),
-	MIB32(PPE_MIB_RXPKT256TO511,	"rx_256_511byte"),
-	MIB32(PPE_MIB_RXPKT512TO1023,	"rx_512_1023byte"),
-	MIB32(PPE_MIB_RXPKT1024TO1518,	"rx_1024_1518byte"),
-	MIB32(PPE_MIB_RXPKT1519TOX,	"rx_1519_maxbyte"),
-	MIB32(PPE_MIB_RXTOOLONG,	"rx_too_long"),
-	MIB64(PPE_MIB_RXGOODBYTE_L,	"rx_good_bytes"),
-	MIB64(PPE_MIB_RXBADBYTE_L,	"rx_bad_bytes"),
-	MIB32(PPE_MIB_RXUNI,		"rx_unicast"),
-	MIB32(PPE_MIB_TXBROAD,		"tx_broadcast"),
-	MIB32(PPE_MIB_TXPAUSE,		"tx_pause"),
-	MIB32(PPE_MIB_TXMULTI,		"tx_multicast"),
-	MIB32(PPE_MIB_TXUNDERRUN,	"tx_underrun"),
-	MIB32(PPE_MIB_TXPKT64,		"tx_64byte"),
-	MIB32(PPE_MIB_TXPKT65TO127,	"tx_65_127byte"),
-	MIB32(PPE_MIB_TXPKT128TO255,	"tx_128_255byte"),
-	MIB32(PPE_MIB_TXPKT256TO511,	"tx_256_511byte"),
-	MIB32(PPE_MIB_TXPKT512TO1023,	"tx_512_1023byte"),
-	MIB32(PPE_MIB_TXPKT1024TO1518,	"tx_1024_1518byte"),
-	MIB32(PPE_MIB_TXPKT1519TOX,	"tx_1519_maxbyte"),
-	MIB64(PPE_MIB_TXBYTE_L,		"tx_bytes"),
-	MIB32(PPE_MIB_TXCOLLISIONS,	"tx_collisions"),
-	MIB32(PPE_MIB_TXABORTCOL,	"tx_abort_collision"),
-	MIB32(PPE_MIB_TXMULTICOL,	"tx_multi_collision"),
-	MIB32(PPE_MIB_TXSINGLECOL,	"tx_single_collision"),
-	MIB32(PPE_MIB_TXEXCESSIVEDEFER,	"tx_excessive_defer"),
-	MIB32(PPE_MIB_TXDEFER,		"tx_defer"),
-	MIB32(PPE_MIB_TXLATECOL,	"tx_late_collision"),
-	MIB32(PPE_MIB_TXUNI,		"tx_unicast"),
+	MIB_ROW(PPE_MIB_RXBROAD, 1, 0x918, 2, "rx_broadcast"),
+	MIB_ROW(PPE_MIB_RXPAUSE, 1, 0x988, 2, "rx_pause"),
+	MIB_ROW(PPE_MIB_RXMULTI, 1, 0x920, 2, "rx_multicast"),
+	MIB_ROW(PPE_MIB_RXFCSERR, 1, 0x928, 2, "rx_fcs_error"),
+	MIB_ROW(PPE_MIB_RXALIGNERR, 1, 0, 0, "rx_align_error"),
+	MIB_ROW(PPE_MIB_RXRUNT, 1, 0x938, 1, "rx_runt"),
+	MIB_ROW(PPE_MIB_RXFRAG, 1, 0x930, 1, "rx_fragment"),
+	MIB_ROW(PPE_MIB_RXJUMBOFCSERR, 1, 0x934, 1, "rx_jumbo_fcs_error"),
+	MIB_ROW(PPE_MIB_RXJUMBOALIGNERR, 1, 0, 0, "rx_jumbo_align_error"),
+	MIB_ROW(PPE_MIB_RXPKT64, 1, 0x940, 2, "rx_64byte"),
+	MIB_ROW(PPE_MIB_RXPKT65TO127, 1, 0x948, 2, "rx_65_127byte"),
+	MIB_ROW(PPE_MIB_RXPKT128TO255, 1, 0x950, 2, "rx_128_255byte"),
+	MIB_ROW(PPE_MIB_RXPKT256TO511, 1, 0x958, 2, "rx_256_511byte"),
+	MIB_ROW(PPE_MIB_RXPKT512TO1023, 1, 0x960, 2, "rx_512_1023byte"),
+	MIB_ROW(PPE_MIB_RXPKT1024TO1518, 1, 0x968, 2, "rx_1024_1518byte"),
+	MIB_ROW(PPE_MIB_RXPKT1519TOX, 1, 0, 0, "rx_1519_maxbyte"),
+	MIB_ROW(PPE_MIB_RXTOOLONG, 1, 0x93c, 1, "rx_too_long"),
+	MIB_ROW(PPE_MIB_RXGOODBYTE_L, 2, 0x910, 2, "rx_good_bytes"),
+	MIB_ROW(PPE_MIB_RXBADBYTE_L, 2, 0, 0, "rx_bad_bytes"),
+	MIB_ROW(PPE_MIB_RXUNI, 1, 0x970, 2, "rx_unicast"),
+	MIB_ROW(PPE_MIB_TXBROAD, 1, 0x874, 2, "tx_broadcast"),
+	MIB_ROW(PPE_MIB_TXPAUSE, 1, 0x894, 2, "tx_pause"),
+	MIB_ROW(PPE_MIB_TXMULTI, 1, 0x86c, 2, "tx_multicast"),
+	MIB_ROW(PPE_MIB_TXUNDERRUN, 1, 0x87c, 2, "tx_underrun"),
+	MIB_ROW(PPE_MIB_TXPKT64, 1, 0x834, 2, "tx_64byte"),
+	MIB_ROW(PPE_MIB_TXPKT65TO127, 1, 0x83c, 2, "tx_65_127byte"),
+	MIB_ROW(PPE_MIB_TXPKT128TO255, 1, 0x844, 2, "tx_128_255byte"),
+	MIB_ROW(PPE_MIB_TXPKT256TO511, 1, 0x84c, 2, "tx_256_511byte"),
+	MIB_ROW(PPE_MIB_TXPKT512TO1023, 1, 0x854, 2, "tx_512_1023byte"),
+	MIB_ROW(PPE_MIB_TXPKT1024TO1518, 1, 0x85c, 2, "tx_1024_1518byte"),
+	MIB_ROW(PPE_MIB_TXPKT1519TOX, 1, 0, 0, "tx_1519_maxbyte"),
+	MIB_ROW(PPE_MIB_TXBYTE_L, 2, 0x814, 2, "tx_bytes"),
+	MIB_ROW(PPE_MIB_TXCOLLISIONS, 1, 0, 0, "tx_collisions"),
+	MIB_ROW(PPE_MIB_TXABORTCOL, 1, 0, 0, "tx_abort_collision"),
+	MIB_ROW(PPE_MIB_TXMULTICOL, 1, 0, 0, "tx_multi_collision"),
+	MIB_ROW(PPE_MIB_TXSINGLECOL, 1, 0, 0, "tx_single_collision"),
+	MIB_ROW(PPE_MIB_TXEXCESSIVEDEFER, 1, 0, 0, "tx_excessive_defer"),
+	MIB_ROW(PPE_MIB_TXDEFER, 1, 0, 0, "tx_defer"),
+	MIB_ROW(PPE_MIB_TXLATECOL, 1, 0, 0, "tx_late_collision"),
+	MIB_ROW(PPE_MIB_TXUNI, 1, 0x864, 2, "tx_unicast"),
 };
+
+/* What a counter has reached, and the raw register value that total was last
+ * brought up to date from.
+ */
+struct qca_ppe_mib_stats {
+	u64 total;
+	u64 last;
+};
+
+static struct qca_ppe_mib_stats *ppe_port_mib(struct qca_ppe_priv *priv,
+					      int port)
+{
+	return priv->port_mib + port * ARRAY_SIZE(qca_ppe_mib);
+}
+
+/* The GMAC keeps most counters in a single 32-bit register and neither MAC
+ * ever stops counting, so the registers wrap where the totals reported to
+ * userspace must not: each total takes the difference since the last fold, at
+ * the width of the register it came from.
+ *
+ * A difference is only meaningful across a counter that kept running. Two
+ * things break that, and both take a baseline instead: a port muxed to its
+ * XGMAC starts reading a second MAC's independent counters, since the idle
+ * block reads back zero; and resetting a port zeroes the MIB it owns, which
+ * an unguarded difference would read as a wrap and add 2^32 for.
+ */
+static void ppe_mib_fold(struct qca_ppe_priv *priv, int port)
+{
+	struct qca_ppe_mib_stats *stats;
+	bool xgmac, rebase;
+	int i;
+
+	/* The CPU port owns no MAC MIB, and phylink brings its fixed link up
+	 * like any other, so the fold guards itself rather than each caller.
+	 */
+	if (port < 1)
+		return;
+
+	stats = ppe_port_mib(priv, port);
+	xgmac = priv->port_xgmac[port];
+	rebase = priv->mib_rebase[port] || xgmac != priv->mib_xgmac[port];
+
+	for (i = 0; i < ARRAY_SIZE(qca_ppe_mib); i++) {
+		const struct qca_ppe_mib_desc *mib = &qca_ppe_mib[i];
+		unsigned int reg, size;
+		u32 lo, hi = 0;
+		u64 cur;
+
+		if (xgmac) {
+			reg = PPE_XGMAC_MIB(port - 5, mib->xgmac);
+			size = mib->xgmac_size;
+		} else {
+			reg = PPE_GMAC_MIB(port - 1, mib->offset);
+			size = mib->size;
+		}
+
+		if (!size)
+			continue;
+
+		regmap_read(priv->regmap, reg, &lo);
+		if (size > 1)
+			regmap_read(priv->regmap, reg + 4, &hi);
+		cur = (u64)hi << 32 | lo;
+
+		if (!rebase)
+			stats[i].total += size > 1 ? cur - stats[i].last :
+					  (u32)(cur - stats[i].last);
+		stats[i].last = cur;
+	}
+
+	priv->mib_xgmac[port] = xgmac;
+}
+
+static u64 ppe_mib_total(const struct qca_ppe_mib_stats *stats,
+			 unsigned int offset)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(qca_ppe_mib); i++)
+		if (qca_ppe_mib[i].offset == offset)
+			return stats[i].total;
+
+	return 0;
+}
+
+static void ppe_mib_work(struct work_struct *work)
+{
+	struct qca_ppe_priv *priv = container_of(to_delayed_work(work),
+						 struct qca_ppe_priv,
+						 mib_work);
+	struct dsa_port *dp;
+
+	dsa_switch_for_each_user_port(dp, &priv->ds) {
+		spin_lock_bh(&priv->mib_lock);
+		ppe_mib_fold(priv, dp->index);
+		spin_unlock_bh(&priv->mib_lock);
+	}
+
+	schedule_delayed_work(&priv->mib_work, PPE_MIB_FOLD_INTERVAL);
+}
 
 static void qca_ppe_get_strings(struct dsa_switch *ds, int port,
 				    u32 stringset, uint8_t *data)
@@ -1330,7 +1494,7 @@ static void qca_ppe_get_ethtool_stats(struct dsa_switch *ds, int port,
 					  uint64_t *data)
 {
 	struct qca_ppe_priv *priv = ds_to_priv(ds);
-	int gmac = port - 1;
+	struct qca_ppe_mib_stats *stats;
 	int i;
 
 	if (port < 1 || port >= ds->num_ports) {
@@ -1338,19 +1502,66 @@ static void qca_ppe_get_ethtool_stats(struct dsa_switch *ds, int port,
 		return;
 	}
 
-	for (i = 0; i < ARRAY_SIZE(qca_ppe_mib); i++) {
-		const struct qca_ppe_mib_desc *mib = &qca_ppe_mib[i];
-		u32 val, hi;
+	stats = ppe_port_mib(priv, port);
 
-		regmap_read(priv->regmap, PPE_GMAC_MIB(gmac, mib->offset), &val);
-		if (mib->size == 2)
-			regmap_read(priv->regmap,
-				    PPE_GMAC_MIB(gmac, mib->offset + 4), &hi);
+	spin_lock_bh(&priv->mib_lock);
+	ppe_mib_fold(priv, port);
 
-		data[i] = val;
-		if (mib->size == 2)
-			data[i] |= (u64)hi << 32;
-	}
+	for (i = 0; i < ARRAY_SIZE(qca_ppe_mib); i++)
+		data[i] = stats[i].total;
+
+	spin_unlock_bh(&priv->mib_lock);
+}
+
+/* Shorthand for the reader below, which holds the port's counters under that
+ * name.
+ */
+#define MIB(_c)		ppe_mib_total(stats, PPE_MIB_ ## _c)
+
+static void qca_ppe_get_stats64(struct dsa_switch *ds, int port,
+				struct rtnl_link_stats64 *s)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	struct qca_ppe_mib_stats *stats;
+
+	if (port < 1 || port >= ds->num_ports)
+		return;
+
+	stats = ppe_port_mib(priv, port);
+
+	spin_lock_bh(&priv->mib_lock);
+	ppe_mib_fold(priv, port);
+
+	s->rx_packets = MIB(RXUNI) + MIB(RXMULTI) + MIB(RXBROAD);
+	s->tx_packets = MIB(TXUNI) + MIB(TXMULTI) + MIB(TXBROAD);
+	s->rx_bytes = MIB(RXGOODBYTE_L);
+	s->tx_bytes = MIB(TXBYTE_L);
+	s->multicast = MIB(RXMULTI);
+
+	s->rx_crc_errors = MIB(RXFCSERR) + MIB(RXJUMBOFCSERR);
+	s->rx_frame_errors = MIB(RXALIGNERR) + MIB(RXJUMBOALIGNERR);
+	s->rx_length_errors = MIB(RXRUNT) + MIB(RXFRAG) + MIB(RXTOOLONG);
+	s->rx_errors = s->rx_crc_errors + s->rx_frame_errors +
+		       s->rx_length_errors;
+
+	s->tx_fifo_errors = MIB(TXUNDERRUN);
+	s->tx_aborted_errors = MIB(TXABORTCOL);
+	s->tx_window_errors = MIB(TXLATECOL);
+	s->tx_errors = s->tx_fifo_errors + s->tx_aborted_errors +
+		       s->tx_window_errors;
+
+	s->collisions = MIB(TXCOLLISIONS);
+
+	spin_unlock_bh(&priv->mib_lock);
+}
+
+#undef MIB
+
+static void qca_ppe_teardown(struct dsa_switch *ds)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+
+	cancel_delayed_work_sync(&priv->mib_work);
 }
 
 static void qca_ppe_port_stp_state_set(struct dsa_switch *ds, int port,
@@ -1383,6 +1594,7 @@ static void qca_ppe_port_stp_state_set(struct dsa_switch *ds, int port,
 static const struct dsa_switch_ops qca_ppe_ops = {
 	.get_tag_protocol	= qca_ppe_get_tag_protocol,
 	.setup			= qca_ppe_setup,
+	.teardown		= qca_ppe_teardown,
 	.set_ageing_time	= qca_ppe_set_ageing_time,
 	.port_change_mtu	= qca_ppe_port_change_mtu,
 	.port_max_mtu		= qca_ppe_port_max_mtu,
@@ -1403,6 +1615,7 @@ static const struct dsa_switch_ops qca_ppe_ops = {
 	.get_strings		= qca_ppe_get_strings,
 	.get_sset_count		= qca_ppe_get_sset_count,
 	.get_ethtool_stats	= qca_ppe_get_ethtool_stats,
+	.get_stats64		= qca_ppe_get_stats64,
 };
 
 static void ppe_vsi_init(struct qca_ppe_priv *priv)
@@ -1567,6 +1780,16 @@ static int qca_ppe_probe(struct platform_device *pdev)
 	msleep(100);
 
 	spin_lock_init(&priv->fdb_lock);
+	spin_lock_init(&priv->mib_lock);
+	INIT_DELAYED_WORK(&priv->mib_work, ppe_mib_work);
+
+	priv->port_mib = devm_kcalloc(&pdev->dev,
+				      data->num_ports * ARRAY_SIZE(qca_ppe_mib),
+				      sizeof(*priv->port_mib), GFP_KERNEL);
+	if (!priv->port_mib) {
+		ret = -ENOMEM;
+		goto err_clk;
+	}
 
 	ds = &priv->ds;
 	ds->dev = &pdev->dev;


### PR DESCRIPTION
The PPE forwards traffic between its ports in hardware, so bridged frames never
reach the host. The DSA port netdevs only count what was punted to the CPU, so
the interface statistics miss hardware-forwarded traffic entirely.

The driver already reads the per-port MAC MIB counters for `ethtool -S`; this
reports them through `get_stats64` as well, so the interface counters reflect
what actually crossed the wire. `mt7530` and `ar9331` source their port
statistics from the hardware the same way, as do the `ssdk`/`nss-dp` vendor
drivers for this hardware.

### Reproducer

On an IPQ8074 board (AX3600), two ports of the same bridge, same subnet, so the
traffic is bridged rather than routed. `iperf3` for 20 s from a host on `lan1`
to a host on `lan2`, 2.19 GB at 939 Mbit/s. Measuring `lan2` TX across the
transfer, the DSA software counters being the first entries of `ethtool -S`:

| lan2 TX across the 2.19 GB transfer | bytes |
| --- | --- |
| software counter | 105,728 |
| hardware MIB | 2,467,851,696 |

A factor of roughly 23,000. `lan1` RX moved 2,467,877,899 bytes over the same
window, matching the other end of the same flow. The MIB value lands 4.9% above
payload, which is the expected Ethernet framing plus ACK overhead.

Routed traffic crosses the host on its way between the ports and is counted
correctly either way, which is why this mostly goes unnoticed: a WAN-side check
looks fine.

A second consequence: a port fault becomes readable from the port. Because the
software counters only ever saw CPU-punted frames, a port whose egress is dead
and a healthy one look much alike in `ip -s link`. With the MAC MIB answering,
`tx_packets` staying flat while the bridge keeps forwarding separates a frame
that left the SoC but never hit the wire from one that never reached the MAC,
which `PPE_PRX_DROP_CNT` and `PORT_BRIDGE_CTRL.TXMAC_EN` then decide between.

### Notes

* **What is reported is a 64-bit total, not the register.** The GMAC keeps most
  counters in a single 32-bit register, so a port at line rate with
  minimum-sized frames wraps one in under 49 minutes at 1G and in under five at
  10G. Each port keeps a 64-bit total per counter alongside the raw value that
  total was last brought up to date from, and a fold adds the difference in at
  the width of the register it came from. `get_stats64` and `ethtool -S` both
  fold before they answer, so neither lags the hardware and the two agree; a
  delayed work folds every user port every 30 seconds so that a counter nothing
  reads cannot wrap twice unobserved.
* **A difference is only meaningful across a counter that kept running**, so two
  things take a baseline instead. A port muxed to its XGMAC starts reading a
  second MAC's counters, which advance independently of the first. And
  `qca_ppe_mac_config()` asserts the port reset, which zeroes the MIB that port
  owns; the counters are banked before the reset so nothing is lost, and the
  next fold starts afresh. Left unguarded that reset lands every 32-bit counter
  on 2^32 plus its true value and every 64-bit one back on zero, which is what
  the difference against a stale baseline comes to in each width.
* **Both MACs are read.** Ports 5 and above drive either the GMAC the port
  number names or an XGMAC, and whichever block is idle reads back zero, so
  each MIB row carries its counter twice: the GMAC offset and width, and the
  XGMAC MMC offset and width. Where the XGMAC keeps no equivalent - the
  collision counters, the alignment errors, the bad receive byte count - the
  row reads zero rather than inventing a counter the hardware does not keep.
* The MIB is free running in both MACs: `PPE_MIB_EN` is set without
  `PPE_MIB_RD_CLR`, and `MMC_CONTROL`'s reset value leaves `RSTONRD` clear, so
  reading the counters does not consume them.
* `ndo_get_stats64` has callers that are not allowed to sleep (`bond_get_stats`
  calls `dev_get_stats` under a spinlock). This is safe because the regmap is
  created with `devm_regmap_init_mmio`, and the `regmap_mmio` bus sets
  `.fast_io = true`, so regmap uses a spinlock; `mib_lock` is a spinlock for
  the same reason, and the periodic fold takes it with softirqs disabled.
* The 64-bit byte counters are read low half first, matching the order the
  reference `ssdk` driver uses for them.

### Testing

Tested on a Xiaomi AX3600 (IPQ8074, all four ports GMAC/psgmii), bridged
transfer as above:

* `get_stats64` equals the MIB exactly on every port, and the packet totals
  equal the unicast, multicast and broadcast counters summed. The totals crossed
  2^31 during the transfer with no artifact.
* Repeated reads never step backwards, on any port.
* Bring-up runs `qca_ppe_mac_config()` on all four ports, so the port reset is
  exercised on every boot. Without the banking, `lan1 rx_unicast` comes up at
  4294967866; with it, at 114, and no counter on any port sits at 2^32 plus a
  small value.
* All four ports link at their negotiated speed, `dmesg` clean.

Two paths are not covered by the bench. The 32-bit wrap itself needs roughly
2900 s at line rate with minimum-sized frames to reach, so it is exercised by
the arithmetic rather than by the hardware. And the XGMAC arm is
inspection-only: the board has no XGMAC port. Its offsets are the DesignWare
MMC block as `stmmac` maps it, cross-checked counter by counter against the
GMAC MIB this driver already read.
