### PR TITLE
realtek: add support for ZyXEL GS1900-24E B1

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/realtek
+++ b/package/boot/uboot-tools/uboot-envtools/files/realtek
@@ -25,6 +25,7 @@ zyxel,gs1900-10hp-b1|\
 zyxel,gs1900-16-a1|\
 zyxel,gs1900-24-a1|\
 zyxel,gs1900-24e-a1|\
+zyxel,gs1900-24e-b1|\
 zyxel,gs1900-24ep-a1|\
 zyxel,gs1900-24hp-a1|\
 zyxel,gs1900-24hp-b1|\

--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -145,6 +145,7 @@ realtek_setup_macs()
 	zyxel,gs1900-24-a1|\
 	zyxel,gs1900-24-b1|\
 	zyxel,gs1900-24e-a1|\
+	zyxel,gs1900-24e-b1|\
 	zyxel,gs1900-24ep-a1|\
 	zyxel,gs1900-24hp-a1|\
 	zyxel,gs1900-24hp-b1|\

--- a/target/linux/realtek/base-files/etc/board.d/05_compat-version
+++ b/target/linux/realtek/base-files/etc/board.d/05_compat-version
@@ -21,6 +21,7 @@ case "$(board_name)" in
 	zyxel,gs1900-10hp-b1 | \
 	zyxel,gs1900-16-a1 | \
 	zyxel,gs1900-24e-a1 | \
+	zyxel,gs1900-24e-b1 | \
 	zyxel,gs1900-24ep-a1 | \
 	zyxel,gs1900-24hp-a1 | \
 	zyxel,gs1900-24hp-b1 | \

--- a/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24e-b1.dts
+++ b/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24e-b1.dts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl8380_zyxel_gs1900.dtsi"
+#include "rtl8380_zyxel_gs1900_gpio.dtsi"
+
+/ {
+	compatible = "zyxel,gs1900-24e-b1", "realtek,rtl838x-soc";
+	model = "Zyxel GS1900-24E B1";
+};
+
+/*
+ * Unlike -a1.dts, this DTS deliberately does NOT hog gpio0 pin 1 to
+ * permanently de-assert the shared external-IC reset line (see
+ * commit ba57225066, "realtek: hog the GS1900-24E external IC reset
+ * line", and openwrt/openwrt#18620).
+ */
+
+&mdio_bus0 {
+	ethernet-phy-package@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0>;
+
+		PHY_C22(0, 0)
+		PHY_C22(1, 1)
+		PHY_C22(2, 2)
+		PHY_C22(3, 3)
+		PHY_C22(4, 4)
+		PHY_C22(5, 5)
+		PHY_C22(6, 6)
+		PHY_C22(7, 7)
+	};
+
+	ethernet-phy-package@16 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <16>;
+
+		PHY_C22(16, 16)
+		PHY_C22(17, 17)
+		PHY_C22(18, 18)
+		PHY_C22(19, 19)
+		PHY_C22(20, 20)
+		PHY_C22(21, 21)
+		PHY_C22(22, 22)
+		PHY_C22(23, 23)
+	};
+};
+
+&switch0 {
+	ethernet-ports {
+		SWITCH_PORT_SDS(1, 1, 0, 1, qsgmii)
+		SWITCH_PORT_SDS(0, 2, 0, 0, qsgmii)
+		SWITCH_PORT_SDS(3, 3, 0, 3, qsgmii)
+		SWITCH_PORT_SDS(2, 4, 0, 2, qsgmii)
+		SWITCH_PORT_SDS(5, 5, 1, 1, qsgmii)
+		SWITCH_PORT_SDS(4, 6, 1, 0, qsgmii)
+		SWITCH_PORT_SDS(7, 7, 1, 3, qsgmii)
+		SWITCH_PORT_SDS(6, 8, 1, 2, qsgmii)
+
+		SWITCH_PORT(9, 9, internal)
+		SWITCH_PORT(8, 10, internal)
+		SWITCH_PORT(11, 11, internal)
+		SWITCH_PORT(10, 12, internal)
+		SWITCH_PORT(13, 13, internal)
+		SWITCH_PORT(12, 14, internal)
+		SWITCH_PORT(15, 15, internal)
+		SWITCH_PORT(14, 16, internal)
+
+		SWITCH_PORT_SDS(17, 17, 2, 1, qsgmii)
+		SWITCH_PORT_SDS(16, 18, 2, 0, qsgmii)
+		SWITCH_PORT_SDS(19, 19, 2, 3, qsgmii)
+		SWITCH_PORT_SDS(18, 20, 2, 2, qsgmii)
+		SWITCH_PORT_SDS(21, 21, 3, 1, qsgmii)
+		SWITCH_PORT_SDS(20, 22, 3, 0, qsgmii)
+		SWITCH_PORT_SDS(23, 23, 3, 3, qsgmii)
+		SWITCH_PORT_SDS(22, 24, 3, 2, qsgmii)
+	};
+};
+
+&gpio1 {
+	/delete-node/ poe_enable;
+};

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -488,6 +488,15 @@ define Device/zyxel_gs1900-24e-a1
 endef
 TARGET_DEVICES += zyxel_gs1900-24e-a1
 
