### PR TITLE
realtek: remove stray PoE budget entries for GS1900-8HP A1/B1

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -226,10 +226,6 @@ realtek_setup_poe()
 	netgear,gs310tp-v1)
 		ucidef_set_poe 55 "$(filter_port_list "$lan_list" "lan9 lan10")"
 		;;
-	zyxel,gs1900-8hp-a1|\
-	zyxel,gs1900-8hp-b1)
-		ucidef_set_poe 70 "$lan_list"
-		;;
 	zyxel,gs1900-24ep-a1)
 		ucidef_set_poe 130 "lan1 lan2 lan3 lan4 lan5 lan6 lan7 lan8 lan9 lan10 lan11 lan12"
 		;;


### PR DESCRIPTION
Commits ab649f19ab and 64315f29c4 moved the GS1900-8HP B1 and A1 to the in-kernel PSE MCU driver, but overlooked the /etc/board.d/02_network PoE budget entries. Remove them.

Fixes: ab649f19ab realtek: use Realtek PSE MCU driver for GS1900-8HP B1