### PR TITLE
build: use 64-bit time_t on 32-bit glibc targets

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -248,6 +248,11 @@ ifndef DUMP
   ifneq ($(TOOLCHAIN_LIB_DIRS),)
     TARGET_LDFLAGS+= $(patsubst %,-L%,$(TOOLCHAIN_LIB_DIRS))
   endif
+  ifeq ($(CONFIG_ARCH_64BIT),)
+    ifeq ($(CONFIG_USE_GLIBC),y)
+      TARGET_CPPFLAGS+= -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64
+    endif
+  endif
 endif
 
 TARGET_LINKER?=bfd


### PR DESCRIPTION
musl already hard-codes 64-bit `time_t` on 32-bit architectures, so 32-bit musl builds keep working past 2038-01-19 out of the box. 32-bit glibc builds, by contrast, still default to 32-bit `time_t` and will start returning bogus timestamps in roughly 12 years.

This patch matches musl behaviour by adding `-D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64` to `TARGET_CPPFLAGS` for `USE_GLIBC && !ARCH_64BIT` builds. glibc has supported this ABI since 2.34 (2021), and it is the same transition Debian and Ubuntu applied unconditionally to their 32-bit ports.

64-bit architectures are unaffected. There is no user knob because there is no meaningful case for shipping fresh 32-bit glibc images with 32-bit `time_t` at this point; if a legacy user needs the old ABI a follow-up `USE_LEGACY_TIME32` opt-out could be added.

**ABI note:** this changes glibc struct layouts (`time_t`, `timespec`, `struct stat`, etc.). Any pre-compiled third-party binaries linked against the previous 32-bit-`time_t` glibc ABI will not be compatible. In practice OpenWrt is source-built end-to-end, so the risk surface is limited to closed-source vendor blobs, which typically avoid these APIs.