### PR TITLE
kernel: make INITRAMFS_PRESERVE_MTIME selectable

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -63,6 +63,15 @@ menu "Target Images"
 			help
 			  Ignore the initramfs passed by the bootloader.
 
+		config TARGET_INITRAMFS_PRESERVE_MTIME
+			bool "Preserve cpio archive mtimes in initramfs"
+			depends on TARGET_ROOTFS_INITRAMFS
+			help
+			  Each entry in an initramfs cpio archive carries an
+			  mtime value. When enabled, extracted cpio items take
+			  this mtime, with directory mtime setting deferred
+			  until after creation of any child entries.
+
 		config TARGET_ROOTFS_INITRAMFS_SEPARATE
 			bool "separate ramdisk"
 			depends on USES_SEPARATE_INITRAMFS && TARGET_ROOTFS_INITRAMFS && !TARGET_INITRAMFS_FORCE

--- a/include/kernel-defaults.mk
+++ b/include/kernel-defaults.mk
@@ -77,7 +77,9 @@ ifeq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),y)
 		rm -f $(2)/.config.prev; \
 		mv $(2)/.config $(2)/.config.old; \
 		$(call Kernel/SetInitramfs/PreConfigure,$(1),$(2)); \
-		echo "# CONFIG_INITRAMFS_PRESERVE_MTIME is not set" >> $(2)/.config; \
+		$(if $(CONFIG_TARGET_INITRAMFS_PRESERVE_MTIME), \
+			echo "CONFIG_INITRAMFS_PRESERVE_MTIME=y" >> $(2)/.config;, \
+			echo "# CONFIG_INITRAMFS_PRESERVE_MTIME is not set" >> $(2)/.config;) \
 		$(if $(CONFIG_TARGET_ROOTFS_INITRAMFS_SEPARATE),,echo "CONFIG_INITRAMFS_ROOT_UID=$(shell id -u)" >> $(2)/.config;) \
 		$(if $(CONFIG_TARGET_ROOTFS_INITRAMFS_SEPARATE),,echo "CONFIG_INITRAMFS_ROOT_GID=$(shell id -g)" >> $(2)/.config;) \
 		$(if $(CONFIG_TARGET_ROOTFS_INITRAMFS_SEPARATE), \
@@ -106,7 +108,9 @@ define Kernel/SetNoInitramfs
 	grep -v INITRAMFS $(LINUX_DIR)/.config.old > $(LINUX_DIR)/.config.set
 	echo 'CONFIG_INITRAMFS_SOURCE=""' >> $(LINUX_DIR)/.config.set
 	echo '# CONFIG_INITRAMFS_FORCE is not set' >> $(LINUX_DIR)/.config.set
-	echo "# CONFIG_INITRAMFS_PRESERVE_MTIME is not set" >> $(LINUX_DIR)/.config.set
+	$(if $(CONFIG_TARGET_INITRAMFS_PRESERVE_MTIME), \
+		echo "CONFIG_INITRAMFS_PRESERVE_MTIME=y" >> $(LINUX_DIR)/.config.set,  \
+		echo "# CONFIG_INITRAMFS_PRESERVE_MTIME is not set" >> $(LINUX_DIR)/.config.set)
 endef
 
 define Kernel/Configure/Default


### PR DESCRIPTION
The Linux kernel option `CONFIG_INITRAMFS_PRESERVE_MTIME` controls whether files unpacked from the built-in initramfs keep the mtimes recorded in the cpio archive, rather than being stamped with the boot time.

OpenWrt currently forces this option off from both `Kernel/SetInitramfs` and `Kernel/SetNoInitramfs`, so a target-level `config-<ver>` preference is overwritten unconditionally.

This patch introduces `TARGET_INITRAMFS_PRESERVE_MTIME` so users can opt in without patching the build system. Default behaviour is unchanged (option remains off unless the new symbol is set).

Motivation: userspace on a RAM rootfs may rely on file mtimes as freshness or ordering signals; with the current forced-off behaviour those all show the boot time.