### PR TITLE
mediatek: filogic: add support Netcore N30 Pro/NX35U

### DIFF
--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -556,6 +556,18 @@ define U-Boot/mt7981_mercusys_mr85x
   DEPENDS:=+trusted-firmware-a-mt7981-spim-nand-ubi-ddr3-1866
 endef
 
+define U-Boot/mt7981_netcore_n30-pro
+  NAME:=Netcore N30 Pro
+  BUILD_SUBTARGET:=filogic
+  BUILD_DEVICES:=netcore_n30-pro
+  UBOOT_CONFIG:=mt7981_netcore_n30-pro
+  UBOOT_IMAGE:=u-boot.fip
+  BL2_BOOTDEV:=spim-nand
+  BL2_SOC:=mt7981
+  BL2_DDRTYPE:=ddr3
+  DEPENDS:=+trusted-firmware-a-mt7981-spim-nand-ddr3
+endef
+
 define U-Boot/mt7981_netis_eap930-v1
   NAME:=netis EAP930 V1
   BUILD_SUBTARGET:=filogic
@@ -1363,6 +1375,7 @@ UBOOT_TARGETS := \
 	mt7981_jcg_q30-pro \
 	mt7981_konka_komi-a31 \
 	mt7981_mercusys_mr85x \
+	mt7981_netcore_n30-pro \
 	mt7981_netis_eap930-v1 \
 	mt7981_netis_n6-v2 \
 	mt7981_netis_nx30v2 \

