### PR TITLE
qualcommax: qca_ppe: give multicast queues idle DRR scheduler slots

### DIFF
--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
@@ -691,16 +691,30 @@ static void ppe_l0_scheduler_init(struct qca_ppe_priv *priv)
 		u8 counts[] = { p->ucast_count, p->mcast_count };
 		int k;
 
+		/*
+		 * Multicast queues take the port's top unicast scheduler
+		 * slots, not slots 0..mcast_count-1: sharing a slot puts two
+		 * queues on one DRR node, and when both cross empty->non-empty
+		 * together the node's credit rotation latches - the unicast
+		 * queue holds the active list with no credit left, the
+		 * multicast queue parks on the backup list, and both fall to
+		 * about one dequeue per second until the node is rebuilt or
+		 * the box is rebooted. The low slots carry best-effort unicast
+		 * and all flooding, so that pairing would be exercised
+		 * continuously; the top slots stay idle unless skb->priority
+		 * selects them.
+		 */
 		for (k = 0; k < 2; k++) {
 			for (j = 0; j < counts[k]; j++) {
+				int slot = k ? p->ucast_count - counts[k] + j : j;
 				struct l0_cfg c = {
 					.queue = bases[k] + j,
 					.port = p->port,
-					.sp = p->sp_base + j / PPE_MAX_SP_PRI,
-					.cpri = j % PPE_MAX_SP_PRI,
-					.cdrr = p->cdrr_base + j,
-					.epri = j % PPE_MAX_SP_PRI,
-					.edrr = p->cdrr_base + j,
+					.sp = p->sp_base + slot / PPE_MAX_SP_PRI,
+					.cpri = slot % PPE_MAX_SP_PRI,
+					.cdrr = p->cdrr_base + slot,
+					.epri = slot % PPE_MAX_SP_PRI,
+					.edrr = p->cdrr_base + slot,
 				};
 
 				ppe_l0_entry_write(priv, &c);


### PR DESCRIPTION
The PPE L0 scheduler configuration maps each port's multicast queues onto the same (SP, priority) slots as unicast priorities 0-3, so e.g. port 4's q284 (multicast) and q192 (unicast best-effort) resolve to the same `L0_C_SP` entry and the same DRR node 96. Two queues sharing a DRR node is legal, but when both queues cross the empty->non-empty boundary concurrently, the node's round-rotation/credit state machine can latch:

- the unicast queue sits on the active list with exhausted credit (`L0_C_DRR_HEAD.active_vld=1`, `L0_DRR_CREDIT=0`),
- the multicast queue parks on the backup list (`backup_vld=1`),
- the rotation that would refresh the credit never happens.

Both queues then freeze at roughly one dequeue per second while every other queue on the port keeps running; only a full node teardown (disable and flush BOTH queues, unmap them from the scheduler, rewrite `C_SP`/`E_SP`, remap) or a reboot recovers. Captured live at register level on an IPQ8074 (Xiaomi AX3600): 250 packets pinned in q192 at the buffer ceiling, broadcasts accumulating in q284, cross-linked list pointers (`C_DRR_LL[284]=192` while the two heads claim different lists). The race is between two hardware queues inside the traffic manager, independent of which datapath performs the enqueues.

Unicast priority 0 is the default queue for all best-effort egress and the multicast queues carry all broadcast/unknown flooding, so the two busiest queues of every port share one scheduler node and the race window is exercised continuously in normal operation. The user-visible symptom is a LAN port whose unicast egress "wedges" (ping/ARP through the port dead, ~1 pkt/s trickle) while other traffic classes on the same port keep working, with no link event and nothing in any drop counter.

Map the multicast queues onto the top unicast slots instead (port 4: q284-287 -> SP 49 priorities 4-7, DRR nodes 108-111, paired with q204-207): those slots see no traffic unless `skb->priority` minors 12-15 are deliberately used, so the two-queues-on-one-node race precondition is removed for default configurations while the scheduler topology (no new SPs, no L1 changes) stays untouched.

The same unicast/multicast slot sharing exists in the vendor SSDK DTS expansion (`ssdk_dts.c`, `cdrr_id = base + i%max_pri + (i/max_pri)*max_pri` with the multicast group restarting at the base, tag `NHSS.QSDK.14.0.r8-00026-O`) and in the mainline IPQ9574 PPE driver (`ppe_config.c`, node 284 -> flow 48, drr 96), and neither carries any handling for the latched state, so the deadlock is latent there as well. The CPU port's L0 table (queues 0/4/8 sharing DRR nodes with multicast 256/260 five ways) has the same structural exposure and is deliberately left untouched here.
