### PR TITLE
mediatek: filogic: add support for Huasifei WS1610

### DIFF
--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -508,6 +508,18 @@ define U-Boot/mt7981_h3c_magic-nx30-pro
   DEPENDS:=+trusted-firmware-a-mt7981-spim-nand-ddr3
 endef
 
+define U-Boot/mt7981_huasifei_ws1610-ubi
+  NAME:=Huasifei WS1610 (UBI)
+  BUILD_SUBTARGET:=filogic
+  BUILD_DEVICES:=huasifei_ws1610-ubi
+  UBOOT_CONFIG:=mt7981_huasifei_ws1610-ubi
+  UBOOT_IMAGE:=u-boot.fip
+  BL2_BOOTDEV:=spim-nand-ubi
+  BL2_SOC:=mt7981
+  BL2_DDRTYPE:=ddr4
+  DEPENDS:=+trusted-firmware-a-mt7981-spim-nand-ubi-ddr4
+endef
+
 define U-Boot/mt7981_imou_hx21
   NAME:=Imou HX21
   BUILD_SUBTARGET:=filogic
@@ -1347,6 +1359,7 @@ UBOOT_TARGETS := \
 	mt7981_glinet_gl-xe3000 \
 	mt7981_globitel_bt-r320 \
 	mt7981_h3c_magic-nx30-pro \
+	mt7981_huasifei_ws1610-ubi \
 	mt7981_imou_hx21 \
 	mt7981_jcg_q30-pro \
 	mt7981_konka_komi-a31 \

