### PR TITLE
ramips: mt76x8: fix MT7663 EEPROM cell for MERCUSYS MB130-4G v1

### DIFF
--- a/target/linux/ramips/dts/mt7628an_mercusys_mb130-4g-v1.dts
+++ b/target/linux/ramips/dts/mt7628an_mercusys_mb130-4g-v1.dts
@@ -187,7 +187,7 @@
 					};
 
 					eeprom_radio_8000: eeprom@8000 {
-						reg = <0x8000 0x200>;
+						reg = <0x8000 0x4da8>;
 					};
 				};
 			};


### PR DESCRIPTION
The nvmem cell for the MT7663 (5 GHz) radio was too small. The MT7663 EEPROM at offset 0x8000 requires
the full MT7615_EEPROM_FULL_SIZE (0x4da8), but the cell only declared 0x200 bytes.
The driver always requests the full buffer, also for the MT7663, so the undersized cell makes the nvmem read
fail with -EINVAL. The driver then falls back to default values, which limits TX power to 3 dBm.

Fix this by enlarging the cell to 0x4da8. The offset 0x8000 was already correct — offset 0x0 holds the 
MT7628 (2.4 GHz) calibration data.

[Fixes: #23632](https://github.com/openwrt/openwrt/issues/23632)

See screenshots

before:
<img width="379" height="102" alt="openwrt_confirm_bug_23632" src="https://github.com/user-attachments/assets/caa26b21-770e-4ee1-92d0-eee72a8de026" />
after:
<img width="547" height="529" alt="openwrt_Fix_bug_23632" src="https://github.com/user-attachments/assets/55047dc8-e394-4f66-9dda-6a0a4b430911" />

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
