### PR TITLE
ramips: add support for ASUS RT-N65U

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/rtl8367b.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8367b.c
@@ -1549,6 +1549,12 @@ static int rtl8367b_detect(struct rtl8366_smi *smi)
 		chip_name = "8367RB";
 		smi->rtl8367b_chip = RTL8367B_CHIP_RTL8367RB;
 		break;
+	case 0x2000:
+		if (chip_num == 0x6000) {
+			chip_name = "8367RB";
+			smi->rtl8367b_chip = RTL8367B_CHIP_RTL8367RB;
+		}
+		break;
 	case 0x1010:
 		chip_name = "8367R-VB";
 		smi->rtl8367b_chip = RTL8367B_CHIP_RTL8367R_VB;

--- a/target/linux/ramips/dts/rt3883_asus_rt-n65u.dts
+++ b/target/linux/ramips/dts/rt3883_asus_rt-n65u.dts
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+#include "rt3883.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "asus,rt-n65u", "ralink,rt3883-soc";
+	model = "Asus RT-N65U";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	rtl8367rb {
+		compatible = "realtek,rtl8367b";
+		realtek,extif = <6 1 0 1 1 1 1 1 1 2>;
+		mii-bus = <&mdio0>;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power { // PWR
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+		};
+
+		lan { // LAN
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
+		};
+
+		wan { // WAN
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
+		};
+
+		usb { // USB
+			function = LED_FUNCTION_USB;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+		};
+
+		// There are also two LEDs for Wi-Fi:
+		// - AIR2 (2.4GHz) can be turned on via <&gpio0 1 GPIO_ACTIVE_LOW>,
+		//	 but not off: the RT3352 iNIC coprocessor drives the same line
+		//	 independently, so it isn't declared as a controllable LED here.
+		// - AIR5 (5GHz) is tied directly to the wmac radio state and turns
+		//	 on/off automatically with it; no separate GPIO controls it.
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x200>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&gpio0 {
+	// Enables the LED power rail (all LEDs except PWR).
+	led_all_enable {
+		gpio-hog;
+		gpios = <10 GPIO_ACTIVE_HIGH>;
+		output-low;
+		line-name = "led-all-enable";
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag", "uartf";
+		function = "gpio";
+	};
+};
+
+&pinctrl {
+	mdio_pins: mdio {
+		mdio {
+			groups = "mdio";
+			function = "mdio";
+		};
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+
+	port@0 {
+		status = "okay";
+		mediatek,fixed-link = <1000 1 1 1>;
+		phy-mode = "rgmii";
+	};
+
+	mdio0: mdio-bus {
+		status = "okay";
+	};
+};
+
+&pci {
+	status = "okay";
+};
+
+// PCI port connected to the onboard USB 3.0 host controller.
+&pci1 {
+	status = "okay";
+};
+
+&wmac {
+	ralink,2ghz = <0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};

--- a/target/linux/ramips/image/rt3883.mk
+++ b/target/linux/ramips/image/rt3883.mk
@@ -17,6 +17,17 @@ define Device/asus_rt-n56u
 endef
 TARGET_DEVICES += asus_rt-n56u
 
+define Device/asus_rt-n65u
+  $(Device/uimage-lzma-loader)
+  SOC := rt3883
+  BLOCKSIZE := 64k
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := ASUS
+  DEVICE_MODEL := RT-N65U
+  DEVICE_PACKAGES := kmod-usb3 kmod-usb-ledtrig-usbport kmod-switch-rtl8367b
+endef
+TARGET_DEVICES += asus_rt-n65u
+
 define Device/belkin_f9k1109v1
   $(Device/uimage-lzma-loader)
   SOC := rt3883

--- a/target/linux/ramips/rt3883/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/rt3883/base-files/etc/board.d/01_leds
@@ -7,6 +7,12 @@ board=$(board_name)
 board_config_update
 
 case $board in
+asus,rt-n65u)
+	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "eth0.1" "tx rx"
+	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth0.2" "tx rx"
+	ucidef_set_led_usbport "usb" "USB" "blue:usb" \
+		"usb1-port1" "usb1-port2" "usb2-port1" "usb2-port2"
+	;;
 belkin,f9k1109v1)
 	ucidef_set_led_netdev "lan" "lan" "blue:wps" "eth0"
 	;;

