### PR TITLE
airoha: an7583: adjust thermal polling delays

### DIFF
--- a/target/linux/airoha/dts/an7583.dtsi
+++ b/target/linux/airoha/dts/an7583.dtsi
@@ -261,7 +261,7 @@
 
 	thermal-zones {
 		cpu_thermal: cpu-thermal {
-			polling-delay-passive = <10000>;
+			polling-delay-passive = <1000>;
 			polling-delay = <5000>;
 
 			thermal-sensors = <&thermal 0>;


### PR DESCRIPTION
The CPU thermal zone in an7583.dtsi sets the `polling-delay-passive` to 10000ms while the `polling-delay` is 5000ms. The thermal driver rejects zones whose passive polling delay is greater than the regular polling delay, causing `thermal_zone0` registration to fail with `-EINVAL`.

Reduce the passive polling delay to 2500 ms to fix thermal_zone0 registration. For reference, Airoha SDK sets the values on an7583 to 200ms passive and 1000ms normal.

Boot log before fix:
```
[    0.914820] thermal_sys: Failed to register thermal zone cpu-thermal: -22
[    0.921646] airoha-thermal 1fa20000.syscon:thermal: register thermal zone sensor failed
[    0.929652] airoha-thermal 1fa20000.syscon:thermal: probe with driver airoha-thermal failed with error -22
```

Tested on VSOL V2902A-S, `/sys/class/thermal/thermal_zone0/temp` shows the temperature correctly.