### PR TITLE
airoha: an7583: add BL2 and BL31+U-Boot Artifacts for RFB board and fix boot failure on emmc board caused by redundant env

### DIFF
--- a/package/boot/uboot-airoha/patches/904-configs-airoha-add-missing-config-env-offset-redund.patch
+++ b/package/boot/uboot-airoha/patches/904-configs-airoha-add-missing-config-env-offset-redund.patch
@@ -1,0 +1,46 @@
+From a919f4797049a82cd3367138a20d06c2e0126534 Mon Sep 17 00:00:00 2001
+From: Yalei Zang <yalei.zang@airoha.com>
+Date: Fri, 24 Jul 2026 14:16:33 +0800
+Subject: [PATCH] configs: airoha: add missing CONFIG_ENV_OFFSET_REDUND
+
+The an7581/an7583 defconfigs enable CONFIG_ENV_REDUNDANT to support
+redundant environment, but miss the CONFIG_ENV_OFFSET_REDUND option.
+
+Without a valid redundant offset, executing `saveenv` causes U-Boot to
+write the redundant environment data to an incorrect location (likely
+offset 0 or overlapping), which destroys the eMMC BL2 or FIP partitions.
+This leads to a boot failure (bricked device) after a simple reset.
+
+Signed-off-by: Yalei Zang <yalei.zang@airoha.com>
+---
+ configs/an7581_evb_defconfig | 1 +
+ configs/an7583_evb_defconfig | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/configs/an7581_evb_defconfig b/configs/an7581_evb_defconfig
+index b39ebac8..5e89d418 100644
+--- a/configs/an7581_evb_defconfig
++++ b/configs/an7581_evb_defconfig
+@@ -10,6 +10,7 @@ CONFIG_ENV_OFFSET=0x7c000
+ CONFIG_DM_GPIO=y
+ CONFIG_DEFAULT_DEVICE_TREE="airoha/en7581-evb"
+ CONFIG_SYS_LOAD_ADDR=0x81800000
++CONFIG_ENV_OFFSET_REDUND=0x80000
+ CONFIG_BUILD_TARGET="u-boot.bin"
+ # CONFIG_EFI_LOADER is not set
+ CONFIG_FIT=y
+diff --git a/configs/an7583_evb_defconfig b/configs/an7583_evb_defconfig
+index 4c5bd6dd..48e43b86 100644
+--- a/configs/an7583_evb_defconfig
++++ b/configs/an7583_evb_defconfig
+@@ -10,6 +10,7 @@ CONFIG_ENV_OFFSET=0x7c000
+ CONFIG_DM_GPIO=y
+ CONFIG_DEFAULT_DEVICE_TREE="an7583-evb"
+ CONFIG_SYS_LOAD_ADDR=0x81800000
++CONFIG_ENV_OFFSET_REDUND=0x80000
+ CONFIG_BUILD_TARGET="u-boot.bin"
+ # CONFIG_EFI_LOADER is not set
+ CONFIG_FIT=y
+-- 
+2.43.0
+

--- a/target/linux/airoha/image/an7583.mk
+++ b/target/linux/airoha/image/an7583.mk
@@ -1,3 +1,11 @@
+define Build/an7583-preloader
+  cat $(STAGING_DIR_IMAGE)/an7583_$1-bl2.fip >> $@
+endef
+
+define Build/an7583-bl31-uboot
+  cat $(STAGING_DIR_IMAGE)/an7583_$1-bl31-u-boot.fip >> $@
+endef
+
 define Device/FitImageLzma
   KERNEL_SUFFIX := -uImage.itb
   KERNEL = kernel-bin | lzma | \
@@ -15,6 +23,9 @@ define Device/airoha_an7583-evb
   DEVICE_DTS_CONFIG := config@1
   IMAGE/sysupgrade.bin := append-kernel | pad-to 128k | append-rootfs | \
 	pad-rootfs | append-metadata
+  ARTIFACT/preloader.bin := an7583-preloader rfb
+  ARTIFACT/bl31-uboot.fip := an7583-bl31-uboot rfb
+  ARTIFACTS := preloader.bin bl31-uboot.fip
 endef
 TARGET_DEVICES += airoha_an7583-evb
 
