### PR TITLE
mediatek: filogic: comfast cf-wr632ax: add fan tachometer & increase PWM period

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-comfast-cf-wr632ax-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-comfast-cf-wr632ax-common.dtsi
@@ -80,7 +80,9 @@
 };
 
 &fan {
-	pwms = <&pwm 0 10000>;
+	interrupts-extended = <&pio 4 IRQ_TYPE_EDGE_FALLING>;
+	pulses-per-revolution = <2>;
+	pwms = <&pwm 0 40000>;
 	status = "okay";
 };
 


### PR DESCRIPTION
Add fan tachometer reading - 2 pulses per revolution, open drain, GPIO pin 4.

Increase PWM period from 10000 ns to 40000 ns (reduce PWM frequency from 100 kHz to 25 kHz) to reduce audible friction noise.