### PR TITLE
[25.12]: scripts: dhcp: option to override preferred Client ID per interface

### DIFF
--- a/package/network/config/netifd/Makefile
+++ b/package/network/config/netifd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netifd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/netifd.git

--- a/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
+++ b/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
@@ -14,6 +14,7 @@ proto_dhcp_init_config() {
 	proto_config_add_string 'ipaddr:ipaddr'
 	proto_config_add_string 'hostname:hostname'
 	proto_config_add_string clientid
+	proto_config_add_string sendclientid
 	proto_config_add_string vendorid
 	proto_config_add_boolean 'broadcast:bool'
 	proto_config_add_boolean 'norelease:bool'
@@ -54,8 +55,8 @@ proto_dhcp_setup() {
 	local config="$1"
 	local iface="$2"
 
-	local ipaddr hostname clientid vendorid broadcast norelease reqopts defaultreqopts iface6rd sendopts delegate zone6rd zone mtu6rd customroutes classlessroute
-	json_get_vars ipaddr hostname clientid vendorid broadcast norelease reqopts defaultreqopts iface6rd delegate zone6rd zone mtu6rd customroutes classlessroute
+	local ipaddr hostname clientid sendclientid vendorid broadcast norelease reqopts defaultreqopts iface6rd sendopts delegate zone6rd zone mtu6rd customroutes classlessroute
+	json_get_vars ipaddr hostname clientid sendclientid vendorid broadcast norelease reqopts defaultreqopts iface6rd delegate zone6rd zone mtu6rd customroutes classlessroute
 
 	local opt dhcpopts
 	for opt in $reqopts; do
@@ -70,12 +71,28 @@ proto_dhcp_setup() {
 	[ "$defaultreqopts" = 0 ] && defaultreqopts="-o" || defaultreqopts=
 	[ "$broadcast" = 1 ] && broadcast="-B" || broadcast=
 	[ "$norelease" = 1 ] && norelease="" || norelease="-R"
-	[ -n "$clientid" ] && {
-		clientid="$(hexdump_2hex "$clientid")"
-		[ -z "$clientid" ] && logger -p warn -t dhcp "$iface: ignoring invalid clientid value"
-	}
-	[ -z "$clientid" ] && clientid="$(proto_dhcp_get_default_clientid "$iface")"
-	[ -n "$clientid" ] && clientid="-x 0x3d:$clientid"
+	case "$sendclientid" in
+		global)
+			clientid="$(proto_dhcp_get_default_clientid "$iface")"
+			;;
+		hardware)
+			clientid=''
+			;;
+		none)
+			clientid='-C'
+			;;
+		auto|\
+		*)
+			[ -n "$clientid" ] && {
+				clientid="$(hexdump_2hex "$clientid")"
+				[ -z "$clientid" ] && {
+					logger -p warn -t dhcp "$iface: ignoring invalid clientid value"
+				}
+			}
+			[ -z "$clientid" ] && clientid="$(proto_dhcp_get_default_clientid "$iface")"
+			;;
+	esac
+	[ -n "${clientid##-C}" ] && clientid="-x 0x3d:$clientid"
 	[ -n "$vendorid" ] && append dhcpopts "-x 0x3c:$(echo -n "$vendorid" | hexdump -ve '1/1 "%02x"')"
 	[ -n "$iface6rd" ] && proto_export "IFACE6RD=$iface6rd"
 	[ "$iface6rd" != 0 -a -f /lib/netifd/proto/6rd.sh ] && append dhcpopts "-O 212"

--- a/package/network/ipv6/odhcp6c/Makefile
+++ b/package/network/ipv6/odhcp6c/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=odhcp6c
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/odhcp6c.git

