### PR TITLE
econet: en75_bmt: honor per-partition enable-remap

### DIFF
--- a/target/linux/econet/files/drivers/mtd/nand/en75_bmt.c
+++ b/target/linux/econet/files/drivers/mtd/nand/en75_bmt.c
@@ -1257,7 +1257,7 @@ static int w_init(struct en75_bmt_m *ctx, struct device_node *np)
 			const __be32 *reg;
 			int ret;
 
-			if (!of_property_read_bool(np, name_enable_remap))
+			if (!of_property_read_bool(part_np, name_enable_remap))
 				continue;
 
 			reg = of_get_property(part_np, "reg", NULL);


### PR DESCRIPTION
The per-partition branch of w_init() tested econet,enable-remap on the parent nand node (np) instead of the partition being iterated (part_np). That branch only runs when np does not carry the property, so the test was always false and the loop skipped every partition. As a result econet,enable-remap on a partition node was a silent no-op: no partition ever registered a remap range, and "enable-remap set for ..." was never printed.

Read the property from part_np so per-partition enable-remap works as documented. Boards that place the property on a partition now register that range; boards that place it on the nand node are unaffected.

cc: @cjdelisle 
