### PR TITLE
gpio-button-hotplug: enable get_devtree_pdata everywhere

### DIFF
--- a/package/kernel/gpio-button-hotplug/Makefile
+++ b/package/kernel/gpio-button-hotplug/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=gpio-button-hotplug
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk

--- a/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
+++ b/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
@@ -359,7 +359,6 @@ static irqreturn_t button_handle_irq(int irq, void *_bdata)
 	return IRQ_HANDLED;
 }
 
-#ifdef CONFIG_OF
 static struct gpio_keys_platform_data *
 gpio_keys_get_devtree_pdata(struct device *dev)
 {
@@ -429,15 +428,6 @@ static const struct of_device_id gpio_keys_polled_of_match[] = {
 	{ },
 };
 MODULE_DEVICE_TABLE(of, gpio_keys_polled_of_match);
-
-#else
-
-static inline struct gpio_keys_platform_data *
-gpio_keys_get_devtree_pdata(struct device *dev)
-{
-	return NULL;
-}
-#endif
 
 static int gpio_keys_button_probe(struct platform_device *pdev,
 		struct gpio_keys_button_dev **_bdev, int polled)


### PR DESCRIPTION
Upstream prefers fwnode helpers instead of OF ones (already done). This is important for softward nodes, which upstream is migrating to for its non OF devices.\