### PR TITLE
ledtrig-network: default missing family to WLAN on non-DT LEDs

### DIFF
--- a/target/linux/generic/files/drivers/leds/trigger/ledtrig-network.c
+++ b/target/linux/generic/files/drivers/leds/trigger/ledtrig-network.c
@@ -1070,9 +1070,9 @@ static int net_activate(struct led_classdev *led_cdev)
 		 */
 		parsed = parse_family_token(fn, &online);
 		if (parsed < 0) {
-			pr_info("network: unknown function '%s' for LED %s\n",
+			pr_warn("network: cannot infer family from '%s' for LED %s, defaulting to 'wlan'\n",
 				fn ?: "<NULL>", name);
-			return -EINVAL;
+			parsed = NET_TRIG_WLAN;
 		}
 
 		if (online) {


### PR DESCRIPTION
For LEDs that have no network trigger configuration in Device Tree (no mode or family properties), net_activate() infers the family from the LED name or function string. If that inference fails, the trigger previously returned -EINVAL and refused to activate.

This is too strict for manual activation via sysfs (e.g. echo "network" > /sys/class/leds/<led>/trigger) on LEDs that were not declared for the network trigger in DT. In that case the user expects the trigger to load with sensible defaults.

Change the non-DT activation path to fall back to NET_TRIG_WLAN instead of failing, while keeping the condition visible via pr_warn(). Device Tree paths with dt_mode or dt_family are left unchanged and continue to fail on invalid parameters