@@ -23,6 +34,9 @@ define Device/airoha_an7583-evb-emmc
   DEVICE_MODEL := AN7583 Evaluation Board (EMMC)
   DEVICE_DTS := an7583-evb-emmc
   DEVICE_PACKAGES := kmod-phy-airoha-en8811h kmod-i2c-an7581
+  ARTIFACT/preloader.bin := an7583-preloader rfb
+  ARTIFACT/bl31-uboot.fip := an7583-bl31-uboot rfb
+  ARTIFACTS := preloader.bin bl31-uboot.fip
 endef
 TARGET_DEVICES += airoha_an7583-evb-emmc
 


### PR DESCRIPTION
### 1. Add BL2 and BL31+U-Boot artifacts for AN7583 EVB

Pack the BL2 and BL31+U-Boot artifacts for Airoha AN7583 EVB boards.

Airoha AN7583 is currently supported in upstream U-Boot, and the generated
bootloader files can be used for unfused boards.

### 2. Fix eMMC redundant environment offset

Set `CONFIG_ENV_OFFSET_REDUND` to `0x80000`.

The an7581/an7583 defconfigs enable `CONFIG_ENV_REDUNDANT` to support a
redundant U-Boot environment, but do not define `CONFIG_ENV_OFFSET_REDUND`.

Without a valid redundant environment offset, running saveenv may cause
U-Boot to write the redundant environment data to an invalid location,
potentially corrupting critical eMMC boot data

<details>
<summary> ##Boot Log on an7583 RFB 403 board </summary>

