### PR TITLE
[24.10]: tools/cmake: backport bootstrap fix for GCC 16

### DIFF
--- a/tools/cmake/Makefile
+++ b/tools/cmake/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=cmake
 PKG_VERSION:=3.30.5
 PKG_VERSION_MAJOR:=$(word 1,$(subst ., ,$(PKG_VERSION))).$(word 2,$(subst ., ,$(PKG_VERSION)))
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_CPE_ID:=cpe:/a:kitware:cmake
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/tools/cmake/patches/010-bootstrap-Fix-compilation-with-gcc-16-devirtualizati.patch
+++ b/tools/cmake/patches/010-bootstrap-Fix-compilation-with-gcc-16-devirtualizati.patch
@@ -1,0 +1,31 @@
+From ea04e19daf7010781d0df980b9683a642093e381 Mon Sep 17 00:00:00 2001
+From: Brad King <brad.king@kitware.com>
+Date: Wed, 24 Sep 2025 12:02:37 -0400
+Subject: bootstrap: Fix compilation with gcc 16 devirtualization
+
+Avoid including a header for a subclass whose implementation is not
+compiled during bootstrap.
+
+Fixes: #27256
+---
+ Source/cmake.cxx | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/Source/cmake.cxx
++++ b/Source/cmake.cxx
+@@ -126,12 +126,12 @@
+ #  include "cmExtraEclipseCDT4Generator.h"
+ #  include "cmExtraKateGenerator.h"
+ #  include "cmExtraSublimeTextGenerator.h"
+-#endif
+ 
+ // NOTE: the __linux__ macro is predefined on Android host too, but
+ // main CMakeLists.txt filters out this generator by host name.
+-#if (defined(__linux__) && !defined(__ANDROID__)) || defined(_WIN32)
+-#  include "cmGlobalGhsMultiGenerator.h"
++#  if (defined(__linux__) && !defined(__ANDROID__)) || defined(_WIN32)
++#    include "cmGlobalGhsMultiGenerator.h"
++#  endif
+ #endif
+ 
+ #if defined(__APPLE__)

--- a/tools/cmake/patches/160-disable_xcode_generator.patch
+++ b/tools/cmake/patches/160-disable_xcode_generator.patch
@@ -12,7 +12,7 @@
 --- a/Source/cmake.cxx
 +++ b/Source/cmake.cxx
 @@ -134,7 +134,7 @@
- #  include "cmGlobalGhsMultiGenerator.h"
+ #  endif
  #endif
  
 -#if defined(__APPLE__)


### PR DESCRIPTION
CMake fails to bootstrap its host tool with GCC 16:

    cmake.o: undefined reference to
    `cmGlobalGhsMultiGenerator::cmGlobalGhsMultiGenerator(cmake*)'

Source/cmake.cxx includes cmGlobalGhsMultiGenerator.h guarded only by __linux__, not by CMAKE_BOOTSTRAP. The NewFactory() call is compiled out during bootstrap, but GCC 16 devirtualization still emits the uncalled inline NewFactory() and the cmGlobalGeneratorSimpleFactory<> template, which reference symbols only defined in cmGlobalGhsMultiGenerator.cxx, a file that is not compiled during bootstrap.

Backport the upstream fix, which moves the include behind the existing CMAKE_BOOTSTRAP guard. It is in no 3.30.x release (that branch is EOL); upstream shipped it first in 3.31.10 / 4.0.5 / 4.1.2.

Assisted-by: Claude:claude-opus-4-8