+define Device/zyxel_gs1900-24e-b1
+  $(Device/zyxel_gs1900)
+  SOC := rtl8382
+  DEVICE_MODEL := GS1900-24E
+  DEVICE_VARIANT := B1
+  ZYXEL_VERS := AAHK
+endef
+TARGET_DEVICES += zyxel_gs1900-24e-b1
+
 define Device/zyxel_gs1900-24ep-a1
   $(Device/zyxel_gs1900)
   SOC := rtl8382


### PR DESCRIPTION
Adds support for the Zyxel GS1900-24E **B1** hardware revision, as a sibling to the existing `zyxel_gs1900-24e-a1` target. Only A1 is currently supported upstream; B1 units currently run the A1 image unmodified via manual DTS override, since the compatible string `zyxel,gs1900-24e` (pre-rename) still matches.

Zyxel's documentation describes the A1->B1 change as a simple front-panel button relabel. So far I have found the following (for A1 see https://techinfodepot.shoutwiki.com/wiki/ZyXEL_GS1900-24E):
- PCB: 37ZY-GM2430+212 V1.2 (A1: 37ZY-G724DO+412 V.12)
- RAM: 128 MiB DDR3 (A1: 128 MiB DDR2)
- Flash: mx25l12805d, 16 MiB (A1: 16 MiB SPI-NOR)
- External PHYs: RTL8218D (A1: unknown)
- Rear power switch: absent on this B1 unit (inlet only). A1 is described as having one in the *title* of openwrt/openwrt#18620, but that issue does not explicitly identify the affected hardware as "A1" specifically, nor is it confirmed by a spec sheet or photo
- ZYXEL_VERS firmware family unchanged (AAHK)

The existing A1 MDIO bus addressing and switch-port SerDes layout work correctly on B1 unmodified — Linux's PHY subsystem identifies the external PHY chip at runtime via ID registers rather than from the devicetree, so no port-mapping changes were needed regardless of what A1 actually uses.

This DTS deliberately does not carry forward the `gpio0` mdio-reset gpio-hog added to `-a1.dts` in ba57225066 ("realtek: hog the GS1900-24E external IC reset line", addressing #18620). That fix targets a probe-order race specific to A1's shared reset line between mdio_bus0 and mdio_aux. I could not confirm any reset-line continuity between `gpio0` pin 1 and the external ICs on B1 hardware, so inheriting A1's fix without verification seemed like the wrong default.

My testing suggests it is safe to omit.

I had OpenWrt 24.10.5 (kernel 6.6) running on this unit before applying this patch, which I used to characterize the #18620 regression pattern beforehand. Tagged 802.1Q VLAN traffic, verified via `rx_packets`/`tx_packets` counters and `tcpdump`, showed no errors during normal running state, a software `reboot`, and a full AC power-cycle.

All three phases showed clean bidirectional counter growth, with no sign of the #18620 stuck-RX symptom.

With current master and kernel 6.18.39 (this patch, no gpio-hog), I could not reproduce the issue either.

No reset-line errors, no stuck PHYs, all 24 ports transition blocking->forwarding normally.

Given B1 shows no symptom of the #18620 regression across both kernels and both reboot paths, the gpio-hog is omitted for now. Happy to add it back with an explicit B1-scoped justification if maintainer review turns up a reason it's needed regardless. I have had this running for about three weeks without problems so far.