### PR TITLE
realtek: pcs: refactor TX configuration for RTL930x

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -2994,6 +2994,9 @@ static int rtpcs_930x_sds_config_hw_mode(struct rtpcs_serdes *sds, enum rtpcs_sd
 static int rtpcs_930x_sds_config_media(struct rtpcs_serdes *sds, enum rtpcs_sds_media media,
 				       enum rtpcs_sds_mode hw_mode)
 {
+	if (sds->type != RTPCS_SDS_TYPE_10G)
+		return 0;
+
 	/*
 	 * dal_longan_construct_mac_default_10gmedia_fiber: set medium to fiber.
 	 * TODO: this is unconditional regardless of hw_mode; needs mode-aware

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3006,15 +3006,16 @@ static int rtpcs_930x_sds_config_attachment(struct rtpcs_serdes *sds,
 	if (sds->type != RTPCS_SDS_TYPE_10G)
 		return 0;
 
-	/*
-	 * dal_longan_construct_mac_default_10gmedia_fiber: set medium to fiber.
-	 * TODO: does this apply to all fiber modes or only 10GBase-R?
-	 */
-	ret = rtpcs_sds_write_bits(sds, PAGE_WDIG, 11, 1, 1, 1);
+	ret = rtpcs_sds_select_pll_speed(hw_mode, &speed);
 	if (ret < 0)
 		return ret;
 
-	ret = rtpcs_sds_select_pll_speed(hw_mode, &speed);
+	/*
+	 * dal_longan_construct_mac_default_10gmedia_fiber: vendor sets this
+	 * for any 10G-class port regardless of attachment, despite the
+	 * name; 0 matches this register's hardware reset default.
+	 */
+	ret = rtpcs_sds_write_bits(sds, PAGE_WDIG, 11, 1, 1, speed == RTPCS_SDS_PLL_SPD_10000);
 	if (ret < 0)
 		return ret;
 

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -202,7 +202,7 @@ enum rtpcs_sds_media {
 	RTPCS_SDS_MEDIA_FIBER,
 	RTPCS_SDS_MEDIA_DAC_SHORT,	/*  < 3m */
 	RTPCS_SDS_MEDIA_DAC_LONG,	/* >= 3m */
-	RTPCS_SDS_MEDIA_PCB,
+	RTPCS_SDS_MEDIA_PHY,
 };
 
 enum rtpcs_sds_pll_type {
@@ -593,7 +593,7 @@ static int rtpcs_sds_select_media(enum rtpcs_sds_mode hw_mode, enum rtpcs_sds_me
 		 * the SerDes-to-PHY trace is short and the PHY equalizes for
 		 * itself on the far end.
 		 */
-		*media = RTPCS_SDS_MEDIA_PCB;
+		*media = RTPCS_SDS_MEDIA_PHY;
 		break;
 	}
 
@@ -2530,7 +2530,7 @@ static void rtpcs_930x_sds_rxcal_leq_adapt_lock(struct rtpcs_serdes *sds)
 	/*
 	 * Empirical correction based on media type.
 	 * Direct SerDes connections get a base offset of +3; DAC cables add further
-	 * correction for their attenuation. PHY-attached (PCB) needs none.
+	 * correction for their attenuation. PHY-attached needs none.
 	 */
 	switch (sds->media) {
 	case RTPCS_SDS_MEDIA_FIBER:

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -581,13 +581,18 @@ static int rtpcs_sds_select_media(enum rtpcs_sds_mode hw_mode, enum rtpcs_sds_me
 	case RTPCS_SDS_MODE_OFF:
 		*media = RTPCS_SDS_MEDIA_NONE;
 		break;
-	case RTPCS_SDS_MODE_SGMII:
 	case RTPCS_SDS_MODE_1000BASEX:
 	case RTPCS_SDS_MODE_2500BASEX:
 	case RTPCS_SDS_MODE_10GBASER:
 		*media = RTPCS_SDS_MEDIA_FIBER;
 		break;
 	default:
+		/*
+		 * SGMII, QSGMII, XSGMII and USXGMII always run into a PHY, be
+		 * it on-board or embedded in an SFP copper module; either way
+		 * the SerDes-to-PHY trace is short and the PHY equalizes for
+		 * itself on the far end.
+		 */
 		*media = RTPCS_SDS_MEDIA_PCB;
 		break;
 	}

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -1618,6 +1618,31 @@ static void rtpcs_93xx_sds_fill_caps(struct rtpcs_serdes *sds)
 	}
 }
 
+static int rtpcs_93xx_sds_get_cmu_page(enum rtpcs_sds_mode hw_mode)
+{
+	switch (hw_mode) {
+	case RTPCS_SDS_MODE_SGMII:
+	case RTPCS_SDS_MODE_1000BASEX:
+		return PAGE_ANA_1G2;
+	case RTPCS_SDS_MODE_2500BASEX:
+		return PAGE_ANA_3G1;
+	case RTPCS_SDS_MODE_QSGMII:
+		return PAGE_ANA_5G0;
+	//	return PAGE_ANA_6G0;
+	case RTPCS_SDS_MODE_XSGMII:
+	case RTPCS_SDS_MODE_USXGMII_10GSXGMII:
+	case RTPCS_SDS_MODE_USXGMII_10GDXGMII:
+	case RTPCS_SDS_MODE_USXGMII_10GQXGMII:
+	case RTPCS_SDS_MODE_USXGMII_5GSXGMII:
+	case RTPCS_SDS_MODE_USXGMII_5GDXGMII:
+	case RTPCS_SDS_MODE_USXGMII_2_5GSXGMII:
+	case RTPCS_SDS_MODE_10GBASER:
+		return PAGE_ANA_10G;
+	default:
+		return -EOPNOTSUPP;
+	}
+}
+
 /* RTL930X */
 
 /* This mapping is not coherent so it cannot be expressed arithmetically */
@@ -3235,36 +3260,11 @@ static void rtpcs_931x_sds_rx_reset(struct rtpcs_serdes *sds)
 	msleep(50);
 }
 
-static int rtpcs_931x_sds_cmu_page_get(enum rtpcs_sds_mode hw_mode)
-{
-	switch (hw_mode) {
-	case RTPCS_SDS_MODE_SGMII:
-	case RTPCS_SDS_MODE_1000BASEX:
-		return PAGE_ANA_1G2;
-	case RTPCS_SDS_MODE_2500BASEX:
-		return PAGE_ANA_3G1;
-	case RTPCS_SDS_MODE_QSGMII:
-		return PAGE_ANA_5G0;
-	//	return PAGE_ANA_6G0;
-	case RTPCS_SDS_MODE_XSGMII:
-	case RTPCS_SDS_MODE_USXGMII_10GSXGMII:
-	case RTPCS_SDS_MODE_USXGMII_10GDXGMII:
-	case RTPCS_SDS_MODE_USXGMII_10GQXGMII:
-	case RTPCS_SDS_MODE_USXGMII_5GSXGMII:
-	case RTPCS_SDS_MODE_USXGMII_5GDXGMII:
-	case RTPCS_SDS_MODE_USXGMII_2_5GSXGMII:
-	case RTPCS_SDS_MODE_10GBASER:
-		return PAGE_ANA_10G;
-	default:
-		return -ENOTSUPP;
-	}
-}
-
 static int rtpcs_931x_sds_get_pll_select(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type *pll)
 {
 	int cmu_page, pll_sel;
 
-	cmu_page = rtpcs_931x_sds_cmu_page_get(sds->hw_mode);
+	cmu_page = rtpcs_93xx_sds_get_cmu_page(sds->hw_mode);
 	if (cmu_page < 0)
 		return cmu_page;
 
@@ -3283,7 +3283,7 @@ static int rtpcs_931x_sds_set_pll_select(struct rtpcs_serdes *sds, enum rtpcs_sd
 	int cmu_page, ret, val;
 	int frc_lc_mode_bit;
 
-	cmu_page = rtpcs_931x_sds_cmu_page_get(hw_mode);
+	cmu_page = rtpcs_93xx_sds_get_cmu_page(hw_mode);
 	if (cmu_page < 0)
 		return cmu_page;
 

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -1692,6 +1692,17 @@ static const struct rtpcs_sds_tx_config rtpcs_930x_sds_tx_config_10g = {
 };
 
 /*
+ * PHY-attached 10G-class links (XSGMII, USXGMII): weaker than the fiber/DAC
+ * value above since the far-end PHY equalizes on its own. main_amp reuses
+ * the 1G/2.5G fiber override's value, also the vendor SDK's genuine-fiber
+ * (non-DAC) 10G value; a non-adaptive receiver needing no more than this
+ * should be a safe upper bound for a PHY that equalizes on top.
+ */
+static const struct rtpcs_sds_tx_config rtpcs_930x_sds_tx_config_phy = {
+	.main_amp = 0x9, .impedance = 0x8
+};
+
+/*
  * RTL930X needs a special mapping from logic SerDes ID to physical SerDes ID,
  * which takes the page into account. This applies to most of read/write calls.
  */
@@ -2989,6 +3000,7 @@ static int rtpcs_930x_sds_config_attachment(struct rtpcs_serdes *sds,
 					    enum rtpcs_sds_mode hw_mode)
 {
 	const struct rtpcs_sds_tx_config *tx_cfg;
+	enum rtpcs_sds_pll_speed speed;
 	int ret;
 
 	if (sds->type != RTPCS_SDS_TYPE_10G)
@@ -3002,19 +3014,26 @@ static int rtpcs_930x_sds_config_attachment(struct rtpcs_serdes *sds,
 	if (ret < 0)
 		return ret;
 
-	switch (hw_mode) {
-	case RTPCS_SDS_MODE_1000BASEX:
-	case RTPCS_SDS_MODE_SGMII:
+	ret = rtpcs_sds_select_pll_speed(hw_mode, &speed);
+	if (ret < 0)
+		return ret;
+
+	switch (speed) {
+	case RTPCS_SDS_PLL_SPD_1000:
 		tx_cfg = &rtpcs_930x_sds_tx_config_1g;
 		break;
-	case RTPCS_SDS_MODE_2500BASEX:
+	case RTPCS_SDS_PLL_SPD_2500:
 		tx_cfg = &rtpcs_930x_sds_tx_config_2g5;
 		break;
-	case RTPCS_SDS_MODE_10GBASER:
-	case RTPCS_SDS_MODE_XSGMII:
-	case RTPCS_SDS_MODE_USXGMII_10GSXGMII:
-	case RTPCS_SDS_MODE_USXGMII_10GQXGMII:
-		tx_cfg = &rtpcs_930x_sds_tx_config_10g;
+	case RTPCS_SDS_PLL_SPD_10000:
+		/*
+		 * PHY-attached links equalize on the PHY's own far-end
+		 * receiver, less amp drive needed. Real DAC-vs-fiber
+		 * detection doesn't exist yet, so both of those share
+		 * the same config for now.
+		 */
+		tx_cfg = (attachment == RTPCS_SDS_ATTACH_PHY) ? &rtpcs_930x_sds_tx_config_phy
+							      : &rtpcs_930x_sds_tx_config_10g;
 		break;
 	default:
 		return -EOPNOTSUPP;

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3927,11 +3927,11 @@ static int rtpcs_pcs_config(struct phylink_pcs *pcs, unsigned int neg_mode,
 				if (ret < 0)
 					return ret;
 
-				sds->attachment = attachment;
-
 				ret = sds->ops->config_attachment(sds, attachment, hw_mode);
 				if (ret < 0)
 					return ret;
+
+				sds->attachment = attachment;
 			}
 
 			ret = sds->ops->set_hw_mode(sds, hw_mode);

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -197,12 +197,12 @@ enum rtpcs_sds_mode {
 	RTPCS_SDS_MODE_MAX,
 };
 
-enum rtpcs_sds_media {
-	RTPCS_SDS_MEDIA_NONE,
-	RTPCS_SDS_MEDIA_FIBER,
-	RTPCS_SDS_MEDIA_DAC_SHORT,	/*  < 3m */
-	RTPCS_SDS_MEDIA_DAC_LONG,	/* >= 3m */
-	RTPCS_SDS_MEDIA_PHY,
+enum rtpcs_sds_attachment {
+	RTPCS_SDS_ATTACH_NONE,
+	RTPCS_SDS_ATTACH_FIBER,
+	RTPCS_SDS_ATTACH_DAC_SHORT,	/*  < 3m */
+	RTPCS_SDS_ATTACH_DAC_LONG,	/* >= 3m */
+	RTPCS_SDS_ATTACH_PHY,
 };
 
 enum rtpcs_sds_pll_type {
@@ -259,9 +259,9 @@ struct rtpcs_sds_ops {
 	int (*config_hw_mode)(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode);
 	/* required: set hardware mode */
 	int (*set_hw_mode)(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode);
-	/* optional: configure media-specific parameters */
-	int (*config_media)(struct rtpcs_serdes *sds, enum rtpcs_sds_media media,
-			    enum rtpcs_sds_mode hw_mode);
+	/* optional: configure attachment-specific parameters */
+	int (*config_attachment)(struct rtpcs_serdes *sds, enum rtpcs_sds_attachment attachment,
+				 enum rtpcs_sds_mode hw_mode);
 	/* optional: finalization that must follow power-up, e.g. RX calibration */
 	int (*post_config)(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode);
 };
@@ -295,7 +295,7 @@ struct rtpcs_serdes {
 	s16 link_port[RTPCS_MAX_LINKS_PER_SDS];
 
 	enum rtpcs_sds_mode hw_mode;
-	enum rtpcs_sds_media media;
+	enum rtpcs_sds_attachment attachment;
 	u8 id;
 	u8 num_of_links;
 	bool first_start;
@@ -575,16 +575,17 @@ static int rtpcs_sds_select_hw_mode(struct rtpcs_serdes *sds, phy_interface_t if
 	return 0;
 }
 
-static int rtpcs_sds_select_media(enum rtpcs_sds_mode hw_mode, enum rtpcs_sds_media *media)
+static int rtpcs_sds_select_attachment(enum rtpcs_sds_mode hw_mode,
+				       enum rtpcs_sds_attachment *attachment)
 {
 	switch (hw_mode) {
 	case RTPCS_SDS_MODE_OFF:
-		*media = RTPCS_SDS_MEDIA_NONE;
+		*attachment = RTPCS_SDS_ATTACH_NONE;
 		break;
 	case RTPCS_SDS_MODE_1000BASEX:
 	case RTPCS_SDS_MODE_2500BASEX:
 	case RTPCS_SDS_MODE_10GBASER:
-		*media = RTPCS_SDS_MEDIA_FIBER;
+		*attachment = RTPCS_SDS_ATTACH_FIBER;
 		break;
 	default:
 		/*
@@ -593,7 +594,7 @@ static int rtpcs_sds_select_media(enum rtpcs_sds_mode hw_mode, enum rtpcs_sds_me
 		 * the SerDes-to-PHY trace is short and the PHY equalizes for
 		 * itself on the far end.
 		 */
-		*media = RTPCS_SDS_MEDIA_PHY;
+		*attachment = RTPCS_SDS_ATTACH_PHY;
 		break;
 	}
 
@@ -2502,9 +2503,9 @@ static void rtpcs_930x_sds_rxcal_leq_adapt_lock(struct rtpcs_serdes *sds)
 	 * PHY-attached ports the PHY handles its own equalization, so the SerDes LEQ is left
 	 * in auto-adapt and no correction offset is needed.
 	 */
-	bool direct_serdes = sds->media == RTPCS_SDS_MEDIA_FIBER ||
-			     sds->media == RTPCS_SDS_MEDIA_DAC_SHORT ||
-			     sds->media == RTPCS_SDS_MEDIA_DAC_LONG;
+	bool direct_serdes = sds->attachment == RTPCS_SDS_ATTACH_FIBER ||
+			     sds->attachment == RTPCS_SDS_ATTACH_DAC_SHORT ||
+			     sds->attachment == RTPCS_SDS_ATTACH_DAC_LONG;
 	u32 sum10 = 0, avg10;
 	int i, val;
 
@@ -2528,18 +2529,18 @@ static void rtpcs_930x_sds_rxcal_leq_adapt_lock(struct rtpcs_serdes *sds)
 	avg10 = (sum10 / 10) + (((sum10 % 10) >= 5) ? 1 : 0);
 
 	/*
-	 * Empirical correction based on media type.
+	 * Empirical correction based on attachment type.
 	 * Direct SerDes connections get a base offset of +3; DAC cables add further
 	 * correction for their attenuation. PHY-attached needs none.
 	 */
-	switch (sds->media) {
-	case RTPCS_SDS_MEDIA_FIBER:
+	switch (sds->attachment) {
+	case RTPCS_SDS_ATTACH_FIBER:
 		avg10 += 3;
 		break;
-	case RTPCS_SDS_MEDIA_DAC_SHORT:
+	case RTPCS_SDS_ATTACH_DAC_SHORT:
 		avg10 += 4;	/* base 3 + 1 for short DAC */
 		break;
-	case RTPCS_SDS_MEDIA_DAC_LONG:
+	case RTPCS_SDS_ATTACH_DAC_LONG:
 		avg10 += 6;	/* base 3 + 3 for long DAC */
 		break;
 	default:
@@ -2996,8 +2997,9 @@ static int rtpcs_930x_sds_config_hw_mode(struct rtpcs_serdes *sds, enum rtpcs_sd
 	return 0;
 }
 
-static int rtpcs_930x_sds_config_media(struct rtpcs_serdes *sds, enum rtpcs_sds_media media,
-				       enum rtpcs_sds_mode hw_mode)
+static int rtpcs_930x_sds_config_attachment(struct rtpcs_serdes *sds,
+					    enum rtpcs_sds_attachment attachment,
+					    enum rtpcs_sds_mode hw_mode)
 {
 	if (sds->type != RTPCS_SDS_TYPE_10G)
 		return 0;
@@ -3481,19 +3483,19 @@ static int rtpcs_931x_sds_config_tx_amps(struct rtpcs_serdes *sds, u8 pre_amp, u
  * rtpcs_931x_sds_config_tx - Configure static TX path parameters
  */
 static int rtpcs_931x_sds_config_tx(struct rtpcs_serdes *sds,
-				    enum rtpcs_sds_media sds_media)
+				    enum rtpcs_sds_attachment attachment)
 {
 	const struct rtpcs_sds_tx_config *tx_cfg;
 
 	if (sds->type != RTPCS_SDS_TYPE_10G)
 		return 0;
 
-	switch (sds_media) {
-	case RTPCS_SDS_MEDIA_DAC_SHORT:
+	switch (attachment) {
+	case RTPCS_SDS_ATTACH_DAC_SHORT:
 		tx_cfg = &rtpcs_931x_sds_tx_cfg_sdac;
 		break;
 
-	case RTPCS_SDS_MEDIA_DAC_LONG:
+	case RTPCS_SDS_ATTACH_DAC_LONG:
 		tx_cfg = &rtpcs_931x_sds_tx_cfg_ldac;
 		break;
 
@@ -3515,14 +3517,15 @@ static int rtpcs_931x_sds_config_tx(struct rtpcs_serdes *sds,
  * rtpcs_931x_sds_config_rx - Configure static RX path parameters
  */
 static int rtpcs_931x_sds_config_rx(struct rtpcs_serdes *sds,
-				    enum rtpcs_sds_media sds_media)
+				    enum rtpcs_sds_attachment attachment)
 {
 	/* TODO: Put all static RX configuration here */
 	return 0;
 }
 
-static int rtpcs_931x_sds_config_media(struct rtpcs_serdes *sds, enum rtpcs_sds_media sds_media,
-				       enum rtpcs_sds_mode hw_mode)
+static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
+					    enum rtpcs_sds_attachment attachment,
+					    enum rtpcs_sds_mode hw_mode)
 {
 	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
 	bool is_dac, is_10g;
@@ -3555,21 +3558,21 @@ static int rtpcs_931x_sds_config_media(struct rtpcs_serdes *sds, enum rtpcs_sds_
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xf, 5, 0, 0x4);
 	rtpcs_sds_write_bits(sds, PAGE_ANA_5G0, 0x12, 7, 6, 0x1);
 
-	if (sds_media == RTPCS_SDS_MEDIA_NONE)
+	if (attachment == RTPCS_SDS_ATTACH_NONE)
 		return 0;
 
 	/* config SerDes TX path (amps, impedance, etc.) */
-	ret = rtpcs_931x_sds_config_tx(sds, sds_media);
+	ret = rtpcs_931x_sds_config_tx(sds, attachment);
 	if (ret < 0)
 		return ret;
 
 	/* config SerDes RX path (LEQ, DFE, etc.) */
-	ret = rtpcs_931x_sds_config_rx(sds, sds_media);
+	ret = rtpcs_931x_sds_config_rx(sds, attachment);
 	if (ret < 0)
 		return ret;
 
-	is_dac = (sds_media == RTPCS_SDS_MEDIA_DAC_SHORT ||
-		  sds_media == RTPCS_SDS_MEDIA_DAC_LONG);
+	is_dac = (attachment == RTPCS_SDS_ATTACH_DAC_SHORT ||
+		  attachment == RTPCS_SDS_ATTACH_DAC_LONG);
 	is_10g = (hw_mode == RTPCS_SDS_MODE_10GBASER ||
 		  hw_mode == RTPCS_SDS_MODE_XSGMII ||
 		  rtpcs_sds_mode_is_usxgmii(hw_mode));
@@ -3578,14 +3581,14 @@ static int rtpcs_931x_sds_config_media(struct rtpcs_serdes *sds, enum rtpcs_sds_
 	rtpcs_sds_write_bits(sds, PAGE_ANA_5G0, 0x7, 15, 15, is_dac ? 0x1 : 0x0);
 	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x0, 11, 10, 0x3);
 
-	switch (sds_media) {
-	case RTPCS_SDS_MEDIA_DAC_SHORT:
-	case RTPCS_SDS_MEDIA_DAC_LONG:
+	switch (attachment) {
+	case RTPCS_SDS_ATTACH_DAC_SHORT:
+	case RTPCS_SDS_ATTACH_DAC_LONG:
 		rtpcs_sds_write(sds, PAGE_ANA_COM, 0x19, 0xf0a5);	/* from XS1930-10 SDK */
 		rtpcs_sds_write(even_sds, PAGE_ANA_10G, 0x8, 0x02a0); /* [10:7] impedance */
 		break;
 
-	case RTPCS_SDS_MEDIA_FIBER:
+	case RTPCS_SDS_ATTACH_FIBER:
 		if (is_10g)
 			rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xf, 5, 0, 0x2); /* from DMS1250 SDK */
 
@@ -3888,7 +3891,7 @@ static int rtpcs_pcs_config(struct phylink_pcs *pcs, unsigned int neg_mode,
 	struct rtpcs_link *link = rtpcs_phylink_pcs_to_link(pcs);
 	struct rtpcs_ctrl *ctrl = link->ctrl;
 	struct rtpcs_serdes *sds = link->sds;
-	enum rtpcs_sds_media sds_media;
+	enum rtpcs_sds_attachment attachment;
 	enum rtpcs_sds_mode hw_mode;
 	int ret;
 
@@ -3919,14 +3922,14 @@ static int rtpcs_pcs_config(struct phylink_pcs *pcs, unsigned int neg_mode,
 			if (ret < 0)
 				return ret;
 
-			if (sds->ops->config_media) {
-				ret = rtpcs_sds_select_media(hw_mode, &sds_media);
+			if (sds->ops->config_attachment) {
+				ret = rtpcs_sds_select_attachment(hw_mode, &attachment);
 				if (ret < 0)
 					return ret;
 
-				sds->media = sds_media;
+				sds->attachment = attachment;
 
-				ret = sds->ops->config_media(sds, sds_media, hw_mode);
+				ret = sds->ops->config_attachment(sds, attachment, hw_mode);
 				if (ret < 0)
 					return ret;
 			}
@@ -4315,7 +4318,7 @@ static const struct rtpcs_sds_ops rtpcs_930x_sds_ops = {
 	.activate		= rtpcs_930x_sds_activate,
 	.config_hw_mode		= rtpcs_930x_sds_config_hw_mode,
 	.set_hw_mode		= rtpcs_930x_sds_set_mode,
-	.config_media		= rtpcs_930x_sds_config_media,
+	.config_attachment	= rtpcs_930x_sds_config_attachment,
 	.post_config		= rtpcs_930x_sds_post_config,
 };
 
@@ -4362,7 +4365,7 @@ static const struct rtpcs_sds_ops rtpcs_931x_sds_ops = {
 	.activate		= rtpcs_931x_sds_activate,
 	.config_hw_mode		= rtpcs_931x_sds_config_hw_mode,
 	.set_hw_mode		= rtpcs_931x_sds_set_mode,
-	.config_media		= rtpcs_931x_sds_config_media,
+	.config_attachment	= rtpcs_931x_sds_config_attachment,
 };
 
 static const struct rtpcs_sds_regs rtpcs_931x_sds_regs = {

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -2020,8 +2020,8 @@ static int rtpcs_930x_sds_activate(struct rtpcs_serdes *sds)
 	return rtpcs_sds_write_bits(sds, PAGE_TGR_STD_0, MII_BMCR, 11, 11, 0); /* BMCR_PDOWN */
 }
 
-static void rtpcs_930x_sds_tx_config(struct rtpcs_serdes *sds,
-				     enum rtpcs_sds_mode hw_mode)
+static int rtpcs_930x_sds_tx_config(struct rtpcs_serdes *sds,
+				    enum rtpcs_sds_mode hw_mode)
 {
 	/* parameters: rtl9303_80G_txParam_s2 */
 	enum rtpcs_page page;
@@ -2031,6 +2031,14 @@ static void rtpcs_930x_sds_tx_config(struct rtpcs_serdes *sds,
 	int post_amp = 0x2;
 	int pre_en = 0x1;
 	int post_en = 0x1;
+	int ret;
+
+	ret = rtpcs_93xx_sds_get_cmu_page(hw_mode);
+	if (ret < 0)
+		return ret;
+
+	/* TX config happens on extended CMU page */
+	page = ret + 1;
 
 	switch (hw_mode) {
 	case RTPCS_SDS_MODE_1000BASEX:
@@ -2038,13 +2046,11 @@ static void rtpcs_930x_sds_tx_config(struct rtpcs_serdes *sds,
 		pre_amp = 0x1;
 		main_amp = 0x9;
 		post_amp = 0x1;
-		page = PAGE_ANA_1G2_EXT;
 		break;
 	case RTPCS_SDS_MODE_2500BASEX:
 		pre_amp = 0;
 		post_amp = 0x8;
 		pre_en = 0;
-		page = PAGE_ANA_3G1_EXT;
 		break;
 	case RTPCS_SDS_MODE_10GBASER:
 	case RTPCS_SDS_MODE_USXGMII_10GSXGMII:
@@ -2055,13 +2061,12 @@ static void rtpcs_930x_sds_tx_config(struct rtpcs_serdes *sds,
 		main_amp = 0x10;
 		post_amp = 0;
 		post_en	= 0;
-		page = PAGE_ANA_10G_EXT;
 		break;
 	case RTPCS_SDS_MODE_QSGMII:
-		return;
+		return 0;
 	default:
 		pr_err("%s: unsupported SerDes hw mode\n", __func__);
-		return;
+		return -EOPNOTSUPP;
 	}
 
 	rtpcs_sds_write_bits(sds, page, 0x01, 15, 11, pre_amp);
@@ -2070,6 +2075,7 @@ static void rtpcs_930x_sds_tx_config(struct rtpcs_serdes *sds,
 	rtpcs_sds_write_bits(sds, page, 0x07,  3,  3, post_en);
 	rtpcs_sds_write_bits(sds, page, 0x07,  8,  4, main_amp);
 	rtpcs_sds_write_bits(sds, page, 0x18, 15, 12, impedance);
+	return 0;
 }
 
 static int rtpcs_930x_sds_set_debug(struct rtpcs_serdes *sds, unsigned int debug_sel)
@@ -2995,8 +3001,7 @@ static int rtpcs_930x_sds_config_media(struct rtpcs_serdes *sds, enum rtpcs_sds_
 	 */
 	rtpcs_sds_write_bits(sds, PAGE_WDIG, 11, 1, 1, 1);
 
-	rtpcs_930x_sds_tx_config(sds, hw_mode);
-	return 0;
+	return rtpcs_930x_sds_tx_config(sds, hw_mode);
 }
 
 static int rtpcs_930x_sds_post_config(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode)

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -349,6 +349,7 @@ struct rtpcs_sds_tx_config {
 	u8 pre_amp;
 	u8 main_amp;
 	u8 post_amp;
+	u8 impedance;
 };
 
 /* Calculation helpers */
@@ -1678,6 +1679,18 @@ static const struct reg_field rtpcs_930x_usxgmii_submode_fields[] = {
 	[7] = REG_FIELD(RTPCS_930X_SDS_SUBMODE_CTRL_1, 25, 29),
 };
 
+static const struct rtpcs_sds_tx_config rtpcs_930x_sds_tx_config_1g = {
+	.pre_amp = 0x1, .main_amp = 0x9, .post_amp = 0x1, .impedance = 0x8
+};
+
+static const struct rtpcs_sds_tx_config rtpcs_930x_sds_tx_config_2g5 = {
+	.main_amp = 0x9, .post_amp = 0x8, .impedance = 0x8
+};
+
+static const struct rtpcs_sds_tx_config rtpcs_930x_sds_tx_config_10g = {
+	.main_amp = 0x10, .impedance = 0x8
+};
+
 /*
  * RTL930X needs a special mapping from logic SerDes ID to physical SerDes ID,
  * which takes the page into account. This applies to most of read/write calls.
@@ -2026,17 +2039,10 @@ static int rtpcs_930x_sds_activate(struct rtpcs_serdes *sds)
 	return rtpcs_sds_write_bits(sds, PAGE_TGR_STD_0, MII_BMCR, 11, 11, 0); /* BMCR_PDOWN */
 }
 
-static int rtpcs_930x_sds_tx_config(struct rtpcs_serdes *sds,
-				    enum rtpcs_sds_mode hw_mode)
+static int rtpcs_930x_sds_tx_config(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode,
+				    const struct rtpcs_sds_tx_config *tx_conf)
 {
-	/* parameters: rtl9303_80G_txParam_s2 */
 	enum rtpcs_page page;
-	int impedance = 0x8;
-	int pre_amp = 0x2;
-	int main_amp = 0x9;
-	int post_amp = 0x2;
-	int pre_en = 0x1;
-	int post_en = 0x1;
 	int ret;
 
 	ret = rtpcs_93xx_sds_get_cmu_page(hw_mode);
@@ -2046,42 +2052,23 @@ static int rtpcs_930x_sds_tx_config(struct rtpcs_serdes *sds,
 	/* TX config happens on extended CMU page */
 	page = ret + 1;
 
-	switch (hw_mode) {
-	case RTPCS_SDS_MODE_1000BASEX:
-	case RTPCS_SDS_MODE_SGMII:
-		pre_amp = 0x1;
-		main_amp = 0x9;
-		post_amp = 0x1;
-		break;
-	case RTPCS_SDS_MODE_2500BASEX:
-		pre_amp = 0;
-		post_amp = 0x8;
-		pre_en = 0;
-		break;
-	case RTPCS_SDS_MODE_10GBASER:
-	case RTPCS_SDS_MODE_USXGMII_10GSXGMII:
-	case RTPCS_SDS_MODE_USXGMII_10GQXGMII:
-	case RTPCS_SDS_MODE_XSGMII:
-		pre_en = 0;
-		pre_amp = 0;
-		main_amp = 0x10;
-		post_amp = 0;
-		post_en	= 0;
-		break;
-	case RTPCS_SDS_MODE_QSGMII:
-		return 0;
-	default:
-		pr_err("%s: unsupported SerDes hw mode\n", __func__);
-		return -EOPNOTSUPP;
-	}
+	ret = rtpcs_sds_write_bits(sds, page, 0x18, 15, 12, tx_conf->impedance);
+	if (!ret)
+		ret = rtpcs_sds_write_bits(sds, page, 0x07, 8, 4, tx_conf->main_amp);
 
-	rtpcs_sds_write_bits(sds, page, 0x01, 15, 11, pre_amp);
-	rtpcs_sds_write_bits(sds, page, 0x06,  4,  0, post_amp);
-	rtpcs_sds_write_bits(sds, page, 0x07,  0,  0, pre_en);
-	rtpcs_sds_write_bits(sds, page, 0x07,  3,  3, post_en);
-	rtpcs_sds_write_bits(sds, page, 0x07,  8,  4, main_amp);
-	rtpcs_sds_write_bits(sds, page, 0x18, 15, 12, impedance);
-	return 0;
+	/* pre-amp */
+	if (!ret)
+		ret = rtpcs_sds_write_bits(sds, page, 0x01, 15, 11, tx_conf->pre_amp);
+	if (!ret)
+		ret = rtpcs_sds_write_bits(sds, page, 0x07, 0, 0, tx_conf->pre_amp ? 1 : 0);
+
+	/* post-amp */
+	if (!ret)
+		ret = rtpcs_sds_write_bits(sds, page, 0x06, 4, 0, tx_conf->post_amp);
+	if (!ret)
+		ret = rtpcs_sds_write_bits(sds, page, 0x07, 3, 3, tx_conf->post_amp ? 1 : 0);
+
+	return ret;
 }
 
 static int rtpcs_930x_sds_set_debug(struct rtpcs_serdes *sds, unsigned int debug_sel)
@@ -3001,17 +2988,39 @@ static int rtpcs_930x_sds_config_attachment(struct rtpcs_serdes *sds,
 					    enum rtpcs_sds_attachment attachment,
 					    enum rtpcs_sds_mode hw_mode)
 {
+	const struct rtpcs_sds_tx_config *tx_cfg;
+	int ret;
+
 	if (sds->type != RTPCS_SDS_TYPE_10G)
 		return 0;
 
 	/*
 	 * dal_longan_construct_mac_default_10gmedia_fiber: set medium to fiber.
-	 * TODO: this is unconditional regardless of hw_mode; needs mode-aware
-	 * handling.
+	 * TODO: does this apply to all fiber modes or only 10GBase-R?
 	 */
-	rtpcs_sds_write_bits(sds, PAGE_WDIG, 11, 1, 1, 1);
+	ret = rtpcs_sds_write_bits(sds, PAGE_WDIG, 11, 1, 1, 1);
+	if (ret < 0)
+		return ret;
 
-	return rtpcs_930x_sds_tx_config(sds, hw_mode);
+	switch (hw_mode) {
+	case RTPCS_SDS_MODE_1000BASEX:
+	case RTPCS_SDS_MODE_SGMII:
+		tx_cfg = &rtpcs_930x_sds_tx_config_1g;
+		break;
+	case RTPCS_SDS_MODE_2500BASEX:
+		tx_cfg = &rtpcs_930x_sds_tx_config_2g5;
+		break;
+	case RTPCS_SDS_MODE_10GBASER:
+	case RTPCS_SDS_MODE_XSGMII:
+	case RTPCS_SDS_MODE_USXGMII_10GSXGMII:
+	case RTPCS_SDS_MODE_USXGMII_10GQXGMII:
+		tx_cfg = &rtpcs_930x_sds_tx_config_10g;
+		break;
+	default:
+		return -EOPNOTSUPP;
+	}
+
+	return rtpcs_930x_sds_tx_config(sds, hw_mode, tx_cfg);
 }
 
 static int rtpcs_930x_sds_post_config(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode)


### PR DESCRIPTION
This series refactors TX configuration for RTL930x, bringing it into a better shape. While mostly being some code improvements, it also employs behavioral changes regarding when TX tuning should be applied.

Real-traffic testing across various modes, especially those affected by the changes, showed no regressions. This is consistent with the reasoning that PHY-attached links need less SerDes-side TX tuning since the PHY's own adaptive equalizer compensates for it. Whether it's measurably better is unverified — that would require signal-quality measurement this driver has no way to do.
