### PR TITLE
mediatek: filogic: add support netis NR109GPE V2

### DIFF
--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -568,6 +568,18 @@ define U-Boot/mt7981_netis_n6-v2
   DEPENDS:=+trusted-firmware-a-mt7981-spim-nand-ddr3-1866
 endef
 
+define U-Boot/mt7981_netis_nr109gpev2
+  NAME:=netis NR109GPE V2
+  BUILD_SUBTARGET:=filogic
+  BUILD_DEVICES:=netis_nr109gpev2
+  UBOOT_CONFIG:=mt7981_netis_nr109gpev2
+  UBOOT_IMAGE:=u-boot.fip
+  BL2_BOOTDEV:=spim-nand
+  BL2_SOC:=mt7981
+  BL2_DDRTYPE:=ddr3-1866
+  DEPENDS:=+trusted-firmware-a-mt7981-spim-nand-ddr3-1866
+endef
+
 define U-Boot/mt7981_netis_nx30v2
   NAME:=netis NX30 V2
   BUILD_SUBTARGET:=filogic
@@ -1352,6 +1364,7 @@ UBOOT_TARGETS := \
 	mt7981_konka_komi-a31 \
 	mt7981_netis_eap930-v1 \
 	mt7981_netis_n6-v2 \
+	mt7981_netis_nr109gpev2 \
 	mt7981_netis_nx30v2 \
 	mt7981_netis_nx31 \
 	mt7981_netis_nx32u \

