### PR TITLE
target: allow per-feed Config.in additions via wildcard include

### DIFF
--- a/include/toplevel.mk
+++ b/include/toplevel.mk
@@ -77,7 +77,7 @@ _ignore = $(foreach p,$(IGNORE_PACKAGES),--ignore $(p))
 
 prepare-tmpinfo: FORCE
 	@+$(MAKE) -r -s $(STAGING_DIR_HOST)/.prereq-build $(PREP_MK)
-	mkdir -p tmp/info feeds
+	mkdir -p tmp/info feeds target/linux/feeds
 	[ -e $(TOPDIR)/feeds/base ] || ln -sf ../package $(TOPDIR)/feeds/base
 	$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f include/scan.mk SCAN_TARGET="packageinfo" SCAN_DIR="package" SCAN_NAME="package" SCAN_DEPTH=5 SCAN_EXTRA=""
 	$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f include/scan.mk SCAN_TARGET="targetinfo" SCAN_DIR="target/linux" SCAN_NAME="target" SCAN_DEPTH=3 SCAN_EXTRA="" SCAN_MAKEOPTS="TARGET_BUILD=1"

--- a/target/Config.in
+++ b/target/Config.in
@@ -216,3 +216,4 @@ config ARCH
 	default "riscv64"   if riscv64
 	default "x86_64"    if x86_64
 
+source "target/linux/feeds/*/Config.in"


### PR DESCRIPTION
## Motivation

`scripts/feeds` already supports feeds that ship targets — a feed with `target/linux/<board>/` is symlinked under `target/linux/feeds/<board>/`, and `include/target.mk` looks up `$(TOPDIR)/target/linux/feeds/$(BOARD)` in `PLATFORM_DIR` (commits ebc36ebb234, 0bdf8d12063).

What is not covered today is a way for such a feed to contribute target-wide Kconfig defaults or knobs. Every out-of-tree target feed has to patch `target/Config.in` with something like:

```kconfig
if TARGET_myboard
source "target/linux/feeds/myboard/Config.in"
endif
```

which forces a downstream delta against `target/Config.in` for every consumer.

## Change

Add one wildcard include at the end of `target/Config.in`:

```kconfig
source "target/linux/feeds/*/Config.in"
```

Any feed that drops a `Config.in` in its `target/linux/<board>/` directory is picked up automatically once the feed is installed. Feeds scope their symbols to the correct target with the usual `if TARGET_<board> ... endif` inside their own `Config.in`.

## Safety when no matching file exists

Kconfig's `zconf_nextfile()` already treats `GLOB_NOMATCH` on a pattern containing `*` as an empty include and does not emit any warning:

https://github.com/openwrt/openwrt/blob/main/scripts/config/lexer.l#L454-L458
```c
/* ignore wildcard patterns that return no result */
if (err == GLOB_NOMATCH && strchr(name, "*")) {
    err = 0;
    gl.gl_pathc = 0;
}
```

So the line is a no-op on a stock tree with no target-in-feed installed, and no changes are required to `menuconfig`/`defconfig` behavior for anyone not using target feeds.

## Verified

`make defconfig` on a tree with an out-of-tree target feed picks up the feed's `Config.in` symbols with no other changes to `target/Config.in`.