### PR TITLE
generic: mips: 6.18: backport fix for highmem init

### DIFF
--- a/target/linux/generic/backport-6.18/300-v7.1-MIPS-mm-fix-highmem-init.patch
+++ b/target/linux/generic/backport-6.18/300-v7.1-MIPS-mm-fix-highmem-init.patch
@@ -1,0 +1,34 @@
+From 6d5fbecd0213489bc4de71a0da194d18e654fd6e Mon Sep 17 00:00:00 2001
+From: Kyle Hendry <kylehendrydev@gmail.com>
+Date: Sun, 21 Jun 2026 11:47:02 -0700
+Subject: MIPS: mm: Add check for highmem before removing memory block
+
+If a device has less physical memory than the highmem threshold
+bootmem_init() doesn't set highstart_pfn. This results in highmem_init()
+wrongly disabling the entire memory range if the cpu doesn't support
+highmem. Add a check that highstart_pfn is non zero before removing the
+highmem block.
+
+Fixes: f171b55f1441 ("mips: fix HIGHMEM initialization")
+Signed-off-by: Kyle Hendry <kylehendrydev@gmail.com>
+Signed-off-by: Thomas Bogendoerfer <tsbogend@alpha.franken.de>
+---
+ arch/mips/mm/init.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+--- a/arch/mips/mm/init.c
++++ b/arch/mips/mm/init.c
+@@ -431,10 +431,11 @@ static inline void __init highmem_init(v
+ 	unsigned long tmp;
+ 
+ 	/*
+-	 * If CPU cannot support HIGHMEM discard the memory above highstart_pfn
++	 * If CPU cannot support HIGHMEM discard any memory above highstart_pfn
+ 	 */
+ 	if (cpu_has_dc_aliases) {
+-		memblock_remove(PFN_PHYS(highstart_pfn), -1);
++		if (highstart_pfn)
++			memblock_remove(PFN_PHYS(highstart_pfn), -1);
+ 		return;
+ 	}
+ 


### PR DESCRIPTION
Fix bug in MIPS highmem init that prevents bcm47xx devices from booting
