### PR TITLE
realtek: restore rootfs_data for ews2910p and include firmware2

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/05_compat-version
+++ b/target/linux/realtek/base-files/etc/board.d/05_compat-version
@@ -13,6 +13,8 @@ case "$(board_name)" in
 	hpe,1920-24g-poe-370w)
 		ucidef_set_compat_version "1.1"
 	;;
+	engenius,ews2910p-v1 | \
+	engenius,ews2910p-v3 | \
 	zyxel,gs1900-8-a1 | \
 	zyxel,gs1900-8-b1 | \
 	zyxel,gs1900-8hp-a1 | \

--- a/target/linux/realtek/dts/rtl8380_engenius_ews2910p-v1.dts
+++ b/target/linux/realtek/dts/rtl8380_engenius_ews2910p-v1.dts
@@ -7,7 +7,7 @@
 	model = "EnGenius EWS2910P v1";
 };
 
-&firmware_partition_1 {
+&firmware_partition {
 	compatible = "openwrt,uimage";
 	openwrt,ih-magic = <0x03802910>;
 };

--- a/target/linux/realtek/dts/rtl8380_engenius_ews2910p-v3.dts
+++ b/target/linux/realtek/dts/rtl8380_engenius_ews2910p-v3.dts
@@ -7,7 +7,7 @@
 	model = "EnGenius EWS2910P v3";
 };
 
-&firmware_partition_1 {
+&firmware_partition {
 	compatible = "openwrt,uimage";
 	openwrt,ih-magic = <0x03010500>;
 };

--- a/target/linux/realtek/dts/rtl8380_engenius_ews2910p.dtsi
+++ b/target/linux/realtek/dts/rtl8380_engenius_ews2910p.dtsi
@@ -153,20 +153,16 @@
 				reg = <0x90000 0x10000>;
 			};
 			partition@a0000 {
-				label = "rootfs_data";
+				label = "jffs2-cfg";
 				reg = <0xa0000 0xd60000>;
 			};
 			partition@e00000 {
 				label = "jffs2-log";
 				reg = <0xe00000 0x200000>;
 			};
-			firmware_partition_1: partition@1000000 {
+			firmware_partition: partition@1000000 {
 				label = "firmware";
-				reg = <0x1000000 0x800000>;
-			};
-			firmware_partition_2: partition@1800000 {
-				label = "firmware2";
-				reg = <0x1800000 0x800000>;
+				reg = <0x1000000 0x1000000>;
 			};
 		};
 	};

--- a/target/linux/realtek/image/common.mk
+++ b/target/linux/realtek/image/common.mk
@@ -41,8 +41,16 @@ endef
 # The "IMG-" uImage name allows flashing the iniramfs from the vendor Web UI.
 # Avoided for sysupgrade, as the vendor FW would do an incomplete flash.
 define Device/engenius_ews2910p
-  IMAGE_SIZE := 8192k
+  IMAGE_SIZE := 16384k
   DEVICE_VENDOR := EnGenius
+  DEVICE_COMPAT_VERSION := 2.0
+  DEVICE_COMPAT_MESSAGE := The secondary firmware partition has been cannibalized \
+	in this version. Do not upgrade if you want to preserve dual booting. \
+	Furthermore, check that the firmware you flash fits in the pre-existing \
+	8MiB firmware partition. On subsequent sysupgrades, this limitation \
+	will not apply. Any files you had previously in the overlayfs are \
+	available by manually mounting /dev/mtd3 with: \
+	mount -t jffs2 /dev/mtdblock3 /mnt
   KERNEL_INITRAMFS := \
 	kernel-bin | \
 	append-dtb | \


### PR DESCRIPTION
In 2022, commit 7bba7ccde9cb021e24ec83f1332aafd5898e23ef repurposed a partition used by the vendor firmware for use as rootfs_data, the jffs2 filesystem used in the overlay. However, this had the effect of preventing sysupgrades from properly clearing and regenerating the overlay.

Revert that change and instead cannibalize the 8MiB firmware2 partition to provide extra space for the overlayfs.

@svanheule @mrnuke 