### PR TITLE
ppp: Update MPPE options in PPTP configuration

### DIFF
--- a/package/network/services/ppp/Makefile
+++ b/package/network/services/ppp/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ppp
 PKG_VERSION:=2.5.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.samba.org/pub/ppp

--- a/package/network/services/ppp/files/etc/ppp/options.pptp
+++ b/package/network/services/ppp/files/etc/ppp/options.pptp
@@ -3,5 +3,7 @@ noauth
 nobsdcomp
 nodeflate
 idle 0
-mppe required,no40,no56,stateless
+mppe-required
+nomppe-40
+nomppe-stateful
 maxfail 0


### PR DESCRIPTION
After the update of ppp to 2.5.0 (in 9cecf2b16e0ea8560e50ef6719938bd80b963704), the MPPE library implementation changed.

This commit updates the sample file to conform to the config syntax of the new library.

Old options syntax:

https://github.com/openwrt/openwrt/blob/8c1bd9b6a5056260393024a8d666f9367fac4885/package/network/services/ppp/patches/201-mppe_mppc_1.1.patch#L209-L214

New options syntax:

https://github.com/ppp-project/ppp/blob/3bf289c6e4c4638a61bbd5808617ab9719ce6f8c/pppd/ccp.c#L114-L159