### PR TITLE
realtek: pse: extend support to more devices

### DIFF
--- a/target/linux/realtek/dts/macros.dtsi
+++ b/target/linux/realtek/dts/macros.dtsi
@@ -32,6 +32,14 @@
 		enet-phy-pair-order = <##po>; \
 	};
 
+#define HASH_PSE_CELLS #pse-cells
+
+#define PSE_PI(p) \
+	pse_pi##p: pse-pi@p { \
+		reg = <p>; \
+		HASH_PSE_CELLS = <0>; \
+	};
+
 #define SWITCH_PORT(p, l, m) \
 	port##p: port@##p { \
 		reg = <##p>; \

--- a/target/linux/realtek/dts/rtl8391_zyxel_gs1920-24hp-v2.dts
+++ b/target/linux/realtek/dts/rtl8391_zyxel_gs1920-24hp-v2.dts
@@ -124,6 +124,10 @@
 	PHY_C22_SFP(27, 27, 3)
 };
 
+&pse {
+	compatible = "zyxel,gs1920-24hp-v2-pse", "realtek,pse-mcu-gen1-smbus";
+};
+
 &switch0 {
 	ethernet-ports {
 		SWITCH_PORT_SDS(24, 25, 6, 0, qsgmii)

--- a/target/linux/realtek/dts/rtl8392_zyxel_gs1920-24hp-v1.dts
+++ b/target/linux/realtek/dts/rtl8392_zyxel_gs1920-24hp-v1.dts
@@ -78,6 +78,10 @@
 	PHY_C22_SFP(51, 27, 3)
 };
 
+&pse {
+	compatible = "zyxel,gs1920-24hp-v1-pse", "realtek,pse-mcu-gen1-smbus";
+};
+
 &switch0 {
 	ethernet-ports {
 		SWITCH_PORT_SDS(48, 25, 12, 0, qsgmii)

--- a/target/linux/realtek/dts/rtl839x_zyxel_gs1920-24hp-common.dtsi
+++ b/target/linux/realtek/dts/rtl839x_zyxel_gs1920-24hp-common.dtsi
@@ -112,6 +112,40 @@
 		i2c-gpio,delay-us = <2>;
 		#address-cells = <1>;
 		#size-cells = <0>;
+
+		pse: ethernet-pse@20 {
+			reg = <0x20>;
+
+			pse-pis {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				PSE_PI(0)
+				PSE_PI(1)
+				PSE_PI(2)
+				PSE_PI(3)
+				PSE_PI(4)
+				PSE_PI(5)
+				PSE_PI(6)
+				PSE_PI(7)
+				PSE_PI(8)
+				PSE_PI(9)
+				PSE_PI(10)
+				PSE_PI(11)
+				PSE_PI(12)
+				PSE_PI(13)
+				PSE_PI(14)
+				PSE_PI(15)
+				PSE_PI(16)
+				PSE_PI(17)
+				PSE_PI(18)
+				PSE_PI(19)
+				PSE_PI(20)
+				PSE_PI(21)
+				PSE_PI(22)
+				PSE_PI(23)
+			};
+		};
 	};
 };
 
@@ -245,3 +279,28 @@
 		};
 	};
 };
+
+&phy0 { pses = <&pse_pi0>; };
+&phy1 { pses = <&pse_pi1>; };
+&phy2 { pses = <&pse_pi2>; };
+&phy3 { pses = <&pse_pi3>; };
+&phy4 { pses = <&pse_pi4>; };
+&phy5 { pses = <&pse_pi5>; };
+&phy6 { pses = <&pse_pi6>; };
+&phy7 { pses = <&pse_pi7>; };
+&phy8 { pses = <&pse_pi8>; };
+&phy9 { pses = <&pse_pi9>; };
+&phy10 { pses = <&pse_pi10>; };
+&phy11 { pses = <&pse_pi11>; };
+&phy12 { pses = <&pse_pi12>; };
+&phy13 { pses = <&pse_pi13>; };
+&phy14 { pses = <&pse_pi14>; };
+&phy15 { pses = <&pse_pi15>; };
+&phy16 { pses = <&pse_pi16>; };
+&phy17 { pses = <&pse_pi17>; };
+&phy18 { pses = <&pse_pi18>; };
+&phy19 { pses = <&pse_pi19>; };
+&phy20 { pses = <&pse_pi20>; };
+&phy21 { pses = <&pse_pi21>; };
+&phy22 { pses = <&pse_pi22>; };
+&phy23 { pses = <&pse_pi23>; };

