### PR TITLE
build: gate firmware image signing behind SIGN_FIRMWARE

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -83,6 +83,15 @@ menu "Global build settings"
 		  --allow-untrusted when installing self-compiled packages to a
 		  firmware compiled by the same buildhost as public key matches.
 
+	config SIGN_FIRMWARE
+		bool "Cryptographically sign firmware images"
+		default n if BUILDBOT
+		default y
+		help
+		  Append a signature to firmware images so that sysupgrade can verify
+		  their authenticity before flashing. OpenWrt's build infrastructure
+		  signs images with temporary keys; disabling this drops the signature.
+
 	comment "General build options"
 
 	config TESTING_KERNEL

--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -91,12 +91,12 @@ metadata_json = \
 define Build/append-metadata
 	$(if $(SUPPORTED_DEVICES),-echo $(call metadata_json) | fwtool -I - $@)
 	sha256sum "$@" | cut -d" " -f1 > "$@.sha256sum"
-	[ ! -s "$(BUILD_KEY)" -o ! -s "$(BUILD_KEY).ucert" -o ! -s "$@" ] || { \
+	$(if $(CONFIG_SIGN_FIRMWARE),[ ! -s "$(BUILD_KEY)" -o ! -s "$(BUILD_KEY).ucert" -o ! -s "$@" ] || { \
 		cp "$(BUILD_KEY).ucert" "$@.ucert" ;\
 		usign -S -m "$@" -s "$(BUILD_KEY)" -x "$@.sig" ;\
 		ucert -A -c "$@.ucert" -x "$@.sig" ;\
 		fwtool -S "$@.ucert" "$@" ;\
-	}
+	})
 endef
 
 metadata_gl_json = \
@@ -122,12 +122,12 @@ metadata_gl_json = \
 define Build/append-gl-metadata
 	$(if $(SUPPORTED_DEVICES),-echo $(call metadata_gl_json,$(SUPPORTED_DEVICES)) | fwtool -I - $@)
 	sha256sum "$@" | cut -d" " -f1 > "$@.sha256sum"
-	[ ! -s "$(BUILD_KEY)" -o ! -s "$(BUILD_KEY).ucert" -o ! -s "$@" ] || { \
+	$(if $(CONFIG_SIGN_FIRMWARE),[ ! -s "$(BUILD_KEY)" -o ! -s "$(BUILD_KEY).ucert" -o ! -s "$@" ] || { \
 		cp "$(BUILD_KEY).ucert" "$@.ucert" ;\
 		usign -S -m "$@" -s "$(BUILD_KEY)" -x "$@.sig" ;\
 		ucert -A -c "$@.ucert" -x "$@.sig" ;\
 		fwtool -S "$@.ucert" "$@" ;\
-	}
+	})
 endef
 
 define Build/append-teltonika-metadata


### PR DESCRIPTION
Firmware image signing in append-metadata/append-gl-metadata was conditional only by the presence of the build key. Add an explicit SIGN_FIRMWARE option (default enabled except with BUILDBOT) so appending the fwtool signature can be toggled on its own.

It's disable on buildbot since we use a decentralized building with no individual keys on builders. Instead, a fake key is currently used, which adds an insecure signature.

The future of signing firmware  and key distribution across the build infrastructure should be discussed separately.