### PR TITLE
airoha: fix SCU regmap mapping for pcie nodes

### DIFF
--- a/target/linux/airoha/dts/an7581.dtsi
+++ b/target/linux/airoha/dts/an7581.dtsi
@@ -784,6 +784,8 @@
 
 			mediatek,pbus-csr = <&pbus_csr 0x0 0x4>;
 
+			airoha,scu = <&scuclk>;
+
 			interrupts = <GIC_SPI 39 IRQ_TYPE_LEVEL_HIGH>;
 			bus-range = <0x00 0xff>;
 			#interrupt-cells = <1>;
@@ -825,6 +827,8 @@
 
 			mediatek,pbus-csr = <&pbus_csr 0x8 0xc>;
 
+			airoha,scu = <&scuclk>;
+
 			interrupts = <GIC_SPI 40 IRQ_TYPE_LEVEL_HIGH>;
 			bus-range = <0x00 0xff>;
 			#interrupt-cells = <1>;
@@ -865,6 +869,8 @@
 			reset-names = "phy-lane2", "perstout";
 
 			mediatek,pbus-csr = <&pbus_csr 0x10 0x14>;
+
+			airoha,scu = <&scuclk>;
 
 			interrupts = <GIC_SPI 41 IRQ_TYPE_LEVEL_HIGH>;
 			bus-range = <0x00 0xff>;


### PR DESCRIPTION
Add the 'airoha,scu' property referencing '&scuclk' to pcie0, pcie1, and pcie2 nodes in the device tree. This update fixes the following error during PCIe controller initialization:

    mtk-pcie-gen3 1fc00000.pcie: error -ENODEV: failed to map SCU regmap

By correctly specifying the SCU clock reference, the PCIe controllers are able to map the SCU regmap and initialize properly.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
