### PR TITLE
uboot-airoha: fix ethernet on an7581 boards

### DIFF
--- a/package/boot/uboot-airoha/patches/401-add-nokia-xg-040g-md.patch
+++ b/package/boot/uboot-airoha/patches/401-add-nokia-xg-040g-md.patch
@@ -293,3 +293,13 @@
 +&eth {
 +	status = "okay";
 +};
+--- /dev/null
++++ b/arch/arm/dts/an7581-nokia-xg-040g-md-u-boot.dtsi
+@@ -0,0 +1,7 @@
++// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
++
++#include "an7581-u-boot.dtsi"
++
++&gdm1 {
++	status = "okay";
++};

--- a/package/boot/uboot-airoha/patches/999-airoha-add-gemtek-w1700k.patch
+++ b/package/boot/uboot-airoha/patches/999-airoha-add-gemtek-w1700k.patch
@@ -316,3 +316,13 @@ Signed-off-by: Kenneth Kasilag <kenneth@kasilag.me>
 +&gdm1 {
 +	status = "okay";
 +};
+--- /dev/null
++++ b/arch/arm/dts/an7581-w1700k-ubi-u-boot.dtsi
+@@ -0,0 +1,7 @@
++// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
++
++#include "an7581-u-boot.dtsi"
++
++&gdm1 {
++	status = "okay";
++};


### PR DESCRIPTION
U-Boot v2026.07 added arch/arm/dts/an7581-u-boot.dtsi with gdm1 set to
status = "disabled". It is appended to the end of the board DTS, so it
overrides whatever the board enabled and U-Boot comes up without a
network device.

Both boards are fixed the same way, with a board specific -u-boot.dtsi
that includes the SoC one explicitly (U-Boot only uses the first
matching *-u-boot.dtsi).

* Nokia XG-040G-MD - tested on hardware, TFTP recovery boot works again.
  Fixes #24385.
* Gemtek W1700K - compile tested and verified against the generated DTB
  only, I have no such device. Testing appreciated.