### PR TITLE
lua: fix tonumber() returning nil for leading dot decimals

### DIFF
--- a/package/utils/lua/Makefile
+++ b/package/utils/lua/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lua
 PKG_VERSION:=5.1.5
-PKG_RELEASE:=11
+PKG_RELEASE:=12
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.lua.org/ftp/ \

--- a/package/utils/lua/patches-host/013-lnum-strtoul-parsing-fixes.patch
+++ b/package/utils/lua/patches-host/013-lnum-strtoul-parsing-fixes.patch
@@ -9,6 +9,15 @@
      }
    } else if ((v > LUA_INTEGER_MAX) || (*endptr && (!isspace(*endptr)))) {
      return TK_NUMBER;	/* not in signed range, or has '.', 'e' etc. trailing */
+@@ -147,7 +149,7 @@ int luaO_str2d (const char *s, lua_Numbe
+    */
+   if (res_i) {
+     ret= luaO_str2i(s,res_i,&endptr);
+-    if (ret==0) return 0;
++    if (ret==0) ret = TK_NUMBER;
+   }
+   if (ret==TK_NUMBER) {
+     lua_assert(res_n);
 @@ -310,3 +312,13 @@ int try_unmint( lua_Integer *r, lua_Inte
    return 0;
  }

--- a/package/utils/lua/patches/013-lnum-strtoul-parsing-fixes.patch
+++ b/package/utils/lua/patches/013-lnum-strtoul-parsing-fixes.patch
@@ -9,6 +9,15 @@
      }
    } else if ((v > LUA_INTEGER_MAX) || (*endptr && (!isspace(*endptr)))) {
      return TK_NUMBER;	/* not in signed range, or has '.', 'e' etc. trailing */
+@@ -147,7 +149,7 @@ int luaO_str2d (const char *s, lua_Numbe
+    */
+   if (res_i) {
+     ret= luaO_str2i(s,res_i,&endptr);
+-    if (ret==0) return 0;
++    if (ret==0) ret = TK_NUMBER;
+   }
+   if (ret==TK_NUMBER) {
+     lua_assert(res_n);
 @@ -310,3 +312,13 @@ int try_unmint( lua_Integer *r, lua_Inte
    return 0;
  }


### PR DESCRIPTION
tonumber('.5') returns nil on OpenWrt's Lua 5.1 even though the lexer handles .5 as a literal fine. The problem is in the LNUM patch's luaO_str2d(). It tries integer parsing first via luaO_str2i(), and when strtoul() can't handle a leading dot (returns endptr == s), str2d bails out entirely instead of falling through to strtod() which would parse it correctly.

Fix: when str2i returns 0, set ret = TK_NUMBER so the float path gets a chance to run. strtod(".5") works, and garbage strings like "hello" still get rejected when strtod returns endptr == s.

Built lua 5.1.5 with all OpenWrt patches applied and verified:
```
assert(tonumber('.5') == .5)       -- was nil, now 0.5
assert(tonumber('.5e1') == 5)      -- was nil, now 5
assert(tonumber('.123') == 0.123)  -- was nil, now 0.123
assert(tonumber('0.5') == 0.5)     -- still works
assert(tonumber('42') == 42)       -- still works
assert(tonumber('') == nil)        -- still rejected
assert(tonumber('abc') == nil)     -- still rejected
```

Fixes: https://github.com/openwrt/openwrt/issues/23672

Note: this replaces #23856, which GitHub auto-closed when I deleted my old fork during personal cleanup (deleting a fork silently closes its open PRs). Same commit and same review-ready state as before the fold-into-013 discussion with @BKPepe; nothing about the code has changed.