--- a/target/linux/realtek/dts/rtl9301_linksys_lgs328mpc-v2.dts
+++ b/target/linux/realtek/dts/rtl9301_linksys_lgs328mpc-v2.dts
@@ -36,6 +36,50 @@
 			debounce-interval = <60>;
 		};
 	};
+
+	i2c_poe: i2c-poe {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio0  9 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio0 17 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <5>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		pse: ethernet-pse@2a {
+			compatible = "linksys,lgs328mpc-v2-pse", "realtek,pse-mcu-gen2-i2c";
+			reg = <0x2a>;
+
+			pse-pis {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				PSE_PI(0)
+				PSE_PI(1)
+				PSE_PI(2)
+				PSE_PI(3)
+				PSE_PI(4)
+				PSE_PI(5)
+				PSE_PI(6)
+				PSE_PI(7)
+				PSE_PI(8)
+				PSE_PI(9)
+				PSE_PI(10)
+				PSE_PI(11)
+				PSE_PI(12)
+				PSE_PI(13)
+				PSE_PI(14)
+				PSE_PI(15)
+				PSE_PI(16)
+				PSE_PI(17)
+				PSE_PI(18)
+				PSE_PI(19)
+				PSE_PI(20)
+				PSE_PI(21)
+				PSE_PI(22)
+				PSE_PI(23)
+			};
+		};
+	};
 };
 
 &i2c_mst1 {
@@ -49,3 +93,28 @@
 		};
 	};
 };
+
+&phy0  { pses = <&pse_pi0>; };
+&phy1  { pses = <&pse_pi1>; };
+&phy2  { pses = <&pse_pi2>; };
+&phy3  { pses = <&pse_pi3>; };
+&phy4  { pses = <&pse_pi4>; };
+&phy5  { pses = <&pse_pi5>; };
+&phy6  { pses = <&pse_pi6>; };
+&phy7  { pses = <&pse_pi7>; };
+&phy8  { pses = <&pse_pi8>; };
+&phy9  { pses = <&pse_pi9>; };
+&phy10 { pses = <&pse_pi10>; };
+&phy11 { pses = <&pse_pi11>; };
+&phy12 { pses = <&pse_pi12>; };
+&phy13 { pses = <&pse_pi13>; };
+&phy14 { pses = <&pse_pi14>; };
+&phy15 { pses = <&pse_pi15>; };
+&phy16 { pses = <&pse_pi16>; };
+&phy17 { pses = <&pse_pi17>; };
+&phy18 { pses = <&pse_pi18>; };
+&phy19 { pses = <&pse_pi19>; };
+&phy20 { pses = <&pse_pi20>; };
+&phy21 { pses = <&pse_pi21>; };
+&phy22 { pses = <&pse_pi22>; };
+&phy23 { pses = <&pse_pi23>; };

--- a/target/linux/realtek/dts/rtl9301_zyxel_xgs1930-28hp.dts
+++ b/target/linux/realtek/dts/rtl9301_zyxel_xgs1930-28hp.dts
@@ -176,6 +176,13 @@
 		tx-fault-gpio = <&gpio1 28 GPIO_ACTIVE_HIGH>;
 		los-gpio = <&gpio1 24 GPIO_ACTIVE_HIGH>;
 	};
+
+	poe_power: regulator-poe {
+		compatible = "regulator-fixed";
+		regulator-name = "poe-power";
+		gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
 };
 
 &gpio0 {
@@ -185,13 +192,6 @@
 		output-high;
 		line-name = "sfp-enable";
 	};
-
-	poe_mcu_enable_hog {
-		gpio-hog;
-		gpios = <19 GPIO_ACTIVE_HIGH>;
-		output-high;
-		line-name = "poe-mcu-enable";
-	};
 };
 
 &i2c_mst1 {
@@ -199,7 +199,44 @@
 
 	i2c0: i2c@0 {
 		reg = <0>;
-		/* PoE MCU sits here at 0x20 */
+
+		pse: ethernet-pse@20 {
+			compatible = "zyxel,xgs1930-28hp-pse", "realtek,pse-mcu-gen2-smbus";
+			reg = <0x20>;
+
+			enable-gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>;
+			power-supply = <&poe_power>;
+
+			pse-pis {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				PSE_PI(0)
+				PSE_PI(1)
+				PSE_PI(2)
+				PSE_PI(3)
+				PSE_PI(4)
+				PSE_PI(5)
+				PSE_PI(6)
+				PSE_PI(7)
+				PSE_PI(8)
+				PSE_PI(9)
+				PSE_PI(10)
+				PSE_PI(11)
+				PSE_PI(12)
+				PSE_PI(13)
+				PSE_PI(14)
+				PSE_PI(15)
+				PSE_PI(16)
+				PSE_PI(17)
+				PSE_PI(18)
+				PSE_PI(19)
+				PSE_PI(20)
+				PSE_PI(21)
+				PSE_PI(22)
+				PSE_PI(23)
+			};
+		};
 	};
 };
 