--- a/package/boot/uboot-mediatek/patches/468-add-netcore-n30-pro.patch
+++ b/package/boot/uboot-mediatek/patches/468-add-netcore-n30-pro.patch
@@ -1,0 +1,360 @@
+--- /dev/null
++++ b/arch/arm/dts/mt7981-netcore-n30-pro.dts
+@@ -0,0 +1,160 @@
++// SPDX-License-Identifier: GPL-2.0
++
++/dts-v1/;
++#include "mt7981.dtsi"
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++
++/ {
++	model = "Netcore N30 Pro";
++	compatible = "netcore,n30-pro", "mediatek,mt7981";
++	chosen {
++		stdout-path = &uart0;
++		tick-timer = &timer0;
++	};
++
++	memory@40000000 {
++		device_type = "memory";
++		reg = <0x40000000 0x20000000>;
++	};
++
++	gpio-keys {
++		compatible = "gpio-keys";
++
++		reset {
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
++		};
++
++		wps {
++			label = "wps";
++			linux,code = <KEY_WPS_BUTTON>;
++			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		wps {
++			label = "wps";
++			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
++		};
++
++		wan {
++			label = "wan";
++			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
++		};
++
++		internet {
++			label = "internet";
++			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
++		};
++
++		usb {
++			label = "usb";
++			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
++		};
++
++		wifi {
++			label = "wifi";
++			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
++		};
++
++	};
++
++};
++
++&uart0 {
++	status = "okay";
++};
++
++&eth {
++	status = "okay";
++	mediatek,gmac-id = <0>;
++	phy-mode = "2500base-x";
++	mediatek,switch = "auto";
++	reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
++
++	fixed-link {
++		speed = <2500>;
++		full-duplex;
++	};
++};
++
++&pio {
++	spi_flash_pins: spi0-pins-func-1 {
++		mux {
++			function = "flash";
++			groups = "spi0", "spi0_wp_hold";
++		};
++
++		conf-pu {
++			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
++			drive-strength = <MTK_DRIVE_8mA>;
++			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
++		};
++
++		conf-pd {
++			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
++			drive-strength = <MTK_DRIVE_8mA>;
++			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
++		};
++	};
++};
++
++&spi0 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi_flash_pins>;
++	status = "okay";
++	enhance_timing;
++	dma_ext;
++	ipm_design;
++	support_quad;
++	tick_dly = <2>;
++	sample_sel = <0>;
++
++	spi_nand@0 {
++		compatible = "spi-nand";
++		reg = <0>;
++		spi-max-frequency = <52000000>;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "BL2";
++				reg = <0x0 0x100000>;
++			};
++
++			partition@100000 {
++				label = "u-boot-env";
++				reg = <0x100000 0x80000>;
++			};
++
++			partition@180000 {
++				label = "Factory";
++				reg = <0x180000 0x200000>;
++			};
++
++			partition@380000 {
++				label = "FIP";
++				reg = <0x380000 0x200000>;
++			};
++
++			partition@580000 {
++				label = "ubi";
++				reg = <0x580000 0x7280000>;
++			};
++		};
++	};
++};
++
++&watchdog {
++	status = "disabled";
++};
+--- /dev/null
++++ b/configs/mt7981_netcore_n30-pro_defconfig
+@@ -0,0 +1,127 @@
++CONFIG_ARM=y
++CONFIG_SYS_HAS_NONCACHED_MEMORY=y
++CONFIG_POSITION_INDEPENDENT=y
++CONFIG_ARCH_MEDIATEK=y
++CONFIG_TEXT_BASE=0x41e00000
++CONFIG_SYS_MALLOC_F_LEN=0x4000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEFAULT_DEVICE_TREE="mt7981-netcore-n30-pro"
++CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_TARGET_MT7981=y
++CONFIG_SYS_LOAD_ADDR=0x46000000
++CONFIG_DEBUG_UART_BASE=0x11002000
++CONFIG_DEBUG_UART_CLOCK=40000000
++CONFIG_DEBUG_UART=y
++CONFIG_BUTTON_CMD=y
++CONFIG_FIT=y
++CONFIG_SPI_BOOT=y
++CONFIG_AUTOBOOT_MENU_SHOW=y
++CONFIG_OF_SYSTEM_SETUP=y
++CONFIG_USE_PREBOOT=y
++CONFIG_SYS_CBSIZE=512
++CONFIG_SYS_PBSIZE=1049
++CONFIG_LOGLEVEL=7
++CONFIG_CONSOLE_MUX=y
++CONFIG_LOG=y
++# CONFIG_BOARD_INIT is not set
++CONFIG_BOARD_LATE_INIT=y
++CONFIG_UPDATE_FIT=y
++CONFIG_HUSH_PARSER=y
++CONFIG_SYS_PROMPT="MT7981> "
++CONFIG_CMD_CPU=y
++CONFIG_CMD_LICENSE=y
++# CONFIG_BOOTM_NETBSD is not set
++# CONFIG_BOOTM_PLAN9 is not set
++# CONFIG_BOOTM_RTEMS is not set
++# CONFIG_BOOTM_VXWORKS is not set
++CONFIG_CMD_BOOTMENU=y
++CONFIG_CMD_ASKENV=y
++CONFIG_CMD_ERASEENV=y
++CONFIG_CMD_ENV_FLAGS=y
++CONFIG_CMD_STRINGS=y
++# CONFIG_CMD_UNLZ4 is not set
++# CONFIG_CMD_UNZIP is not set
++CONFIG_CMD_DFU=y
++CONFIG_CMD_DM=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_MTD=y
++CONFIG_CMD_PCI=y
++CONFIG_CMD_SF_TEST=y
++CONFIG_CMD_TFTPPUT=y
++CONFIG_CMD_TFTPSRV=y
++CONFIG_CMD_RARP=y
++CONFIG_CMD_CDP=y
++CONFIG_CMD_LINK_LOCAL=y
++CONFIG_CMD_DHCP=y
++CONFIG_CMD_DNS=y
++CONFIG_CMD_PING=y
++CONFIG_CMD_SNTP=y
++CONFIG_CMD_PXE=y
++CONFIG_CMD_CACHE=y
++CONFIG_CMD_PSTORE=y
++CONFIG_CMD_PSTORE_MEM_ADDR=0x42ff0000
++CONFIG_CMD_UUID=y
++CONFIG_CMD_HASH=y
++CONFIG_CMD_SMC=y
++CONFIG_CMD_FS_GENERIC=y
++CONFIG_CMD_FS_UUID=y
++CONFIG_CMD_UBI=y
++CONFIG_CMD_UBI_RENAME=y
++CONFIG_ENV_OVERWRITE=y
++CONFIG_ENV_IS_IN_UBI=y
++CONFIG_ENV_UBI_PART="ubi"
++CONFIG_ENV_UBI_VOLUME="ubootenv"
++CONFIG_ENV_UBI_VOLUME_CREATE=y
++CONFIG_ENV_USE_DEFAULT_ENV_TEXT_FILE=y
++CONFIG_ENV_DEFAULT_ENV_TEXT_FILE="defenvs/netcore_n30-pro.env"
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_NETCONSOLE=y
++CONFIG_USE_IPADDR=y
++CONFIG_IPADDR="192.168.1.1"
++CONFIG_USE_SERVERIP=y
++CONFIG_SERVERIP="192.168.1.254"
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_BUTTON=y
++CONFIG_BUTTON_GPIO=y
++CONFIG_CLK=y
++CONFIG_GPIO_HOG=y
++CONFIG_LED=y
++CONFIG_LED_BLINK=y
++CONFIG_LED_SW_BLINK=y
++CONFIG_LED_GPIO=y
++# CONFIG_MMC is not set
++CONFIG_MTD=y
++CONFIG_DM_MTD=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_DM_SPI_FLASH=y
++CONFIG_SPI_FLASH_SFDP_SUPPORT=y
++CONFIG_SPI_FLASH_EON=y
++CONFIG_SPI_FLASH_GIGADEVICE=y
++CONFIG_SPI_FLASH_ISSI=y
++CONFIG_SPI_FLASH_MACRONIX=y
++CONFIG_SPI_FLASH_SPANSION=y
++CONFIG_SPI_FLASH_STMICRO=y
++CONFIG_SPI_FLASH_WINBOND=y
++CONFIG_SPI_FLASH_XMC=y
++CONFIG_SPI_FLASH_XTX=y
++CONFIG_SPI_FLASH_MTD=y
++CONFIG_PHY_FIXED=y
++CONFIG_MEDIATEK_ETH=y
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++CONFIG_PINCTRL_MT7981=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MTK_POWER_DOMAIN=y
++CONFIG_DM_SERIAL=y
++CONFIG_SERIAL_RX_BUFFER=y
++CONFIG_DM_RNG=y
++CONFIG_RNG_MTK_V2=y
++CONFIG_MTK_SERIAL=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_MTK_SPIM=y
++CONFIG_HEXDUMP=y
++# CONFIG_TOOLS_LIBCRYPTO is not set
++# CONFIG_TOOLS_KWBIMAGE is not set
+--- /dev/null
++++ b/defenvs/netcore_n30-pro.env
+@@ -0,0 +1,64 @@
++#misc settings
++serverip=192.168.1.254
++ipaddr=192.168.1.1
++ncip=192.168.1.254
++loadaddr=0x46000000
++return_bootmenu=askenv - Press ENTER to return to menu ; bootmenu 60
++
++#file name defines
++bootfile_bl2=openwrt-mediatek-filogic-netcore_n30-pro-spim-nand-preloader.bin
++bootfile_fip=openwrt-mediatek-filogic-netcore_n30-pro-spim-nand-bl31-uboot.fip
++bootfile_rec=openwrt-mediatek-filogic-netcore_n30-pro-initramfs.itb
++bootfile_fw=openwrt-mediatek-filogic-netcore_n30-pro-squashfs-sysupgrade.itb
++
++#boot commands
++bootconf=config-1
++boot_recovery=tftpboot $bootfile_rec && iminfo && bootm $loadaddr#$bootconf
++boot_nand=ubi read $loadaddr fit;bootm $loadaddr#$bootconf
++bootcmd=run boot_nand; while true; do run boot_recovery; done
++
++#bootmenu
++bootmenu_default=0
++bootmenu_0=Startup system (Default)=run bootcmd
++bootmenu_1=Upgrade firmware via TFTP=run upgrade_fw ; run return_bootmenu
++bootmenu_2=Startup recovery image via TFTP=run boot_recovery ; run return_bootmenu
++bootmenu_3=Upgrade BL2 preloader via TFTP=run upgrade_bl2 ; run return_bootmenu
++bootmenu_4=Upgrade BL31+U-Boot FIP via TFTP=run upgrade_fip ; run return_bootmenu
++bootmenu_5=Reset all settings to factory default.=run reset_all; reset
++bootmenu_6=Reboot.=reset
++
++#upgrade commands
++upgrade_bl2=run led_blink_downloading && tftpboot $bootfile_bl2 && run led_blink_writing && nand erase BL2 && nand write $loadaddr BL2; run led_on
++upgrade_fip=run led_blink_downloading && tftpboot $bootfile_fip && run led_blink_writing && nand erase FIP && nand write $loadaddr FIP; run led_on
++upgrade_fw=run led_blink_downloading && tftpboot $bootfile_fw && iminfo && run led_blink_writing && if ubi check fit; then ubi remove fit; else true; fi && ubi create fit $filesize && ubi write $loadaddr fit $filesize; run led_on
++
++#restore offical bootloader
++offical_download=run led_blink_downloading; setenv failed 1; while test $failed -eq 1; do setenv bl2addr 0x46000000 && tftpboot $bl2addr bl2.img && setenv fipaddr 0x46380000 && tftpboot $fipaddr fip.bin && setenv failed 0; done; setenv customer 0; setenv customeraddr 0x46580000 && tftpboot $customeraddr customer && setenv customer 1; test $failed -eq 0
++offical_write=run led_blink_writing; nand erase BL2 && nand write $bl2addr BL2 && nand erase FIP && nand write $fipaddr FIP; ubi detach; mtd erase ubi; ubi part ubi; if test $customer -eq 1; then ubi create customer $filesize; ubi write $customeraddr customer $filesize; fi; true
++offical_upgrade=run offical_download offical_write led_on; echo upgrade offical bootloader done; while true; do sleep 10; done
++
++#factory default
++reset_env=env default -a && saveenv
++reset_usr=ubi check rootfs_data && ubi remove rootfs_data; run create_rootfs_data
++reset_all=run reset_env reset_usr
++
++#prepare ethaddr and rootfs_data at preload
++rootfs_data_max=0x5300000
++create_rootfs_data=if env exists rootfs_data_max; then ubi create rootfs_data $rootfs_data_max; else ubi create rootfs_data -; fi
++set_ethaddr=mtd read Factory $loadaddr 0x1fe000 0x1000 && setexpr tmpaddr $loadaddr + 0xf20 && mw.b $loadaddr 0 6 && cmp.b $loadaddr $tmpaddr 6 || readmem -b ethaddr $tmpaddr 0x6
++preboot=run set_ethaddr; if ubi part; then else mtd erase ubi; ubi part ubi; fi; ubi check rootfs_data || run create_rootfs_data
++
++#led
++led_blink_downloading=led internet blink 100; led wifi blink 100; led wps blink 100
++led_blink_writing=led internet blink 1000; led wifi blink 1000; led wps blink 1000
++led_on=led internet on; led wifi on; led wps on
++
++#netconsole
++netconsole=setenv stdout serial,nc;setenv stdin serial,nc
++nonetconsole=setenv stdout serial;setenv stdin serial
++
++# button commands
++button_cmd_0=run netconsole led_on; sleep 5; if button wps; then run nonetconsole offical_upgrade; fi
++button_cmd_0_name=wps
++button_cmd_1=run netconsole led_on reset_all; sleep 5; if button reset; then run nonetconsole; while true; do run upgrade_fw && run boot_nand; done; fi
++button_cmd_1_name=reset

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -43,6 +43,7 @@ jcg,q30-pro|\
 konka,komi-a31|\
 mercusys,mr85x-ubi|\
 mercusys,mr90x-v1-ubi|\
