### PR TITLE
mediatek: filogic: drop dead eth0 MAC assignment on TP-Link BE450

### DIFF
--- a/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -37,7 +37,6 @@ preinit_set_mac_address() {
 		;;
 	tplink,be450)
 		addr=$(get_mac_binary "/tmp/tp_data/default-mac" 0)
-		ip link set dev eth0 address "$addr"
 		ip link set dev lan1 address "$addr"
 		ip link set dev lan2 address "$addr"
 		ip link set dev lan3 address "$addr"


### PR DESCRIPTION
Follow-up to #24180. The eth0 assignment added there never takes effect: 05_set_preinit_iface brings eth0 up in its default case before 10_fix_eth_mac.sh runs, and the kernel refuses a MAC change on a running interface (EBUSY). The script can't run earlier either, since it needs /tmp/tp_data, which 09_mount_cfg_part mounts.

I only caught this after testing a locally built image on the device. My earlier test ran the same commands from an init.d script, by which point the interfaces are down again, so it passed there and told me nothing.

The lan port assignments are unaffected and keep working: those interfaces are still down when the script runs, and preinit_ip opens lan1 later. With no macaddr in /etc/config/network, a reboot brings lan1-3 and br-lan up with the label MAC (addr_assign_type 3), while eth0 gets a fresh random address every time.

Dropping the line costs nothing. The DSA user ports carry their own addresses and br-lan takes its address from them.

Note for whoever looks at this next: asus,tuf-ax4200, ax4200q and ax6000 have the same ip link set dev eth0 address in this script and hit the same default case in 05_set_preinit_iface, so their eth0 assignment is probably silently failing too, though I don't have that hardware to confirm.

@jonasjelonek 