@@ -234,13 +271,6 @@
 		led-controller {
 			compatible = "realtek,rtl8231-leds";
 			status = "disabled";
-		};
-
-		poe_enable_hog {
-			gpio-hog;
-			gpios = <12 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "poe-enable";
 		};
 	};
 };
@@ -425,3 +455,28 @@
 	nvmem-cells = <&factory_macaddr>;
 	nvmem-cell-names = "mac-address";
 };
+
+&phy0 { pses = <&pse_pi0>; };
+&phy1 { pses = <&pse_pi1>; };
+&phy2 { pses = <&pse_pi2>; };
+&phy3 { pses = <&pse_pi3>; };
+&phy4 { pses = <&pse_pi4>; };
+&phy5 { pses = <&pse_pi5>; };
+&phy6 { pses = <&pse_pi6>; };
+&phy7 { pses = <&pse_pi7>; };
+&phy8 { pses = <&pse_pi8>; };
+&phy9 { pses = <&pse_pi9>; };
+&phy10 { pses = <&pse_pi10>; };
+&phy11 { pses = <&pse_pi11>; };
+&phy12 { pses = <&pse_pi12>; };
+&phy13 { pses = <&pse_pi13>; };
+&phy14 { pses = <&pse_pi14>; };
+&phy15 { pses = <&pse_pi15>; };
+&phy16 { pses = <&pse_pi16>; };
+&phy17 { pses = <&pse_pi17>; };
+&phy18 { pses = <&pse_pi18>; };
+&phy19 { pses = <&pse_pi19>; };
+&phy20 { pses = <&pse_pi20>; };
+&phy21 { pses = <&pse_pi21>; };
+&phy22 { pses = <&pse_pi22>; };
+&phy23 { pses = <&pse_pi23>; };

--- a/target/linux/realtek/dts/rtl9302_zyxel_xmg1915-10ep.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xmg1915-10ep.dts
@@ -35,38 +35,14 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			pse_pi0: pse-pi@0 {
-				reg = <0>;
-				#pse-cells = <0>;
-			};
-			pse_pi1: pse-pi@1 {
-				reg = <1>;
-				#pse-cells = <0>;
-			};
-			pse_pi2: pse-pi@2 {
-				reg = <2>;
-				#pse-cells = <0>;
-			};
-			pse_pi3: pse-pi@3 {
-				reg = <3>;
-				#pse-cells = <0>;
-			};
-			pse_pi4: pse-pi@4 {
-				reg = <4>;
-				#pse-cells = <0>;
-			};
-			pse_pi5: pse-pi@5 {
-				reg = <5>;
-				#pse-cells = <0>;
-			};
-			pse_pi6: pse-pi@6 {
-				reg = <6>;
-				#pse-cells = <0>;
-			};
-			pse_pi7: pse-pi@7 {
-				reg = <7>;
-				#pse-cells = <0>;
-			};
+			PSE_PI(0)
+			PSE_PI(1)
+			PSE_PI(2)
+			PSE_PI(3)
+			PSE_PI(4)
+			PSE_PI(5)
+			PSE_PI(6)
+			PSE_PI(7)
 		};
 	};
 };

--- a/target/linux/realtek/dts/rtl9312_plasmacloud_psx28.dts
+++ b/target/linux/realtek/dts/rtl9312_plasmacloud_psx28.dts
@@ -14,21 +14,74 @@
 			gpios = <&gpio1 28 GPIO_ACTIVE_LOW>;
 		};
 	};
+};
 
