### PR TITLE
realtek: add support for Zyxel GS1900-10HP B1

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/realtek
+++ b/package/boot/uboot-tools/uboot-envtools/files/realtek
@@ -21,6 +21,7 @@ zyxel,gs1900-8-a1|\
 zyxel,gs1900-8hp-a1|\
 zyxel,gs1900-8hp-b1|\
 zyxel,gs1900-10hp-a1|\
+zyxel,gs1900-10hp-b1|\
 zyxel,gs1900-16-a1|\
 zyxel,gs1900-24-a1|\
 zyxel,gs1900-24e-a1|\

--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -229,9 +229,6 @@ realtek_setup_poe()
 	netgear,gs310tp-v1)
 		ucidef_set_poe 55 "$(filter_port_list "$lan_list" "lan9 lan10")"
 		;;
-	zyxel,gs1900-10hp-a1)
-		ucidef_set_poe 77 "$(filter_port_list "$lan_list" "lan9 lan10")"
-		;;
 	zyxel,gs1900-8hp-a1|\
 	zyxel,gs1900-8hp-b1)
 		ucidef_set_poe 70 "$lan_list"

--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -140,6 +140,7 @@ realtek_setup_macs()
 	panasonic,m8eg-pn28080k|\
 	vimin,vm-s100-0800ms|\
 	zyxel,gs1900-10hp-a1|\
+	zyxel,gs1900-10hp-b1|\
 	zyxel,gs1900-16-a1|\
 	zyxel,gs1900-24-a1|\
 	zyxel,gs1900-24-b1|\

--- a/target/linux/realtek/base-files/etc/board.d/05_compat-version
+++ b/target/linux/realtek/base-files/etc/board.d/05_compat-version
@@ -18,6 +18,7 @@ case "$(board_name)" in
 	zyxel,gs1900-8hp-a1 | \
 	zyxel,gs1900-8hp-b1 | \
 	zyxel,gs1900-10hp-a1 | \
+	zyxel,gs1900-10hp-b1 | \
 	zyxel,gs1900-16-a1 | \
 	zyxel,gs1900-24e-a1 | \
 	zyxel,gs1900-24ep-a1 | \

--- a/target/linux/realtek/dts/rtl8380_zyxel_gs1900-10hp-a1.dts
+++ b/target/linux/realtek/dts/rtl8380_zyxel_gs1900-10hp-a1.dts
@@ -1,90 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "rtl8380_zyxel_gs1900.dtsi"
-#include "rtl8380_zyxel_gs1900_gpio.dtsi"
+#include "rtl8380_zyxel_gs1900-10hp.dtsi"
 
 / {
 	compatible = "zyxel,gs1900-10hp-a1", "realtek,rtl838x-soc";
 	model = "Zyxel GS1900-10HP A1 Switch";
-
-	/* i2c of the left SFP cage: port 9 */
-	i2c0: i2c-gpio-0 {
-		compatible = "i2c-gpio";
-		sda-gpios = <&gpio1 24 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		scl-gpios = <&gpio1 25 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		i2c-gpio,delay-us = <2>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-	};
-
-	sfp0: sfp-p9 {
-		compatible = "sff,sfp";
-		i2c-bus = <&i2c0>;
-		los-gpio = <&gpio1 27 GPIO_ACTIVE_HIGH>;
-		tx-fault-gpio = <&gpio1 22 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio1 26 GPIO_ACTIVE_LOW>;
-		tx-disable-gpio = <&gpio1 23 GPIO_ACTIVE_HIGH>;
-		#thermal-sensor-cells = <0>;
-	};
-
-	/* i2c of the right SFP cage: port 10 */
-	i2c1: i2c-gpio-1 {
-		compatible = "i2c-gpio";
-		sda-gpios = <&gpio1 30 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		scl-gpios = <&gpio1 31 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		i2c-gpio,delay-us = <2>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-	};
-
-	sfp1: sfp-p10 {
-		compatible = "sff,sfp";
-		i2c-bus = <&i2c1>;
-		los-gpio = <&gpio1 33 GPIO_ACTIVE_HIGH>;
-		tx-fault-gpio = <&gpio1 28 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio1 32 GPIO_ACTIVE_LOW>;
-		tx-disable-gpio = <&gpio1 29 GPIO_ACTIVE_HIGH>;
-		#thermal-sensor-cells = <0>;
-	};
 };
 