+netcore,n30-pro|\
 netcore,n60|\
 netcore,n60-pro|\
 netis,eap930-v1|\

--- a/target/linux/mediatek/dts/mt7981b-netcore-n30-pro.dts
+++ b/target/linux/mediatek/dts/mt7981b-netcore-n30-pro.dts
@@ -1,0 +1,113 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR MIT) */
+
+/dts-v1/;
+#include "mt7981b-netis-common.dtsi"
+
+/ {
+	model = "Netcore N30 Pro";
+	compatible = "netcore,n30-pro", "mediatek,mt7981";
+
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_wps;
+		led-failsafe = &led_wps;
+		led-running = &led_wps;
+		led-upgrade = &led_wps;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_wps: wps {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WPS;
+			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		internet {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN_ONLINE;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_USB;
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "usbport";
+			trigger-sources = <&usb3_port1>, <&usb3_port2>;
+		};
+
+		wifi2g {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wifi5g {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	reg_5v: regulator-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-5V";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&pio 23 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&switch {
+	ports {
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan4";
+		};
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&xhci {
+	vbus-supply = <&reg_5v>;
+	status = "okay";
+
+	usb3_port1: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+
+	usb3_port2: port@2 {
+		reg = <2>;
+		#trigger-source-cells = <0>;
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -183,6 +183,10 @@ mercusys,mr90x-v1-ubi)
 	ucidef_set_led_netdev "lan-2" "lan-2" "green:lan-2" "lan2" "link tx rx"
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "eth1" "link tx rx"
 	;;
+netcore,n30-pro)
+	ucidef_set_led_netdev "wanact" "WANACT" "green:wan-online" "eth1" "tx rx"
+	ucidef_set_led_netdev "wanlink" "WANLINK" "green:wan" "eth1" "link"
+	;;
 netcore,n60)
 	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:green:wan" "eth1" "link tx rx"
 	;;

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -85,6 +85,7 @@ mediatek_setup_interfaces()
 	iptime,ax7800m-6e|\
 	jdcloud,re-cp-03|\
 	mediatek,mt7981-rfb|\
+	netcore,n30-pro|\
 	netcore,n60|\
 	netcore,n60-pro|\
 	nradio,c8-668gl|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -175,6 +175,7 @@ platform_do_upgrade() {
 	netis,nx32u|\
 	nokia,ea0326gmp|\
 	openwrt,one|\
+	netcore,n30-pro|\
 	netcore,n60|\
 	netcore,n60-pro|\
 	qihoo,360t7|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2693,6 +2693,31 @@ define Device/mercusys_mr90x-v1-ubi
 endef
 TARGET_DEVICES += mercusys_mr90x-v1-ubi
 
+define Device/netcore_n30-pro
+  DEVICE_VENDOR := Netcore
+  DEVICE_MODEL := N30 Pro
+  DEVICE_ALT0_VENDOR := netis
+  DEVICE_ALT0_MODEL := NX35U
+  DEVICE_DTS := mt7981b-netcore-n30-pro
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTC_FLAGS := --pad 4096
+  DEVICE_DTS_LOADADDR := 0x43f00000
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3 kmod-usb-ledtrig-usbport
+  KERNEL_LOADADDR := 0x44000000
+  KERNEL := kernel-bin | libdeflate-gzip
+  KERNEL_INITRAMFS := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  KERNEL_INITRAMFS_SUFFIX := .itb
+  KERNEL_IN_UBI := 1
+  UBOOTENV_IN_UBI := 1
+  IMAGES := sysupgrade.itb
+  IMAGE_SIZE := 117248k
+  IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | pad-rootfs | append-metadata
+  ARTIFACTS := spim-nand-preloader.bin spim-nand-bl31-uboot.fip
+  ARTIFACT/spim-nand-preloader.bin	:= mt7981-bl2 spim-nand-ddr3
+  ARTIFACT/spim-nand-bl31-uboot.fip	:= mt7981-bl31-uboot netcore_n30-pro
+endef
+TARGET_DEVICES += netcore_n30-pro
+
 define Device/netcore_n60
   DEVICE_VENDOR := Netcore
   DEVICE_MODEL := N60
@@ -2879,14 +2904,12 @@ define Device/netis_nx30v2
   DEVICE_VARIANT := V2
   DEVICE_ALT0_VENDOR := Netcore
   DEVICE_ALT0_MODEL := POWER 30AX
-  DEVICE_ALT1_VENDOR := Netcore
-  DEVICE_ALT1_MODEL := N30 Pro
-  DEVICE_ALT2_VENDOR := GWBN
-  DEVICE_ALT2_MODEL := GW3001
-  DEVICE_ALT3_VENDOR := GLC
-  DEVICE_ALT3_MODEL := W7
-  DEVICE_ALT4_VENDOR := netis
-  DEVICE_ALT4_MODEL := MEX605
+  DEVICE_ALT1_VENDOR := GWBN
+  DEVICE_ALT1_MODEL := GW3001
+  DEVICE_ALT2_VENDOR := GLC
+  DEVICE_ALT2_MODEL := W7
+  DEVICE_ALT3_VENDOR := netis
+  DEVICE_ALT3_MODEL := MEX605
   DEVICE_DTS := mt7981b-netis-nx30v2
   DEVICE_DTS_DIR := ../dts
   DEVICE_DTC_FLAGS := --pad 4096


### PR DESCRIPTION
mediatek: filogic: add support Netcore N30 Pro/NX35U

Additional info for N30 Pro:
https://github.com/openwrt/openwrt/pull/18631#discussion_r3340370190

- Hardware specification:
  SoC: MediaTek MT7981B
  Flash: 128MB
  RAM: DDR3 512MB
  Ethernet: 5x 1G
  Button: Reset, WPS
  USB: 1x USB3.0

- MAC addresses
  | Interface   | Source                   | Offset   | Address (this unit)       |
  | ----------- | ------------------------ | -------- | ------------------------- |
  | WAN         | Factory mac-base         | 0x1fef26 | 08:64:2A:D7:82:11         |
  | LAN/CPU     | Factory mac-base         | 0x1fef20 | 08:64:2A:D7:82:10 (label) |
  | WiFi 2.4GHz | radio calibration (auto) | --       | 08:64:2A:D7:82:12         |
  | WiFi 5GHz   | radio calibration (auto) | --       | 8A:64:2A:D7:82:12         |

- Official LED layout, from left to right:
  power internet wps wifi wan lan usb

- Redefinition for OpenWrt:
  power, wifi and lan: unchanged
  internet: used for WAN RX/TX indication
  wps: used for led-boot, led-failsafe, led-running and led-upgrade
  wan: used for WAN link indication

- Installing OpenWrt:
  - Setup a tftp server on your PC. Copy xxx-preloader.bin,
    xxx-bl31-uboot.fip and xxx-initramfs.itb to tftp root directory.
  - Connect to the router via ssh or telnet, username: useradmin,
    password is the web login password of the router.
  - Backup all critical flash partitions with the following commands
    where x.x.x.x is the IP of your PC.

    ```shell
    IP=x.x.x.x
    cd /dev
    for d in /sys/class/mtd/mtd?; do
        if [ "$(cat $d/name)" = "BL2" ]; then
            tftp -l $(basename $d) -r bl2.img -p $IP
        elif [ "$(cat $d/name)" = "FIP" ]; then
            tftp -l $(basename $d) -r fip.bin -p $IP
        elif [ "$(cat $d/name)" = "Factory" ]; then
            tftp -l $(basename $d) -r factory.bin -p $IP
        fi
    done
    for d in /sys/devices/virtual/ubi/ubi0/ubi0_*; do
        [ "$(cat $d/name)" != "customer" ] && continue
        tftp -l $(basename $d) -r customer -p $IP
        break
    done
    ```

  - Flash with the following commands:

    ```shell
    cd /tmp
    tftp -r xxx-preloader.bin -g x.x.x.x
    tftp -r xxx-bl31-uboot.fip -g x.x.x.x
    mtd write xxx-preloader.bin spi0.0
    mtd write xxx-bl31-uboot.fip FIP
    mtd erase ubi
    ```

  - Set a static ip(192.168.1.254) for your PC. And then reboot
    the router. It will run initramfs image automatically.
  - After openwrt boots up, perform sysupgrade via web UI.

- Reverting to the vendor firmware:
  - Setup a tftp server on your PC with ip address 192.168.1.254.
    And make sure bl2.img, fip.bin, factory.bin and customer are
    located in tftp root directory.
  - Power off the router.
  - Press and hold WPS key, then power on the router.
  - Release WPS key, when internet/wifi/wps leds are blinking.
  - Wait until internet/wifi/wps leds light up, power off the router.
  - Press and hold reset key, power up the router, release reset key
    15s later.
  - Connect to http://192.168.1.1/, now you can upload vendor .bin
    firmware.

- Uboot netconsole:
  Uboot netconsole can be enabled by WPS or reset key.

  - Setup a linux PC with ip 192.168.1.254.
    Open a new terminal and execute
    'stty -isig -echo cbreak; nc -lup 6666'
  - Press and hold WPS(or reset) key, then power on the router.
  - Release key once internet/wifi/wps leds are all on.
    DON'T hold the key more than 5s after internet/wifi/wps leds on,
    or it will try to revert to vendor firmware.
  - 5s later, uboot bootmenu will show on the terminal.