### PR TITLE
realtek: Support PSE equipment via devicetree

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -196,8 +196,7 @@ realtek_setup_poe()
 		ucidef_set_poe 193 "lan8 lan7 lan6 lan5 lan4 lan3 lan2 lan1 lan16 lan15 lan14 lan13 lan12 lan11 lan10 lan9 lan24 lan23
 				lan22 lan21 lan20 lan19 lan18 lan17"
 		;;
-	edgecore,ecs4100-12ph|\
-	netgear,gs110tpp-v1)
+	edgecore,ecs4100-12ph)
 		ucidef_set_poe 130 "$(filter_port_list "$lan_list" "lan9 lan10")"
 		;;
 	datto,l8)

--- a/target/linux/realtek/dts/macros.dtsi
+++ b/target/linux/realtek/dts/macros.dtsi
@@ -40,6 +40,13 @@
 		HASH_PSE_CELLS = <0>; \
 	};
 
+#define PSE_PI_SUPPLY(p, s) \
+	pse_pi##p: pse-pi@p { \
+		reg = <p>; \
+		HASH_PSE_CELLS = <0>; \
+		vpwr-supply = <s>; \
+	};
+
 #define SWITCH_PORT(p, l, m) \
 	port##p: port@##p { \
 		reg = <##p>; \

--- a/target/linux/realtek/dts/rtl8380_netgear_gs110tpp-v1.dts
+++ b/target/linux/realtek/dts/rtl8380_netgear_gs110tpp-v1.dts
@@ -35,14 +35,16 @@
 			gpios = <&gpio1 34 GPIO_ACTIVE_LOW>;
 		};
 	};
-};
 
-&gpio1 {
-	poe-enable {
-		gpio-hog;
-		gpios = <10 GPIO_ACTIVE_HIGH>;
-		output-high;
-		line-name = "poe-enable";
+	device_power: regulator-device {
+		compatible = "regulator-fixed";
+		regulator-name = "ext-psu";
+		regulator-always-on;
+		regulator-boot-on;
+
+		regulator-max-microvolt = <54000000>;
+		regulator-min-microvolt = <54000000>;
+		regulator-power-budget-milliwatt = <130000>;
 	};
 };
 
@@ -52,6 +54,52 @@
 
 &uart1 {
 	status = "okay";
+
+	pse: ethernet-pse {
+		compatible = "netgear,gs110tpp-v1-pse", "realtek,pse-mcu-gen1";
+		current-speed = <19200>;
+
+		enable-gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
+
+		pse-pis {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			PSE_PI_SUPPLY(0, &device_power)
+			PSE_PI_SUPPLY(1, &device_power)
+			PSE_PI_SUPPLY(2, &device_power)
+			PSE_PI_SUPPLY(3, &device_power)
+			PSE_PI_SUPPLY(4, &device_power)
+			PSE_PI_SUPPLY(5, &device_power)
+			PSE_PI_SUPPLY(6, &device_power)
+			PSE_PI_SUPPLY(7, &device_power)
+		};
+	};
+};
+
+&phy8 {
+	pses = <&pse_pi7>;
+};
+&phy9 {
+	pses = <&pse_pi6>;
+};
+&phy10 {
+	pses = <&pse_pi5>;
+};
+&phy11 {
+	pses = <&pse_pi4>;
+};
+&phy12 {
+	pses = <&pse_pi3>;
+};
+&phy13 {
+	pses = <&pse_pi2>;
+};
+&phy14 {
+	pses = <&pse_pi1>;
+};
+&phy15 {
+	pses = <&pse_pi0>;
 };
 
 &mdio_bus0 {

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -267,7 +267,7 @@ define Device/netgear_gs110tpp-v1
   $(Device/netgear_nge)
   DEVICE_MODEL := GS110TPP
   DEVICE_VARIANT := v1
-  DEVICE_PACKAGES += realtek-poe
+  DEVICE_PACKAGES += kmod-pse-realtek-mcu-uart
 endef
 TARGET_DEVICES += netgear_gs110tpp-v1
 


### PR DESCRIPTION
Switch to a devicetree description of the PSE equipment, so the realtek-poe daemon and its config file are no longer required.

The third commit dropping the legacy config doesn't have to be merged, but perhaps the file can serve as a table of still-to-be-converted devices.