### PR TITLE
kernel: modules: add kmod-hwmon-ina3221

### DIFF
--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -265,6 +265,21 @@ endef
 $(eval $(call KernelPackage,hwmon-ina2xx))
 
 
+define KernelPackage/hwmon-ina3221
+  TITLE:=INA3221 monitoring support
+  KCONFIG:=CONFIG_SENSORS_INA3221
+  FILES:=$(LINUX_DIR)/drivers/hwmon/ina3221.ko
+  AUTOLOAD:=$(call AutoProbe,ina3221)
+  $(call AddDepends/hwmon,+kmod-i2c-core +kmod-regmap-i2c)
+endef
+
+define KernelPackage/hwmon-ina3221/description
+ Kernel module for ina3221 triple dc current and voltage monitor chips
+endef
+
+$(eval $(call KernelPackage,hwmon-ina3221))
+
+
 define KernelPackage/hwmon-it87
   TITLE:=IT87 monitoring support
   KCONFIG:=CONFIG_SENSORS_IT87


### PR DESCRIPTION
This add support for INA3221 voltage and current monitor chips by adding a package with the corresponding kernel module.

From datasheet: "The INA3221 is a three-channel, high-side current and bus voltage monitor with an I2C- and SMBUS-compatible interface."
INA3221 modules are widely available. Many devices allow to connect them hardware-wise. (Mainly single board computers like Raspberry PI.)
