### PR TITLE
airoha: align OPP node names and label ATF memory

### DIFF
--- a/target/linux/airoha/dts/an7581.dtsi
+++ b/target/linux/airoha/dts/an7581.dtsi
@@ -188,57 +188,57 @@
 			required-opps = <&smcc_opp3>;
 		};
 
-		opp-7000000000 {
+		opp-700000000 {
 			opp-hz = /bits/ 64 <700000000>;
 			required-opps = <&smcc_opp4>;
 		};
 
-		opp-7500000000 {
+		opp-750000000 {
 			opp-hz = /bits/ 64 <750000000>;
 			required-opps = <&smcc_opp5>;
 		};
 
-		opp-8000000000 {
+		opp-800000000 {
 			opp-hz = /bits/ 64 <800000000>;
 			required-opps = <&smcc_opp6>;
 		};
 
-		opp-8500000000 {
+		opp-850000000 {
 			opp-hz = /bits/ 64 <850000000>;
 			required-opps = <&smcc_opp7>;
 		};
 
-		opp-9000000000 {
+		opp-900000000 {
 			opp-hz = /bits/ 64 <900000000>;
 			required-opps = <&smcc_opp8>;
 		};
 
-		opp-9500000000 {
+		opp-950000000 {
 			opp-hz = /bits/ 64 <950000000>;
 			required-opps = <&smcc_opp9>;
 		};
 
-		opp-10000000000 {
+		opp-1000000000 {
 			opp-hz = /bits/ 64 <1000000000>;
 			required-opps = <&smcc_opp10>;
 		};
 
-		opp-10500000000 {
+		opp-1050000000 {
 			opp-hz = /bits/ 64 <1050000000>;
 			required-opps = <&smcc_opp11>;
 		};
 
-		opp-11000000000 {
+		opp-1100000000 {
 			opp-hz = /bits/ 64 <1100000000>;
 			required-opps = <&smcc_opp12>;
 		};
 
-		opp-11500000000 {
+		opp-1150000000 {
 			opp-hz = /bits/ 64 <1150000000>;
 			required-opps = <&smcc_opp13>;
 		};
 
-		opp-12000000000 {
+		opp-1200000000 {
 			opp-hz = /bits/ 64 <1200000000>;
 			required-opps = <&smcc_opp14>;
 		};

--- a/target/linux/airoha/dts/an7581.dtsi
+++ b/target/linux/airoha/dts/an7581.dtsi
@@ -20,7 +20,7 @@
 		#size-cells = <2>;
 		ranges;
 
-		atf@80000000 {
+		atf: atf@80000000 {
 			no-map;
 			reg = <0x0 0x80000000 0x0 0x200000>;
 		};

--- a/target/linux/airoha/dts/an7583.dtsi
+++ b/target/linux/airoha/dts/an7583.dtsi
@@ -130,57 +130,57 @@
 			required-opps = <&smcc_opp3>;
 		};
 
-		opp-7000000000 {
+		opp-700000000 {
 			opp-hz = /bits/ 64 <700000000>;
 			required-opps = <&smcc_opp4>;
 		};
 
-		opp-7500000000 {
+		opp-750000000 {
 			opp-hz = /bits/ 64 <750000000>;
 			required-opps = <&smcc_opp5>;
 		};
 
-		opp-8000000000 {
+		opp-800000000 {
 			opp-hz = /bits/ 64 <800000000>;
 			required-opps = <&smcc_opp6>;
 		};
 
-		opp-8500000000 {
+		opp-850000000 {
 			opp-hz = /bits/ 64 <850000000>;
 			required-opps = <&smcc_opp7>;
 		};
 
-		opp-9000000000 {
+		opp-900000000 {
 			opp-hz = /bits/ 64 <900000000>;
 			required-opps = <&smcc_opp8>;
 		};
 
-		opp-9500000000 {
+		opp-950000000 {
 			opp-hz = /bits/ 64 <950000000>;
 			required-opps = <&smcc_opp9>;
 		};
 
-		opp-10000000000 {
+		opp-1000000000 {
 			opp-hz = /bits/ 64 <1000000000>;
 			required-opps = <&smcc_opp10>;
 		};
 
-		opp-10500000000 {
+		opp-1050000000 {
 			opp-hz = /bits/ 64 <1050000000>;
 			required-opps = <&smcc_opp11>;
 		};
 
-		opp-11000000000 {
+		opp-1100000000 {
 			opp-hz = /bits/ 64 <1100000000>;
 			required-opps = <&smcc_opp12>;
 		};
 
-		opp-11500000000 {
+		opp-1150000000 {
 			opp-hz = /bits/ 64 <1150000000>;
 			required-opps = <&smcc_opp13>;
 		};
 
-		opp-12000000000 {
+		opp-1200000000 {
 			opp-hz = /bits/ 64 <1200000000>;
 			required-opps = <&smcc_opp14>;
 		};

--- a/target/linux/airoha/dts/an7583.dtsi
+++ b/target/linux/airoha/dts/an7583.dtsi
@@ -18,7 +18,7 @@
 		#size-cells = <2>;
 		ranges;
 
-		atf@80000000 {
+		atf: atf@80000000 {
 			no-map;
 			reg = <0x0 0x80000000 0x0 0x200000>;
 		};


### PR DESCRIPTION
## Summary

This PR contains two small device tree cleanups for Airoha AN7581/AN7583:

- Align OPP node names with their corresponding `opp-hz` values.
- Add a label to the ATF reserved memory node so it can be referenced by
  other device tree nodes or overlays.

## Details

### OPP node name alignment

The OPP node names are updated to match the existing `opp-hz` values.

This is only a node name cleanup. The actual OPP frequencies and operating
parameters are not changed.

### ATF reserved memory label

Add a label for the ATF reserved memory region:
