### PR TITLE
formalities: downgrade require_linked_github_account to warning

### DIFF
--- a/.github/formalities.json
+++ b/.github/formalities.json
@@ -23,7 +23,7 @@
   "check_space_after_assignment": false,
   "check_makefile_indentation": false,
   "check_pkg_release": "warning",
-  "require_linked_github_account": true,
+  "require_linked_github_account": "warning",
   "enable_stale_bot": false,
   "enable_labeler_yml": true
 }


### PR DESCRIPTION
Some contributors still submit patches via the mailing list or are not using GitHub entirely, so an unlinked commit author email should not be treated as a hard failure.

Fixes: https://github.com/openwrt/openwrt/pull/24306#issuecomment-5017088714 and https://github.com/openwrt/openwrt/pull/24302