### PR TITLE
kernel: rtl8367b: support post-init register writes

### DIFF
--- a/target/linux/generic/files/Documentation/devicetree/bindings/net/realtek,rtl8367b.yaml
+++ b/target/linux/generic/files/Documentation/devicetree/bindings/net/realtek,rtl8367b.yaml
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/net/realtek,rtl8367b.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Realtek RTL8367B family Ethernet switches
+
+maintainers:
+  - Nickolay Savchenko <n.savchenko@axioma.lv>
+  - Mieczyslaw Nalewaj <namiltd@yahoo.com>
+
+properties:
+  compatible:
+    const: realtek,rtl8367b
+
+  mii-bus:
+    $ref: /schemas/types.yaml#/definitions/phandle
+    description: MDIO bus used to access the switch registers.
+
+  phy-id:
+    $ref: /schemas/types.yaml#/definitions/uint32
+    maximum: 31
+    description: MDIO address used to access the switch registers.
+
+  sda-gpios:
+    maxItems: 1
+    description: GPIO used for the proprietary SMI data signal.
+
+  sck-gpios:
+    maxItems: 1
+    description: GPIO used for the proprietary SMI clock signal.
+
+  resets:
+    maxItems: 1
+
+  reset-names:
+    const: switch
+
+  mdio-bus:
+    $ref: /schemas/net/mdio.yaml#
+    unevaluatedProperties: false
+    description: Optional container for the switch-internal MDIO bus.
+
+  realtek,extif:
+    $ref: /schemas/types.yaml#/definitions/uint32-array
+    minItems: 10
+    maxItems: 10
+    description:
+      External interface configuration. The values select the CPU port,
+      transmit and receive delays, interface mode, forced mode, pause,
+      link, duplex and speed settings, in that order.
+
+  realtek,init-regs:
+    $ref: /schemas/types.yaml#/definitions/uint32-matrix
+    minItems: 1
+    maxItems: 32
+    items:
+      items:
+        - description: Switch register address
+          minimum: 0
+          maximum: 0xffff
+        - description: Value written to the register
+          minimum: 0
+          maximum: 0xffff
+    description:
+      Register/value pairs written after the chip-specific initialization
+      table and before the external interface is configured. This permits
+      board-specific post-initialization without changing other switches.
+
+required:
+  - compatible
+  - realtek,extif
+
+oneOf:
+  - required:
+      - mii-bus
+  - required:
+      - sda-gpios
+      - sck-gpios
+
+additionalProperties: false
+
+examples:
+  - |
+    #include <dt-bindings/gpio/gpio.h>
+
+    switch {
+        compatible = "realtek,rtl8367b";
+        sda-gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
+        sck-gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
+        realtek,extif = <6 1 2 1 1 1 1 1 1 2>;
+        realtek,init-regs = <0x1301 0x0778>,
+                            <0x1302 0x7777>;
+    };

--- a/target/linux/generic/files/drivers/net/phy/rtl8367b.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8367b.c
@@ -26,6 +26,7 @@
 
 #define RTL8367B_PHY_ADDR_MAX	8
 #define RTL8367B_PHY_REG_MAX	31
+#define RTL8367B_MAX_INIT_REGS	32
 
 #define RTL8367B_VID_MASK	0x3fff
 #define RTL8367B_FID_MASK	0xf
@@ -579,6 +580,46 @@ static int rtl8367b_init_regs(struct rtl8366_smi *smi)
 	return rtl8367b_write_initvals(smi, initvals, count);
 }
 
+static int rtl8367b_init_post(struct rtl8366_smi *smi)
+{
+	struct device_node *np = smi->parent->of_node;
+	const __be32 *prop;
+	u32 reg, val;
+	int count, i, err;
+
+	prop = of_get_property(np, "realtek,init-regs", &count);
+	if (!prop)
+		return 0;
+
+	if (!count || count % (2 * sizeof(*prop))) {
+		dev_err(smi->parent,
+			"realtek,init-regs must contain register/value pairs\n");
+		return -EINVAL;
+	}
+
+	count /= sizeof(*prop);
+	if (count > RTL8367B_MAX_INIT_REGS * 2) {
+		dev_err(smi->parent,
+			"realtek,init-regs has too many pairs: %d\n", count / 2);
+		return -E2BIG;
+	}
+
+	for (i = 0; i < count; i += 2) {
+		reg = be32_to_cpup(prop++);
+		val = be32_to_cpup(prop++);
+		if (reg > U16_MAX || val > U16_MAX) {
+			dev_err(smi->parent,
+				"invalid init register/value pair: %#x/%#x\n",
+				reg, val);
+			return -ERANGE;
+		}
+
+		REG_WR(smi, reg, val);
+	}
+
+	return 0;
+}
+
 static int rtl8367b_reset_chip(struct rtl8366_smi *smi)
 {
 	int timeout = 10;
@@ -852,6 +893,10 @@ static int rtl8367b_setup(struct rtl8366_smi *smi)
 	int i;
 
 	err = rtl8367b_init_regs(smi);
+	if (err)
+		return err;
+
+	err = rtl8367b_init_post(smi);
 	if (err)
 		return err;
 
@@ -1625,4 +1670,3 @@ MODULE_DESCRIPTION("Realtek RTL8367B ethernet switch driver");
 MODULE_AUTHOR("Gabor Juhos <juhosg@openwrt.org>");
 MODULE_LICENSE("GPL v2");
 MODULE_ALIAS("platform:" RTL8367B_DRIVER_NAME);
-


### PR DESCRIPTION
This adds an optional `realtek,init-regs` property to the legacy RTL8367B
swconfig driver. Boards may use it for a small sequence of register/value
writes after the chip-specific initialization table and before external
interface setup, avoiding board-specific register sequences in the shared
driver.

The property is a no-op when absent, so existing RTL8367B users retain their
current initialization path. Present properties are rejected when empty,
odd-sized, larger than 32 register/value pairs, or when either member of a
pair exceeds the switch's 16-bit register/value width. Register write errors
are propagated.

The commit also documents the existing legacy RTL8367B DT interface and the
new property in a binding schema.

This implements the generic approach suggested during review of #24249. The
device-specific DTS conversion remains intentionally outside this PR.

Co-authored-by: Mieczyslaw Nalewaj <namiltd@yahoo.com>

Run-tested: not yet (draft)

Static validation:

- `scripts/checkpatch.pl --strict`: 0 errors, warnings, or checks
- `dt-doc-validate realtek,rtl8367b.yaml`: pass
- `git diff --check`: pass
