### PR TITLE
realtek: use Realtek PSE MCU driver for GS1900-8HP A1

### DIFF
--- a/target/linux/realtek/dts/rtl8380_zyxel_gs1900-8hp-a1.dts
+++ b/target/linux/realtek/dts/rtl8380_zyxel_gs1900-8hp-a1.dts
@@ -10,4 +10,32 @@
 
 &uart1 {
 	status = "okay";
+
+	pse: ethernet-pse {
+		compatible = "zyxel,gs1900-8hp-a1-pse", "realtek,pse-mcu-gen1";
+		current-speed = <19200>;
+
+		pse-pis {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			PSE_PI(0)
+			PSE_PI(1)
+			PSE_PI(2)
+			PSE_PI(3)
+			PSE_PI(4)
+			PSE_PI(5)
+			PSE_PI(6)
+			PSE_PI(7)
+		};
+	};
 };
+
+&phy8 { pses = <&pse_pi0>; };
+&phy9 { pses = <&pse_pi1>; };
+&phy10 { pses = <&pse_pi2>; };
+&phy11 { pses = <&pse_pi3>; };
+&phy12 { pses = <&pse_pi4>; };
+&phy13 { pses = <&pse_pi5>; };
+&phy14 { pses = <&pse_pi6>; };
+&phy15 { pses = <&pse_pi7>; };

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -443,7 +443,7 @@ define Device/zyxel_gs1900-8hp-a1
   DEVICE_VARIANT := A1
   ZYXEL_VERS := AAHI
   SUPPORTED_DEVICES += zyxel,gs1900-8hp-v1
-  DEVICE_PACKAGES += realtek-poe
+  DEVICE_PACKAGES += kmod-pse-realtek-mcu-uart
 endef
 TARGET_DEVICES += zyxel_gs1900-8hp-a1
 


### PR DESCRIPTION
Switch the GS1900-8HP A1 to the PSE driver that is being upstreamed. This isn't run-tested, but since the PSE between A1 and B1 seem to be identical, this is mostly a formality.