### PR TITLE
mpc85xx: add missing image relocate hack for 6.18 kernel

### DIFF
--- a/target/linux/mpc85xx/patches-6.12/107-powerpc-85xx-add-ws-ap3825i-support.patch
+++ b/target/linux/mpc85xx/patches-6.12/107-powerpc-85xx-add-ws-ap3825i-support.patch
@@ -55,8 +55,8 @@ WS-AP3825i AP.
  
 --- a/arch/powerpc/boot/wrapper
 +++ b/arch/powerpc/boot/wrapper
-@@ -348,6 +348,11 @@ adder875-redboot)
-     platformo="$object/fixed-head.o $object/redboot-8xx.o"
+@@ -353,6 +353,11 @@ simpleboot-ws-ap3710i)
+     link_address='0x3000000'
      binary=y
      ;;
 +simpleboot-ws-ap3825i)

--- a/target/linux/mpc85xx/patches-6.18/106-powerpc-85xx-ws-ap3710i-support.patch
+++ b/target/linux/mpc85xx/patches-6.18/106-powerpc-85xx-ws-ap3710i-support.patch
@@ -46,3 +46,17 @@
  # Board ports in arch/powerpc/platform/86xx/Kconfig
  image-$(CONFIG_MVME7100)                += dtbImage.mvme7100
  
+--- a/arch/powerpc/boot/wrapper
++++ b/arch/powerpc/boot/wrapper
+@@ -339,6 +339,11 @@ adder875-redboot)
+     platformo="$object/fixed-head.o $object/redboot-8xx.o"
+     binary=y
+     ;;
++simpleboot-ws-ap3710i)
++    platformo="$object/fixed-head.o $object/simpleboot.o"
++    link_address='0x3000000'
++    binary=y
++    ;;
+ simpleboot-*)
+     platformo="$object/fixed-head.o $object/simpleboot.o"
+     binary=y

--- a/target/linux/mpc85xx/patches-6.18/107-powerpc-85xx-add-ws-ap3825i-support.patch
+++ b/target/linux/mpc85xx/patches-6.18/107-powerpc-85xx-add-ws-ap3825i-support.patch
@@ -55,8 +55,8 @@ WS-AP3825i AP.
  
 --- a/arch/powerpc/boot/wrapper
 +++ b/arch/powerpc/boot/wrapper
-@@ -339,6 +339,11 @@ adder875-redboot)
-     platformo="$object/fixed-head.o $object/redboot-8xx.o"
+@@ -344,6 +344,11 @@ simpleboot-ws-ap3710i)
+     link_address='0x3000000'
      binary=y
      ;;
 +simpleboot-ws-ap3825i)


### PR DESCRIPTION
We also need to refresh the 6.12 kernel patches.

Fixes: 87940bfc69f4 ("mpc85xx: relocate simpleImage for WS-AP3710i")

Cc @blocktrron