--- a/package/boot/uboot-mediatek/patches/474-add-netis-nr109gpev2.patch
+++ b/package/boot/uboot-mediatek/patches/474-add-netis-nr109gpev2.patch
@@ -1,0 +1,341 @@
+--- /dev/null
++++ b/arch/arm/dts/mt7981-netis-nr109gpev2.dts
+@@ -0,0 +1,141 @@
++// SPDX-License-Identifier: GPL-2.0
++
++/dts-v1/;
++#include "mt7981.dtsi"
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++
++/ {
++	model = "netis NR109GPE V2";
++	compatible = "netis,nr109gpev2", "mediatek,mt7981";
++	chosen {
++		stdout-path = &uart0;
++		tick-timer = &timer0;
++	};
++
++	memory@40000000 {
++		device_type = "memory";
++		reg = <0x40000000 0x20000000>;
++	};
++
++	gpio-keys {
++		compatible = "gpio-keys";
++
++		reset {
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		system {
++			label = "system";
++			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
++		};
++
++		upgrade {
++			label = "upgrade";
++			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
++		};
++
++		wan {
++			label = "wan";
++			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&uart0 {
++	status = "okay";
++};
++
++&eth {
++    status = "okay";
++    mediatek,gmac-id = <1>;
++    phy-mode = "gmii";
++    phy-handle = <&phy0>;
++    phy0: ethernet-phy@0 {
++              compatible = "ethernet-phy-id03a2.9461";
++              reg = <0>;
++              phy-mode = "gmii";
++    };
++};
++
++&pio {
++	spi_flash_pins: spi0-pins-func-1 {
++		mux {
++			function = "flash";
++			groups = "spi0", "spi0_wp_hold";
++		};
++
++		conf-pu {
++			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
++			drive-strength = <MTK_DRIVE_8mA>;
++			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
++		};
++
++		conf-pd {
++			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
++			drive-strength = <MTK_DRIVE_8mA>;
++			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
++		};
++	};
++};
++
++&spi0 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi_flash_pins>;
++	status = "okay";
++	enhance_timing;
++	dma_ext;
++	ipm_design;
++	support_quad;
++	tick_dly = <2>;
++	sample_sel = <0>;
++
++	spi_nand@0 {
++		compatible = "spi-nand";
++		reg = <0>;
++		spi-max-frequency = <52000000>;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "BL2";
++				reg = <0x0 0x100000>;
++			};
++
++			partition@100000 {
++				label = "u-boot-env";
++				reg = <0x100000 0x80000>;
++			};
++
++			partition@180000 {
++				label = "Factory";
++				reg = <0x180000 0x200000>;
++			};
++
++			partition@380000 {
++				label = "FIP";
++				reg = <0x380000 0x200000>;
++			};
++
++			partition@580000 {
++				label = "ubi";
++				reg = <0x580000 0x7280000>;
++			};
++		};
++	};
++};
++
++&watchdog {
++	status = "disabled";
++};
+--- /dev/null
++++ b/configs/mt7981_netis_nr109gpev2_defconfig
+@@ -0,0 +1,129 @@
++CONFIG_ARM=y
++CONFIG_SYS_HAS_NONCACHED_MEMORY=y
++CONFIG_POSITION_INDEPENDENT=y
++CONFIG_ARCH_MEDIATEK=y
++CONFIG_TEXT_BASE=0x41e00000
++CONFIG_SYS_MALLOC_F_LEN=0x4000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEFAULT_DEVICE_TREE="mt7981-netis-nr109gpev2"
++CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_TARGET_MT7981=y
++CONFIG_SYS_LOAD_ADDR=0x46000000
++CONFIG_DEBUG_UART_BASE=0x11002000
++CONFIG_DEBUG_UART_CLOCK=40000000
++CONFIG_DEBUG_UART=y
++CONFIG_BUTTON_CMD=y
++CONFIG_FIT=y
++CONFIG_SPI_BOOT=y
++CONFIG_AUTOBOOT_MENU_SHOW=y
++CONFIG_OF_SYSTEM_SETUP=y
++CONFIG_USE_PREBOOT=y
++CONFIG_SYS_CBSIZE=512
++CONFIG_SYS_PBSIZE=1049
++CONFIG_LOGLEVEL=7
++CONFIG_CONSOLE_MUX=y
++CONFIG_LOG=y
++# CONFIG_BOARD_INIT is not set
++CONFIG_BOARD_LATE_INIT=y
++CONFIG_UPDATE_FIT=y
++CONFIG_HUSH_PARSER=y
++CONFIG_SYS_PROMPT="MT7981> "
++CONFIG_CMD_CPU=y
++CONFIG_CMD_LICENSE=y
++# CONFIG_BOOTM_NETBSD is not set
++# CONFIG_BOOTM_PLAN9 is not set
++# CONFIG_BOOTM_RTEMS is not set
++# CONFIG_BOOTM_VXWORKS is not set
++CONFIG_CMD_BOOTMENU=y
++CONFIG_CMD_ASKENV=y
++CONFIG_CMD_ERASEENV=y
++CONFIG_CMD_ENV_FLAGS=y
++CONFIG_CMD_STRINGS=y
++# CONFIG_CMD_UNLZ4 is not set
++# CONFIG_CMD_UNZIP is not set
++CONFIG_CMD_DFU=y
++CONFIG_CMD_DM=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_MTD=y
++CONFIG_CMD_PCI=y
++CONFIG_CMD_SF_TEST=y
++CONFIG_CMD_TFTPPUT=y
++CONFIG_CMD_TFTPSRV=y
++CONFIG_CMD_RARP=y
++CONFIG_CMD_CDP=y
++CONFIG_CMD_LINK_LOCAL=y
++CONFIG_CMD_DHCP=y
++CONFIG_CMD_DNS=y
++CONFIG_CMD_PING=y
++CONFIG_CMD_SNTP=y
++CONFIG_CMD_PXE=y
++CONFIG_CMD_CACHE=y
++CONFIG_CMD_PSTORE=y
++CONFIG_CMD_PSTORE_MEM_ADDR=0x42ff0000
++CONFIG_CMD_UUID=y
++CONFIG_CMD_HASH=y
++CONFIG_CMD_SMC=y
++CONFIG_CMD_FS_GENERIC=y
++CONFIG_CMD_FS_UUID=y
++CONFIG_CMD_UBI=y
++CONFIG_CMD_UBI_RENAME=y
++CONFIG_ENV_OVERWRITE=y
++CONFIG_ENV_IS_IN_UBI=y
++CONFIG_ENV_UBI_PART="ubi"
++CONFIG_ENV_UBI_VOLUME="ubootenv"
++CONFIG_ENV_UBI_VOLUME_CREATE=y
++CONFIG_ENV_USE_DEFAULT_ENV_TEXT_FILE=y
++CONFIG_ENV_DEFAULT_ENV_TEXT_FILE="defenvs/netis-nr109gpev2.env"
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_NETCONSOLE=y
++CONFIG_USE_IPADDR=y
++CONFIG_IPADDR="192.168.1.1"
++CONFIG_USE_SERVERIP=y
++CONFIG_SERVERIP="192.168.1.254"
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_BUTTON=y
++CONFIG_BUTTON_GPIO=y
++CONFIG_CLK=y
++CONFIG_GPIO_HOG=y
++CONFIG_LED=y
++CONFIG_LED_BLINK=y
++CONFIG_LED_SW_BLINK=y
++CONFIG_LED_GPIO=y
++# CONFIG_MMC is not set
++CONFIG_MTD=y
++CONFIG_DM_MTD=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_DM_SPI_FLASH=y
++CONFIG_SPI_FLASH_SFDP_SUPPORT=y
++CONFIG_SPI_FLASH_EON=y
++CONFIG_SPI_FLASH_GIGADEVICE=y
++CONFIG_SPI_FLASH_ISSI=y
++CONFIG_SPI_FLASH_MACRONIX=y
++CONFIG_SPI_FLASH_SPANSION=y
++CONFIG_SPI_FLASH_STMICRO=y
++CONFIG_SPI_FLASH_WINBOND=y
++CONFIG_SPI_FLASH_XMC=y
++CONFIG_SPI_FLASH_XTX=y
++CONFIG_SPI_FLASH_MTD=y
++CONFIG_PHY_FIXED=y
++CONFIG_MEDIATEK_ETH=y
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++CONFIG_PINCTRL_MT7981=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MTK_POWER_DOMAIN=y
++CONFIG_DM_SERIAL=y
++CONFIG_SERIAL_RX_BUFFER=y
++CONFIG_ARM_SMCCC=y
++CONFIG_CMD_RNG=y
++CONFIG_DM_RNG=y
++CONFIG_RNG_MTK_V2=y
++CONFIG_MTK_SERIAL=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_MTK_SPIM=y
++CONFIG_HEXDUMP=y
++# CONFIG_TOOLS_LIBCRYPTO is not set
++# CONFIG_TOOLS_KWBIMAGE is not set
+--- /dev/null
++++ b/defenvs/netis-nr109gpev2.env
+@@ -0,0 +1,62 @@
++#misc settings
++serverip=192.168.1.254
++ipaddr=192.168.1.1
++ncip=192.168.1.254
++loadaddr=0x46000000
++return_bootmenu=askenv - Press ENTER to return to menu ; bootmenu 60
++
++#file name defines
++bootfile_bl2=openwrt-mediatek-filogic-netis_nr109gpev2-spim-nand-preloader.bin
++bootfile_fip=openwrt-mediatek-filogic-netis_nr109gpev2-spim-nand-bl31-uboot.fip
++bootfile_rec=openwrt-mediatek-filogic-netis_nr109gpev2-initramfs.itb
++bootfile_fw=openwrt-mediatek-filogic-netis_nr109gpev2-squashfs-sysupgrade.itb
++
++#boot commands
++bootconf=config-1
++boot_recovery=tftpboot $bootfile_rec && iminfo && bootm $loadaddr#$bootconf
++boot_nand=ubi read $loadaddr fit;bootm $loadaddr#$bootconf
++bootcmd=run boot_nand; while true; do run boot_recovery; done
++
++#bootmenu
++bootmenu_default=0
++bootmenu_0=Startup system (Default)=run bootcmd
++bootmenu_1=Upgrade firmware via TFTP=run upgrade_fw ; run return_bootmenu
++bootmenu_2=Startup recovery image via TFTP=run boot_recovery ; run return_bootmenu
++bootmenu_3=Upgrade BL2 preloader via TFTP=run upgrade_bl2 ; run return_bootmenu
++bootmenu_4=Upgrade BL31+U-Boot FIP via TFTP=run upgrade_fip ; run return_bootmenu
++bootmenu_5=Reset all settings to factory default.=run reset_all; reset
++bootmenu_6=Reboot.=reset
++
++#upgrade commands
++upgrade_bl2=run led_blink_downloading && tftpboot $bootfile_bl2 && run led_blink_writing && nand erase BL2 && nand write $loadaddr BL2; run led_on
++upgrade_fip=run led_blink_downloading && tftpboot $bootfile_fip && run led_blink_writing && nand erase FIP && nand write $loadaddr FIP; run led_on
++upgrade_fw=run led_blink_downloading && tftpboot $bootfile_fw && iminfo && run led_blink_writing && if ubi check fit; then ubi remove fit; else true; fi && ubi create fit $filesize && ubi write $loadaddr fit $filesize; run led_on
++
++#restore offical bootloader
++offical_download=run led_blink_downloading; setenv failed 1; while test $failed -eq 1; do setenv bl2addr 0x46000000 && tftpboot $bl2addr bl2.img && setenv fipaddr 0x46380000 && tftpboot $fipaddr fip.bin && setenv failed 0; done; setenv customer 0; setenv customeraddr 0x46580000 && tftpboot $customeraddr customer && setenv customer 1; test $failed -eq 0
++offical_write=run led_blink_writing; nand erase BL2 && nand write $bl2addr BL2 && nand erase FIP && nand write $fipaddr FIP; ubi detach; mtd erase ubi; ubi part ubi; if test $customer -eq 1; then ubi create customer $filesize; ubi write $customeraddr customer $filesize; fi; true
++offical_upgrade=run offical_download offical_write led_on; echo upgrade offical bootloader done; while true; do sleep 10; done
++
++#factory default
++reset_env=env default -a && saveenv
++reset_usr=ubi check rootfs_data && ubi remove rootfs_data; run create_rootfs_data
++reset_all=run reset_env reset_usr
++
++#prepare ethaddr and rootfs_data at preload
++rootfs_data_max=0x5300000
++create_rootfs_data=if env exists rootfs_data_max; then ubi create rootfs_data $rootfs_data_max; else ubi create rootfs_data -; fi
++set_ethaddr=mtd read Factory $loadaddr 0x1fe000 0x1000 && setexpr tmpaddr $loadaddr + 0xf20 && mw.b $loadaddr 0 6 && cmp.b $loadaddr $tmpaddr 6 || readmem -b ethaddr $tmpaddr 0x6
++preboot=run set_ethaddr; if ubi part; then else mtd erase ubi; ubi part ubi; fi; ubi check rootfs_data || run create_rootfs_data
++
++#led
++led_blink_downloading=led system blink 100; led wan blink 100
++led_blink_writing=led system blink 1000; led wan blink 1000
++led_on=led system on; led wan on
++
++#netconsole
++netconsole=setenv stdout serial,nc;setenv stdin serial,nc
++nonetconsole=setenv stdout serial;setenv stdin serial
++
++# button commands
++button_cmd_0=run netconsole led_on reset_all; sleep 5; if button reset; then run nonetconsole; while true; do run upgrade_fw && run boot_nand; done; fi
++button_cmd_0_name=reset

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -46,6 +46,7 @@ netcore,n60|\
 netcore,n60-pro|\
 netis,eap930-v1|\
 netis,n6-v2|\
+netis,nr109gpev2|\
 netis,nx30v2|\
 netis,nx31|\
 netis,nx32u|\

--- a/target/linux/mediatek/dts/mt7981b-netis-nr109gpev2.dts
+++ b/target/linux/mediatek/dts/mt7981b-netis-nr109gpev2.dts
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include "mt7981b.dtsi"
+
+/ {
+	model = "netis NR109GPE V2";
+	compatible = "netis,nr109gpev2", "mediatek,mt7981";
+
+	aliases {
+		serial0 = &uart0;
+		label-mac-device = &gmac0;
+		led-boot = &led_system;
+		led-failsafe = &led_upgrade;
+		led-running = &led_system;
+		led-upgrade = &led_upgrade;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		rootdisk = <&ubi_rootdisk>;
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x20000000>;
+		device_type = "memory";
+	};
+
+	rtkgsw@0 {
+		compatible = "mediatek,rtk-gsw";
+		mediatek,ethsys = <&ethsys>;
+		mediatek,mdio = <&mdio_bus>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
+		status = "okay";
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@10 {
+				reg = <16>;
+				mode = "disable";
+			};
+
+			port@11 {
+				reg = <17>;
+				mode = "hsgmii";
+				speed = <2500>;
+				duplex = "full";
+				link = "up";
+				rgmii-tx-delay = <1>;
+				rgmii-rx-delay = <3>;
+				cpuport;
+				tx-pause;
+				rx-pause;
+			};
+		};
+
+		portmap@0 {
+			compatible = "swconfig,port";
+			swconfig,segment = "lan";
+			swconfig,portmap = <0 0>;
+		};
+		portmap@1 {
+			compatible = "swconfig,port";
+			swconfig,segment = "lan";
+			swconfig,portmap = <1 1>;
+		};
+		portmap@2 {
+			compatible = "swconfig,port";
+			swconfig,segment = "lan";
+			swconfig,portmap = <2 2>;
+		};
+		portmap@3 {
+			compatible = "swconfig,port";
+			swconfig,segment = "lan";
+			swconfig,portmap = <3 3>;
+		};
+		portmap@4 {
+			compatible = "swconfig,port";
+			swconfig,segment = "lan";
+			swconfig,portmap = <4 4>;
+		};
+		portmap@5 {
+			compatible = "swconfig,port";
+			swconfig,segment = "lan";
+			swconfig,portmap = <5 5>;
+		};
+		portmap@6 {
+			compatible = "swconfig,port";
+			swconfig,segment = "lan";
+			swconfig,portmap = <6 6>;
+		};
+		portmap@7 {
+			compatible = "swconfig,port";
+			swconfig,segment = "lan";
+			swconfig,portmap = <7 7>;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led_upgrade: upgrade {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cells = <&macaddr_lan>;
+		nvmem-cell-names = "mac-address";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+
+		nvmem-cells = <&macaddr_wan>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&crypto {
+	status = "okay";
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x0 0x100000>;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_lan: macaddr@1fef20 {
+						reg = <0x1fef20 0x6>;
+					};
+
+					macaddr_wan: macaddr@1fef26 {
+						reg = <0x1fef26 0x6>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x7280000>;
+				compatible = "linux,ubi";
+
+				volumes {
+					ubi_rootdisk: ubi-volume-fit {
+						volname = "fit";
+					};
+				};
+			};
+		};
+	};
+};
+
+&sgmiisys0 {
+	/delete-property/ mediatek,pnswap;
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};

--- a/target/linux/mediatek/files/drivers/net/phy/rtk/rtl8367c/include/rtk_switch.h
+++ b/target/linux/mediatek/files/drivers/net/phy/rtk/rtl8367c/include/rtk_switch.h
@@ -18,10 +18,12 @@
 #ifndef __RTK_SWITCH_H__
 #define __RTK_SWITCH_H__
 
+#include <linux/of.h>
 #include <rtk_types.h>
 
 #define UNDEFINE_PHY_PORT   (0xFF)
 #define RTK_SWITCH_PORT_NUM (32)
+#define RTK_SWITCH_EXT_PORT_NUM (3)
 
 #define MAXPKTLEN_CFG_ID_MAX (1)
 
@@ -736,6 +738,6 @@ rtk_uint32 rtk_switch_isValidTrunkGrpId(rtk_uint32 grpId);
 
 int gsw_debug_proc_init(void);
 void gsw_debug_proc_exit(void);
-int rtl8367s_swconfig_init(void (*reset_func)(void));
+int rtl8367s_swconfig_init(void (*reset_func)(void), struct device_node *of_node);
 
 #endif

--- a/target/linux/mediatek/files/drivers/net/phy/rtk/rtl8367s.c
+++ b/target/linux/mediatek/files/drivers/net/phy/rtk/rtl8367s.c
@@ -21,14 +21,11 @@
 
 //include from rtl8367c dir
 #include  "./rtl8367c/include/rtk_switch.h"
+#include  "./rtl8367c/include/rtk_error.h"
 #include  "./rtl8367c/include/vlan.h"
 #include  "./rtl8367c/include/stat.h"
 #include  "./rtl8367c/include/port.h"
 
-#define RTL8367C_SW_CPU_PORT    6
-
- //RTL8367C_PHY_PORT_NUM + ext0 + ext1
-#define RTL8367C_NUM_PORTS 7
 #define RTL8367C_NUM_VIDS  4096
 
 struct rtl8367_priv {
@@ -48,8 +45,13 @@ struct rtl8367_vlan_info {
 };
 
 struct rtl8367_priv  rtl8367_priv_data;
-
-unsigned int rtl8367c_port_id[RTL8367C_NUM_PORTS]={0,1,2,3,4,EXT_PORT1,EXT_PORT0};
+/*
+* Use the original hard-coded values as the defaults to preserve backward compatibility.
+* It seems that these default values only work for RTL8367C?
+*/
+unsigned int rtk_sw_port_id[RTK_SWITCH_PORT_NUM] = {0,1,2,3,4,EXT_PORT1,EXT_PORT0};
+unsigned int rtk_sw_num_ports = 7;
+unsigned int rtk_sw_cpu_port = 6;
 
 void (*rtl8367_switch_reset_func)(void)=NULL;
 
@@ -121,13 +123,13 @@ static  struct rtl8367_mib_counter  rtl8367c_mib_counters[] = {
 /*rtl8367c  proprietary switch API wrapper */
 static inline unsigned int rtl8367c_sw_to_phy_port(int port)
 {
-	return rtl8367c_port_id[port];
+	return rtk_sw_port_id[port];
 }
 
 static inline unsigned int rtl8367c_portmask_phy_to_sw(rtk_portmask_t phy_portmask)
 {
 	int i;
-	for (i = 0; i < RTL8367C_NUM_PORTS; i++) {
+	for (i = 0; i < rtk_sw_num_ports; i++) {
 		if(RTK_PORTMASK_IS_PORT_SET(phy_portmask,rtl8367c_sw_to_phy_port(i))) {
 			RTK_PORTMASK_PORT_CLEAR(phy_portmask,rtl8367c_sw_to_phy_port(i));
 			RTK_PORTMASK_PORT_SET(phy_portmask,i);
@@ -201,7 +203,7 @@ static int rtl8367c_set_vlan( unsigned short vid, u32 mbr, u32 untag, u8 fid)
 
 	memset(&vlan_cfg, 0x00, sizeof(rtk_vlan_cfg_t));
 
-	for (i = 0; i < RTL8367C_NUM_PORTS; i++) {
+	for (i = 0; i < rtk_sw_num_ports; i++) {
 		if (mbr & (1 << i)) {
 			RTK_PORTMASK_PORT_SET(vlan_cfg.mbr, rtl8367c_sw_to_phy_port(i));
 			if(untag & (1 << i))
@@ -218,7 +220,7 @@ static int rtl8367c_get_pvid( int port, int *pvid)
 {
 	u32 prio=0;
 
-	if (port >= RTL8367C_NUM_PORTS)
+	if (port >= rtk_sw_num_ports)
 		return -EINVAL;
 
 	return rtk_vlan_portPvid_get(rtl8367c_sw_to_phy_port(port),pvid,&prio);
@@ -229,7 +231,7 @@ static int rtl8367c_set_pvid( int port, int pvid)
 {
 	u32 prio=0;
 
-	if (port >= RTL8367C_NUM_PORTS)
+	if (port >= rtk_sw_num_ports)
 		return -EINVAL;
 
 	return rtk_vlan_portPvid_set(rtl8367c_sw_to_phy_port(port),pvid,prio);
@@ -286,7 +288,7 @@ static int rtl8367_sw_reset_port_mibs(struct switch_dev *dev,
 	int port;
 
 	port = val->port_vlan;
-	if (port >= RTL8367C_NUM_PORTS)
+	if (port >= rtk_sw_num_ports)
 		return -EINVAL;
 
 	return rtl8367c_reset_port_mibs(port);
@@ -300,7 +302,7 @@ static int rtl8367_sw_get_port_mib(struct switch_dev *dev,
 	unsigned long long counter = 0;
 	static char mib_buf[4096];
 
-	if (val->port_vlan >= RTL8367C_NUM_PORTS)
+	if (val->port_vlan >= rtk_sw_num_ports)
 		return -EINVAL;
 
 	len += snprintf(mib_buf + len, sizeof(mib_buf) - len,
@@ -347,7 +349,7 @@ static int rtl8367_sw_get_vlan_info(struct switch_dev *dev,
 	len += snprintf(vlan_buf + len, sizeof(vlan_buf) - len,
 			"VLAN %d: Ports: '", vlan.vid);
 
-	for (i = 0; i <RTL8367C_NUM_PORTS; i++) {
+	for (i = 0; i <rtk_sw_num_ports; i++) {
 		if (!(vlan.member & (1 << i)))
 			continue;
 
@@ -380,7 +382,7 @@ static int rtl8367_sw_get_vlan_ports(struct switch_dev *dev, struct switch_val *
 
 	port = &val->value.ports[0];
 	val->len = 0;
-	for (i = 0; i <RTL8367C_NUM_PORTS ; i++) {
+	for (i = 0; i <rtk_sw_num_ports ; i++) {
 		if (!(vlan.member & BIT(i)))
 			continue;
 
@@ -462,7 +464,7 @@ static int rtl8367_sw_get_port_link(struct switch_dev *dev, int port,
 {
 	int speed;
 
-	if (port >= RTL8367C_NUM_PORTS)
+	if (port >= rtk_sw_num_ports)
 		return -EINVAL;
 
 	if(rtl8367c_get_port_link(port,(int *)&link->link,(int *)&speed,(int *)&link->duplex))
@@ -555,11 +557,45 @@ static const struct switch_dev_ops rtl8367_sw_ops = {
 	.get_port_link = rtl8367_sw_get_port_link,
 };
 
-int rtl8367s_swconfig_init(void (*reset_func)(void))
+static void rtk_sw_build_port_map(struct device_node *of_ports)
+{
+	u32 reg;
+	int cpuport = -1;
+	rtk_portmask_t pmask;
+	unsigned int i, idx = 0;
+	struct device_node *pp;
+
+	if (rtk_switch_logPortMask_get(&pmask) != RT_ERR_OK)
+		return;
+
+	for_each_available_child_of_node(of_ports, pp) {
+		if (!of_property_read_u32(pp, "reg", &reg) && of_property_read_bool(pp, "cpuport"))
+			cpuport = reg;
+	}
+
+	RTK_PORTMASK_SCAN(pmask, i){
+		if ( rtk_switch_isUtpPort(i) == RT_ERR_OK || rtk_switch_isExtPort(i) == RT_ERR_OK ){
+			if(i == cpuport)
+				rtk_sw_cpu_port = idx;
+			rtk_sw_port_id[idx++] = i;
+		}
+	}
+	rtk_sw_num_ports = idx;
+}
+
+int rtl8367s_swconfig_init(void (*reset_func)(void), struct device_node *of_node)
 {
 	struct rtl8367_priv  *priv = &rtl8367_priv_data;
 	struct switch_dev *dev=&priv->swdev;
 	int err=0;
+	struct device_node *of_ports;
+
+	// for backward compatibility, call rtk_sw_build_port_map only if "ports" exists.
+	of_ports = of_get_child_by_name(of_node, "ports");
+	if(of_ports){
+		rtk_sw_build_port_map(of_ports);
+		of_node_put(of_ports);
+	}
 
 	rtl8367_switch_reset_func = reset_func ;
 
@@ -567,11 +603,12 @@ int rtl8367s_swconfig_init(void (*reset_func)(void))
 	priv->global_vlan_enable =0;
 
 	dev->name = "RTL8367C";
-	dev->cpu_port = RTL8367C_SW_CPU_PORT;
-	dev->ports = RTL8367C_NUM_PORTS;
+	dev->cpu_port = rtk_sw_cpu_port;
+	dev->ports = rtk_sw_num_ports;
 	dev->vlans = RTL8367C_NUM_VIDS;
 	dev->ops = &rtl8367_sw_ops;
 	dev->alias = "RTL8367C";
+	dev->of_node = of_node;
 	err = register_switch(dev, NULL);
 
 	pr_info("[%s]\n",__func__);

--- a/target/linux/mediatek/files/drivers/net/phy/rtk/rtl8367s_dbg.c
+++ b/target/linux/mediatek/files/drivers/net/phy/rtk/rtl8367s_dbg.c
@@ -106,37 +106,25 @@ static void rtk_hal_dump_mib(void)
 
 }
 
-static int rtk_hal_dump_vlan(void)
+static int rtk_hal_dump_vlan(struct seq_file *seq)
 {
 	rtk_vlan_cfg_t vlan;
+	rtk_portmask_t pmask;
+	int port;
 	int i;
 
-	printk("vid    portmap\n");
+	if (rtk_switch_logPortMask_get(&pmask) != RT_ERR_OK)
+		return -1;
+
+	seq_printf(seq, "vid    portmap\n");
 	for (i = 0; i < RTK_SW_VID_RANGE; i++) {
 		rtk_vlan_get(i, &vlan);
-		printk("%3d    ", i);
-		printk("%c",
-		       RTK_PORTMASK_IS_PORT_SET(vlan.mbr,
-	                                UTP_PORT0) ? '1' : '-');
-		printk("%c",
-	       	RTK_PORTMASK_IS_PORT_SET(vlan.mbr,
-	                                UTP_PORT1) ? '1' : '-');
-		printk("%c",
-		       RTK_PORTMASK_IS_PORT_SET(vlan.mbr,
-	                                UTP_PORT2) ? '1' : '-');
-		printk("%c",
-		       RTK_PORTMASK_IS_PORT_SET(vlan.mbr,
-	                                UTP_PORT3) ? '1' : '-');
-		printk("%c",
-	       	RTK_PORTMASK_IS_PORT_SET(vlan.mbr,
-	                                UTP_PORT4) ? '1' : '-');
-		printk("%c",
-		       RTK_PORTMASK_IS_PORT_SET(vlan.mbr,
-	                                EXT_PORT0) ? '1' : '-');
-		printk("%c",
-		       RTK_PORTMASK_IS_PORT_SET(vlan.mbr,
-	                                EXT_PORT1) ? '1' : '-');
-		printk("\n");
+		seq_printf(seq, "%3d    ", i);
+
+		RTK_PORTMASK_SCAN(pmask, port){
+			seq_printf(seq, "%c", RTK_PORTMASK_IS_PORT_SET(vlan.mbr,port) ? '1' : '-');
+		}
+		seq_printf(seq, "\n");
 	}
 
 	return 0;
@@ -468,7 +456,7 @@ static int esw_cnt_read(struct seq_file *seq, void *v)
 
 static int vlan_read(struct seq_file *seq, void *v)
 {
-	rtk_hal_dump_vlan();
+	rtk_hal_dump_vlan(seq);
 	return 0;
 }
 

--- a/target/linux/mediatek/files/drivers/net/phy/rtk/rtl8367s_mdio.c
+++ b/target/linux/mediatek/files/drivers/net/phy/rtk/rtl8367s_mdio.c
@@ -28,10 +28,38 @@
 #include  "./rtl8367c/include/rtl8367c_asicdrv_port.h"
 #include  "./rtl8367c/include/rtl8367c_asicdrv_mii_mgr.h"
 
+struct ext_port_setting{
+	u32 delay_tx;
+	u32 delay_rx;
+	rtk_mode_ext_t mode;
+	rtk_port_mac_ability_t mac;
+};
+
 struct rtk_gsw {
  	struct device           *dev;
  	struct mii_bus          *bus;
 	struct gpio_desc        *reset_gpiod;
+	struct ext_port_setting	ext[RTK_SWITCH_EXT_PORT_NUM];
+};
+
+static const struct {
+    const char    *name;
+    rtk_mode_ext_t mode;
+} rtk_ext_mode_map[] = {
+    { "disable",        MODE_EXT_DISABLE   },
+    { "rgmii",          MODE_EXT_RGMII     },
+    { "mii-mac",        MODE_EXT_MII_MAC   },
+    { "mii-phy",        MODE_EXT_MII_PHY   },
+    { "tmii-mac",       MODE_EXT_TMII_MAC  },
+    { "tmii-phy",       MODE_EXT_TMII_PHY  },
+    { "gmii",           MODE_EXT_GMII      },
+    { "rmii-mac",       MODE_EXT_RMII_MAC  },
+    { "rmii-phy",       MODE_EXT_RMII_PHY  },
+    { "sgmii",          MODE_EXT_SGMII     },
+    { "hsgmii",         MODE_EXT_HSGMII    },
+    { "1000x-100fx",    MODE_EXT_1000X_100FX },
+    { "1000x",          MODE_EXT_1000X     },
+    { "100fx",          MODE_EXT_100FX     },
 };
 
 static struct rtk_gsw *_gsw;
@@ -199,11 +227,121 @@ static void set_rtl8367s_rgmii(void)
 
 }
 
+static void _rtk_parse_ext_port_dt(struct device_node *port_np, struct ext_port_setting *ext)
+{
+	int i;
+	u32 speed;
+	const char *str;
+	rtk_mode_ext_t mode = MODE_EXT_DISABLE;
+
+	if (of_property_read_string(port_np, "mode", &str))
+		return;
+	for (i = 0; i < ARRAY_SIZE(rtk_ext_mode_map); i++) {
+		if (!strcasecmp(str, rtk_ext_mode_map[i].name)) {
+			mode = rtk_ext_mode_map[i].mode;
+			break;
+		}
+	}
+	if (mode == MODE_EXT_DISABLE)
+		return;
+
+	ext->mode = mode;
+	ext->mac.forcemode = MAC_FORCE;
+
+	if (!of_property_read_u32(port_np, "speed", &speed)) {
+		switch (speed) {
+			case 10:
+				ext->mac.speed = PORT_SPEED_10M;
+				break;
+			case 100:
+				ext->mac.speed = PORT_SPEED_100M;
+				break;
+			case 1000:
+				ext->mac.speed = PORT_SPEED_1000M;
+				break;
+			case 2500:
+				ext->mac.speed = PORT_SPEED_2500M;
+				break;
+			default:
+				dev_warn(_gsw->dev, "ext_port - unsupported speed %u, defaulting to 1000M\n", speed);
+				ext->mac.speed = PORT_SPEED_1000M;
+				break;
+		}
+	}
+
+	if (!of_property_read_string(port_np, "duplex", &str))
+		ext->mac.duplex = !strcasecmp(str, "half") ? PORT_HALF_DUPLEX : PORT_FULL_DUPLEX;
+	if (!of_property_read_string(port_np, "link", &str))
+		ext->mac.link = !strcasecmp(str, "down") ? PORT_LINKDOWN : PORT_LINKUP;
+	if (of_property_read_bool(port_np, "nway"))
+		ext->mac.nway = ENABLED;
+	if (of_property_read_bool(port_np, "tx-pause"))
+		ext->mac.txpause = ENABLED;
+	if (of_property_read_bool(port_np, "rx-pause"))
+		ext->mac.rxpause = ENABLED;
+
+	of_property_read_u32(port_np, "rgmii-tx-delay", &ext->delay_tx);
+	of_property_read_u32(port_np, "rgmii-rx-delay", &ext->delay_rx);
+}
+
+static void rtk_parse_ext_port_dt(struct device_node *np, struct rtk_gsw *gsw)
+{
+	u32 reg;
+	struct device_node *ports_np, *pp;
+
+	ports_np = of_get_child_by_name(np, "ports");
+	if (!ports_np)
+		return;
+
+	for_each_available_child_of_node(ports_np, pp) {
+		if (!of_property_read_u32(pp, "reg", &reg)
+			&& reg >= EXT_PORT0
+			&& reg - EXT_PORT0 < ARRAY_SIZE(gsw->ext))
+			_rtk_parse_ext_port_dt(pp, &gsw->ext[reg - EXT_PORT0]);
+	}
+
+	of_node_put(ports_np);
+}
+
+static int rtk_set_ext_port(void)
+{
+	int i;
+	int ret = 1;
+	struct ext_port_setting	*ext;
+
+	for (i = 0; i < ARRAY_SIZE(_gsw->ext); i++) {
+		ext = &_gsw->ext[i];
+
+		if (ext->mode == MODE_EXT_DISABLE)
+			continue;
+
+		rtk_port_macForceLinkExt_set(EXT_PORT0 + i, ext->mode, &ext->mac);
+
+		if (ext->mode == MODE_EXT_RGMII) {
+			rtk_port_rgmiiDelayExt_set(EXT_PORT0 + i, ext->delay_tx, ext->delay_rx);
+		} else if ((ext->mode == MODE_EXT_HSGMII) || (ext->mode == MODE_EXT_SGMII)) {
+			rtk_port_sgmiiNway_set(EXT_PORT0 + i, ext->mac.nway);
+		} else {
+			; // nothing
+		}
+
+		ret = 0;
+	}
+
+	if (!ret)
+		rtk_port_phyEnableAll_set(ENABLED);
+
+	return ret;
+}
+
 static void init_gsw(void)
 {
 	rtl8367s_hw_init();
-	set_rtl8367s_sgmii();
-	set_rtl8367s_rgmii();
+
+	if(rtk_set_ext_port()) {
+		set_rtl8367s_sgmii();
+		set_rtl8367s_rgmii();
+	}
 }
 
 // below are platform driver
@@ -247,6 +385,8 @@ static int rtk_gsw_probe(struct platform_device *pdev)
 
 	_gsw = gsw;
 
+	rtk_parse_ext_port_dt(np, gsw);
+
 	init_gsw();
 
 	//init default vlan or init swconfig
@@ -260,7 +400,7 @@ static int rtk_gsw_probe(struct platform_device *pdev)
 
 		} else {
 #ifdef CONFIG_SWCONFIG
-		rtl8367s_swconfig_init(&init_gsw);
+		rtl8367s_swconfig_init(&init_gsw, np);
 #else
 		rtl8367s_vlan_config(0);
 #endif

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -212,6 +212,9 @@ netgear,wax220)
 netis,n6-v2)
 	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "wan" "link tx rx"
 	;;
+netis,nr109gpev2)
+	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth1" "link tx rx"
+	;;
 netis,nx30v2)
 	ucidef_set_led_netdev "wanlink" "WANLINK" "blue:wan" "eth1" "link"
 	ucidef_set_led_netdev "wanact" "WANACT" "blue:wan-online" "eth1" "tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -157,6 +157,10 @@ mediatek_setup_interfaces()
 	wavlink,wl-wnt100x3-ubootmod)
 		ucidef_set_interfaces_lan_wan eth0 eth1
 		;;
+	netis,nr109gpev2)
+		ucidef_set_interfaces_lan_wan "eth0" "eth1"
+		ucidef_add_switch "switch0" "0:lan" "1:lan" "2:lan" "3:lan" "4:lan" "5:lan" "6:lan" "7:lan" "9u@eth0"
+		;;
 	bazis,ax3000wm|\
 	cudy,m3000-v1|\
 	cudy,m3000-v1-ubootmod|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -169,6 +169,7 @@ platform_do_upgrade() {
 	mercusys,mr90x-v1-ubi|\
 	netis,eap930-v1|\
 	netis,n6-v2|\
+	netis,nr109gpev2|\
 	netis,nx30v2|\
 	netis,nx31|\
 	netis,nx32u|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2822,6 +2822,30 @@ define Device/netis_n6-v2
 endef
 TARGET_DEVICES += netis_n6-v2
 
+define Device/netis_nr109gpev2
+  DEVICE_VENDOR := netis
+  DEVICE_MODEL := NR109GPE
+  DEVICE_VARIANT := V2
+  DEVICE_DTS := mt7981b-netis-nr109gpev2
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTC_FLAGS := --pad 4096
+  DEVICE_DTS_LOADADDR := 0x43f00000
+  DEVICE_PACKAGES :=
+  KERNEL_LOADADDR := 0x44000000
+  KERNEL := kernel-bin | libdeflate-gzip
+  KERNEL_INITRAMFS := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  KERNEL_INITRAMFS_SUFFIX := .itb
+  KERNEL_IN_UBI := 1
+  UBOOTENV_IN_UBI := 1
+  IMAGES := sysupgrade.itb
+  IMAGE_SIZE := 117248k
+  IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | pad-rootfs | append-metadata
+  ARTIFACTS := spim-nand-preloader.bin spim-nand-bl31-uboot.fip
+  ARTIFACT/spim-nand-preloader.bin	:= mt7981-bl2 spim-nand-ddr3-1866
+  ARTIFACT/spim-nand-bl31-uboot.fip	:= mt7981-bl31-uboot netis_nr109gpev2
+endef
+TARGET_DEVICES += netis_nr109gpev2
+
 define Device/netis_nx30v2
   DEVICE_VENDOR := netis
   DEVICE_MODEL := NX30


### PR DESCRIPTION
mediatek: filogic: add support netis NR109GPE V2

- Hardware specification:
  SoC: MediaTek MT7981B
  Switch: RTL8370MB
  Flash: 128MB
  RAM: DDR3 256MB
  Ethernet: 9x 1G
  Button: Reset

- MAC addresses
  | Interface   | Source                   | Offset   |
  | ----------- | ------------------------ | -------- |
  | WAN         | Factory mac-base         | 0x1fef26 |
  | LAN/CPU     | Factory mac-base         | 0x1fef20 |

- Official LED layout:
  lan8 ... lan1 wan internet
  internet led is a dual-color led, blue for online and red for offline.

- Redefinition for OpenWrt:
  lan* and wan: unchanged
  internet-blue: led-boot, led-running
  internet-red: led-failsafe, led-upgrade

- Installing OpenWrt:
  - Setup a tftp server on your PC. Copy xxx-preloader.bin, 
    xxx-bl31-uboot.fip and xxx-initramfs.itb to tftp root directory.
  - Connect to the router via ssh or telnet, username: root,
    password is the web login password of the router.
  - Flash with the following commands:

    ```shell
    cd /tmp
    tftp -r xxx-preloader.bin -g x.x.x.x
    tftp -r xxx-bl31-uboot.fip -g x.x.x.x
    mtd write xxx-preloader.bin spi0.0
    mtd write xxx-bl31-uboot.fip FIP
    mtd erase ubi
    ```

  - Set a static ip(192.168.1.254) for your PC and 
    **connect it to WAN port**. Then reboot the router. 
    It will run initramfs image automatically.
  - After openwrt boots up, **connect PC to any LAN port**,
    perform sysupgrade via web UI.