### PR TITLE
uboot-mediatek: fix BT-R320 Ethernet mode

### DIFF
--- a/package/boot/uboot-mediatek/patches/472-add-globitel-bt-r320.patch
+++ b/package/boot/uboot-mediatek/patches/472-add-globitel-bt-r320.patch
@@ -63,12 +63,12 @@
 +&eth {
 +	status = "okay";
 +	mediatek,gmac-id = <0>;
-+	phy-mode = "sgmii";
++	phy-mode = "2500base-x";
 +	mediatek,switch = "mt7531";
 +	reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
 +
 +	fixed-link {
-+		speed = <1000>;
++		speed = <2500>;
 +		full-duplex;
 +	};
 +};


### PR DESCRIPTION
The BT-R320 U-Boot DTS configures the MT7981-MT7531 link as SGMII at
1 Gbps, while the Linux DTS uses 2500base-x at 2.5 Gbps. The physical
link comes up, but ping and TFTP fail with "ARP Retry count exceeded".

Tested on BT-R320 V1.2 with U-Boot 2026.07:
- unmodified image: ping fails
- patched image: ping and TFTP work
- TFTP initramfs and production both boot

Reported in #24078.
