### PR TITLE
[25.12] mediatek: cleanup Huasifei WH3000 / WH3000 Pro dts

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-huasifei-wh3000-pro-nand.dts
+++ b/target/linux/mediatek/dts/mt7981b-huasifei-wh3000-pro-nand.dts
@@ -12,13 +12,20 @@
 &spi0 {
 	status = "okay";
 
-	spi_nand: flash@0 {
+	spi_nand@0 {
 		compatible = "spi-nand";
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
+
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4e 0x41 0x4e 0x44>;
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
 
 		mediatek,nmbm;
 		mediatek,bmt-max-ratio = <1>;

--- a/target/linux/mediatek/dts/mt7981b-huasifei-wh3000-pro.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-huasifei-wh3000-pro.dtsi
@@ -43,7 +43,6 @@
 		mode {
 			label = "mode";
 			linux,code = <BTN_0>;
-			linux,input-type = <EV_SW>;
 			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
 			debounce-interval = <60>;
 		};

--- a/target/linux/mediatek/dts/mt7981b-huasifei-wh3000.dts
+++ b/target/linux/mediatek/dts/mt7981b-huasifei-wh3000.dts
@@ -29,7 +29,6 @@
 		button-mode {
 			label = "mode";
 			linux,code = <BTN_0>;
-			linux,input-type = <EV_SW>;
 			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
 			debounce-interval = <60>;
 		};

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1836,11 +1836,7 @@ define Device/huasifei_wh3000-pro-nand
   DEVICE_VARIANT := NAND
   DEVICE_DTS := mt7981b-huasifei-wh3000-pro-nand
   DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 229376k
-  KERNEL_IN_UBI := 1
+  IMAGE_SIZE := 231936k
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware \
 	kmod-usb3 kmod-hwmon-pwmfan


### PR DESCRIPTION
WH3000 / WH3000 Pro button:
- These routers has no switch button, it's a regular button `linux,input-type = <EV_SW>;` removed

WH3000 Pro NAND:
- Add spi-nand calibration
- Align image size with vendor U-Boot partition layout: `nmbm0:1024k(bl2),512k(u-boot-env),2048k(factory),2048k(fip),231936k(ubi)`
- Remove redundant options from firmware build recipe
- Remove redundant `spi_nand:` label from DTS


Link: https://github.com/openwrt/openwrt/pull/23227

(cherry picked from commit 7ba90841deb3ac913a370aeab2d6aa9869266568)