### PR TITLE
realtek: reclaim completed TX buffers on RX poll

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.18/drivers/net/ethernet/rtl838x_eth.c
@@ -89,7 +89,8 @@ struct rteth_rx_info {
 };
 
 struct rteth_tx_info {
-	int			slot;
+	unsigned int		send_count;  /* skbs handed to the hardware */
+	unsigned int		clean_count; /* skbs released after completion */
 	struct sk_buff		*skb[RTETH_TX_RING_SIZE];
 };
 
@@ -657,6 +658,49 @@ static void rteth_free_tx_buffers(struct rteth_ctrl *ctrl)
 					 tx_info->skb[i]->len, DMA_TO_DEVICE);
 			rteth_free_skb(&tx_info->skb[i]);
 		}
+		tx_info->send_count = 0;
+		tx_info->clean_count = 0;
+	}
+}
+
+static void rteth_reclaim_tx_ring(struct rteth_ctrl *ctrl, int r)
+{
+	struct rteth_tx_info *tx_info = &ctrl->tx_info[r];
+
+	BUILD_BUG_ON(RTETH_TX_RING_SIZE & (RTETH_TX_RING_SIZE - 1));
+
+	while (tx_info->send_count != tx_info->clean_count) {
+		int i = tx_info->clean_count & (RTETH_TX_RING_SIZE - 1);
+
+		if (ctrl->tx_data[r].ring[i] & RING_OWN_HW)
+			break;
+
+		dma_unmap_single(&ctrl->pdev->dev, ctrl->tx_data[r].frag[i].dma,
+				 tx_info->skb[i]->len, DMA_TO_DEVICE);
+		dev_consume_skb_any(tx_info->skb[i]);
+		tx_info->skb[i] = NULL;
+		tx_info->clean_count++;
+	}
+}
+
+static void rteth_reclaim_tx_rings(struct rteth_ctrl *ctrl)
+{
+	for (int r = 0; r < RTETH_TX_RINGS; r++) {
+		struct netdev_queue *txq;
+
+		/* Cached-memory fast path, made stable by the lock below */
+		if (READ_ONCE(ctrl->tx_info[r].send_count) ==
+		    READ_ONCE(ctrl->tx_info[r].clean_count))
+			continue;
+
+		txq = netdev_get_tx_queue(ctrl->dev, r);
+
+		__netif_tx_lock(txq, smp_processor_id());
+
+		if (!netif_xmit_frozen_or_stopped(txq))
+			rteth_reclaim_tx_ring(ctrl, r);
+
+		__netif_tx_unlock(txq);
 	}
 }
 
@@ -735,7 +779,8 @@ static int rteth_setup_ring_buffer(struct rteth_ctrl *ctrl)
 		}
 
 		ctrl->tx_data[r].ring[RTETH_TX_RING_SIZE - 1] |= RING_WRAP;
-		ctrl->tx_info[r].slot = 0;
+		ctrl->tx_info[r].send_count = 0;
+		ctrl->tx_info[r].clean_count = 0;
 	}
 
 	if (highmem)
@@ -1073,7 +1118,7 @@ static int rteth_start_xmit(struct sk_buff *skb, struct net_device *dev)
 		return NETDEV_TX_OK;
 	}
 
-	slot = ctrl->tx_info[ring].slot;
+	slot = ctrl->tx_info[ring].send_count & (RTETH_TX_RING_SIZE - 1);
 	frag = &ctrl->tx_data[ring].frag[slot];
 	packet_dma = ctrl->tx_data[ring].ring[slot];
 	packet_skb = &ctrl->tx_info[ring].skb[slot];
@@ -1086,11 +1131,8 @@ static int rteth_start_xmit(struct sk_buff *skb, struct net_device *dev)
 		return NETDEV_TX_BUSY;
 	}
 
-	if (likely(*packet_skb)) {
-		/* cleanup old data of this slot */
-		dma_unmap_single(&ctrl->pdev->dev, frag->dma, (*packet_skb)->len, DMA_TO_DEVICE);
-		dev_consume_skb_any(*packet_skb);
-	}
+	if (unlikely(*packet_skb))
+		rteth_reclaim_tx_ring(ctrl, ring);
 
 	*packet_skb = skb;
 	frag->len = len;