```log
[2026-07-24 14:35:18.348] tftp    tftp 192.168.1.126:openwrt-airoha-an7583-airoha_an7583-evb-emmc-preloader.bin
[2026-07-24 14:35:20.099] Using airoha-gdm1 device
[2026-07-24 14:35:20.099] TFTP from server 192.168.1.126; our IP address is 192.168.1.1
[2026-07-24 14:35:20.104] Filename 'openwrt-airoha-an7583-airoha_an7583-evb-emmc-preloader.bin'.
[2026-07-24 14:35:20.110] Load address: 0x81800000
[2026-07-24 14:35:20.110] Loading: *#########
[2026-07-24 14:35:20.145] 	 3.8 MiB/s
[2026-07-24 14:35:20.145] done
[2026-07-24 14:35:20.145] Bytes transferred = 119392 (1d260 hex)
[2026-07-24 14:35:20.148] U-Boot> mmc write 81800000 4 100
[2026-07-24 14:35:31.122] MMC write: dev # 0, block # 4, count 256 ... 256 blocks written: OK
[2026-07-24 14:35:31.150] U-Boot> tftp 192.168.1.126:openwrt-airoha-an7583-airoha_an7583-evb-emmc-bl31-uboot.fip
[2026-07-24 14:35:47.154] Using airoha-gdm1 device
[2026-07-24 14:35:47.154] TFTP from server 192.168.1.126; our IP address is 192.168.1.1
[2026-07-24 14:35:47.158] Filename 'openwrt-airoha-an7583-airoha_an7583-evb-emmc-bl31-uboot.fip'.
[2026-07-24 14:35:47.164] Load address: 0x81800000
[2026-07-24 14:35:47.164] Loading: *########################
[2026-07-24 14:35:47.238] 	 4.7 MiB/s
[2026-07-24 14:35:47.238] done
[2026-07-24 14:35:47.238] Bytes transferred = 340070 (53066 hex)
[2026-07-24 14:35:47.241] U-Boot> mmc write 81800000 120 3000 300 00 300
[2026-07-24 14:35:59.421] MMC write: dev # 0, block # 256, count 768 ... 768 blocks written: OK
[2026-07-24 14:35:59.485] U-Boot> INFO:    GICv3 without legacy support detected.
[2026-07-24 14:36:12.366] INFO:    ARM GICv3 driver initialized in EL3
[2026-07-24 14:36:12.369] INFO:    Maximum SPI INTID supported: 287
[2026-07-24 14:36:12.412] 
[2026-07-24 14:36:12.412] 
[2026-07-24 14:36:12.412] U-Boot 2026.07-OpenWrt-unknown (Jun 10 2026 - 09:43:38 +0000)
[2026-07-24 14:36:12.417] 
[2026-07-24 14:36:12.417] CPU:   Airoha AN7583
[2026-07-24 14:36:12.417] DRAM:  512 MiB
[2026-07-24 14:36:12.499] Core:  40 devices, 21 uclasses, devicetree: separate
[2026-07-24 14:36:12.502] MMC:   mmc@1fa0e000: 0
[2026-07-24 14:36:12.504] Loading Environment from MMC... Reading from MMC(0)... OK
[2026-07-24 14:36:12.568] In:    serial
[2026-07-24 14:36:12.571] Out:   serial
[2026-07-24 14:36:12.571] Err:   serial
[2026-07-24 14:36:12.573] Net:   eth0: airoha-gdm1, eth1: airoha-gdm2, eth2: airoha-gdm3
[2026-07-24 14:36:13.030] Hit any key to stop autoboot: 3Hit any key to stop autoboot: 0
[2026-07-24 14:36:13.849] U-Boot> setenv ipaddr 192.168.1.1
[2026-07-24 14:36:20.321] U-Boot> 
[2026-07-24 14:36:20.330] U-Boot> setenv serverip 192.168.1.126
[2026-07-24 14:36:20.349] U-Boot> 
[2026-07-24 14:36:20.362] U-Boot> setenv bootargs "root=/dev/mmcblk0p5 ro rootwait gpt"
[2026-07-24 14:36:20.384] U-Boot> 
[2026-07-24 14:36:20.392] U-Boot> setenv boot_default boot
[2026-07-24 14:36:20.410] U-Boot> 
[2026-07-24 14:36:20.424] U-Boot> saveenv
[2026-07-24 14:36:20.860] Saving Environment to MMC... Writing to redundant MMC(0)... OK
[2026-07-24 14:36:20.868] U-Boot> setenv bootcmd "mmc read 0x81800000 0x420 0x14fff; bootm 81800000"
[2026-07-24 14:36:25.415] U-Boot> 
[2026-07-24 14:36:25.422] U-Boot> setenv boot_default boot
[2026-07-24 14:36:25.447] U-Boot> 
[2026-07-24 14:36:25.456] U-Boot> saveenv
[2026-07-24 14:36:25.821] Saving Environment to MMC... Writing to MMC(0)... OK
[2026-07-24 14:36:25.829] U-Boot> tftp 192.168.1.126:
[2026-07-24 14:36:30.350] Using airoha-gdm1 device
[2026-07-24 14:36:30.350] TFTP from server 192.168.1.126; our IP address is 192.168.1.1
[2026-07-24 14:36:30.355] Filename ''.
[2026-07-24 14:36:30.360] Load address: 0x81800000
[2026-07-24 14:36:30.362] Loading: *
[2026-07-24 14:36:30.362] TFTP error: 'File not found' (1)
[2026-07-24 14:36:30.364] Not retrying...
[2026-07-24 14:36:30.367] U-Boot> tftp 192.168.1.126:openwrt-airoha-an7583-airoha_an7583-evb-emmc-squashfs-sysupgrade.bin
[2026-07-24 14:36:38.002] Using airoha-gdm1 device
[2026-07-24 14:36:38.002] TFTP from server 192.168.1.126; our IP address is 192.168.1.1
[2026-07-24 14:36:38.007] Filename 'openwrt-airoha-an7583-airoha_an7583-evb-emmc-squashfs-sysupgrade.bin'.
[2026-07-24 14:36:38.014] Load address: 0x81800000
[2026-07-24 14:36:38.017] Loading: *#################################################################
[2026-07-24 14:36:38.216] 	 #################################################################
[2026-07-24 14:36:38.397] 	 #################################################################
[2026-07-24 14:36:38.576] 	 #################################################################
[2026-07-24 14:36:38.762] 	 #################################################################
[2026-07-24 14:36:38.948] 	 #################################################################
[2026-07-24 14:36:39.138] 	 #################################################################
[2026-07-24 14:36:39.331] 	 #################################################################
[2026-07-24 14:36:39.507] 	 #################################################################
[2026-07-24 14:36:39.730] 	 #################################################################
[2026-07-24 14:36:39.993] 	 #################################################################
[2026-07-24 14:36:40.192] 	 #################################################################
[2026-07-24 14:36:40.416] 	 #################################################################
[2026-07-24 14:36:40.598] 	 #################################################################
[2026-07-24 14:36:40.779] 	 #################################################################
[2026-07-24 14:36:40.944] 	 #################################################################
[2026-07-24 14:36:41.104] 	 #################################################################
[2026-07-24 14:36:41.272] 	 #################################################################
[2026-07-24 14:36:41.493] 	 #################################################################
[2026-07-24 14:36:41.669] 	 #################################################################
[2026-07-24 14:36:41.832] 	 #################################################################
[2026-07-24 14:36:42.005] 	 ############################
[2026-07-24 14:36:42.076] 	 4.8 MiB/s
[2026-07-24 14:36:42.076] done
[2026-07-24 14:36:42.076] Bytes transferred = 20447508 (1380114 hex)
[2026-07-24 14:36:42.079] U-Boot> mmc write 81800000 420 14fff
[2026-07-24 14:36:51.768] MMC write: dev # 0, block # 1056, count 86015 ... 86015 blocks written: OK
[2026-07-24 14:36:58.046] U-Boot> INFO:    GICv3 without legacy support detected.
[2026-07-24 14:37:14.387] INFO:    ARM GICv3 driver initialized in EL3
[2026-07-24 14:37:14.390] INFO:    Maximum SPI INTID supported: 287
[2026-07-24 14:37:14.434] 
[2026-07-24 14:37:14.434] 
[2026-07-24 14:37:14.434] U-Boot 2026.07-OpenWrt-unknown (Jun 10 2026 - 09:43:38 +0000)
[2026-07-24 14:37:14.438] 
[2026-07-24 14:37:14.438] CPU:   Airoha AN7583
[2026-07-24 14:37:14.438] DRAM:  512 MiB
[2026-07-24 14:37:14.521] Core:  40 devices, 21 uclasses, devicetree: separate
[2026-07-24 14:37:14.524] MMC:   mmc@1fa0e000: 0
[2026-07-24 14:37:14.527] Loading Environment from MMC... Reading from MMC(0)... OK
[2026-07-24 14:37:14.590] In:    serial
[2026-07-24 14:37:14.594] Out:   serial
[2026-07-24 14:37:14.594] Err:   serial
[2026-07-24 14:37:14.597] Net:   eth0: airoha-gdm1, eth1: airoha-gdm2, eth2: airoha-gdm3
[2026-07-24 14:37:15.051] Hit any key to stop autoboot: 3Hit any key to stop autoboot: 2Hit any key to stop autoboot: 1Hit any key to stop autoboot: 0
[2026-07-24 14:37:18.070] MMC read: dev # 0, block # 1056, count 86015 ... 86015 blocks read: OK
[2026-07-24 14:37:20.512] ## Loading kernel (any) from FIT Image at 81800000 ...
[2026-07-24 14:37:20.514]    Using 'config-1' configuration
[2026-07-24 14:37:20.517]    Trying 'kernel-1' kernel subimage
[2026-07-24 14:37:20.520]      Description:  ARM64 OpenWrt Linux-6.18.39
[2026-07-24 14:37:20.525]      Type:         Kernel Image
[2026-07-24 14:37:20.528]      Compression:  lzma compressed
[2026-07-24 14:37:20.530]      Data Start:   0x818000e8
[2026-07-24 14:37:20.532]      Data Size:    4608934 Bytes = 4.4 MiB
[2026-07-24 14:37:20.534]      Architecture: AArch64
[2026-07-24 14:37:20.536]      OS:           Linux
[2026-07-24 14:37:20.539]      Load Address: 0x80200000
[2026-07-24 14:37:20.541]      Entry Point:  0x80200000
[2026-07-24 14:37:20.544]      Hash algo:    crc32
[2026-07-24 14:37:20.547]      Hash value:   625f96a7
[2026-07-24 14:37:20.551]      Hash algo:    sha1
[2026-07-24 14:37:20.551]      Hash value:   940af22364ae1a5e700fa051f60ee8d8fa8ea7a1
[2026-07-24 14:37:20.556]    Verifying Hash Integrity ... crc32+ sha1+ OK
[2026-07-24 14:37:20.636] ## Loading fdt (any) from FIT Image at 81800000 ...
[2026-07-24 14:37:20.640]    Using 'config-1' configuration
[2026-07-24 14:37:20.643]    Trying 'fdt-1' fdt subimage
[2026-07-24 14:37:20.646]      Description:  ARM64 OpenWrt airoha_an7583-evb-emmc device tree blob
[2026-07-24 14:37:20.652]      Type:         Flat Device Tree
[2026-07-24 14:37:20.654]      Compression:  uncompressed
[2026-07-24 14:37:20.658]      Data Start:   0x81c655d8
[2026-07-24 14:37:20.660]      Data Size:    16230 Bytes = 15.8 KiB
[2026-07-24 14:37:20.663]      Architecture: AArch64
[2026-07-24 14:37:20.665]      Hash algo:    crc32
[2026-07-24 14:37:20.668]      Hash value:   c13d3a0d
[2026-07-24 14:37:20.671]      Hash algo:    sha1
[2026-07-24 14:37:20.674]      Hash value:   a4ebf8e54b5d0e172e4f55bf9770d063e9b35556
[2026-07-24 14:37:20.679]    Verifying Hash Integrity ... crc32+ sha1+ OK
[2026-07-24 14:37:20.682]    Booting using the fdt blob at 0x81c655d8
[2026-07-24 14:37:20.685] Working FDT set to 81c655d8
[2026-07-24 14:37:20.688]    Uncompressing Kernel Image to 80200000
[2026-07-24 14:37:21.567]    Loading Device Tree to 000000009eb25000, end 000000009eb2bf65 ... OK
[2026-07-24 14:37:21.571] Working FDT set to 9eb25000
[2026-07-24 14:37:21.576] 
[2026-07-24 14:37:21.576] Starting kernel ...
[2026-07-24 14:37:21.576] 
[2026-07-24 14:37:21.644] INFO:    mt_on[0:1], entry 800030fc
[2026-07-24 14:37:21.698] [    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[2026-07-24 14:37:21.703] [    0.000000] Linux version 6.18.39 (sd5@PC24010019) (aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 14.3.0 unknown) 14.3.0, GNU ld (GNU Binutils) 2.44) #0 SMP Wed Jun 10 09:43:38 2026
[2026-07-24 14:37:21.718] [    0.000000] Machine model: Airoha AN7583 Evaluation Board
[2026-07-24 14:37:21.723] [    0.000000] OF: reserved mem: 0x0000000080000000..0x00000000801fffff (2048 KiB) nomap non-reusable atf@80000000
[2026-07-24 14:37:21.734] [    0.000000] OF: reserved mem: 0x0000000084000000..0x00000000849fffff (10240 KiB) nomap non-reusable npu-binary@84000000
[2026-07-24 14:37:21.745] [    0.000000] OF: reserved mem: 0x0000000087000000..0x0000000088ffffff (32768 KiB) nomap non-reusable qdma0-buf@87000000
[2026-07-24 14:37:21.756] [    0.000000] OF: reserved mem: 0x0000000089000000..0x0000000089ffffff (16384 KiB) nomap non-reusable qdma1-buf@89000000
[2026-07-24 14:37:21.766] [    0.000000] Zone ranges:
[2026-07-24 14:37:21.770] [    0.000000]   DMA      [mem 0x0000000080000000-0x000000009fffffff]
[2026-07-24 14:37:21.775] [    0.000000]   DMA32    empty
...
</details>