-&uart1 {
-	status = "okay";
-};
-
-&switch0 {
-	ethernet-ports {
-		port@24 {
-			reg = <24>;
-			label = "lan9";
-			pcs-handle = <&serdes4 0>;
-			phy-mode = "1000base-x";
-			managed = "in-band-status";
-			sfp = <&sfp0>;
-		};
-
-		port@26 {
-			reg = <26>;
-			label = "lan10";
-			pcs-handle = <&serdes5 0>;
-			phy-mode = "1000base-x";
-			managed = "in-band-status";
-			sfp = <&sfp1>;
-		};
-	};
-};
-
-&thermal_zones {
-	sfp-thermal {
-		polling-delay-passive = <10000>;
-		polling-delay = <10000>;
-		thermal-sensors = <&sfp0>, <&sfp1>;
-		trips {
-			sfp-crit {
-				temperature = <110000>;
-				hysteresis = <1000>;
-				type = "critical";
-			};
-		};
-	};
+&pse {
+	compatible = "zyxel,gs1900-10hp-a1-pse", "realtek,pse-mcu-gen1";
+	current-speed = <19200>;
 };

--- a/target/linux/realtek/dts/rtl8380_zyxel_gs1900-10hp-b1.dts
+++ b/target/linux/realtek/dts/rtl8380_zyxel_gs1900-10hp-b1.dts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl8380_zyxel_gs1900-10hp.dtsi"
+
+/ {
+	compatible = "zyxel,gs1900-10hp-b1", "realtek,rtl838x-soc";
+	model = "Zyxel GS1900-10HP B1 Switch";
+};
+
+&pse {
+	compatible = "zyxel,gs1900-10hp-b1-pse", "realtek,pse-mcu-gen2";
+	current-speed = <115200>;
+};

--- a/target/linux/realtek/dts/rtl8380_zyxel_gs1900-10hp.dtsi
+++ b/target/linux/realtek/dts/rtl8380_zyxel_gs1900-10hp.dtsi
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl8380_zyxel_gs1900.dtsi"
+#include "rtl8380_zyxel_gs1900_gpio.dtsi"
+
+/ {
+	/* i2c of the left SFP cage: port 9 */
+	i2c0: i2c-gpio-0 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 24 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 25 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp0: sfp-p9 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		los-gpio = <&gpio1 27 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpio = <&gpio1 22 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 26 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	/* i2c of the right SFP cage: port 10 */
+	i2c1: i2c-gpio-1 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 30 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 31 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp1: sfp-p10 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		los-gpio = <&gpio1 33 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpio = <&gpio1 28 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 32 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 29 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
+	};
+};
+
+&uart1 {
+	status = "okay";
+
+	/* PoE MCU; compatible and current-speed are set per variant */
+	pse: ethernet-pse {
+		pse-pis {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			PSE_PI(0)
+			PSE_PI(1)
+			PSE_PI(2)
+			PSE_PI(3)
+			PSE_PI(4)
+			PSE_PI(5)
+			PSE_PI(6)
+			PSE_PI(7)
+		};
+	};
+};
+
+&switch0 {
+	ethernet-ports {
+		port@24 {
+			reg = <24>;
+			label = "lan9";
+			pcs-handle = <&serdes4 0>;
+			phy-mode = "1000base-x";
+			managed = "in-band-status";
+			sfp = <&sfp0>;
+		};
+
+		port@26 {
+			reg = <26>;
+			label = "lan10";
+			pcs-handle = <&serdes5 0>;
+			phy-mode = "1000base-x";
+			managed = "in-band-status";
+			sfp = <&sfp1>;
+		};
+	};
+};
+
+&thermal_zones {
+	sfp-thermal {
+		polling-delay-passive = <10000>;
+		polling-delay = <10000>;
+		thermal-sensors = <&sfp0>, <&sfp1>;
+		trips {
+			sfp-crit {
+				temperature = <110000>;
+				hysteresis = <1000>;
+				type = "critical";
+			};
+		};
+	};
+};
+
+/* Copper ports lan1..lan8 (phy8..phy15) -> MCU PoE ports 0..7 */
+&phy8  { pses = <&pse_pi0>; };
+&phy9  { pses = <&pse_pi1>; };
+&phy10 { pses = <&pse_pi2>; };
+&phy11 { pses = <&pse_pi3>; };
+&phy12 { pses = <&pse_pi4>; };
+&phy13 { pses = <&pse_pi5>; };
+&phy14 { pses = <&pse_pi6>; };
+&phy15 { pses = <&pse_pi7>; };

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -391,7 +391,7 @@ define Device/zyxel_gs1900-10hp-a1
   DEVICE_MODEL := GS1900-10HP
   DEVICE_VARIANT := A1
   ZYXEL_VERS := AAZI
-  DEVICE_PACKAGES += realtek-poe
+  DEVICE_PACKAGES += kmod-pse-realtek-mcu-uart
   SUPPORTED_DEVICES += zyxel,gs1900-10hp
 endef
 TARGET_DEVICES += zyxel_gs1900-10hp-a1

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -396,6 +396,16 @@ define Device/zyxel_gs1900-10hp-a1
 endef
 TARGET_DEVICES += zyxel_gs1900-10hp-a1
 
+define Device/zyxel_gs1900-10hp-b1
+  $(Device/zyxel_gs1900)
+  SOC := rtl8380
+  DEVICE_MODEL := GS1900-10HP
+  DEVICE_VARIANT := B1
+  ZYXEL_VERS := AAZI
+  DEVICE_PACKAGES += kmod-pse-realtek-mcu-uart
+endef
+TARGET_DEVICES += zyxel_gs1900-10hp-b1
+
 define Device/zyxel_gs1900-16-a1
   $(Device/zyxel_gs1900)
   SOC := rtl8382


### PR DESCRIPTION
The GS1900-10HP B1 keeps the RTL8380M SoC and port layout of the A1 but changes the PoE subsystem, so it needs its own device tree instead of reusing the A1. Where the A1 uses a Broadcom BCM59121 behind a Gen1 MCU (UART 19200, driven by the realtek-poe daemon), the B1 uses a Realtek RTL8238 PSE fronted by a Nuvoton MCU speaking the Gen2 protocol at 115200 baud. It is therefore wired to the in-kernel realtek-pse-mcu UART driver and controlled via the standard PSE-PD/ethtool interface.

Specifications:
- SoC: Realtek RTL8380M
- Ports: 8x 10/100/1000 (PoE+), 2x SFP
- PoE: Realtek RTL8238 via Nuvoton MCU (Gen2, UART 115200)

Tested by probing the MCU on ttyS1 and by loading the kernel driver (RTL8238B, 8 ports) with per-port control via ethtool, verified across a cold power-cycle.

Big thx to @jonasjelonek for building the driver itself! 