### PR TITLE
kernel: set MACOSX_DEPLOYMENT_TARGET to host version

### DIFF
--- a/include/kernel.mk
+++ b/include/kernel.mk
@@ -121,6 +121,10 @@ ifneq (,$(KERNEL_CC))
   KERNEL_MAKE_FLAGS += CC="$(KERNEL_CC)"
 endif
 
+ifeq ($(HOST_OS),Darwin)
+  KERNEL_MAKE_FLAGS += MACOSX_DEPLOYMENT_TARGET="$(shell sw_vers -productVersion)"
+endif
+
 KERNEL_NOSTDINC_FLAGS = \
 	-nostdinc $(if $(DUMP),, -isystem $(shell $(TARGET_CC) -print-file-name=include))
 


### PR DESCRIPTION
Fix a warning interpreted as error when building the Linux kernel on macOS host, by setting `MACOSX_DEPLOYMENT_TARGET` to the version of the host. Fixes:

``` C
make target/linux/compile -j 1 V=s
…
make[5]: Entering directory '/Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/linux-6.18.38'
  HOSTCC  scripts/mod/modpost.o
scripts/mod/modpost.c:1719:9: error: 'strchrnul' is only available on macOS 15.4 or newer [-Werror,-Wunguarded-availability-new]
 1719 |                 sep = strchrnul(namespace, ',');
      |                       ^~~~~~~~~
```

Workaround: Global build settings, Kernel build options, uncheck: *Compile the kernel with warnings as errors*
`CONFIG_KERNEL_WERROR=n`

My experience with the build system is not good. Please let me know if `kernel.mk` is the correct place for this or if you can suggest a better approach. After searching for the error, I found that other projects set `MACOSX_DEPLOYMENT_TARGET`, and `kernel.mk` seemed appropriate to me.

Build and run tested: WRT3200ACM, and x64 on macOS 15.7.7 host with Xcode 16.4.

@robimarko @mcprat @aparcar @BKPepe @jonasjelonek 