### PR TITLE
ramips: fix frame engine DMA descriptor handling

### DIFF
--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -344,8 +344,8 @@ static void fe_txd_unmap(struct device *dev, struct fe_tx_buf *tx_buf)
 			       dma_unmap_len(tx_buf, dma_len1),
 			       DMA_TO_DEVICE);
 
-	dma_unmap_len_set(tx_buf, dma_addr0, 0);
-	dma_unmap_len_set(tx_buf, dma_addr1, 0);
+	dma_unmap_len_set(tx_buf, dma_len0, 0);
+	dma_unmap_len_set(tx_buf, dma_len1, 0);
 	if (tx_buf->skb && (tx_buf->skb != (struct sk_buff *)DMA_DUMMY_DESC))
 		dev_kfree_skb_any(tx_buf->skb);
 	tx_buf->skb = NULL;

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -970,6 +970,16 @@ static int fe_poll_rx(struct napi_struct *napi, int budget,
 				 ring->rx_buf_size, DMA_FROM_DEVICE);
 		pktlen = RX_DMA_GET_PLEN0(trxd.rxd2);
 		skb->dev = netdev;
+		if (unlikely(pktlen > skb_tailroom(skb))) {
+			if (net_ratelimit())
+				netdev_warn(netdev,
+					    "dropping invalid RX length %u (buffer %u, descriptor %08x)\n",
+					    pktlen, skb_tailroom(skb), trxd.rxd2);
+			stats->rx_length_errors++;
+			stats->rx_dropped++;
+			dev_kfree_skb_any(skb);
+			goto replace_desc;
+		}
 		skb_put(skb, pktlen);
 		if (trxd.rxd4 & checksum_bit)
 			skb->ip_summed = CHECKSUM_UNNECESSARY;
@@ -987,6 +997,7 @@ static int fe_poll_rx(struct napi_struct *napi, int budget,
 
 		napi_gro_receive(napi, skb);
 
+replace_desc:
 		ring->rx_data[idx] = new_data;
 		rxd->rxd1 = (unsigned int)dma_addr;
 


### PR DESCRIPTION
The shared ramips frame-engine driver can retain stale TX DMA length metadata after a descriptor is unmapped. It also trusts the RX descriptor length before extending the skb.

This PR contains two generic fixes split out of #24249 after review because they affect all users of the shared frame-engine driver, not only RT6855A:

- clear `dma_len0` and `dma_len1` after unmapping a TX descriptor, so a reused slot cannot trigger a bogus DMA unmap;
- reject RX descriptor lengths larger than the allocated skb tailroom, account the malformed packet, and safely replace the descriptor instead of corrupting the skb.

The changes are independent and kept as two commits.

Testing:

- `git diff --check`;
- each commit passes `scripts/checkpatch.pl` with 0 errors and 0 warnings;
- both fixes were built and exercised on a ZyXEL Keenetic Giga II during RT6855A Ethernet bring-up, including sustained LAN/WAN traffic and repeated cold boots.
