### PR TITLE
bpf-headers: use $(TOPDIR) instead of $(CURDIR)/../../.. to locate kernel details

### DIFF
--- a/package/kernel/bpf-headers/Makefile
+++ b/package/kernel/bpf-headers/Makefile
@@ -16,7 +16,7 @@ PKG_NAME:=linux
 PKG_PATCHVER:=6.12
 
 # Manually include kernel version and hash from kernel details file
-GENERIC_PLATFORM_DIR := $(CURDIR)/../../../target/linux/generic
+GENERIC_PLATFORM_DIR := $(TOPDIR)/target/linux/generic
 include $(GENERIC_PLATFORM_DIR)/kernel-$(PKG_PATCHVER)
 
 PKG_VERSION:=$(PKG_PATCHVER)$(strip $(LINUX_VERSION-$(PKG_PATCHVER)))


### PR DESCRIPTION
The `GENERIC_PLATFORM_DIR` path in `package/kernel/bpf-headers/Makefile` relies on the package being exactly three directories deep under the OpenWrt root, which is only true when it lives in-tree at `package/kernel/bpf-headers/`. When the package is scanned or built from a feed — e.g. via `src-cpy` of `package/` into `feeds/<name>/` or any other overlay that keeps a deeper directory layout — the relative path resolves outside the tree and the include fails:

```
Makefile:20: /.../feeds/openwrt_core/kernel/bpf-headers/../../../target/linux/generic/kernel-6.12: No such file or directory
ERROR: please fix feeds/openwrt_core/kernel/bpf-headers/Makefile - see logs/... for details
```

Every other core package uses `$(TOPDIR)`-anchored includes; `bpf-headers` is the only one still using `$(CURDIR)`-relative traversal:

```
$ grep -rl "CURDIR.*\.\./\.\./\.\." package/
package/kernel/bpf-headers/Makefile
```

Switch to `$(TOPDIR)` so the location works both in-tree and from any feed depth. No functional change in the in-tree case: `$(CURDIR)/../../..` resolves to the same directory as `$(TOPDIR)` when `package/kernel/bpf-headers/` is scanned from its canonical location.