### PR TITLE
qcom: dts: stop enabling the driverless QCE crypto nodes

### DIFF
--- a/target/linux/ipq40xx/dts/qcom-ipq4018-a42.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-a42.dts
@@ -99,10 +99,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	serial_pins: serial_pinmux {
 		mux {
@@ -178,10 +174,6 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-ap120c-ac.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-ap120c-ac.dts
@@ -99,10 +99,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &blsp_dma {
 	status = "okay";
 };
@@ -240,10 +236,6 @@
 
 	pinctrl-0 = <&serial0_pins>;
 	pinctrl-names = "default";
-};
-
-&cryptobam {
-	status = "okay";
 };
 
 &ethphy4 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-ap4050dn.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-ap4050dn.dts
@@ -51,10 +51,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		crypto@8e3a000 {
-			status = "okay";
-		};
-
 		watchdog@b017000 {
 			status = "okay";
 		};
@@ -360,10 +356,6 @@
 	qcom,ath10k-calibration-variant = "huawei-ap4050dn";
 	nvmem-cells = <&macaddr_resulta_10190 2>, <&precal_art_5000>;
 	nvmem-cell-names = "mac-address", "pre-calibration";
-};
-
-&cryptobam {
-	status = "okay";
 };
 
 &mdio {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-cap-ac.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-cap-ac.dts
@@ -115,10 +115,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	serial_pins: serial_pinmux {
 		mux {
@@ -213,10 +209,6 @@
 
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-};
-
-&cryptobam {
-	status = "okay";
 };
 
 &mdio {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-cs-w3-wd1200g-eup.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-cs-w3-wd1200g-eup.dts
@@ -85,10 +85,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	serial_pins: serial_pinmux {
 		mux {
@@ -231,10 +227,6 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-dap-2610.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-dap-2610.dts
@@ -74,10 +74,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &blsp1_spi1 {
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
@@ -175,10 +171,6 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-ea6350v3.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-ea6350v3.dts
@@ -80,17 +80,9 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-eap1300.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-eap1300.dts
@@ -88,10 +88,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	serial_pins: serial_pinmux {
 		mux {
@@ -219,10 +215,6 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-ecw5211.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-ecw5211.dts
@@ -95,10 +95,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	mdio_pins: mdio_pinmux {
 		mux_mdio {
@@ -269,10 +265,6 @@
 
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-};
-
-&cryptobam {
-	status = "okay";
 };
 
 &mdio {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-emd1.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-emd1.dts
@@ -83,10 +83,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	serial_pins: serial_pinmux {
 		mux {
@@ -190,10 +186,6 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-emr3500.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-emr3500.dts
@@ -81,10 +81,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	serial_pins: serial_pinmux {
 		mux {
@@ -187,10 +183,6 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-ens620ext.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-ens620ext.dts
@@ -100,14 +100,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &blsp_dma {
 	status = "okay";
 };

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-ex61x0v2.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-ex61x0v2.dtsi
@@ -151,10 +151,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	serial_pins: serial_pinmux {
 		mux {
@@ -313,10 +309,6 @@
 };
 
 &blsp_dma {
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-fritzbox-4040.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-fritzbox-4040.dts
@@ -109,10 +109,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	serial_pins: serial_pinmux {
 		mux {
@@ -138,10 +134,6 @@
 			output-high;
 		};
 	};
-};
-
-&cryptobam {
-	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-gl-a1300.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-gl-a1300.dts
@@ -110,14 +110,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &blsp1_spi1 {
 	status = "okay";
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-gl-ap1300.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-gl-ap1300.dts
@@ -95,14 +95,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &blsp1_spi1 {
 	status = "okay";
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-hap-ac2.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-hap-ac2.dts
@@ -103,10 +103,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	serial_pins: serial_pinmux {
 		mux {
@@ -209,10 +205,6 @@
 
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-};
-
-&cryptobam {
-	status = "okay";
 };
 
 &usb3_hs_phy {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-jalapeno.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-jalapeno.dtsi
@@ -55,10 +55,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	mdio_pins: mdio_pinmux {
 		pinmux_1 {
@@ -219,10 +215,6 @@
 
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-};
-
-&cryptobam {
-	status = "okay";
 };
 
 &mdio {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-magic-2-wifi-next.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-magic-2-wifi-next.dts
@@ -80,10 +80,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	spi_0_pins: spi_0_pinmux {
 		mux {
@@ -131,10 +127,6 @@
 			input;
 		};
 	};
-};
-
-&cryptobam {
-	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-map-ac1300.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-map-ac1300.dts
@@ -70,10 +70,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &blsp1_spi1 {
 	status = "okay";
 
@@ -225,10 +221,6 @@
 			output-high;
 		};
 	};
-};
-
-&cryptobam {
-	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-mf287_common.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-mf287_common.dtsi
@@ -116,14 +116,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &gmac {
 	status = "okay";
 	nvmem-cell-names = "mac-address";

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-nbg6617.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-nbg6617.dts
@@ -123,10 +123,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	serial_pins: serial_pinmux {
 		mux {
@@ -261,10 +257,6 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-pa1200.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-pa1200.dts
@@ -91,10 +91,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	serial_pins: serial_pinmux {
 		mux {
@@ -170,10 +166,6 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-rt-ac58u.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-rt-ac58u.dts
@@ -125,14 +125,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &blsp_dma {
 	status = "okay";
 };

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-rutx.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-rutx.dtsi
@@ -67,14 +67,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	serial_pins: serial_pinmux {
 		mux {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-sxtsq-5-ac.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-sxtsq-5-ac.dts
@@ -114,10 +114,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	serial_pins: serial_pinmux {
 		mux {
@@ -212,10 +208,6 @@
 
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-};
-
-&cryptobam {
-	status = "okay";
 };
 
 &wifi1 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-wac510.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-wac510.dts
@@ -147,10 +147,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	mdio_pins: mdio_pinmux {
 		mux_1 {
@@ -336,10 +332,6 @@
 
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-};
-
-&cryptobam {
-	status = "okay";
 };
 
 &gmac {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-wap-ac.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-wap-ac.dtsi
@@ -179,14 +179,6 @@
 	pinctrl-names = "default";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &watchdog {
 	status = "okay";
 };

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-wr-1.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-wr-1.dts
@@ -168,14 +168,6 @@
 	pinctrl-names = "default";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &ethphy0 {
 	leds {
 		#address-cells = <1>;

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-wre6606.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-wre6606.dts
@@ -111,10 +111,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	serial_pins: serial_pinmux {
 		mux {
@@ -233,10 +229,6 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-wrtq-329acn.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-wrtq-329acn.dts
@@ -75,10 +75,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &blsp_dma {
 	status = "okay";
 };
@@ -198,10 +194,6 @@
 
 	pinctrl-0 = <&serial0_pins>;
 	pinctrl-names = "default";
-};
-
-&cryptobam {
-	status = "okay";
 };
 
 &gmac {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-a62.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-a62.dts
@@ -99,10 +99,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	serial_pins: serial_pinmux {
 		mux {
@@ -189,10 +185,6 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-cm520-79f.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-cm520-79f.dts
@@ -126,10 +126,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &blsp_dma {
 	status = "okay";
 };
@@ -139,10 +135,6 @@
 };
 
 &blsp1_uart2 {
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-deco-m5.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-deco-m5.dtsi
@@ -299,14 +299,6 @@
 	};
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &prng {
 	status = "okay";
 };

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-e2600ac.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-e2600ac.dtsi
@@ -108,14 +108,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &tlmm {
 	i2c_0_pins: i2c-0-pinmux {
 		mux {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-eap2200.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-eap2200.dts
@@ -78,10 +78,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &blsp_dma {
 	status = "okay";
 };
@@ -166,10 +162,6 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_0_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-fritzbox-7530.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-fritzbox-7530.dts
@@ -117,10 +117,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	serial_0_pins: serial_pinmux {
 		mux {
@@ -236,10 +232,6 @@
 			};
 		};
 	};
-};
-
-&cryptobam {
-	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-fritzrepeater-1200.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-fritzrepeater-1200.dts
@@ -81,10 +81,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	serial_0_pins: serial_pinmux {
 		mux {
@@ -217,10 +213,6 @@
 			};
 		};
 	};
-};
-
-&cryptobam {
-	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-fritzrepeater-3000.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-fritzrepeater-3000.dts
@@ -83,10 +83,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	serial_0_pins: serial_pinmux {
 		mux {
@@ -195,10 +191,6 @@
 			};
 		};
 	};
-};
-
-&cryptobam {
-	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-gl-b2200.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-gl-b2200.dts
@@ -100,10 +100,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &vqmmc {
 	status = "okay";
 };
@@ -117,10 +113,6 @@
 };
 
 &blsp_dma {
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-habanero-dvk.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-habanero-dvk.dts
@@ -99,10 +99,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &vqmmc {
 	status = "okay";
 };
@@ -313,10 +309,6 @@
 
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-};
-
-&cryptobam {
-	status = "okay";
 };
 
 &pcie0 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-hap-ac3-lte6-kit.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-hap-ac3-lte6-kit.dts
@@ -241,10 +241,6 @@
 	pinctrl-names = "default";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
 &usb3_ss_phy {
 	status = "okay";
 };
@@ -321,10 +317,6 @@
 };
 
 &wifi1 {
-	status = "okay";
-};
-
-&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-hap-ac3.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-hap-ac3.dts
@@ -157,10 +157,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	serial_pins: serial_pinmux {
 		mux {
@@ -303,10 +299,6 @@
 
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-};
-
-&cryptobam {
-	status = "okay";
 };
 
 &usb2 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-lbr20.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-lbr20.dts
@@ -124,10 +124,6 @@
 	pinctrl-names = "default";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &watchdog {
 	status = "okay";
 };
@@ -441,10 +437,6 @@
 	status = "okay";
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-};
-
-&cryptobam {
-	status = "okay";
 };
 
 &gmac {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-le1.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-le1.dts
@@ -178,14 +178,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &gmac {
 	status = "okay";
 };

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-lhgg-60ad.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-lhgg-60ad.dts
@@ -129,10 +129,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	serial_pins: serial_pinmux {
 		mux {
@@ -224,10 +220,6 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-map-ac2200.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-map-ac2200.dts
@@ -64,10 +64,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &nand {
 	pinctrl-0 = <&nand_pins>;
 	pinctrl-names = "default";
@@ -208,10 +204,6 @@
 		bias-pull-down;
 		line-name = "enable external PA output-low";
 	};
-};
-
-&cryptobam {
-	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-mf18a.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-mf18a.dts
@@ -133,10 +133,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &blsp_dma {
 	status = "okay";
 };
@@ -212,10 +208,6 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-mf282plus.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-mf282plus.dts
@@ -115,10 +115,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &blsp_dma {
 	status = "okay";
 };
@@ -194,10 +190,6 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-mf286d.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-mf286d.dts
@@ -109,10 +109,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &blsp_dma {
 	status = "okay";
 };
@@ -188,10 +184,6 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-mf289f.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-mf289f.dts
@@ -305,14 +305,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &gmac {
 	status = "okay";
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-ncp-hg100-cellular.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-ncp-hg100-cellular.dts
@@ -529,14 +529,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &mdio {
 	status = "okay";
 	pinctrl-0 = <&mdio_pins>;

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-oap100.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-oap100.dts
@@ -157,10 +157,6 @@
 	};
 };
 
-&cryptobam {
-	status = "okay";
-};
-
 &blsp1_spi1 {
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-orbi.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-orbi.dtsi
@@ -116,10 +116,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &vqmmc {
 	status = "okay";
 };
@@ -328,10 +324,6 @@
 
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-};
-
-&cryptobam {
-	status = "okay";
 };
 
 &mdio {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-pa2200.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-pa2200.dts
@@ -94,10 +94,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	serial_pins: serial_pinmux {
 		mux {
@@ -177,10 +173,6 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-r619ac.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-r619ac.dtsi
@@ -91,10 +91,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &blsp_dma {
 	status = "okay";
 };
@@ -197,10 +193,6 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_0_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-rbx20.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-rbx20.dtsi
@@ -116,10 +116,6 @@
 	pinctrl-names = "default";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &watchdog {
 	status = "okay";
 };
@@ -219,10 +215,6 @@
 	status = "okay";
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-};
-
-&cryptobam {
-	status = "okay";
 };
 
 &gmac {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-rt-ac42u.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-rt-ac42u.dts
@@ -142,14 +142,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &blsp_dma {
 	status = "okay";
 };

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-rtl30vw.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-rtl30vw.dts
@@ -176,10 +176,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &blsp_dma {
 	status = "okay";
 };
@@ -321,10 +317,6 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-whw03.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-whw03.dtsi
@@ -154,16 +154,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-	num-channels = <4>;
-	qcom,num-ees = <2>;
-};
-
-&crypto {
-	status = "okay";
-};
-
 &blsp1_uart1 {
 	status = "okay";
 	pinctrl-0 = <&serial_0_pins>;

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-wia3300-20.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-wia3300-20.dts
@@ -253,14 +253,6 @@
 	pinctrl-names = "default";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &ethphy3 {
 	leds {
 		#address-cells = <1>;

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-wpj419.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-wpj419.dts
@@ -308,14 +308,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &usb3_ss_phy {
 	status = "okay";
 };

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-wtr-m2133hp.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-wtr-m2133hp.dts
@@ -160,10 +160,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	serial_0_pins: serial0_pinmux {
 		mux {
@@ -221,10 +217,6 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_0_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-xx8300.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-xx8300.dtsi
@@ -70,10 +70,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &blsp_dma {
 	status = "okay";
 };
@@ -83,10 +79,6 @@
 	pinctrl-0 = <&serial_0_pins>;
 	pinctrl-names = "default";
 
-};
-
-&cryptobam {
-	status = "okay";
 };
 
 &nand {

--- a/target/linux/ipq40xx/dts/qcom-ipq4028-wpj428.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4028-wpj428.dts
@@ -106,10 +106,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &tlmm {
 	mdio_pins: mdio_pinmux {
 		mux_1 {
@@ -244,10 +240,6 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4029-ap-303h.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4029-ap-303h.dts
@@ -107,10 +107,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &blsp_dma {
 	status = "okay";
 };
@@ -125,10 +121,6 @@
 	/* Texas Instruments CC2540T BLE radio */
 	pinctrl-0 = <&serial_1_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4029-aruba-glenmorangie.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4029-aruba-glenmorangie.dtsi
@@ -60,10 +60,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &blsp_dma {
 	status = "okay";
 };
@@ -92,10 +88,6 @@
 		reg = <0x29>;
 		read-only;
 	};
-};
-
-&cryptobam {
-	status = "okay";
 };
 
 &qpic_bam {

--- a/target/linux/ipq40xx/dts/qcom-ipq4029-gl-b1300.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4029-gl-b1300.dts
@@ -112,15 +112,7 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &blsp_dma {
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4029-gl-s1300.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4029-gl-s1300.dts
@@ -98,10 +98,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &vqmmc {
 	status = "okay";
 };
@@ -115,10 +111,6 @@
 };
 
 &blsp_dma {
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4029-meraki-common.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4029-meraki-common.dtsi
@@ -65,10 +65,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &blsp_dma {
 	status = "okay";
 };
@@ -76,10 +72,6 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_0_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4029-ws-ap3915i.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4029-ws-ap3915i.dts
@@ -97,10 +97,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &blsp_dma {
 	status = "okay";
 };
@@ -108,10 +104,6 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4029-ws-ap391x.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4029-ws-ap391x.dts
@@ -129,10 +129,6 @@
 	pinctrl-names = "default";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &watchdog {
 	status = "okay";
 };
@@ -164,10 +160,6 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&cryptobam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/dts/qcom-ipq40x9-dr40x9.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq40x9-dr40x9.dts
@@ -305,16 +305,6 @@
 	pinctrl-names = "default";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	num-channels = <4>;
-	qcom,num-ees = <2>;
-	status = "okay";
-};
-
 &mdio {
 	status = "okay";
 	pinctrl-0 = <&mdio_pins>;

--- a/target/linux/qualcommax/dts/ipq5018-ax6000.dts
+++ b/target/linux/qualcommax/dts/ipq5018-ax6000.dts
@@ -102,14 +102,6 @@
 	pinctrl-names = "default";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &prng {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq5018-ax830.dts
+++ b/target/linux/qualcommax/dts/ipq5018-ax830.dts
@@ -138,14 +138,6 @@
 	pinctrl-names = "default";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &prng {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq5018-ax850.dts
+++ b/target/linux/qualcommax/dts/ipq5018-ax850.dts
@@ -137,14 +137,6 @@
 	pinctrl-names = "default";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &prng {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq5018-gl-b3000.dts
+++ b/target/linux/qualcommax/dts/ipq5018-gl-b3000.dts
@@ -174,14 +174,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &prng {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq5018-mr3000d-ci.dts
+++ b/target/linux/qualcommax/dts/ipq5018-mr3000d-ci.dts
@@ -83,14 +83,6 @@
 	pinctrl-names = "default";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &prng {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq5018-mx-base.dtsi
+++ b/target/linux/qualcommax/dts/ipq5018-mx-base.dtsi
@@ -74,14 +74,6 @@
 	pinctrl-names = "default";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &prng {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq5018-pz-l8.dts
+++ b/target/linux/qualcommax/dts/ipq5018-pz-l8.dts
@@ -82,14 +82,6 @@
 	pinctrl-names = "default";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &prng {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq5018-redmi-ax5400.dts
+++ b/target/linux/qualcommax/dts/ipq5018-redmi-ax5400.dts
@@ -96,14 +96,6 @@
 	pinctrl-names = "default";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &prng {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq5018-scr50axe.dts
+++ b/target/linux/qualcommax/dts/ipq5018-scr50axe.dts
@@ -254,14 +254,6 @@
 	pinctrl-names = "default";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &prng {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq5018-wn-dax3000gr.dts
+++ b/target/linux/qualcommax/dts/ipq5018-wn-dax3000gr.dts
@@ -132,14 +132,6 @@
 	pinctrl-names = "default";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &prng {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq5018-wrc-x3000gs2.dts
+++ b/target/linux/qualcommax/dts/ipq5018-wrc-x3000gs2.dts
@@ -126,14 +126,6 @@
 	pinctrl-names = "default";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &prng {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq5018-wrc-x3000gst2.dts
+++ b/target/linux/qualcommax/dts/ipq5018-wrc-x3000gst2.dts
@@ -126,14 +126,6 @@
 	pinctrl-names = "default";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &prng {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq6010-wax610-base.dtsi
+++ b/target/linux/qualcommax/dts/ipq6010-wax610-base.dtsi
@@ -183,14 +183,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &qpic_bam {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq6018-rbx350.dtsi
+++ b/target/linux/qualcommax/dts/ipq6018-rbx350.dtsi
@@ -220,14 +220,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &qpic_bam {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8070-cax1800.dts
+++ b/target/linux/qualcommax/dts/ipq8070-cax1800.dts
@@ -85,14 +85,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &qpic_bam {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8070-rm2-6.dts
+++ b/target/linux/qualcommax/dts/ipq8070-rm2-6.dts
@@ -107,14 +107,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &prng {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8071-ap8220.dts
+++ b/target/linux/qualcommax/dts/ipq8071-ap8220.dts
@@ -208,14 +208,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &prng {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8071-ax3600.dtsi
+++ b/target/linux/qualcommax/dts/ipq8071-ax3600.dtsi
@@ -59,14 +59,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &qpic_bam {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8071-eap102.dts
+++ b/target/linux/qualcommax/dts/ipq8071-eap102.dts
@@ -254,14 +254,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &prng {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8071-mf269.dts
+++ b/target/linux/qualcommax/dts/ipq8071-mf269.dts
@@ -248,14 +248,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &prng {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8072-301w.dts
+++ b/target/linux/qualcommax/dts/ipq8072-301w.dts
@@ -246,14 +246,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &qpic_bam {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8072-aw1000.dts
+++ b/target/linux/qualcommax/dts/ipq8072-aw1000.dts
@@ -187,14 +187,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &prng {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8072-ax880.dts
+++ b/target/linux/qualcommax/dts/ipq8072-ax880.dts
@@ -236,14 +236,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
 &prng {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8072-ax9000.dts
+++ b/target/linux/qualcommax/dts/ipq8072-ax9000.dts
@@ -142,14 +142,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &qpic_bam {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8072-dl-wrx36.dts
+++ b/target/linux/qualcommax/dts/ipq8072-dl-wrx36.dts
@@ -84,14 +84,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &qpic_bam {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8072-eap620hd-v1.dts
+++ b/target/linux/qualcommax/dts/ipq8072-eap620hd-v1.dts
@@ -122,14 +122,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &qpic_bam {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8072-haze.dts
+++ b/target/linux/qualcommax/dts/ipq8072-haze.dts
@@ -123,14 +123,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &qpic_bam {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8072-linkhub-hh500v.dts
+++ b/target/linux/qualcommax/dts/ipq8072-linkhub-hh500v.dts
@@ -247,14 +247,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &prng {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8072-mx5300.dts
+++ b/target/linux/qualcommax/dts/ipq8072-mx5300.dts
@@ -114,14 +114,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &qpic_bam {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8072-mx8500.dts
+++ b/target/linux/qualcommax/dts/ipq8072-mx8500.dts
@@ -93,14 +93,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &qpic_bam {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8072-sax1v1k.dts
+++ b/target/linux/qualcommax/dts/ipq8072-sax1v1k.dts
@@ -90,14 +90,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &qpic_bam {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8072-wpq873.dts
+++ b/target/linux/qualcommax/dts/ipq8072-wpq873.dts
@@ -113,14 +113,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &qpic_bam {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8072-zbt-z800ax.dts
+++ b/target/linux/qualcommax/dts/ipq8072-zbt-z800ax.dts
@@ -255,14 +255,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &prng {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8074-deco-x80-5g.dts
+++ b/target/linux/qualcommax/dts/ipq8074-deco-x80-5g.dts
@@ -379,14 +379,6 @@ to suit the TP-Link Deco X80-5G target */
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &prng {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8074-nbg7815.dts
+++ b/target/linux/qualcommax/dts/ipq8074-nbg7815.dts
@@ -68,14 +68,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &qpic_bam {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8074-rax120v2.dts
+++ b/target/linux/qualcommax/dts/ipq8074-rax120v2.dts
@@ -526,14 +526,6 @@
 	qcom,ath11k-calibration-variant = "Netgear-RAX120v2";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &prng {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8074-rbx750.dtsi
+++ b/target/linux/qualcommax/dts/ipq8074-rbx750.dtsi
@@ -68,14 +68,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &edma {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8074-rt-ax89x.dts
+++ b/target/linux/qualcommax/dts/ipq8074-rt-ax89x.dts
@@ -354,14 +354,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &ssphy_0 {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8074-sxk80.dtsi
+++ b/target/linux/qualcommax/dts/ipq8074-sxk80.dtsi
@@ -195,14 +195,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &qpic_bam {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8074-wxr-5950ax12.dts
+++ b/target/linux/qualcommax/dts/ipq8074-wxr-5950ax12.dts
@@ -163,14 +163,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &qpic_bam {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq807x-nwax10ax.dtsi
+++ b/target/linux/qualcommax/dts/ipq807x-nwax10ax.dtsi
@@ -50,10 +50,6 @@
 	status = "okay";
 };
 
-&crypto {
-	status = "okay";
-};
-
 &edma {
 	status = "okay";
 };

--- a/target/linux/qualcommax/dts/ipq8174-mx4x00.dtsi
+++ b/target/linux/qualcommax/dts/ipq8174-mx4x00.dtsi
@@ -74,14 +74,6 @@
 	status = "okay";
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
 &qpic_bam {
 	status = "okay";
 };

--- a/target/linux/qualcommbe/dts/ipq9570-kiwi-dvk.dts
+++ b/target/linux/qualcommbe/dts/ipq9570-kiwi-dvk.dts
@@ -72,6 +72,14 @@
 	status = "okay";
 };
 
+&crypto {
+	status = "disabled";
+};
+
+&cryptobam {
+	status = "disabled";
+};
+
 &qcom_ppe {
 	ethernet-ports {
 		#address-cells = <1>;


### PR DESCRIPTION
ce120be361 ("kernel: disable qualcomm crypto") dropped the CRYPTO_DEV_QCE kernel configs, so crypto@73a000 and its BAM no longer have a driver. The qualcommax board device trees still override both nodes to "okay", which leaves enabled consumers that can never probe.

On ipq807x this is more than dead code: the GCC clock controller registers the USB GDSC power domains, so the genpd core installs a sync_state() callback on it (dev_set_drv_sync_state() in drivers/pmdomain/core.c), and fw_devlink then defers that callback forever. On the 6.18 testing kernel every ipq807x board logs

    qcom,gcc-ipq8074 1800000.clock-controller: sync_state() pending due to 73a000.crypto

on each boot, and unused power domains are never released.

Drop the overrides and fall back to the SoC dtsi defaults. On ipq8074, mainline ships both nodes disabled and no mainline board enables them; on ipq5018/ipq6018 they are enabled by default, but the GCC drivers there register no power domains, so no sync_state() dependency exists.

Observed on a Xiaomi AX3600 on the 6.18 testing kernel; with this change the built DTB returns crypto@73a000 to its disabled default.

cc @neheb