@@ -1106,7 +1148,7 @@ static int rteth_start_xmit(struct sk_buff *skb, struct net_device *dev)
 	/* Hand frag over to switch */
 	dma_wmb();
 	ctrl->tx_data[ring].ring[slot] = packet_dma | RING_OWN_HW;
-	ctrl->tx_info[ring].slot = (slot + 1) % RTETH_TX_RING_SIZE;
+	ctrl->tx_info[ring].send_count++;
 	wmb();
 
 	spin_lock(&ctrl->tx_lock);
@@ -1296,6 +1338,8 @@ static int rteth_poll_rx(struct napi_struct *napi, int budget)
 	struct rteth_rx_info *rx_q = container_of(napi, struct rteth_rx_info, napi);
 	struct rteth_ctrl *ctrl = rx_q->ctrl;
 	int work_done, ring = rx_q->id;
+
+	rteth_reclaim_tx_rings(ctrl);
 
 	work_done = rteth_hw_receive(ctrl->dev, ring, budget);
 	if (work_done < budget && napi_complete_done(napi, work_done))


### PR DESCRIPTION
### realtek: reclaim completed TX buffers on RX poll

Split out of #24400 per review. The conduit transmit path frees a TX skb only when its descriptor slot is reused, `RTETH_TX_RING_SIZE` transmissions later; until then the skb stays charged to the sending socket. Negligible with standard frames, but with jumbo MTUs a handful of completed transmissions exhausts the sender's budget: eight ~9k echo replies exceed the kernel ICMP socket limit (`2 * SKB_TRUESIZE(64 * 1024)`), after which every further reply of any size is dropped (`Icmp: OutErrors` grows, `OutMsgs` stalls) until unrelated transmissions recycle the slots. On the bench (RTL9303, Hasivo S1100W-8XGT-SE) this is a reproducible ICMP blackout after exactly 8 jumbo echo replies, healed deterministically by any 16 device-originated frames.

Design, addressing the review concerns on the first attempt:

- the driver-private ring info tracks the oldest pending slot and a pending count, so finding work costs one cached read per TX ring — while nothing is pending the poll takes no lock and never touches the uncached descriptor memory;
- the walk starts at the oldest pending slot and stops at the first descriptor the hardware still owns: uncached reads = completed slots + 1, not the whole ring;
- the TX queue lock is held only for that bounded walk;
- the transmit path reuses the same walk for the ring-wrap case instead of its old duplicated per-slot cleanup;
- stopped or watchdog-frozen queues are skipped, leaving `rteth_tx_timeout()` recovery untouched.

**Performance (RTL9303, iperf3 8 s × 3 runs, MTU 1500, median):**

| | master | with reclaim |
|---|---|---|
| TCP host→device | 170 Mbit/s | 173 Mbit/s (+1.8%) |
| TCP device→host | 115 Mbit/s | **128 Mbit/s (+11.3%)** |
| UDP 1400 device→host | 61.8 Mbit/s | 64.4 Mbit/s (+4.2%) |
| UDP 64 device→host | 3.01 Mbit/s | 3.18 Mbit/s (+5.6%) |
| ping RTT avg | 0.409 ms | 0.401 ms |

Device-sourced TCP improves because the socket's `sk_wmem` now drains as soon as a poll runs instead of up to 16 transmissions later, so the sender is throttled less. No path gets slower.

Functional check with the jumbo series from #24400 on top: the ICMP blackout is gone (40/40 sequential and 150/150 sustained ~9k echoes, was 8/40 and 2/150), byte-exact MTU enforcement unaffected, and jumbo iperf3 reaches 467/222 Mbit/s (host→device/device→host) at MTU 9000 versus 173/128 at 1500.

CC @plappermaul

*Bench testing and analysis assisted by Claude Fable 5 (Anthropic AI).*
