### PR TITLE
realtek: fix fan control for Plasma Cloud PSX28/ESX28

### DIFF
--- a/target/linux/realtek/base-files/etc/init.d/hwmon_fancontrol
+++ b/target/linux/realtek/base-files/etc/init.d/hwmon_fancontrol
@@ -6,7 +6,7 @@ plasmacloud_common() {
 	# configuring onboard temp/fan controller to run the fan on its own
 	# for more information, please read https://www.kernel.org/doc/Documentation/hwmon/sysfs-interface
 
-	local path_to_hwmon="$(find /sys/devices/platform/1b000000.switchcore/1b000000.switchcore:i2c@100c/i2c-4/4-002e/hwmon/ -type d -maxdepth 1 -mindepth 1 -name 'hwmon*')"
+	local path_to_hwmon="$(find /sys/bus/i2c/devices/4-002e/hwmon/ -type d -maxdepth 1 -mindepth 1 -name 'hwmon*')"
 
 	# adt7476 fan control chip
 	# 3 temp sensors. Set to lowest speed at 35C and max speed at 70C


### PR DESCRIPTION
Commit 82ddc472d722 ("realtek: dts: convert to upstream switch notation") adjusted the switch description in the device tree to match upstream. This was a correct change, however it broke the fan control script for Plasma Cloud PSX28/ESX28 devices because it uses a full-fledged platform device path including the switch node (because the I2C is a child of the switch):

`/sys/devices/platform/1b000000.switchcore/1b000000.switchcore:i2c@100c/i2c-4/4-002e/hwmon/`

Since the mentioned change, this path doesn't exist anymore. Instead of just changing the intermediate parts to match the DT structure again, do not rely on that at all. Instead, use

`/sys/bus/i2c/devices/4-002e/hwmon/`

as the path which relies less on the DT structure and still points to the same device. This makes fan control on those device work again, reducing the fan speed during boot which has been broken since the commit.

Fixes: 82ddc472d722 ("realtek: dts: convert to upstream switch notation")
Fixes: 2b5555c1950d ("realtek: rtl931x: Add support for Plasma Cloud PSX28 Switch")
