### PR TITLE
mediatek: power off ZBT Z8102AX modems on shutdown

### DIFF
--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -495,8 +495,8 @@ generate_gpioswitch() {
 
 	json_select gpioswitch
 		json_select "$cfg"
-			local name pin default
-			json_get_vars name pin default
+			local name pin default shutdown
+			json_get_vars name pin default shutdown
 			uci -q batch <<-EOF
 				delete system.$cfg
 				set system.$cfg='gpio_switch'
@@ -504,6 +504,8 @@ generate_gpioswitch() {
 				set system.$cfg.gpio_pin='$pin'
 				set system.$cfg.value='$default'
 			EOF
+			[ -n "$shutdown" ] &&
+				uci -q set system.$cfg.shutdown_value="$shutdown"
 		json_select ..
 	json_select ..
 }

--- a/package/base-files/files/etc/init.d/gpio_switch
+++ b/package/base-files/files/etc/init.d/gpio_switch
@@ -52,6 +52,17 @@ load_gpio_switch()
 	fi
 }
 
+shutdown_gpio_switch()
+{
+	local value
+
+	config_get value "$1" shutdown_value
+	[ -n "$value" ] || return 0
+
+	config_set "$1" value "$value"
+	load_gpio_switch "$1"
+}
+
 service_triggers()
 {
 	procd_add_reload_trigger "system"
@@ -62,5 +73,18 @@ start_service()
 	[ -e /sys/class/gpio/ ] && {
 		config_load system
 		config_foreach load_gpio_switch gpio_switch
+	}
+}
+
+reload_service()
+{
+	start_service
+}
+
+stop_service()
+{
+	[ -e /sys/class/gpio/ ] && {
+		config_load system
+		config_foreach shutdown_gpio_switch gpio_switch
 	}
 }

--- a/package/base-files/files/lib/functions/uci-defaults.sh
+++ b/package/base-files/files/lib/functions/uci-defaults.sh
@@ -629,12 +629,14 @@ ucidef_add_gpio_switch() {
 	local name="$2"
 	local pin="$3"
 	local default="${4:-0}"
+	local shutdown="$5"
 
 	json_select_object gpioswitch
 		json_select_object "$cfg"
 			json_add_string name "$name"
 			json_add_string pin "$pin"
 			json_add_int default "$default"
+			[ -n "$shutdown" ] && json_add_int shutdown "$shutdown"
 		json_select ..
 	json_select ..
 }

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/03_gpio_switches
@@ -15,8 +15,8 @@ teltonika,rutc50)
 	;;
 zbtlink,zbt-z8102ax|\
 zbtlink,zbt-z8102ax-v2)
-	ucidef_add_gpio_switch "5g1" "Power 1st modem" "5g1" "1"
-	ucidef_add_gpio_switch "5g2" "Power 2nd modem" "5g2" "1"
+	ucidef_add_gpio_switch "5g1" "Power 1st modem" "5g1" "1" "0"
+	ucidef_add_gpio_switch "5g2" "Power 2nd modem" "5g2" "1" "0"
 	ucidef_add_gpio_switch "pcie" "Power PCIe port" "pcie" "1"
 	ucidef_add_gpio_switch "sim1" "SIM 1" "sim1" "1"
 	ucidef_add_gpio_switch "sim2" "SIM 2" "sim2" "1"


### PR DESCRIPTION
The ZBT Z8102AX and Z8102AX V2 keep both modem power GPIOs asserted during a warm reboot. As a result, a modem does not receive a power cycle and can remain unavailable after a USB composition change that only takes effect after power removal.

Add an optional `shutdown_value` to the generic `gpio_switch` configuration. The value is applied when the service is stopped during shutdown, while a normal configuration reload only reapplies the configured running value. Configure both Z8102AX modem power switches (`5g1` and `5g2`) to go low on shutdown. PCIe power and SIM selection GPIOs are left unchanged.

Tested on a ZBT Z8102AX V2 with two Meig SLM828 modems:

- reload kept both GPIOs at `1` and both USB modems present
- stop changed both GPIOs to `0` and both USB modems disappeared
- start restored both GPIOs to `1` and both USB modems re-enumerated
- shell syntax and `git diff --check` pass
- generated board JSON contains `"shutdown": 0` for the modem power switch