-	gpio-export {
-		compatible = "gpio-export";
+&i2c_mst1 {
+	i2c5: i2c@5 {
+		reg = <5>;
+		#address-cells = <1>;
+		#size-cells = <0>;
 
-		poe_mcu_reset {
-			gpio-export,name = "poe_mcu_reset";
-			gpio-export,output = <1>;
-			gpios = <&gpio1 29 GPIO_ACTIVE_LOW>;
+		pse: ethernet-pse@20 {
+			compatible = "plasmacloud,psx28-pse", "realtek,pse-mcu-gen2-smbus";
+			reg = <0x20>;
+
+			enable-gpios = <&gpio1 29 GPIO_ACTIVE_HIGH>;
+
+			pse-pis {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				PSE_PI(0)
+				PSE_PI(1)
+				PSE_PI(2)
+				PSE_PI(3)
+				PSE_PI(4)
+				PSE_PI(5)
+				PSE_PI(6)
+				PSE_PI(7)
+				PSE_PI(8)
+				PSE_PI(9)
+				PSE_PI(10)
+				PSE_PI(11)
+				PSE_PI(12)
+				PSE_PI(13)
+				PSE_PI(14)
+				PSE_PI(15)
+				PSE_PI(16)
+				PSE_PI(17)
+				PSE_PI(18)
+				PSE_PI(19)
+				PSE_PI(20)
+				PSE_PI(21)
+				PSE_PI(22)
+				PSE_PI(23)
+			};
 		};
 	};
 };
 
-&i2c_mst1 {
-	/* i2c for rtl8239 PoE PSE Chip */
-	i2c@5 {
-		reg = <5>;
-	};
-};
+&phy0 { pses = <&pse_pi0>; };
+&phy1 { pses = <&pse_pi1>; };
+&phy4 { pses = <&pse_pi2>; };
+&phy5 { pses = <&pse_pi3>; };
+&phy8 { pses = <&pse_pi4>; };
+&phy9 { pses = <&pse_pi5>; };
+&phy12 { pses = <&pse_pi6>; };
+&phy13 { pses = <&pse_pi7>; };
+&phy16 { pses = <&pse_pi8>; };
+&phy17 { pses = <&pse_pi9>; };
+&phy20 { pses = <&pse_pi10>; };
+&phy21 { pses = <&pse_pi11>; };
+&phy24 { pses = <&pse_pi12>; };
+&phy25 { pses = <&pse_pi13>; };
+&phy28 { pses = <&pse_pi14>; };
+&phy29 { pses = <&pse_pi15>; };
+&phy32 { pses = <&pse_pi16>; };
+&phy33 { pses = <&pse_pi17>; };
+&phy36 { pses = <&pse_pi18>; };
+&phy37 { pses = <&pse_pi19>; };
+&phy40 { pses = <&pse_pi20>; };
+&phy41 { pses = <&pse_pi21>; };
+&phy44 { pses = <&pse_pi22>; };
+&phy45 { pses = <&pse_pi23>; };

--- a/target/linux/realtek/dts/rtl9313_ubnt_usw-pro-xg-8-poe.dts
+++ b/target/linux/realtek/dts/rtl9313_ubnt_usw-pro-xg-8-poe.dts
@@ -225,7 +225,32 @@
 		};
 	};
 
-	i2c6: i2c@6 { reg = <6>; }; /* PoE MCU at 0x20 */
+	i2c_poe: i2c@6 {
+		reg = <6>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		pse: ethernet-pse@20 {
+			compatible = "ubnt,usw-pro-xg-8-poe-pse", "realtek,pse-mcu-gen2-smbus";
+			reg = <0x20>;
+
+			enable-gpios = <&gpio1 15 GPIO_ACTIVE_HIGH>;
+
+			pse-pis {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				PSE_PI(0)
+				PSE_PI(1)
+				PSE_PI(2)
+				PSE_PI(3)
+				PSE_PI(4)
+				PSE_PI(5)
+				PSE_PI(6)
+				PSE_PI(7)
+			};
+		};
+	};
 };
 
 &mdio_ctrl {
@@ -289,3 +314,11 @@
 	};
 };
 
+&phy0 { pses = <&pse_pi0>; };
+&phy8 { pses = <&pse_pi1>; };
+&phy16 { pses = <&pse_pi2>; };
+&phy24 { pses = <&pse_pi3>; };
+&phy32 { pses = <&pse_pi4>; };
+&phy40 { pses = <&pse_pi5>; };
+&phy48 { pses = <&pse_pi6>; };
+&phy50 { pses = <&pse_pi7>; };

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12hp.dts
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12hp.dts
@@ -66,38 +66,14 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 
-				pse_pi0: pse-pi@0 {
-					reg = <0>;
-					#pse-cells = <0>;
-				};
-				pse_pi1: pse-pi@1 {
-					reg = <1>;
-					#pse-cells = <0>;
-				};
-				pse_pi2: pse-pi@2 {
-					reg = <2>;
-					#pse-cells = <0>;
-				};
-				pse_pi3: pse-pi@3 {
-					reg = <3>;
-					#pse-cells = <0>;
-				};
-				pse_pi4: pse-pi@4 {
-					reg = <4>;
-					#pse-cells = <0>;
-				};
-				pse_pi5: pse-pi@5 {
-					reg = <5>;
-					#pse-cells = <0>;
-				};
-				pse_pi6: pse-pi@6 {
-					reg = <6>;
-					#pse-cells = <0>;
-				};
-				pse_pi7: pse-pi@7 {
-					reg = <7>;
-					#pse-cells = <0>;
-				};
+				PSE_PI(0)
+				PSE_PI(1)
+				PSE_PI(2)
+				PSE_PI(3)
+				PSE_PI(4)
+				PSE_PI(5)
+				PSE_PI(6)
+				PSE_PI(7)
 			};
 		};
 	};

