### PR TITLE
toolchain: drop $(REVISION) from GCC version

### DIFF
--- a/toolchain/gcc/common.mk
+++ b/toolchain/gcc/common.mk
@@ -45,7 +45,7 @@ endif
 PATCH_DIR=../patches-$(GCC_MAJOR_VERSION).x
 
 BUGURL=http://bugs.openwrt.org/
-PKGVERSION=OpenWrt GCC $(PKG_VERSION) $(REVISION)
+PKGVERSION=OpenWrt GCC $(PKG_VERSION)
 
 HOST_BUILD_PARALLEL:=1
 


### PR DESCRIPTION
Storing the ever changing revision in the GCC binary may result in leakage in package builds. If two equal GCC versions build the same package version with different OpenWrt revisions, the package becomes unreproducible.

Solve this by dropping the revision.

Below is an example of the `cni` package:

    │ ├── readelf --wide --decompress --string-dump=.comment {}
    │ │ @@ -1,4 +1,4 @@
    │ │
    │ │  String dump of section '.comment':
    │ │ -  [     0]  GCC: (OpenWrt GCC 14.4.0 r35470-1b2aeb4f8a) 14.4.0
    │ │ +  [     0]  GCC: (OpenWrt GCC 14.4.0 r35485-0f256a0a7a) 14.4.0