### PR TITLE
realtek: use Realtek PSE MCU driver for Engenius EWS2910P

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -203,10 +203,6 @@ realtek_setup_poe()
 	datto,l8)
 		ucidef_set_poe 55 "lan5 lan6 lan7 lan8 lan4 lan3 lan2 lan1"
 		;;
-	engenius,ews2910p-v1|\
-	engenius,ews2910p-v3)
-		ucidef_set_poe 60 "$(filter_port_list "$lan_list" "lan9 lan10")"
-		;;
 	hpe,1920-8g-poe-65w)
 		ucidef_set_poe 65 "$(filter_port_list_reverse "$lan_list" "lan9 lan10")"
 		;;

--- a/target/linux/realtek/dts/rtl8380_engenius_ews2910p-v1.dts
+++ b/target/linux/realtek/dts/rtl8380_engenius_ews2910p-v1.dts
@@ -11,3 +11,8 @@
 	compatible = "openwrt,uimage";
 	openwrt,ih-magic = <0x03802910>;
 };
+
+&pse {
+	compatible = "engenius,ews2910p-v1-pse", "realtek,pse-mcu-gen1";
+	current-speed = <19200>;
+};

--- a/target/linux/realtek/dts/rtl8380_engenius_ews2910p-v3.dts
+++ b/target/linux/realtek/dts/rtl8380_engenius_ews2910p-v3.dts
@@ -11,3 +11,8 @@
 	compatible = "openwrt,uimage";
 	openwrt,ih-magic = <0x03010500>;
 };
+
+&pse {
+	compatible = "engenius,ews2910p-v3-pse", "realtek,pse-mcu-gen2";
+	current-speed = <115200>;
+};

--- a/target/linux/realtek/dts/rtl8380_engenius_ews2910p.dtsi
+++ b/target/linux/realtek/dts/rtl8380_engenius_ews2910p.dtsi
@@ -230,4 +230,31 @@
 
 &uart1 {
 	status = "okay";
+
+	/* PoE MCU; compatible and current-speed are set per variant */
+	pse: ethernet-pse {
+		pse-pis {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			PSE_PI(0)
+			PSE_PI(1)
+			PSE_PI(2)
+			PSE_PI(3)
+			PSE_PI(4)
+			PSE_PI(5)
+			PSE_PI(6)
+			PSE_PI(7)
+		};
+	};
 };
+
+/* Copper ports lan1..lan8 (phy8..phy15) -> MCU PoE ports 0..7 */
+&phy8  { pses = <&pse_pi0>; };
+&phy9  { pses = <&pse_pi1>; };
+&phy10 { pses = <&pse_pi2>; };
+&phy11 { pses = <&pse_pi3>; };
+&phy12 { pses = <&pse_pi4>; };
+&phy13 { pses = <&pse_pi5>; };
+&phy14 { pses = <&pse_pi6>; };
+&phy15 { pses = <&pse_pi7>; };

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -109,7 +109,7 @@ define Device/engenius_ews2910p-v1
   SOC := rtl8380
   DEVICE_MODEL := EWS2910P
   DEVICE_VARIANT := v1
-  DEVICE_PACKAGES += realtek-poe
+  DEVICE_PACKAGES += kmod-pse-realtek-mcu-uart
   UIMAGE_MAGIC := 0x03802910
   SUPPORTED_DEVICES += engenius,ews2910p
 endef
@@ -120,6 +120,7 @@ define Device/engenius_ews2910p-v3
   SOC := rtl8380
   DEVICE_MODEL := EWS2910P
   DEVICE_VARIANT := v3
+  DEVICE_PACKAGES += kmod-pse-realtek-mcu-uart
   UIMAGE_MAGIC := 0x03010500
 endef
 TARGET_DEVICES += engenius_ews2910p-v3


### PR DESCRIPTION
Convert both v1 and v3 to PSE MCU driver. Tested on a v3.
