### PR TITLE
tools: automake: do not error on missing conditional

### DIFF
--- a/tools/automake/patches/010-m4-cond-no-error.patch
+++ b/tools/automake/patches/010-m4-cond-no-error.patch
@@ -1,0 +1,12 @@
+--- a/m4/cond.m4
++++ b/m4/cond.m4
+@@ -27,6 +27,8 @@ else
+ fi
+ AC_CONFIG_COMMANDS_PRE(
+ [if test -z "${$1_TRUE}" && test -z "${$1_FALSE}"; then
+-  AC_MSG_ERROR([[conditional "$1" was never defined.
++  [$1]_TRUE='#'
++  [$1]_FALSE='#'
++  AC_MSG_WARN([[conditional "$1" was never defined.
+ Usually this means the macro was only invoked conditionally.]])
+ fi])])


### PR DESCRIPTION
@robimarko @Ansuel 

Now that cond.m4 is not being overwritten and is actively used, make it less aggressive on encountering an undefined conditional not set by a macro which is itself conditionally called, where the condition is set to intentionally not trigger the macro.

This prevents the need to further patch a configure.ac file to edit the improper usage of or remove a disabled macro which triggers the error "conditional ___ is not defined..." in the cases where autoreconf is still necessary for another reason, or, if this is the only build issue,
autoreconf can now be used to avoid this.

Instead of erroring, align the behavior of AM_CONDITIONAL closer to the gnulib variant gl_CONDITIONAL
which ignores and disables the conditional in this case.
