### PR TITLE
realtek: mdio: Add polling configuration for RTL8264

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/mdio/mdio-realtek-otto.c
@@ -92,6 +92,7 @@
 #define RTMD_PHY_RTL8224			0x001ccad0
 #define RTMD_PHY_RTL8226			0x001cc838
 #define RTMD_PHY_RTL8261			0x001ccaf3
+#define RTMD_PHY_RTL8264			0x001ccaf2
 #define RTMD_PHY_RTL8264B			0x001cc813
 
 #define RTMD_PHY_MAC_1G				3
@@ -738,6 +739,7 @@ static int rtmd_get_phy_info(struct rtmd_ctrl *ctrl, int pn, struct rtmd_phy_inf
 		phyinfo->poll_lpa_1000 = RTMD_PHY_POLL_MMD(31, 0xa414, 11);
 		break;
 	case RTMD_PHY_RTL8261:
+	case RTMD_PHY_RTL8264:
 	case RTMD_PHY_RTL8264B:
 		phyinfo->mac_type = RTMD_PHY_MAC_2G_PLUS;
 		phyinfo->has_giga_lite = true;


### PR DESCRIPTION
RTL8264 polling is not configured until now. Boot log gives "skip polling setup for phy 0x001ccaf2 on port xx". Add the PHY features to rtmd_get_phy_info().
