### PR TITLE
ramips: add support for Zyxel Keenetic Giga III

### DIFF
--- a/target/linux/ramips/dts/mt7621_zyxel_keenetic-giga-iii.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_keenetic-giga-iii.dts
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "zyxel,keenetic-giga-iii", "mediatek,mt7621-soc";
+	model = "Zyxel Keenetic Giga III";
+
+	aliases {
+		label-mac-device = &gmac1;
+
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		fn1 {
+			label = "fn1";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+		};
+
+		fn2 {
+			label = "fn2";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
+			default-state = "keep";
+		};
+
+		fn {
+			function = "fn";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+		};
+
+		internet {
+			function = "internet";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		};
+
+		wifi2g {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wifi5g {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		usb2 {
+			function = LED_FUNCTION_USB;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <2>;
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+			trigger-sources = <&ehci_port2>;
+			linux,default-trigger = "usbport";
+		};
+
+		usb3 {
+			function = LED_FUNCTION_USB;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <3>;
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+			trigger-sources = <&xhci_ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+	ubi-concat {
+		compatible = "mtd-concat";
+		devices = <&ubiconcat0 &ubiconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ubi";
+				reg = <0x0 0x7500000>;
+			};
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "u-config";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x80000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
+				macaddr_factory_8004: macaddr@8004 {
+					reg = <0x8004 0x6>;
+				};
+			};
+		};
+
+		partition@180000 {
+			label = "firmware";
+			reg = <0x180000 0x3e40000>;
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			ubiconcat0: partition@400000 {
+				label = "ubiconcat0";
+				reg = <0x400000 0x3a40000>;
+			};
+		};
+
+		partition@3fc0000 {
+			label = "u-state";
+			reg = <0x3fc0000 0x80000>;
+		};
+
+		partition@4040000 {
+			label = "u-config-res";
+			reg = <0x4040000 0x80000>;
+			read-only;
+		};
+
+		partition@40c0000 {
+			label = "factory-res";
+			reg = <0x40c0000 0x80000>;
+			read-only;
+		};
+
+		ubiconcat1: partition@4140000 {
+			label = "ubiconcat1";
+			reg = <0x4140000 0x3ac0000>;
+		};
+
+		partition@7c00000 {
+			label = "mtk-nand-bbt";
+			reg = <0x7c00000 0x400000>;
+			read-only;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+	reset-gpios = <&gpio 19 GPIO_ACTIVE_LOW>,
+		      <&gpio 8 GPIO_ACTIVE_LOW>;
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_8004>;
+		nvmem-cell-names = "eeprom", "mac-address";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4>;
+		nvmem-cell-names = "eeprom", "mac-address";
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&wanphy>;
+
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio {
+	wanphy: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart3", "uart2", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
+};
+
+&reg_vusb33 {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2093,6 +2093,19 @@ define Device/keenetic_kn-3510
 endef
 TARGET_DEVICES += keenetic_kn-3510
 
+define Device/zyxel_keenetic-giga-iii
+  $(Device/nand)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 51000k
+  DEVICE_VENDOR := Zyxel
+  DEVICE_MODEL := Keenetic Giga III
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb3 kmod-usb-ledtrig-usbport
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+	check-size | pad-to $$(BLOCKSIZE) | zyimage -d 0x2880 -v "KN-GIGA3"
+endef
+TARGET_DEVICES += zyxel_keenetic-giga-iii
+
 define Device/lenovo_newifi-d1
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -142,6 +142,11 @@ keenetic,kn-1910|\
 keenetic,kn-3010)
 	ucidef_set_led_netdev "internet" "internet" "green:internet" "wan"
 	;;
+zyxel,keenetic-giga-iii)
+	ucidef_set_led_netdev "internet" "internet" "green:internet" "wan"
+	ucidef_set_led_wlan "wifi2g" "WiFi 2.4GHz" "green:wlan-2ghz" "phy1tpt"
+	ucidef_set_led_wlan "wifi5g" "WiFi 5GHz" "green:wlan-5ghz" "phy0tpt"
+	;;
 linksys,e5600)
 	ucidef_set_led_netdev "wan" "wan link" "blue:wan" "wan" "link"
 	;;

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -204,6 +204,21 @@ platform_do_upgrade() {
 		CI_KERNPART="kernel"
 		nand_do_upgrade "$1"
 		;;
+	zyxel,keenetic-giga-iii)
+		local magic="$(nand_get_magic_long "$1" 0)"
+
+		# Preserve the original port's stock uImage write path; normal
+		# OpenWrt sysupgrade images continue through nand_do_upgrade.
+		if [ "$magic" = "27051956" ]; then
+			mtd -f write "$1" firmware
+			sync
+			umount -a
+			reboot -f
+			exit 1
+		fi
+
+		nand_do_upgrade "$1"
+		;;
 	ubnt,edgerouter-x|\
 	ubnt,edgerouter-x-sfp)
 		platform_upgrade_ubnt_erx "$1"


### PR DESCRIPTION
## Description

Add support for the Zyxel Keenetic Giga III (KN-GIGA3) as a modernized
continuation of Oleg S' original port from openwrt/openwrt#4587.

The port adds the device tree, NAND image recipe, LED defaults, and
device-specific sysupgrade handling. It preserves the stock NAND partitioning,
mtd-concat UBI layout, calibration and MAC offsets, DSA port order, USB power
GPIOs, and KN-GIGA3 factory image wrapper.

The selected ramips/mt7621 profile builds initramfs, factory, and sysupgrade
images.

### Installation via U-Boot/TFTP

The following recovery installation method is carried over from the original
PR and has not been retested for this submission:

1. Rename the factory image to `kgiga3_recovery.bin` and place it in the root
   directory of a TFTP server.
2. Configure the directly connected computer as `192.168.1.2/24` and connect
   it to one of the router's LAN ports.
3. With the router powered off, hold Reset while applying power. Release Reset
   after approximately five seconds.
4. Allow the router time to fetch and install the image before attempting to
   connect to `192.168.1.1`.

This U-Boot/TFTP path remains untested on the submitted version. Installation
through the KeeneticOS web interface is not recommended here.

### Known limitation

The stock bootloader uses a vendor-specific raw-NAND USTA record for
dual-image boot state. A previous downstream implementation acknowledged
successful boots through `/dev/mtdblock`, which is unsafe for raw NAND, so
that write path is intentionally not included.

Normal boot and sysupgrade have been validated. Vendor USTA success
acknowledgement is not currently implemented.

### Testing

The selected ramips/mt7621 device profile was build-tested on OpenWrt main.
A configuration-preserving sysupgrade and cold boot were tested on hardware
using the preceding revision.

Ethernet, WAN, persistent overlay, both Wi-Fi radios, encrypted client
association, DHCP, Wi-Fi traffic, USB 2.0/3.0 enumeration, the physical LED
GPIO mappings, and the WPS/FN buttons were validated.

The review-requested conversion to modern LED color/function naming was
build-tested and validated through DTS compilation/decompilation. The
resulting expected sysfs names and matching `01_leds` references were checked
statically. A focused runtime retest of those new sysfs names, trigger
availability, and physical LED behavior is deferred until the device is
available again.

Reset, clean-config `sysupgrade -n`, recovery/TFTP, vendor USTA
acknowledgement, and dual-image failover remain untested.