--- a/package/boot/uboot-mediatek/patches/504-add-huasifei-ws1610.patch
+++ b/package/boot/uboot-mediatek/patches/504-add-huasifei-ws1610.patch
@@ -1,0 +1,316 @@
+--- /dev/null
++++ b/configs/mt7981_huasifei_ws1610-ubi_defconfig
+@@ -0,0 +1,111 @@
++CONFIG_ARM=y
++CONFIG_ARM_SMCCC=y
++CONFIG_SYS_HAS_NONCACHED_MEMORY=y
++CONFIG_POSITION_INDEPENDENT=y
++CONFIG_ARCH_MEDIATEK=y
++CONFIG_TEXT_BASE=0x41e00000
++CONFIG_SYS_MALLOC_F_LEN=0x4000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEFAULT_DEVICE_TREE="mt7981-huasifei-ws1610-ubi"
++CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_TARGET_MT7981=y
++CONFIG_SYS_LOAD_ADDR=0x46000000
++CONFIG_PRE_CON_BUF_ADDR=0x4007ef00
++CONFIG_DEBUG_UART_BASE=0x11002000
++CONFIG_DEBUG_UART_CLOCK=40000000
++CONFIG_DEBUG_UART=y
++CONFIG_FIT=y
++CONFIG_BOOTDELAY=30
++CONFIG_AUTOBOOT_KEYED=y
++CONFIG_AUTOBOOT_MENU_SHOW=y
++CONFIG_USE_PREBOOT=y
++CONFIG_DEFAULT_FDT_FILE="mediatek/mt7981-huasifei-ws1610-ubi.dtb"
++CONFIG_LOGLEVEL=7
++CONFIG_PRE_CONSOLE_BUFFER=y
++CONFIG_LOG=y
++# CONFIG_BOARD_INIT is not set
++CONFIG_BOARD_LATE_INIT=y
++CONFIG_HUSH_PARSER=y
++CONFIG_SYS_PROMPT="MT7981> "
++CONFIG_CMD_CPU=y
++CONFIG_CMD_LICENSE=y
++CONFIG_CMD_BOOTMENU=y
++CONFIG_CMD_ASKENV=y
++CONFIG_CMD_ERASEENV=y
++CONFIG_CMD_ENV_FLAGS=y
++CONFIG_CMD_RNG=y
++CONFIG_CMD_STRINGS=y
++CONFIG_CMD_DM=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_MTD=y
++CONFIG_CMD_PART=y
++CONFIG_CMD_TFTPSRV=y
++CONFIG_CMD_RARP=y
++CONFIG_CMD_CDP=y
++CONFIG_CMD_SNTP=y
++CONFIG_CMD_LINK_LOCAL=y
++CONFIG_CMD_DHCP=y
++CONFIG_CMD_DNS=y
++CONFIG_CMD_PING=y
++CONFIG_CMD_PXE=y
++CONFIG_CMD_CACHE=y
++CONFIG_CMD_UUID=y
++CONFIG_CMD_HASH=y
++CONFIG_CMD_SMC=y
++CONFIG_CMD_UBI=y
++CONFIG_CMD_UBI_RENAME=y
++CONFIG_OF_EMBED=y
++CONFIG_ENV_OVERWRITE=y
++CONFIG_ENV_IS_IN_UBI=y
++CONFIG_ENV_REDUNDANT=y
++CONFIG_ENV_UBI_PART="ubi"
++CONFIG_ENV_UBI_VOLUME="ubootenv"
++CONFIG_ENV_UBI_VOLUME_REDUND="ubootenv2"
++CONFIG_ENV_RELOC_GD_ENV_ADDR=y
++CONFIG_ENV_USE_DEFAULT_ENV_TEXT_FILE=y
++CONFIG_ENV_DEFAULT_ENV_TEXT_FILE="defenvs/huasifei_ws1610-ubi_env"
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_VERSION_VARIABLE=y
++CONFIG_NETCONSOLE=y
++CONFIG_USE_IPADDR=y
++CONFIG_IPADDR="192.168.1.1"
++CONFIG_USE_SERVERIP=y
++CONFIG_SERVERIP="192.168.1.254"
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_BUTTON=y
++CONFIG_BUTTON_GPIO=y
++CONFIG_CLK=y
++CONFIG_GPIO_HOG=y
++CONFIG_LED=y
++CONFIG_LED_BLINK=y
++CONFIG_LED_GPIO=y
++# CONFIG_MMC is not set
++CONFIG_MTD=y
++CONFIG_DM_MTD=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_MTD_UBI_FASTMAP=y
++CONFIG_PHY_FIXED=y
++CONFIG_MEDIATEK_ETH=y
++CONFIG_PHY=y
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++CONFIG_PINCTRL_MT7981=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MTK_POWER_DOMAIN=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_RAM=y
++CONFIG_DM_RNG=y
++CONFIG_RNG_MTK_V2=y
++CONFIG_DM_SERIAL=y
++CONFIG_SERIAL_RX_BUFFER=y
++CONFIG_MTK_SERIAL=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_MTK_SPIM=y
++CONFIG_ZSTD=y
++CONFIG_HEXDUMP=y
+--- /dev/null
++++ b/arch/arm/dts/mt7981-huasifei-ws1610-ubi.dts
+@@ -0,0 +1,131 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++
++/dts-v1/;
++#include "mt7981.dtsi"
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/linux-event-codes.h>
++
++/ {
++	#address-cells = <1>;
++	#size-cells = <1>;
++	model = "Huasifei WS1610 (UBI)";
++	compatible = "mediatek,mt7981", "mediatek,mt7981-rfb";
++
++	chosen {
++		stdout-path = &uart0;
++		tick-timer = &timer0;
++	};
++
++	memory@40000000 {
++		device_type = "memory";
++		reg = <0x40000000 0x40000000>;
++	};
++
++	gpio-keys {
++		compatible = "gpio-keys";
++
++		button-reset {
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	gpio-leds {
++		compatible = "gpio-leds";
++
++		led_sim1: led-sim1 {
++			label = "green:sim1";
++			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
++		};
++
++		led_sim2: led-sim2 {
++			label = "green:sim2";
++			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&uart0 {
++	mediatek,force-highspeed;
++	status = "okay";
++};
++
++&eth {
++	status = "okay";
++	mediatek,gmac-id = <1>;
++	phy-mode = "gmii";
++	phy-handle = <&int_gbe_phy>;
++
++	mdio {
++		int_gbe_phy: ethernet-phy@0 {
++			compatible = "ethernet-phy-ieee802.3-c22";
++			reg = <0>;
++			phy-mode = "gmii";
++			phy-is-integrated;
++		};
++	};
++};
++
++&pio {
++	spi_flash_pins: spi0-pins-func-1 {
++		mux {
++			function = "flash";
++			groups = "spi0", "spi0_wp_hold";
++		};
++
++		conf-pu {
++			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
++			drive-strength = <MTK_DRIVE_8mA>;
++			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
++		};
++
++		conf-pd {
++			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
++			drive-strength = <MTK_DRIVE_8mA>;
++			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
++		};
++	};
++};
++
++&spi0 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi_flash_pins>;
++	status = "okay";
++	must_tx;
++	enhance_timing;
++	dma_ext;
++	ipm_design;
++	support_quad;
++	tick_dly = <2>;
++	sample_sel = <0>;
++
++	nand@0 {
++		compatible = "spi-nand";
++		reg = <0>;
++		spi-max-frequency = <52000000>;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "bl2";
++				reg = <0x0000000 0x0100000>;
++			};
++
++			partition@100000 {
++				compatible = "linux,ubi";
++				label = "ubi";
++				reg = <0x0100000 0x0ff00000>;
++			};
++		};
++	};
++};
++
++&watchdog {
++	status = "disabled";
++};
+--- /dev/null
++++ b/defenvs/huasifei_ws1610-ubi_env
+@@ -0,0 +1,65 @@
++ipaddr=192.168.1.1
++serverip=192.168.1.254
++loadaddr=0x46000000
++console=earlycon=uart8250,mmio32,0x11002000 console=ttyS0
++bootcmd=run boot_ubi
++bootconf=config-1
++bootdelay=3
++bootfile=openwrt-mediatek-filogic-huasifei_ws1610-ubi-initramfs-recovery.itb
++bootfile_bl2=openwrt-mediatek-filogic-huasifei_ws1610-ubi-preloader.bin
++bootfile_factory=Factory.bin
++bootfile_fip=openwrt-mediatek-filogic-huasifei_ws1610-ubi-bl31-uboot.fip
++bootfile_upg=openwrt-mediatek-filogic-huasifei_ws1610-ubi-squashfs-sysupgrade.itb
++bootled_pwr=green:sim1
++bootled_rec=green:sim2
++preboot=if env exists _firstboot && run ubi_installed ; then setenv _firstboot && run _switch_to_menu && run _init_env ; fi
++bootmenu_confirm_return=askenv - Press ENTER to return to menu ; bootmenu 60
++bootmenu_default=1
++bootmenu_delay=3
++bootmenu_title=      ( ( ( OpenWrt ) ) )
++bootmenu_0=Initialize all-in-UBI layout using Factory.bin.=run _firstboot ; run bootmenu_confirm_return
++bootmenu_0d=Run default boot command.=run boot_default
++bootmenu_1=Boot system via TFTP.=run boot_tftp ; run bootmenu_confirm_return
++bootmenu_2=Boot production system from NAND.=run boot_production ; run bootmenu_confirm_return
++bootmenu_3=Boot recovery system from NAND.=run boot_recovery ; run bootmenu_confirm_return
++bootmenu_4=Load BL31+U-Boot FIP via TFTP then write to NAND.=run boot_tftp_write_fip ; run bootmenu_confirm_return
++bootmenu_5=Load recovery system via TFTP then write to NAND.=run boot_tftp_write_recovery ; run bootmenu_confirm_return
++bootmenu_6=Load production system via TFTP then write to NAND.=run boot_tftp_write_production ; run bootmenu_confirm_return
++bootmenu_7=Load BL2 preloader via TFTP then write to NAND (last).=run boot_tftp_write_bl2 ; run bootmenu_confirm_return
++bootmenu_8=Reboot.=reset
++bootmenu_9=Reset all settings to factory defaults.=if run reset_factory ; then reset ; else setenv confirm ; run bootmenu_confirm_return ; fi
++boot_default=if button reset ; then run boot_recovery_button ; else run bootcmd ; fi
++boot_production=led $bootled_pwr on ; run ubi_read_production && bootm $loadaddr#$bootconf ; led $bootled_pwr off
++boot_recovery=led $bootled_rec on ; run ubi_read_recovery && bootm $loadaddr#$bootconf ; led $bootled_rec off
++boot_recovery_button=led $bootled_rec on ; run boot_tftp ; run boot_recovery ; run boot_tftp_forever
++boot_ubi=run boot_production ; run boot_recovery ; run boot_tftp_forever
++boot_tftp_forever=led $bootled_rec on ; while true ; do run boot_tftp ; sleep 1 ; done
++boot_tftp=tftpboot $loadaddr $bootfile && iminfo $loadaddr && bootm $loadaddr#$bootconf
++boot_tftp_write_recovery=tftpboot $loadaddr $bootfile && iminfo $loadaddr && run ubi_write_recovery
++boot_tftp_write_production=tftpboot $loadaddr $bootfile_upg && iminfo $loadaddr && run ubi_write_production
++boot_tftp_write_fip=tftpboot $loadaddr $bootfile_fip && run ubi_write_fip && run env_invalidate
++boot_tftp_write_bl2=run ubi_verify_install && tftpboot $loadaddr $bootfile_bl2 && run mtd_write_bl2
++reset_factory=askenv confirm "Type RESET to continue:" 5 && test "$confirm" = RESET && ubi part ubi && run ubi_remove_rootfs && run env_invalidate
++env_invalidate=ubi part ubi && env erase
++mtd_write_bl2=test 0x$filesize -ge 0x10000 && test 0x$filesize -le 0x100000 && mtd erase bl2 && mtd write bl2 $loadaddr 0 $filesize
++ubi_create_env=ubi check ubootenv || ubi create ubootenv 0x1f000 dynamic ; ubi check ubootenv2 || ubi create ubootenv2 0x1f000 dynamic ; ubi check ubootenv && ubi check ubootenv2
++ubi_format=ubi detach ; mtd erase ubi && ubi part ubi
++ubi_init=tftpboot $loadaddr $bootfile_factory && test 0x$filesize -eq 0x200000 && askenv confirm "Type ERASE to continue:" 5 && test "$confirm" = ERASE && run ubi_format && run ubi_write_factory
++ubi_installed=ubi part ubi && ubi check factory && ubi check fip && ubi check recovery && ubi check fit
++ubi_verify_install=ubi part ubi && ubi check factory && ubi check fip && ubi check ubootenv && ubi check ubootenv2 && ubi read $loadaddr recovery && iminfo $loadaddr && ubi read $loadaddr fit && iminfo $loadaddr
++ubi_prepare_rootfs=if ubi check rootfs_data ; then true ; elif env exists rootfs_data_max ; then ubi create rootfs_data $rootfs_data_max dynamic || ubi create rootfs_data - dynamic ; else ubi create rootfs_data - dynamic ; fi
++ubi_read_production=ubi read $loadaddr fit && iminfo $loadaddr && run ubi_prepare_rootfs
++ubi_read_recovery=ubi check recovery && ubi read $loadaddr recovery && iminfo $loadaddr
++ubi_remove_fit=if ubi check fit ; then ubi remove fit ; else echo "fit absent" ; fi
++ubi_remove_recovery=if ubi check recovery ; then ubi remove recovery ; else echo "recovery absent" ; fi
++ubi_remove_fip=if ubi check fip ; then ubi remove fip ; else echo "fip absent" ; fi
++ubi_remove_rootfs=if ubi check rootfs_data ; then ubi remove rootfs_data ; else echo "rootfs_data absent" ; fi
++ubi_write_factory=ubi create factory 0x1000 static && ubi write $loadaddr factory 0x1000
++ubi_write_fip=test 0x$filesize -le 0x200000 && run _ubi_write_fip
++ubi_write_production=run ubi_remove_fit && run ubi_remove_rootfs && ubi create fit $filesize dynamic && ubi write $loadaddr fit $filesize
++ubi_write_recovery=run ubi_remove_recovery && run ubi_remove_rootfs && ubi create recovery $filesize dynamic && ubi write $loadaddr recovery $filesize
++_ubi_write_fip=run ubi_remove_rootfs && run ubi_remove_fip && ubi create fip $filesize static && ubi write $loadaddr fip $filesize
++_init_env=setenv _init_env && run ubi_create_env && saveenv && saveenv
++_firstboot=if run ubi_init ; then setenv confirm && setenv _firstboot && run _switch_to_menu && run _init_env ; fi
++_switch_to_menu=setenv _switch_to_menu ; setenv bootdelay 3 ; setenv bootmenu_delay 3 ; setenv bootmenu_default 0 ; setenv bootmenu_0 $bootmenu_0d ; setenv bootmenu_0d ; run _bootmenu_update_title
++_bootmenu_update_title=setenv _bootmenu_update_title ; setenv bootmenu_title "$bootmenu_title       $ver"

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -38,6 +38,7 @@ cudy,wr3000s-v1-ubootmod|\
 cudy,wr3000h-v1-ubootmod|\
 cudy,wr3000p-v1-ubootmod|\
 h3c,magic-nx30-pro|\
+huasifei,ws1610-ubi|\
 imou,hx21|\
 jcg,q30-pro|\
 konka,komi-a31|\

--- a/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
+++ b/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
@@ -22,6 +22,7 @@ set_preinit_iface() {
 		ip link set eth0 up
 		ifname=eth0
 		;;
+	huasifei,ws1610-ubi|\
 	smartrg,sdg-841-t6|\
 	smartrg,sdg-8622|\
 	smartrg,sdg-8632|\
@@ -49,4 +50,3 @@ set_preinit_iface() {
 }
 
 boot_hook_add preinit_main set_preinit_iface
-

--- a/target/linux/mediatek/dts/mt7981b-huasifei-ws1610-ubi.dts
+++ b/target/linux/mediatek/dts/mt7981b-huasifei-ws1610-ubi.dts
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "mt7981b.dtsi"
+
+/ {
+	model = "Huasifei WS1610 (OpenWrt U-Boot UBI layout)";
+	compatible = "huasifei,ws1610-ubi", "mediatek,mt7981b";
+
+	aliases {
+		led-boot = &led_sim1;
+		led-failsafe = &led_sim2;
+		led-running = &led_sim1;
+		led-upgrade = &led_sim1;
+		label-mac-device = &gmac0;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		bootargs = "root=/dev/fit0 rootwait";
+		rootdisk = <&ubi_rootdisk>;
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_4g: led-4g {
+			function = LED_FUNCTION_MOBILE;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <1>;
+			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led_5g: led-5g {
+			function = LED_FUNCTION_MOBILE;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <2>;
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lan: led-lan {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wifi: led-wifi {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "network";
+		};
+
+		led_sim1: led-sim1 {
+			function = LED_FUNCTION_MOBILE;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <3>;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_sim2: led-sim2 {
+			function = LED_FUNCTION_MOBILE;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <4>;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	/*
+	 * GPIO5 controls the modem 5 V rail.
+	 * Exported value 0 = modem powered off, 1 = modem powered on.
+	 *
+	 * GPIO4 is an active-high modem reset trigger.
+	 * A rising edge restarts the modem.
+	 * A falling edge causes no observed action.
+	 */
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		modem-power {
+			gpio-export,name = "modem_power";
+			gpio-export,output = <1>;
+			gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		modem-reset {
+			gpio-export,name = "modem_reset";
+			gpio-export,output = <0>;
+			gpios = <&pio 4 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+	status = "okay";
+
+	/* Port labeled 2.5G LAN/WAN */
+	gmac0: mac@0 {
+		label = "wan";
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+		phy-handle = <&rtl8221b_phy>;
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 0>;
+	};
+
+	/* Port labeled LAN */
+	gmac1: mac@1 {
+		label = "lan";
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 1>;
+	};
+};
+
+&fan {
+	interrupt-parent = <&pio>;
+	interrupts = <12 IRQ_TYPE_EDGE_FALLING>;
+	pulses-per-revolution = <2>;
+	pwms = <&pwm 0 40000>;
+	status = "okay";
+};
+
+&mdio_bus {
+	rtl8221b_phy: ethernet-phy@6 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <6>;
+		reset-assert-us = <100000>;
+		reset-deassert-us = <100000>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_LOW>;
+		realtek,aldps-enable;
+	};
+};
+
+&pio {
+	pwm0_pins: pwm0-pins {
+		mux {
+			function = "pwm";
+			groups = "pwm0_1";
+		};
+	};
+
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&pwm {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm0_pins>;
+	status = "okay";
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	nand@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-rx-bus-width = <4>;
+		spi-tx-bus-width = <4>;
+
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4e 0x41 0x4e 0x44>;
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bl2";
+				reg = <0x0000000 0x0100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				compatible = "linux,ubi";
+				label = "ubi";
+				reg = <0x0100000 0x0ff00000>;
+
+				volumes {
+					ubi_factory: ubi-volume-factory {
+						volname = "factory";
+					};
+
+					ubi-volume-fip {
+						volname = "fip";
+					};
+
+					ubi_rootdisk: ubi-volume-fit {
+						volname = "fit";
+					};
+
+					ubi_ubootenv: ubi-volume-ubootenv {
+						volname = "ubootenv";
+					};
+
+					ubi_ubootenv2: ubi-volume-ubootenv2 {
+						volname = "ubootenv2";
+					};
+				};
+			};
+		};
+	};
+};
+
+&ubi_factory {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		eeprom_factory_0: eeprom@0 {
+			reg = <0x0 0x1000>;
+		};
+
+		macaddr_factory_4: macaddr@4 {
+			compatible = "mac-base";
+			reg = <0x4 0x6>;
+			#nvmem-cell-cells = <1>;
+		};
+	};
+};
+
+&ubi_ubootenv {
+	nvmem-layout {
+		compatible = "u-boot,env-redundant-bool";
+	};
+};
+
+&ubi_ubootenv2 {
+	nvmem-layout {
+		compatible = "u-boot,env-redundant-bool";
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&xhci {
+	phys = <&u2port0 PHY_TYPE_USB2>,
+	       <&u3port0 PHY_TYPE_USB3>;
+	mediatek,u3p-dis-msk = <0x0>;
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+	status = "okay";
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_4 2>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_4 3>;
+		nvmem-cell-names = "mac-address";
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -140,6 +140,9 @@ huasifei,wh3000)
 huasifei,wh3000r-nand)
 	ucidef_set_led_netdev "wan" "WAN" "blue:wan-online" "wan" "link"
 	;;
+huasifei,ws1610-ubi)
+	ucidef_set_led_netdev "lan" "LAN" "green:lan" "lan" "link tx rx"
+	;;
 iptime,ax3000q)
 	ucidef_set_led_netdev "wan" "WAN" "amber:wan" "wan" "link tx rx"
 	;;

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -187,6 +187,7 @@ mediatek_setup_interfaces()
 	comfast,cf-wr632ax|\
 	comfast,cf-wr632ax-ubi|\
 	comfast,cf-wr632ax-ubootmod|\
+	huasifei,ws1610-ubi|\
 	keenetic,kn-3911|\
 	smartrg,sdg-8622|\
 	smartrg,sdg-8632|\

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/03_gpio_switches
@@ -9,6 +9,10 @@ huasifei,wh3000-pro-emmc|\
 huasifei,wh3000-pro-nand)
 	ucidef_add_gpio_switch "modem_power" "Modem power" "modem_power" "0"
 	;;
+huasifei,ws1610-ubi)
+	ucidef_add_gpio_switch "modem_power" "Modem power" "modem_power" "1"
+	ucidef_add_gpio_switch "modem_reset" "Modem reset" "modem_reset" "0"
+	;;
 teltonika,rutc50)
 	ucidef_add_gpio_switch "modem_power" "Modem power button" "modem_power" "1"
 	ucidef_add_gpio_switch "modem_reset" "Modem reset" "modem_reset" "0"

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -160,6 +160,7 @@ platform_do_upgrade() {
 	gatonetworks,gdsp|\
 	globitel,bt-r320|\
 	h3c,magic-nx30-pro|\
+	huasifei,ws1610-ubi|\
 	imou,hx21|\
 	jcg,q30-pro|\
 	jdcloud,re-cp-03|\
@@ -407,6 +408,7 @@ platform_check_image() {
 	gatonetworks,gdsp|\
 	globitel,bt-r320|\
 	h3c,magic-nx30-pro|\
+	huasifei,ws1610-ubi|\
 	jcg,q30-pro|\
 	jdcloud,re-cp-03|\
 	konka,komi-a31|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2045,6 +2045,35 @@ define Device/huasifei_wh3000r-nand
 endef
 TARGET_DEVICES += huasifei_wh3000r-nand
 
+define Device/huasifei_ws1610-ubi
+  DEVICE_VENDOR := Huasifei
+  DEVICE_MODEL := WS1610
+  DEVICE_VARIANT := OpenWrt U-Boot UBI layout
+  DEVICE_DTS := mt7981b-huasifei-ws1610-ubi
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-hwmon-pwmfan kmod-ledtrig-network \
+	kmod-mt7915e kmod-mt7981-firmware \
+	mt7981-wo-firmware kmod-usb3 \
+	kmod-usb-net-qmi-wwan kmod-usb-net-cdc-ether kmod-usb-net-cdc-ncm \
+	kmod-usb-serial-option kmod-usbmon mdio-tools uqmi
+  KERNEL_IN_UBI := 1
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  UBOOTENV_IN_UBI := 1
+  IMAGES := sysupgrade.itb
+  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
+  KERNEL := kernel-bin | libdeflate-gzip
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/sysupgrade.itb := append-kernel | \
+	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
+  ARTIFACTS := preloader.bin bl31-uboot.fip
+  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ubi-ddr4
+  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot huasifei_ws1610-ubi
+endef
+TARGET_DEVICES += huasifei_ws1610-ubi
+
 define Device/imou_hx21
   DEVICE_VENDOR := Imou
   DEVICE_MODEL := HX21


### PR DESCRIPTION
Add support for the Huasifei WS1610 using an OpenWrt U-Boot
all-in-UBI layout.

Hardware:

* MediaTek MT7981B SoC
* 1 GiB DDR4 RAM
* 256 MiB Winbond SPI-NAND
* MediaTek MT7976CN 2.4/5 GHz 802.11ax Wi-Fi
* One 2.5 GbE WAN port using an RTL8221B PHY
* One 1 GbE LAN port using the MT7981 internal PHY
* M.2 and mini PCIe modem slots using USB 3.0
* Two Nano-SIM slots
* Six green LEDs
* Reset button
* 4-pin fan header (GND, TACH, PWM, 5V)
* UART at 115200 8n1 (3.3V, GND, RX, TX)
* 12-36 VDC input

Vendor flash layout:
  * BL2:        0x0000000 - 0x0100000
  * u-boot-env: 0x0100000 - 0x0180000
  * Factory:    0x0180000 - 0x0380000
  * FIP:        0x0380000 - 0x0580000
  * woem:       0x0580000 - 0x0620000
  * ubi:        0x0620000 - 0x7620000
  * ubi2:       0x7620000 - 0xe620000
  * wtinfo:     0xe620000 - 0xe680000
  * nvram:      0xe680000 - 0xe6e0000

OpenWrt U-Boot flash layout:
  * BL2: 0x0000000 - 0x0100000
  * UBI: 0x0100000 - 0x10000000

MAC addresses:
  * Base MAC is stored in Factory at offset 0x4
  * WAN:     base + 0
  * LAN:     base + 1
  * 2.4 GHz: base + 2
  * 5 GHz:   base + 3

UBI contains factory data, FIP, redundant U-Boot environments,
recovery and production firmware, and rootfs_data. The factory
volume stores the first 4 KiB of the original Factory partition,
including the Wi-Fi EEPROM and base MAC address.

Conversion reformats all flash after BL2 as one UBI partition.
NMBM and the vendor partition layout are not retained, so all listed
stock partitions must be backed up before conversion.

Installation requires a 3.3 V UART adapter and a TFTP server at
192.168.1.254 connected to the LAN port. OpenWrt U-Boot uses
192.168.1.1.

Before installation, log in to the vendor firmware over SSH and
back up every stock partition:

    backup=/tmp/ws1610-backup
    mkdir -p "$backup"
    for part in BL2 u-boot-env Factory FIP woem ubi ubi2 wtinfo nvram; do
        mtd dump "$part" > "$backup/$part.bin"
    done
    wc -c "$backup"/*.bin

Verify the sizes against the vendor layout and copy all nine files
off the router. Place the exact 2 MiB Factory backup as Factory.bin,
together with the generated WS1610 images, in the TFTP root.

It is recommended to test OpenWrt U-Boot from RAM before modifying
flash. Power off the router and run:

    sudo mtk_uartboot -s /dev/ttyUSB0 \
        -p mt7981-ram-ddr4-bl2.bin --aarch64 \
        -f openwrt-mediatek-filogic-huasifei_ws1610-ubi-bl31-uboot.fip

Power on when "Handshake..." appears, then open the console:

    sudo tio -b 115200 /dev/ttyUSB0

Confirm that RAM, SPI-NAND, Ethernet and TFTP work. Do not save the
environment or write flash during this test. Power-cycle afterward
and confirm that the vendor bootloader still starts.

For permanent installation, RAM-load OpenWrt U-Boot again and use
the menu in this exact order:

  1. Initialize the all-in-UBI layout using Factory.bin and type ERASE.
  2. Write the BL31 and U-Boot FIP.
  3. Write the persistent recovery image.
  4. Write the production sysupgrade image.
  5. Write the BL2 preloader last.
  6. Reboot.

Initialization checks that Factory.bin is exactly 2 MiB before
formatting flash. The BL2 write is refused until all required volumes
exist and both recovery and production images verify successfully.

Subsequent updates use the standard sysupgrade ITB.

Normal boot tries production, persistent recovery, then repeated
TFTP recovery. Holding reset tries TFTP once before persistent
recovery and repeated TFTP attempts.

Writing FIP, recovery or production from the U-Boot menu removes
rootfs_data; back up the configuration first. Updating FIP also
resets the saved U-Boot environment.

mtk_uartboot can recover an unbootable BL2 or FIP. Restoring the
vendor layout requires all nine partition backups made before
installation.

Signed-off-by: Georg Seema <georgseema@gmail.com>