### PR TITLE
airoha: DTS cleanups for AN7583

### DIFF
--- a/target/linux/airoha/dts/an7583-evb-emmc.dts
+++ b/target/linux/airoha/dts/an7583-evb-emmc.dts
@@ -256,6 +256,10 @@
 	status = "okay";
 };
 
+&gsw_port1 {
+	status = "okay";
+};
+
 &gsw_phy1 {
 	pinctrl-names = "gbe-led";
 	pinctrl-0 = <&gswp1_led0_pins>;
@@ -265,6 +269,10 @@
 &gsw_phy1_led0 {
 	status = "okay";
 	active-low;
+};
+
+&gsw_port2 {
+	status = "okay";
 };
 
 &gsw_phy2 {
@@ -278,6 +286,10 @@
 	active-low;
 };
 
+&gsw_port3 {
+	status = "okay";
+};
+
 &gsw_phy3 {
 	pinctrl-names = "gbe-led";
 	pinctrl-0 = <&gswp3_led0_pins>;
@@ -287,6 +299,10 @@
 &gsw_phy3_led0 {
 	status = "okay";
 	active-low;
+};
+
+&gsw_port4 {
+	status = "okay";
 };
 
 &gsw_phy4 {

--- a/target/linux/airoha/dts/an7583-evb-emmc.dts
+++ b/target/linux/airoha/dts/an7583-evb-emmc.dts
@@ -258,6 +258,7 @@
 
 &gsw_port1 {
 	status = "okay";
+	label = "lan1";
 };
 
 &gsw_phy1 {
@@ -273,6 +274,7 @@
 
 &gsw_port2 {
 	status = "okay";
+	label = "lan2";
 };
 
 &gsw_phy2 {
@@ -288,6 +290,7 @@
 
 &gsw_port3 {
 	status = "okay";
+	label = "lan3";
 };
 
 &gsw_phy3 {
@@ -303,6 +306,7 @@
 
 &gsw_port4 {
 	status = "okay";
+	label = "lan4";
 };
 
 &gsw_phy4 {

--- a/target/linux/airoha/dts/an7583-evb.dts
+++ b/target/linux/airoha/dts/an7583-evb.dts
@@ -115,6 +115,7 @@
 
 &gsw_port1 {
 	status = "okay";
+	label = "lan1";
 };
 
 &gsw_phy1 {

--- a/target/linux/airoha/dts/an7583-evb.dts
+++ b/target/linux/airoha/dts/an7583-evb.dts
@@ -113,6 +113,10 @@
 	status = "okay";
 };
 
+&gsw_port1 {
+	status = "okay";
+};
+
 &gsw_phy1 {
 	pinctrl-names = "gbe-led";
 	pinctrl-0 = <&gswp1_led0_pins>;
@@ -122,30 +126,6 @@
 &gsw_phy1_led0 {
 	status = "okay";
 	active-low;
-};
-
-&gsw_port2 {
-	status = "disabled";
-};
-
-&gsw_port3 {
-	status = "disabled";
-};
-
-&gsw_port4 {
-	status = "disabled";
-};
-
-&gsw_phy2 {
-	status = "disabled";
-};
-
-&gsw_phy3 {
-	status = "disabled";
-};
-
-&gsw_phy4 {
-	status = "disabled";
 };
 
 &mdio_0 {

--- a/target/linux/airoha/dts/an7583.dtsi
+++ b/target/linux/airoha/dts/an7583.dtsi
@@ -710,6 +710,7 @@
 					label = "lan1";
 					phy-mode = "internal";
 					phy-handle = <&gsw_phy1>;
+					status = "disabled";
 				};
 
 				gsw_port2: port@2 {
@@ -717,6 +718,7 @@
 					label = "lan2";
 					phy-mode = "internal";
 					phy-handle = <&gsw_phy2>;
+					status = "disabled";
 				};
 
 				gsw_port3: port@3 {
@@ -724,6 +726,7 @@
 					label = "lan3";
 					phy-mode = "internal";
 					phy-handle = <&gsw_phy3>;
+					status = "disabled";
 				};
 
 				gsw_port4: port@4 {
@@ -731,6 +734,7 @@
 					label = "lan4";
 					phy-mode = "internal";
 					phy-handle = <&gsw_phy4>;
+					status = "disabled";
 				};
 
 				port@6 {
@@ -755,6 +759,7 @@
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <9>;
 					phy-mode = "internal";
+					status = "disabled";
 
 					leds {
 						#address-cells = <1>;
@@ -789,6 +794,7 @@
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <10>;
 					phy-mode = "internal";
+					status = "disabled";
 
 					leds {
 						#address-cells = <1>;
@@ -814,6 +820,7 @@
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <11>;
 					phy-mode = "internal";
+					status = "disabled";
 
 					leds {
 						#address-cells = <1>;
@@ -839,6 +846,7 @@
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <12>;
 					phy-mode = "internal";
+					status = "disabled";
 
 					leds {
 						#address-cells = <1>;

--- a/target/linux/airoha/dts/an7583.dtsi
+++ b/target/linux/airoha/dts/an7583.dtsi
@@ -312,14 +312,6 @@
 		regulator-always-on;
 	};
 
-	sfp1: sfp1 {
-		compatible = "sff,sfp";
-	};
-
-	sfp2: sfp2 {
-		compatible = "sff,sfp";
-	};
-
 	soc {
 		compatible = "simple-bus";
 		#address-cells = <2>;

--- a/target/linux/airoha/dts/an7583.dtsi
+++ b/target/linux/airoha/dts/an7583.dtsi
@@ -769,14 +769,14 @@
 						 * overridden to maintain unique sysfs
 						 * naming.
 						 */
-						gsw_phy1_led0: gsw-phy1-led0@0 {
+						gsw_phy1_led0: led@0 {
 							reg = <0>;
 							function = LED_FUNCTION_LAN;
 							function-enumerator = <1>;
 							status = "disabled";
 						};
 
-						gsw_phy1_led1: gsw-phy1-led1@1 {
+						gsw_phy1_led1: led@1 {
 							reg = <1>;
 							function = LED_FUNCTION_LAN;
 							function-enumerator = <1>;
@@ -795,14 +795,14 @@
 						#address-cells = <1>;
 						#size-cells = <0>;
 
-						gsw_phy2_led0: gsw-phy2-led0@0 {
+						gsw_phy2_led0: led@0 {
 							reg = <0>;
 							function = LED_FUNCTION_LAN;
 							function-enumerator = <2>;
 							status = "disabled";
 						};
 
-						gsw_phy2_led1: gsw-phy2-led1@1 {
+						gsw_phy2_led1: led@1 {
 							reg = <1>;
 							function = LED_FUNCTION_LAN;
 							function-enumerator = <2>;
@@ -821,14 +821,14 @@
 						#address-cells = <1>;
 						#size-cells = <0>;
 
-						gsw_phy3_led0: gsw-phy3-led0@0 {
+						gsw_phy3_led0: led@0 {
 							reg = <0>;
 							function = LED_FUNCTION_LAN;
 							function-enumerator = <3>;
 							status = "disabled";
 						};
 
-						gsw_phy3_led1: gsw-phy3-led1@1 {
+						gsw_phy3_led1: led@1 {
 							reg = <1>;
 							function = LED_FUNCTION_LAN;
 							function-enumerator = <3>;
@@ -847,14 +847,14 @@
 						#address-cells = <1>;
 						#size-cells = <0>;
 
-						gsw_phy4_led0: gsw-phy4-led0@0 {
+						gsw_phy4_led0: led@0 {
 							reg = <0>;
 							function = LED_FUNCTION_LAN;
 							function-enumerator = <4>;
 							status = "disabled";
 						};
 
-						gsw_phy4_led1: gsw-phy4-led1@1 {
+						gsw_phy4_led1: led@1 {
 							reg = <1>;
 							function = LED_FUNCTION_LAN;
 							function-enumerator = <4>;

--- a/target/linux/airoha/dts/an7583.dtsi
+++ b/target/linux/airoha/dts/an7583.dtsi
@@ -707,7 +707,6 @@
 
 				gsw_port1: port@1 {
 					reg = <1>;
-					label = "lan1";
 					phy-mode = "internal";
 					phy-handle = <&gsw_phy1>;
 					status = "disabled";
@@ -715,7 +714,6 @@
 
 				gsw_port2: port@2 {
 					reg = <2>;
-					label = "lan2";
 					phy-mode = "internal";
 					phy-handle = <&gsw_phy2>;
 					status = "disabled";
@@ -723,7 +721,6 @@
 
 				gsw_port3: port@3 {
 					reg = <3>;
-					label = "lan3";
 					phy-mode = "internal";
 					phy-handle = <&gsw_phy3>;
 					status = "disabled";
@@ -731,7 +728,6 @@
 
 				gsw_port4: port@4 {
 					reg = <4>;
-					label = "lan4";
 					phy-mode = "internal";
 					phy-handle = <&gsw_phy4>;
 					status = "disabled";
@@ -739,7 +735,6 @@
 
 				port@6 {
 					reg = <6>;
-					label = "cpu";
 					ethernet = <&gdm1>;
 					phy-mode = "internal";
 


### PR DESCRIPTION
Apply some fixes and cleanups to the DTS files for Airhoa AN7583. This synchronizes the DTS between AN7581 and AN7583 were it is possible. Some fixes were already made for AN7581 and have been adapted for AN7583.