--- a/package/network/ipv6/odhcp6c/files/dhcpv6.sh
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.sh
@@ -12,6 +12,7 @@ proto_dhcpv6_init_config() {
 	proto_config_add_string 'reqaddress:or("try","force","none")'
 	proto_config_add_string reqprefix
 	proto_config_add_string clientid
+	proto_config_add_string 'sendclientid:or("auto","global","hardware")'
 	proto_config_add_string 'reqopts:list(uinteger)'
 	proto_config_add_string 'defaultreqopts:bool'
 	proto_config_add_string 'noslaaconly:bool'
@@ -48,6 +49,18 @@ proto_dhcpv6_init_config() {
 	proto_config_add_boolean dynamic
 }
 
+proto_dhcpv6_get_default_duid() {
+	local duid="$(uci_get network @globals[0] dhcp_default_duid)"
+	[ -n "$duid" ] && {
+		duid="$(hexdump_2hex "$duid")"
+		[ -z "$duid" ] && {
+			logger -p warn -t dhcpv6 "$iface: ignoring invalid dhcp_default_duid value"
+		}
+	}
+	[ -z "$duid" ] && return
+	echo -n $duid
+}
+
 proto_dhcpv6_add_prefix() {
 	append "$3" "$1"
 }
@@ -60,7 +73,7 @@ proto_dhcpv6_setup() {
 	local config="$1"
 	local iface="$2"
 
-	local reqaddress reqprefix clientid reqopts defaultreqopts
+	local reqaddress reqprefix clientid sendclientid reqopts defaultreqopts
 	local noslaaconly forceprefix extendprefix norelease strict_rfc7550
 	local noserverunicast noclientfqdn noacceptreconfig iface_dslite
 	local iface_map iface_464xlat ip6ifaceid userclass vendorclass
@@ -70,7 +83,7 @@ proto_dhcpv6_setup() {
 
 	local ip6prefix ip6prefixes
 
-	json_get_vars reqaddress reqprefix clientid reqopts defaultreqopts
+	json_get_vars reqaddress reqprefix clientid sendclientid reqopts defaultreqopts
 	json_get_vars noslaaconly forceprefix extendprefix norelease strict_rfc7550
 	json_get_vars noserverunicast noclientfqdn noacceptreconfig iface_dslite
 	json_get_vars iface_map iface_464xlat ip6ifaceid userclass vendorclass
@@ -106,15 +119,24 @@ proto_dhcpv6_setup() {
 		append opts "-P$reqprefix"
 	}
 
-	[ -n "$clientid" ] && {
-		clientid="$(hexdump_2hex "$clientid")"
-		[ -z "$clientid" ] && logger -p warn -t dhcpv6 "$iface: ignoring invalid clientid value"
-	}
-	[ -z "$clientid" ] && clientid="$(uci_get network @globals[0] dhcp_default_duid)"
-	[ -n "$clientid" ] && {
-		clientid="$(hexdump_2hex "$clientid")"
-		[ -z "$clientid" ] && logger -p warn -t dhcpv6 "$iface: ignoring invalid dhcp_default_duid value"
-	}
+	case "$sendclientid" in
+		global)
+			clientid="$(proto_dhcpv6_get_default_duid)"
+			;;
+		hardware)
+			clientid=''
+			;;
+		auto|\
+		*)
+			[ -n "$clientid" ] && {
+				clientid="$(hexdump_2hex "$clientid")"
+				[ -z "$clientid" ] && {
+					logger -p warn -t dhcpv6 "$iface: ignoring invalid clientid value"
+				}
+			}
+			[ -z "$clientid" ] && clientid="$(proto_dhcpv6_get_default_duid)"
+			;;
+	esac
 	[ -n "$clientid" ] && append opts "-c$clientid"
 
 	[ "$defaultreqopts" = "0" ] && append opts "-R"


### PR DESCRIPTION
Using UUID-based client IDs for DHCPv4/DHCPv6 with no option of falling back to hardware IDs (ie. MAC-address or DUID-LL) resp. none at all (IPv4), is causing regressions in some setups.

Introduce a new setting to override the preferred client ID to be used for DHCPv4/DHCPv6 on a per-interface basis:

network.<ifname>.sendclientid='auto|global|hardware|none'

- "auto" (default if empty or not present) uses any explicitly defined client ID, or falls back to the global DUID and finally to the DUID-LL resp. MAC address (ie. identical to before this commit).
- "global" uses the global default DUID, if configured, for DHCPv4 and DHCPv6 requests, even if a client ID is explicitly specified for the i/f
- "hardware" will not pass a client ID to udhcpc/odhcp6c, even if a global default DUID is configured or an explicit client ID specified, resulting in the i/f MAC address resp. type 3 DUID(-LL) to be used
- "none" (IPv4 only) will not add an option tag 61 to DHCPv4 requests at all.


Link: https://github.com/openwrt/openwrt/pull/24107

(cherry picked from commit d47ce71a89d6b88a9e1358ffccaeffc7f3f2498f)
