### PR TITLE
realtek: keep bootloader rtl826x PHY/SerDes initialization (RTL8264 ingress fix)

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3876,6 +3876,38 @@ static int rtpcs_pcs_config(struct phylink_pcs *pcs, unsigned int neg_mode,
 	}
 
 	scoped_guard(mutex, &ctrl->lock) {
+
+		/*
+		 * Adopt a SerDes the bootloader already configured for the
+		 * requested USXGMII mode instead of fully reconfiguring it.
+		 * The full deactivate/configure/activate cycle bounces the
+		 * link to the attached PHY, which firmware-driven PHYs like
+		 * the RTL8264 cannot recover from on their system side:
+		 * copper ingress towards the switch MAC dies permanently.
+		 * Restrict adoption to USXGMII with matching mode select
+		 * and submode, where this problem exists and the bootloader
+		 * state is known good.
+		 */
+		if (sds->hw_mode == RTPCS_SDS_MODE_OFF &&
+		    sds->hw_mode != hw_mode &&
+		    rtpcs_93xx_sds_usxgmii_submodes[hw_mode] >= 0 &&
+		    sds->swcore_regs.mac_mode) {
+			u32 cur_mode;
+			u32 cur_submode = RTPCS_93XX_SDS_USXGMII_SUBMODE_10GSX;
+
+			if (sds->swcore_regs.usxgmii_submode)
+				regmap_field_read(sds->swcore_regs.usxgmii_submode,
+						  &cur_submode);
+
+			if (!regmap_field_read(sds->swcore_regs.mac_mode, &cur_mode) &&
+			    ctrl->cfg->sds_hw_mode_vals[hw_mode] == (s16)cur_mode &&
+			    rtpcs_93xx_sds_usxgmii_submodes[hw_mode] == (s16)cur_submode) {
+				dev_info(ctrl->dev,
+					 "SerDes %u already configured for mode %s, keeping bootloader setup\n",
+					 sds->id, phy_modes(interface));
+				sds->hw_mode = hw_mode;
+			}
+		}
 		if (sds->hw_mode != hw_mode) {
 			dev_info(ctrl->dev, "configure SerDes %u for mode %s\n", sds->id,
 				 phy_modes(interface));

--- a/target/linux/realtek/patches-6.18/744-net-phy-realtek-rtl826x-keep-bootloader-init.patch
+++ b/target/linux/realtek/patches-6.18/744-net-phy-realtek-rtl826x-keep-bootloader-init.patch
@@ -1,0 +1,93 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gennaro Cimmino <gcimmino@rayonra.net>
+Date: Tue, 22 Jul 2026 22:30:00 +0200
+Subject: [PATCH] net: phy: realtek: keep bootloader rtl826x initialization on
+ Realtek switches
+
+On RTL93xx switches the SDK bootloader has already reset, patched and
+fully brought up the RTL8264/826x PHYs, including the system-side
+USXGMII interface towards the switch SerDes. Re-running the reset and
+firmware patch in config_init, or rewriting the advertisement and
+restarting copper autonegotiation on the first config_aneg, permanently
+breaks the PHY-to-switch direction: frames received on the copper side
+no longer reach the switch MAC and nothing short of the bootloader
+initialization recovers the link. The Realtek vendor driver skips its
+reset and patch on these SoCs (CONFIG_MACH_REALTEK_RTL) for the same
+reason.
+
+Keep the bootloader state on these SoCs and leave the first
+autonegotiation configuration untouched. Validated on a Hasivo
+S1100W-8XGT-SE (RTL9303 + 2x RTL8264): restores port-to-CPU RX that
+has been broken since the switch to the mainline realtek PHY driver.
+
+Assisted-by: Claude:claude-fable-5
+Signed-off-by: Gennaro Cimmino <gcimmino@rayonra.net>
+---
+--- a/drivers/net/phy/realtek/realtek_main.c
++++ b/drivers/net/phy/realtek/realtek_main.c
+@@ -2859,6 +2859,7 @@
+ static int rtl826x_config_init(struct phy_device *phydev)
+ {
+ 	const unsigned int max_dereset_tries = 5;
++	struct rtl826x_priv *priv = phydev->priv;
+ 	unsigned int tries = 0;
+ 	int ret;
+ 
+@@ -2876,6 +2877,23 @@
+ 	if (ret < 0)
+ 		return ret;
+ 
++	/*
++	 * On Realtek switch SoCs the SDK bootloader has already reset,
++	 * patched and fully initialized the PHY, including the system-side
++	 * USXGMII interface towards the switch SerDes. Redoing the reset and
++	 * patch sequence here - or restarting autonegotiation afterwards -
++	 * permanently breaks the system side: copper frames stop reaching
++	 * the switch MAC and only the bootloader init can recover it. The
++	 * Realtek vendor driver skips its reset and patch on these SoCs for
++	 * the same reason. Keep the bootloader state and leave the first
++	 * autonegotiation setup untouched.
++	 */
++	if (IS_ENABLED(CONFIG_MACH_REALTEK_RTL)) {
++		priv->defer_an_restart = true;
++		phydev_dbg(phydev, "keeping bootloader initialization\n");
++		return rtl826x_config_serdes_polarity(phydev);
++	}
++
+ 	/* toggle reset */
+ 	ret = phy_set_bits_mmd(phydev, MDIO_MMD_VEND1, 0x145, BIT(0));
+ 	if (ret < 0)
+@@ -2953,10 +2971,23 @@
+ 
+ static int rtl826x_config_aneg(struct phy_device *phydev)
+ {
++	struct rtl826x_priv *priv = phydev->priv;
+ 	bool changed = false;
+ 	u16 reg;
+ 	int ret;
+ 
++	/*
++	 * Leave the bootloader-negotiated state completely untouched on the
++	 * first configuration after init: rewriting the advertisement or
++	 * restarting autonegotiation breaks the system-side link (see
++	 * config_init). A later explicit renegotiation request will use the
++	 * regular path.
++	 */
++	if (priv->defer_an_restart) {
++		priv->defer_an_restart = false;
++		return 0;
++	}
++
+ 	phydev->mdix_ctrl = ETH_TP_MDI_AUTO;
+ 	if (phydev->autoneg == AUTONEG_DISABLE)
+ 		return genphy_c45_pma_setup_forced(phydev);
+--- a/drivers/net/phy/realtek/realtek.h
++++ b/drivers/net/phy/realtek/realtek.h
+@@ -11,6 +11,7 @@
+ struct rtl826x_priv {
+ 	struct rtlgen_phy_patch_db *patch;
+ 	bool enable_pma_low_power:1;
++	bool defer_an_restart:1;
+ };
+ 
+ int rtl822x_hwmon_init(struct phy_device *phydev);


### PR DESCRIPTION
Possible fix for the RTL8264 ingress half of #24359, **tested on our hardware** (Hasivo S1100W-8XGT-SE, RTL9303 + 2× RTL8264, all 8 ports USXGMII).

### Mechanism

On these boards the SDK bootloader has already reset, patched and fully brought up the PHYs **and** the switch SerDes: the USXGMII link between them is up and working before Linux starts. The current drivers then re-initialize both sides:

1. `rtl826x_config_init` re-runs the PHY reset + firmware patch,
2. the first `config_aneg` rewrites the advertisement and restarts copper AN,
3. the first `pcs_config` runs the full SerDes deactivate/configure/activate cycle (`hw_mode` starts at OFF).

Each of these three alone permanently kills the PHY→switch direction on RTL8264 (verified individually on silicon); once dead, only the full bootloader init recovers it. The vendor driver skips reset/patch under `CONFIG_MACH_REALTEK_RTL` for the same reason. The wrong-firmware-table theory is ruled out on this board: our dies read `VEND1 0x104 = 0xf802` → the driver already loads `rtl8261n.bin` (see issue comment).

### The two commits

- **PHY**: under `CONFIG_MACH_REALTEK_RTL`, keep the bootloader initialization (skip reset+patch, keep IRQ quiesce + SerDes polarity) and leave the first autonegotiation configuration untouched.
- **PCS**: when the first configuration of a SerDes requests a USXGMII mode and the hardware mode select **and** USXGMII submode already match exactly, adopt the bootloader state instead of reconfiguring. Any mismatch, and all non-USXGMII modes, keep the existing full configuration path — RTL8224/QXGMII boards and SFP setups are unaffected.

### Validation (RAM-boot, current main)

| Signal | main pristine | main + this PR |
|---|:---:|:---:|
| `eth0` rx under ARP flood on lan2 | 0 | **+354** |
| eth0 RX IRQ | never fires | fires |
| 10G ports link speed | stuck at 5G | **10G** |
| SerDes reconfigurations in dmesg | 8 | 0 (adopted ×8) |

### Known limitations / open points

- A later explicit renegotiation (e.g. `ethtool -s`, or any AN restart) still kills ingress — the underlying "USXGMII never recovers" issue is not solved, only avoided. A follow-up that aligns the initial advertisement with the bootloader state (so no config cycle ever restarts AN) is in the works.
- **Egress-to-wire on this board is a separate regression and is NOT fixed by this PR** (port TX MIBs count, wire stays silent, also with this PR applied; bidirectional in U-Boot on the same wire). Under investigation, data in #24359.
- Would appreciate testing on other rtl826x boards (RTL8261N / RTL8264B, and a QXGMII/RTL8224 board to confirm the adoption guard).

@plappermaul @jonasjelonek @andrewjlamarche @carlosz1986

*Bench testing and analysis assisted by Claude Fable 5 (Anthropic AI).*
