### PR TITLE
kernel: use iremap for assembly

### DIFF
--- a/include/kernel.mk
+++ b/include/kernel.mk
@@ -102,6 +102,7 @@ KERNEL_MAKE = $(MAKE) $(KERNEL_MAKEOPTS)
 
 KERNEL_MAKE_FLAGS = \
 	KCFLAGS="$(call iremap,$(BUILD_DIR),$(notdir $(BUILD_DIR))) $(filter-out -fno-plt,$(call qstrip,$(CONFIG_EXTRA_OPTIMIZATION))) $(call qstrip,$(CONFIG_KERNEL_CFLAGS))" \
+	KAFLAGS="$(call iremap,$(BUILD_DIR),$(notdir $(BUILD_DIR)))" \
 	HOSTCFLAGS="$(HOST_CFLAGS) -Wall -Wmissing-prototypes -Wstrict-prototypes" \
 	CROSS_COMPILE="$(KERNEL_CROSS)" \
 	ARCH="$(LINUX_KARCH)" \


### PR DESCRIPTION
Currently assembly code of the Kernel may contain the build path, resulting in
unreproducible firmware images (and Kernels). Fix this by adding a iremap
KAFLAG.

Before:

    strings "/path/to/vmlinux" | grep linux-6.18.38
    /path/to/openwrt/build_dir/target-x86_64_musl/linux-x86_64/linux-6.18.38
    /path/to/openwrt/build_dir/target-x86_64_musl/linux-x86_64/linux-6.18.38

After

    strings "/path/to/vmlinux" | grep linux-6.18.38
    target-x86_64_musl/linux-x86_64/linux-6.18.38
    target-x86_64_musl/linux-x86_64/linux-6.18.38

Signed-off-by: Paul Spooren <mail@aparcar.org>