--- a/target/linux/realtek/image/rtl839x.mk
+++ b/target/linux/realtek/image/rtl839x.mk
@@ -117,8 +117,7 @@ ifeq ($(IB),)
 endif
   DEVICE_VENDOR := Zyxel
   DEVICE_MODEL := GS1920-24HP
-  DEVICE_PACKAGES := \
-	  kmod-hwmon-lm85
+  DEVICE_PACKAGES := kmod-hwmon-lm85 kmod-pse-realtek-mcu-i2c
   $(Device/rt-loader-bootbase)
 endef
 

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -336,11 +336,11 @@ TARGET_DEVICES += zyxel_xgs1250-12-b1
 define Device/zyxel_xgs1930-28hp
   SOC := rtl9301
   DEVICE_MODEL := XGS1930-28HP
-  DEVICE_PACKAGES := kmod-hwmon-gpiofan
   FLASH_ADDR := 0xb4260000
   IMAGE_SIZE := 30336k
   ZYNFW_ALIGN := 0x10000
   $(Device/zyxel_zynos)
+  DEVICE_PACKAGES += kmod-hwmon-gpiofan kmod-pse-realtek-mcu-i2c
 endef
 TARGET_DEVICES += zyxel_xgs1930-28hp
 

--- a/target/linux/realtek/image/rtl930x_nand.mk
+++ b/target/linux/realtek/image/rtl930x_nand.mk
@@ -33,7 +33,7 @@ define Device/linksys_lgs328mpc-v2
   $(Device/linksys_lgs328)
   DEVICE_MODEL := LGS328MPC
   DEVICE_VARIANT := v2
-  DEVICE_PACKAGES += kmod-hwmon-lm63
+  DEVICE_PACKAGES += kmod-hwmon-lm63 kmod-pse-realtek-mcu-i2c
   LINKSYS_MODEL := 60412060
 endef
 TARGET_DEVICES += linksys_lgs328mpc-v2

--- a/target/linux/realtek/image/rtl931x.mk
+++ b/target/linux/realtek/image/rtl931x.mk
@@ -59,7 +59,7 @@ define Device/ubnt_usw-pro-xg-8-poe
   DEVICE_VENDOR := Ubiquiti
   DEVICE_MODEL := UniFi USW Pro XG 8 PoE
   IMAGE_SIZE := 30272k
-  DEVICE_PACKAGES := rtl826x-firmware kmod-hwmon-adt7475
+  DEVICE_PACKAGES := rtl826x-firmware kmod-hwmon-adt7475 kmod-pse-realtek-mcu-i2c
   $(Device/kernel-lzma)
 endef
 TARGET_DEVICES += ubnt_usw-pro-xg-8-poe

--- a/target/linux/realtek/image/rtl931x.mk
+++ b/target/linux/realtek/image/rtl931x.mk
@@ -50,7 +50,7 @@ TARGET_DEVICES += plasmacloud_esx28
 define Device/plasmacloud_psx28
   $(Device/plasmacloud-common)
   DEVICE_MODEL := PSX28
-  DEVICE_PACKAGES += poemgr
+  DEVICE_PACKAGES += kmod-pse-realtek-mcu-i2c
 endef
 TARGET_DEVICES += plasmacloud_psx28
 


### PR DESCRIPTION
A driver can only mature when it's tested on many different real devices. So let's extend it to more of them.

This time:
- Linksys LGS328MPCv2 (@jhbruhn please double-check)
- Plasma Cloud PSX28 (@ecsv @0xharshal any objections?)
- Ubiquiti USW XG Pro 8 PoE
- Zyxel XGS1930-28HP
- Zyxel GS1920-24HPv1/v2

Some testing is still to be done, but it's already running like a charm for some time on most of the devices. I cannot test GS1920-24HPv1 though, this needs verification from someone else. Maybe @andyboeh has some time?