### PR TITLE
tools/cmake: update to 4.4.0

### DIFF
--- a/tools/cmake/Makefile
+++ b/tools/cmake/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cmake
-PKG_VERSION:=4.3.4
+PKG_VERSION:=4.4.0
 PKG_VERSION_MAJOR:=$(word 1,$(subst ., ,$(PKG_VERSION))).$(word 2,$(subst ., ,$(PKG_VERSION)))
 PKG_RELEASE:=1
 PKG_CPE_ID:=cpe:/a:kitware:cmake
@@ -15,7 +15,7 @@ PKG_CPE_ID:=cpe:/a:kitware:cmake
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/Kitware/CMake/releases/download/v$(PKG_VERSION)/ \
 		https://cmake.org/files/v$(PKG_VERSION_MAJOR)/
-PKG_HASH:=fdeff897b9eb49d764539f2b1edc6eb7e1440df325678a97c1978499e931adda
+PKG_HASH:=65757f442fdd242e27f1728fc26dc0cba4164f7a0791a5c788631c00080369bc
 
 HOST_BUILD_PARALLEL:=1
 HOST_CONFIGURE_PARALLEL:=1

--- a/tools/cmake/patches/100-no-testing.patch
+++ b/tools/cmake/patches/100-no-testing.patch
@@ -11,8 +11,8 @@
  # like vs9 or vs10
 --- a/Modules/Dart.cmake
 +++ b/Modules/Dart.cmake
-@@ -47,7 +47,7 @@ if(cmp0145 STREQUAL "")
-   message(AUTHOR_WARNING "${_cmp0145_warning}")
+@@ -46,7 +46,7 @@ if(cmp0145 STREQUAL "")
+   cmake_policy(ISSUE_WARNING CMP0145)
  endif()
  
 -option(BUILD_TESTING "Build the testing tree." ON)

--- a/tools/cmake/patches/130-bootstrap_parallel_make_flag.patch
+++ b/tools/cmake/patches/130-bootstrap_parallel_make_flag.patch
@@ -1,6 +1,6 @@
 --- a/bootstrap
 +++ b/bootstrap
-@@ -1522,7 +1522,10 @@ int main(){ printf("1%c", (char)0x0a); r
+@@ -1510,7 +1510,10 @@ int main(){ printf("1%c", (char)0x0a); r
  ' > "test.c"
  cmake_original_make_flags="${cmake_make_flags}"
  if test "x${cmake_parallel_make}" != "x"; then

--- a/tools/cmake/patches/150-zstd-libarchive.patch
+++ b/tools/cmake/patches/150-zstd-libarchive.patch
@@ -1,6 +1,6 @@
 --- a/Utilities/cmlibarchive/CMakeLists.txt
 +++ b/Utilities/cmlibarchive/CMakeLists.txt
-@@ -680,7 +680,7 @@ IF(ENABLE_ZSTD)
+@@ -682,7 +682,7 @@ IF(ENABLE_ZSTD)
      SET(ZSTD_FIND_QUIETLY TRUE)
    ENDIF (ZSTD_INCLUDE_DIR)
  

--- a/tools/cmake/patches/160-disable_xcode_generator.patch
+++ b/tools/cmake/patches/160-disable_xcode_generator.patch
@@ -1,6 +1,6 @@
 --- a/Source/CMakeLists.txt
 +++ b/Source/CMakeLists.txt
-@@ -923,7 +923,7 @@ if(CMake_USE_XCOFF_PARSER)
+@@ -962,7 +962,7 @@ if(CMake_USE_XCOFF_PARSER)
  endif()
  
  # Xcode only works on Apple


### PR DESCRIPTION
Release notes:https://cmake.org/cmake/help/latest/release/4.4.html

Refresh patches:
- 100-no-testing.patch
- 130-bootstrap_parallel_make_flag.patch
- 150-zstd-libarchive.patch
- 160-disable_xcode_generator.patch