--- a/target/linux/ramips/rt3883/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/rt3883/base-files/etc/board.d/02_network
@@ -12,13 +12,14 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "8@eth0"
 		;;
-	belkin,f9k1109v1)
-		ucidef_add_switch "switch0" \
-			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "5@eth0"
-		;;
+	asus,rt-n65u|\
 	dlink,dir-645)
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "6@eth0"
+		;;
+	belkin,f9k1109v1)
+		ucidef_add_switch "switch0" \
+			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "5@eth0"
 		;;
 	edimax,br-6475nd)
 		ucidef_add_switch "switch0" \
@@ -53,6 +54,10 @@ ramips_setup_macs()
 	asus,rt-n56u)
 		lan_mac=$(macaddr_setbit_la "$(cat /sys/class/net/eth0/address)")
 		wan_mac=$(mtd_get_mac_binary factory 0x8004)
+		;;
+	asus,rt-n65u)
+		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x4)" -4)
+		label_mac=$wan_mac
 		;;
 	belkin,f9k1109v1)
 		wan_mac=$(mtd_get_mac_ascii uboot-env HW_WAN_MAC)


### PR DESCRIPTION
ASUS RT-N65U is a 2.4/5 GHz band 11n (Wi-Fi 4) router, based on RT3883.

Specification:
- CPU1: Ralink RT3883 @ 500MHz, WiSoC 5GHz
- CPU2: Ralink RT3352 @ 400MHz, WiSoC 2.4GHz
- RAM1: 128MB
- RAM2: 16MB
- Flash: Macronix MX25L12805D (16MB)
- WLAN: Ralink RT3883 (5GHz 3T3R), Ralink RT3352 (2.4GHz 2T2R)
- Switch: Realtek RTL8367RB
- 4x 10/100/1000 Mbps Ethernet
- 1x 10/100/1000 Mbps WAN
- USB: ASMedia ASM1042 USB 3.0 Controller
- PMU: UTC UZ1086L-ADJ
- 6x LED, 2x button

Installation (TFTP):
1. Power off the router.
2. Press and hold the Reset button.
3. Power on the router.
4. Wait 5 seconds, then release the Reset button.
5. Connect your PC to the router with Ethernet cable.
6. Configure a static IP address in the `192.168.1.0/24` subnet (except `192.168.1.1`).
7. Configure your TFTP client to use binary (octet) transfer mode.
8. Upload the firmware image (OpenWrt, stock, or Padavan) to `192.168.1.1`.
   The TFTP server accepts any filename.
9. Wait for the firmware flashing process to complete.

WARNING: Flashing the stock firmware after using Padavan may brick
your router due to configuration partition incompatibility.

MAC address layout:
- Wi-Fi 2.4GHz & WAN: label MAC
- Wi-Fi 5GHz & LAN: label MAC + 4

MTD layout:
```
mtd0: 00030000 00010000 "u-boot"
mtd1: 00010000 00010000 "config"
mtd2: 00010000 00010000 "factory"
mtd3: 00fb0000 00010000 "firmware"
mtd4: 001ee3b3 00010000 "kernel"
mtd5: 00dc1c4d 00010000 "rootfs"
mtd6: 00960000 00010000 "rootfs_data"
```

Known issues:
- The RT3352 2.4 GHz iNIC is unsupported because it requires a
  proprietary firmware blob and kernel support
- The Wi-Fi LEDs cannot be disabled independently because they share
  the LED power rail controlled by GPIO10

This work is based on the earlier draft support by @andy9a9 (#11647).
