### PR TITLE
qualcommax: ath11k: restore missing dma_rmb() in RX completion

### DIFF
--- a/target/linux/qualcommax/patches-6.12/0821-wifi-ath11k-add-missing-dma_rmb-in-rx-completion.patch
+++ b/target/linux/qualcommax/patches-6.12/0821-wifi-ath11k-add-missing-dma_rmb-in-rx-completion.patch
@@ -1,0 +1,38 @@
+From: Michael Phan <sonunix@gmail.com>
+Date: Fri, 25 Jul 2026 15:45:00 +0700
+Subject: [PATCH] wifi: ath11k: add missing dma_rmb() in RX completion
+
+Upstream commit ab52e3e44fe9 ("wifi: ath11k: fix rx completion meta data
+corruption") added a dma_rmb() memory barrier plus READ_ONCE() accessors
+so the REO destination ring descriptor is read after the head pointer,
+avoiding stale descriptor data on weakly ordered architectures such as
+aarch64.
+
+The stable 6.12.y backport of that commit applied the READ_ONCE() changes
+but dropped the dma_rmb() barrier. Without the barrier, IPQ807x/IPQ60xx
+(aarch64) targets can read a REO descriptor before the head pointer is
+observed, using stale data. This reproduces on Linksys MX4200 (IPQ8074)
+as a slow RX skb/DMA leak that only recovers by reloading the ath11k
+driver, accompanied by the classic error:
+
+	ath11k: msdu_done bit in attention is not set
+
+Restore the missing barrier to complete the backport. The READ_ONCE()
+hunks are already present in the kernel shipped by OpenWrt, so only the
+barrier is added here.
+
+Signed-off-by: Michael Phan <sonunix@gmail.com>
+---
+ drivers/net/wireless/ath/ath11k/dp_rx.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/drivers/net/wireless/ath/ath11k/dp_rx.c
++++ b/drivers/net/wireless/ath/ath11k/dp_rx.c
+@@ -2648,4 +2648,7 @@ int ath11k_dp_process_rx(struct ath11k_base *ab, int ring_id,
+ try_again:
+ 	ath11k_hal_srng_access_begin(ab, srng);
+ 
++	/* Make sure descriptor is read after the head pointer. */
++	dma_rmb();
++
+ 	while (likely(desc =


### PR DESCRIPTION
## Summary

Restores the `dma_rmb()` memory barrier dropped by the stable 6.12.y backport of upstream commit `ab52e3e44fe9b6` ("wifi: ath11k: fix rx completion meta data corruption").

That upstream commit added **both** a `dma_rmb()` after `ath11k_hal_srng_access_begin()` in `ath11k_dp_process_rx()` **and** `READ_ONCE()` accessors on the REO descriptor. The 6.12.y backport kept the `READ_ONCE()` hunks but omitted the barrier. On weakly ordered aarch64 targets (IPQ807x/IPQ60xx) the descriptor can be read before the head pointer is observed → stale data → the corruption the original commit prevents.

Fixes #24416.

## Root cause (verified)

Current `linux-6.12.y` `ath11k_dp_process_rx()`:

```c
try_again:
	ath11k_hal_srng_access_begin(ab, srng);
                                    <-- dma_rmb() missing
	while (likely(desc = ... ath11k_hal_srng_dst_get_next_entry(ab, srng))) {
		cookie = FIELD_GET(BUFFER_ADDR_INFO1_SW_COOKIE,
				   READ_ONCE(desc->buf_addr_info.info1));   // READ_ONCE present
```

Only the barrier is added; the `READ_ONCE()` changes are already present in the shipped kernel, so a full cherry-pick of the upstream commit does not apply.

## Symptom fixed

Slow RX SKB/DMA leak on IPQ8074 (Linksys MX4200), recoverable only by reloading ath11k, with `ath11k: msdu_done bit in attention is not set` in `logread`.

## Testing

- Built qualcommax/ipq807x sysupgrade image for Linksys MX4200 v1 with this patch (kernel 6.12).
- Deployed to a fleet of 9 MX4200 APs. Before: free RAM drifted down to the point of needing periodic driver reloads. After: RAM stays flat over multi-hour soak; no driver reloads needed and no `msdu_done` errors.
- `git apply --check` of this patch against `linux-6.12.y` `dp_rx.c` applies cleanly.

## Note

The underlying regression is in linux-6.12.y stable (partial backport). A report to stable@vger will be sent separately so non-OpenWrt users are covered; this patch fixes it for OpenWrt now.
