### PR TITLE
download: support spoofed User-Agent per download

### DIFF
--- a/include/download.mk
+++ b/include/download.mk
@@ -141,7 +141,7 @@ define DownloadMethod/unknown
 endef
 
 define DownloadMethod/default
-	$(SCRIPT_DIR)/download.pl "$(DL_DIR)" "$(FILE)" "$(HASH)" "$(URL_FILE)" $(foreach url,$(URL),"$(url)") \
+	SPOOF_USER_AGENT="$(SPOOF_USER_AGENT)" $(SCRIPT_DIR)/download.pl "$(DL_DIR)" "$(FILE)" "$(HASH)" "$(URL_FILE)" $(foreach url,$(URL),"$(url)") \
 	$(if $(filter check,$(1)), \
 		$(call check_hash,$(FILE),$(HASH),$(2)$(call hash_var,$(MD5SUM))) \
 		$(call check_md5,$(MD5SUM),$(2)MD5SUM,$(2)HASH) \
@@ -308,6 +308,7 @@ define Download/Defaults
   SOURCE_VERSION:=
   OPTS:=
   SUBMODULES:=
+  SPOOF_USER_AGENT:=
 endef
 
 define Download/default
@@ -323,6 +324,7 @@ define Download/default
   SOURCE_VERSION:=$(PKG_SOURCE_VERSION)
   $(if $(PKG_MD5SUM),MD5SUM:=$(PKG_MD5SUM))
   $(if $(PKG_HASH),HASH:=$(PKG_HASH))
+  $(if $(PKG_SPOOF_USER_AGENT),SPOOF_USER_AGENT:=$(PKG_SPOOF_USER_AGENT))
 endef
 
 define Download

--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -28,6 +28,7 @@ my $ok;
 
 my $check_certificate = $ENV{DOWNLOAD_CHECK_CERTIFICATE} eq "y";
 my $custom_tool = $ENV{DOWNLOAD_TOOL_CUSTOM};
+my $spoofed_user_agent = $ENV{SPOOF_USER_AGENT} // '';
 my $download_tool;
 
 $url_filename or $url_filename = $filename;
@@ -126,11 +127,13 @@ sub download_cmd {
 	if ($download_tool eq "curl") {
 		return (qw(curl -f --connect-timeout 5 --retry 3 --location),
 			$check_certificate ? () : '--insecure',
+			$spoofed_user_agent ne '' ? ('--user-agent', $spoofed_user_agent) : (),
 			shellwords($ENV{CURL_OPTIONS} || ''),
 			$url);
 	} elsif ($download_tool eq "wget") {
 		return (qw(wget --tries=3 --timeout=5 --output-document=-),
 			$check_certificate ? () : '--no-check-certificate',
+			$spoofed_user_agent ne '' ? ("--user-agent=$spoofed_user_agent") : (),
 			shellwords($ENV{WGET_OPTIONS} || ''),
 			$url);
 	} elsif ($download_tool eq "aria2c") {
@@ -144,6 +147,7 @@ sub download_cmd {
 			"touch $ENV{'TMPDIR'}/aria2c/${rfn}_spp;",
 			qw(aria2c --stderr -c -x2 -s10 -j10 -k1M), $url, $additional_mirrors,
 			$check_certificate ? () : '--check-certificate=false',
+			$spoofed_user_agent ne '' ? ("--user-agent='$spoofed_user_agent'") : (),
 			"--server-stat-of=$ENV{'TMPDIR'}/aria2c/${rfn}_spp",
 			"--server-stat-if=$ENV{'TMPDIR'}/aria2c/${rfn}_spp",
 			"--daemon=false --no-conf", shellwords($ENV{ARIA2C_OPTIONS} || ''),


### PR DESCRIPTION
Some servers/WAFs reject requests whose User-Agent doesn't look like a browser (e.g. HTTP 403), even though the same URL is reachable from a normal desktop browser. At the moment, the generic download infrastructure had no way to influence the User-Agent sent by curl, wget or aria2c.

Add a new SPOOF_USER_AGENT field to Download/Defaults (default empty, i.e. unchanged behaviour for every existing package). It takes the literal User-Agent string to send:
```
  define Download/foo
    URL:=https://example.com/dl/
    FILE:=foo.tar.gz
    HASH:=...
    SPOOF_USER_AGENT:=Mozilla/5.0 (X11; Ubuntu; Linux x86_64; ...
  endef
  $(eval $(call Download,foo))
```
This also works for the package's main source (PKG_SOURCE_URL) by setting PKG_SPOOF_USER_AGENT in the Makefile.
