### PR TITLE
realtek: dts: declare RTL8264 SerDes lane polarity on Hasivo S1100W-8XGT-SE

### DIFF
--- a/target/linux/realtek/dts/rtl9303_hasivo_s1100w-8xgt-se.dts
+++ b/target/linux/realtek/dts/rtl9303_hasivo_s1100w-8xgt-se.dts
@@ -6,6 +6,7 @@
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/leds/common.h>
+#include <dt-bindings/phy/phy.h>
 
 / {
 	compatible = "hasivo,s1100w-8xgt-se", "realtek,rtl930x-soc";
@@ -171,3 +172,12 @@
 		};
 	};
 };
+
+&phy0 { tx-polarity = <PHY_POL_INVERT>; };
+&phy8 { rx-polarity = <PHY_POL_INVERT>; };
+&phy16 { tx-polarity = <PHY_POL_INVERT>; };
+&phy20 { rx-polarity = <PHY_POL_INVERT>; };
+&phy24 { tx-polarity = <PHY_POL_INVERT>; };
+&phy25 { rx-polarity = <PHY_POL_INVERT>; };
+&phy26 { tx-polarity = <PHY_POL_INVERT>; };
+&phy27 { rx-polarity = <PHY_POL_INVERT>; };


### PR DESCRIPTION
### Root cause of #24359 (for the Hasivo S1100W-8XGT-SE): missing SerDes lane polarity in the devicetree

The rtl826x PHY driver programs the RTL8264 system-side lane polarity from the `rx-polarity`/`tx-polarity` DT properties, defaulting to *normal* when absent. This board routes half of its high-speed lanes inverted; the vendor bootloader compensates via HSI_INV/HSO_INV (VEND1 0xC1 bits 6/7), and the driver then clears those bits on every PHY init — killing the USXGMII link of all 8 ports in both directions (egress counted by the MAC MIB but never on the wire, ingress dead, any reinit = permanent death). The S1300WP dts already declares these properties, which is why that board works.

Bootloader values read back on hardware (U-Boot state, per switch port): `0xA7` (HSO_INV) on ports 0/16/24/26, `0x67` (HSI_INV) on ports 8/20/25/27 → alternating `tx-polarity` / `rx-polarity` per port, as declared here.

**Hardware validation on the S1100W-8XGT-SE (RAM-boot, current main):**
- pristine main: ingress and egress both dead (38.8k broadcast → eth0 delta 0; ping 100% loss);
- runtime proof: setting only HSI_INV back on one port instantly restores full bidirectional traffic on it;
- with only this DT change: ingress at full rate (+46k/38.8k flood, production traffic included), egress ping 0% loss / RTT 0.8 ms, ARP visible on the peer;
- **survives `/etc/init.d/network restart` and `ip link set down/up`** (previously any reinit killed traffic permanently);
- 10GBase-T ports now negotiate 10G (a port that used to come up at 5G renegotiated to 10G — likely the "10G links at 5G" symptom seen on related boards).

Complements #24392 (RTL8264 MDIO polling table), which is an independent, also-correct fix. Supersedes my #24378 (keep-bootloader approach), which I will close: with the polarity declared there is nothing left to preserve from the bootloader — the driver's own reinit now works. The keep-bootloader/serdes-adoption experiments turned out to be partial workarounds that only worked because they preserved the bootloader's polarity bits.

CC @plappermaul @jonasjelonek @andrewjlamarche @carlosz1986 — boards with plain RTL8264 (0x001ccaf2) showing this symptom likely need their own per-board polarity read the same way (values above are specific to the S1100W-8XGT-SE wiring).

*Bench testing and analysis assisted by Claude Fable 5 (Anthropic AI).*
