### PR TITLE
mvebu: improve reproducibility of ctera firmware

### DIFF
--- a/target/linux/mvebu/image/Makefile
+++ b/target/linux/mvebu/image/Makefile
@@ -93,6 +93,7 @@ define Build/ctera-firmware
 		> $@.tmp/trailer
 
 	tar $(if $(SOURCE_DATE_EPOCH),--mtime="@$(SOURCE_DATE_EPOCH)") \
+		--numeric-owner --owner=0 --group=0 \
 		-H gnu -C $@.tmp -cf $@.tar header kernel trailer
 
 	# Prepare header and trailer file for fake romdisk
@@ -114,6 +115,7 @@ define Build/ctera-firmware
 		> $@.tmp/trailer
 
 	tar $(if $(SOURCE_DATE_EPOCH),--mtime="@$(SOURCE_DATE_EPOCH)") \
+		--numeric-owner --owner=0 --group=0 \
 		-H gnu -C $@.tmp -rf $@.tar header romdisk trailer
 
 	mv $@.tar $@


### PR DESCRIPTION
Tar happily stores the username, which my vary on different build machines. Set it to numerical and 0.

    --- /tmp/rebuilderdAtD6oX/inputs/openwrt-mvebu-cortexa9-ctera_c200-v2-initramfs-factory.firm
    +++ /tmp/rebuilderdAtD6oX/out/openwrt-mvebu-cortexa9-ctera_c200-v2-initramfs-factory.firm
    ├── file list
    │ @@ -1,6 +1,6 @@
    │ --rw-r--r--   0 buildbot  (1000) buildbot  (1000)      173 2026-07-22 07:32:52.000000 header
    │ --rw-r--r--   0 buildbot  (1000) buildbot  (1000)  6633345 2026-07-22 07:32:52.000000 kernel
    │ --rw-r--r--   0 buildbot  (1000) buildbot  (1000)       37 2026-07-22 07:32:52.000000 trailer
    │ --rw-r--r--   0 buildbot  (1000) buildbot  (1000)      144 2026-07-22 07:32:52.000000 header
    │ --rw-r--r--   0 buildbot  (1000) buildbot  (1000)       64 2026-07-22 07:32:52.000000 romdisk
    │ --rw-r--r--   0 buildbot  (1000) buildbot  (1000)       37 2026-07-22 07:32:52.000000 trailer
    │ +-rw-r--r--   0 rebuilder  (1000) rebuilder  (1000)      173 2026-07-22 07:32:52.000000 header
    │ +-rw-r--r--   0 rebuilder  (1000) rebuilder  (1000)  6633345 2026-07-22 07:32:52.000000 kernel
    │ +-rw-r--r--   0 rebuilder  (1000) rebuilder  (1000)       37 2026-07-22 07:32:52.000000 trailer
    │ +-rw-r--r--   0 rebuilder  (1000) rebuilder  (1000)      144 2026-07-22 07:32:52.000000 header
    │ +-rw-r--r--   0 rebuilder  (1000) rebuilder  (1000)       64 2026-07-22 07:32:52.000000 romdisk
    │ +-rw-r--r--   0 rebuilder  (1000) rebuilder  (1000)       37 2026-07-22 07:32:52.000000 trailer