### PR TITLE
scripts: dl_github_archive: fix zstd args passed to tar

### DIFF
--- a/scripts/dl_github_archive.py
+++ b/scripts/dl_github_archive.py
@@ -139,7 +139,7 @@ class Path(object):
         if ts is not None:
             args.append('--mtime=@%d' % ts)
         if into.endswith('.zst'):
-            args.append('-I zstd -T0 --ultra -20')
+            args += ['-I', 'zstd -T0 --ultra -20']
         elif into.endswith('.xz'):
             envs['XZ_OPT'] = '-7e'
             args.append('-J')


### PR DESCRIPTION
The multi-word zstd option '-I zstd -T0 --ultra -20' was appended as a single argv element. subprocess passes each list element as one argv entry, so tar received the whole string as one argument and failed to recognize it. Split into separate '-I' and 'zstd -T0 --ultra -20' elements so tar correctly interprets the compressor command.

