### PR TITLE
airoha: raise CPU critical temperature from 110°C to 120°C

### DIFF
--- a/target/linux/airoha/dts/an7581.dtsi
+++ b/target/linux/airoha/dts/an7581.dtsi
@@ -332,7 +332,7 @@
 				};
 
 				cpu-critical {
-					temperature = <110000>;
+					temperature = <120000>;
 					hysteresis = <1000>;
 					type = "critical";
 				};

--- a/target/linux/airoha/dts/an7583.dtsi
+++ b/target/linux/airoha/dts/an7583.dtsi
@@ -274,7 +274,7 @@
 				};
 
 				cpu-critical {
-					temperature = <110000>;
+					temperature = <120000>;
 					hysteresis = <1000>;
 					type = "critical";
 				};


### PR DESCRIPTION
The IC maximum operating temperature is 125C. Raise the CPU critical temperature from 110C to 120C to account for possible temperature sensor error.

This keeps the trip point below the IC maximum while avoiding premature critical thermal protection.

Tested on Airoha internal platforms without thermal protection issues.