### PR TITLE
ramips: mt7620: fix jumbo frame mode

### DIFF
--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.h
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.h
@@ -56,9 +56,14 @@
 #define GSW_REG_GMACCR		0x3FE0 /* correct address per MT7620A datasheet */
 #define GMACCR_JMB_LEN_MASK	0x0F
 #define GMACCR_JMB_LEN_SHIFT	2
-// MAX_RX_PKT_LEN field (bits 0:1): 0=1518, 1=1536, 2=jumbo
+/* MAX_RX_PKT_LEN (bits [1:0]):
+ * 0: 1518 (untagged) / 1522 (tagged)
+ * 1: 1536
+ * 2: 1552
+ * 3: jumbo frame mode
+ */
 #define GMACCR_MAX_RX_PKT_LEN_MASK	0x3
-#define GMACCR_MAX_RX_PKT_LEN_JUMBO	0x2
+#define GMACCR_MAX_RX_PKT_LEN_JUMBO	0x3
 
 #define SYSC_REG_CHIP_REV_ID	0x0c
 #define SYSC_REG_CFG1		0x14


### PR DESCRIPTION
## What changed

Select `MAX_RX_PKT_LEN` value 3 for jumbo mode and correct the field
description.

## Why

The affected MT7620 jumbo-frame setup was added by the
[`ramips: ethernet: ralink: mt7620 enable jumbo frames` commit](https://github.com/openwrt/openwrt/pull/23933/commits/d083212e1105b56dec645108bc03bc3172eb7c81)
in OpenWrt PR #23933. That PR adds support for external DSA switches,
while this register programming applies to the MT7620 internal switch.

Value 2 selects a 1552-byte receive limit, while value 3 selects jumbo
mode. The current code therefore advertises an MTU up to 2048 but the
internal switch drops larger frames. The encoding matches the upstream
[MT7530 definitions](https://github.com/torvalds/linux/blob/58717b2a1365d06c8c64b72aa948541b53fe31eb/drivers/net/dsa/mt7530.h#L423-L427).

## Validation

Tested on a ZBT-WE826 with an MT7620:

- Existing value 2 produced `GMACCR=0x00003f0a`; IPv4 packets with a
  total length of 1534 bytes passed, while 1535 bytes were dropped.
- Changing only the field to value 3 produced `GMACCR=0x00003f0b`;
  1792-byte and 1800-byte DF IPv4 packets passed with no loss.
- A firmware containing this change booted with `GMACCR=0x00003f0b`
  and repeated the 1792/1800-byte tests successfully.
- With the MikroTik peer configured for an MTU of 2028, 100 DF IPv4
  echo requests at that limit completed without loss:

```console
root@router:~# ip link set dev eth0 mtu 2048
root@router:~# ip link set dev eth0.2 mtu 2028
root@router:~# ip addr add 192.168.1.2/30 dev eth0.2
root@router:~# ping -I 192.168.1.2 -M do -c 100 -i 0.05 -W 1 -s 2000 192.168.1.1
PING 192.168.1.1 (192.168.1.1) from 192.168.1.2 : 2000(2028) bytes of data.

--- 192.168.1.1 ping statistics ---
100 packets transmitted, 100 received, 0% packet loss, time 4984ms
rtt min/avg/max/mdev = 0.860/0.898/1.040/0.027 ms
```

- `scripts/checkpatch.pl`: 0 errors, 0 warnings.
