### PR TITLE
editor: vscode: do not trim diff file trailing whitespace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,9 @@
     "files.trimTrailingWhitespace": true,
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
-    "files.eol": "\n"
+    "files.eol": "\n",
+
+    "[diff]": {
+        "files.trimTrailingWhitespace": false
+    }
 }


### PR DESCRIPTION
This rule will break the patch structure.

Fixes: af75e1c527d0 ("vscode: update editor formatting and line endings settings")

Example: https://github.com/openwrt/openwrt/commit/1989bf605148a78da140021bd026821883c2a569