### PR TITLE
Add support for ZyXEL GS1900-8HP B2

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/realtek
+++ b/package/boot/uboot-tools/uboot-envtools/files/realtek
@@ -20,6 +20,7 @@ d-link,dgs-1210-28|\
 zyxel,gs1900-8-a1|\
 zyxel,gs1900-8hp-a1|\
 zyxel,gs1900-8hp-b1|\
+zyxel,gs1900-8hp-b2|\
 zyxel,gs1900-10hp-a1|\
 zyxel,gs1900-10hp-b1|\
 zyxel,gs1900-16-a1|\

--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -156,6 +156,7 @@ realtek_setup_macs()
 	zyxel,gs1900-8-b1|\
 	zyxel,gs1900-8hp-a1|\
 	zyxel,gs1900-8hp-b1|\
+	zyxel,gs1900-8hp-b2|\
 	zyxel,gs1920-24hp-v1|\
 	zyxel,xgs1250-12-a1|\
 	zyxel,xgs1250-12-b1)

--- a/target/linux/realtek/base-files/etc/board.d/05_compat-version
+++ b/target/linux/realtek/base-files/etc/board.d/05_compat-version
@@ -17,6 +17,7 @@ case "$(board_name)" in
 	zyxel,gs1900-8-b1 | \
 	zyxel,gs1900-8hp-a1 | \
 	zyxel,gs1900-8hp-b1 | \
+	zyxel,gs1900-8hp-b2 | \
 	zyxel,gs1900-10hp-a1 | \
 	zyxel,gs1900-10hp-b1 | \
 	zyxel,gs1900-16-a1 | \

--- a/target/linux/realtek/dts/rtl8380_zyxel_gs1900-8hp-a1.dts
+++ b/target/linux/realtek/dts/rtl8380_zyxel_gs1900-8hp-a1.dts
@@ -1,41 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "rtl8380_zyxel_gs1900.dtsi"
-#include "rtl8380_zyxel_gs1900_gpio.dtsi"
+#include "rtl8380_zyxel_gs1900-8hp.dtsi"
 
 / {
 	compatible = "zyxel,gs1900-8hp-a1", "realtek,rtl838x-soc";
 	model = "Zyxel GS1900-8HP A1 Switch";
 };
 
-&uart1 {
-	status = "okay";
-
-	pse: ethernet-pse {
-		compatible = "zyxel,gs1900-8hp-a1-pse", "realtek,pse-mcu-gen1";
-		current-speed = <19200>;
-
-		pse-pis {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			PSE_PI(0)
-			PSE_PI(1)
-			PSE_PI(2)
-			PSE_PI(3)
-			PSE_PI(4)
-			PSE_PI(5)
-			PSE_PI(6)
-			PSE_PI(7)
-		};
-	};
+&pse {
+	compatible = "zyxel,gs1900-8hp-a1-pse", "realtek,pse-mcu-gen1";
+	current-speed = <19200>;
 };
-
-&phy8 { pses = <&pse_pi0>; };
-&phy9 { pses = <&pse_pi1>; };
-&phy10 { pses = <&pse_pi2>; };
-&phy11 { pses = <&pse_pi3>; };
-&phy12 { pses = <&pse_pi4>; };
-&phy13 { pses = <&pse_pi5>; };
-&phy14 { pses = <&pse_pi6>; };
-&phy15 { pses = <&pse_pi7>; };

--- a/target/linux/realtek/dts/rtl8380_zyxel_gs1900-8hp-b1.dts
+++ b/target/linux/realtek/dts/rtl8380_zyxel_gs1900-8hp-b1.dts
@@ -1,41 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "rtl8380_zyxel_gs1900.dtsi"
-#include "rtl8380_zyxel_gs1900_gpio.dtsi"
+#include "rtl8380_zyxel_gs1900-8hp.dtsi"
 
 / {
 	compatible = "zyxel,gs1900-8hp-b1", "realtek,rtl838x-soc";
 	model = "Zyxel GS1900-8HP B1 Switch";
 };
 
-&uart1 {
-	status = "okay";
-
-	pse: ethernet-pse {
-		compatible = "zyxel,gs1900-8hp-b1-pse", "realtek,pse-mcu-gen1";
-		current-speed = <19200>;
-
-		pse-pis {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			PSE_PI(0)
-			PSE_PI(1)
-			PSE_PI(2)
-			PSE_PI(3)
-			PSE_PI(4)
-			PSE_PI(5)
-			PSE_PI(6)
-			PSE_PI(7)
-		};
-	};
+&pse {
+	compatible = "zyxel,gs1900-8hp-b1-pse", "realtek,pse-mcu-gen1";
+	current-speed = <19200>;
 };
-
-&phy8 { pses = <&pse_pi0>; };
-&phy9 { pses = <&pse_pi1>; };
-&phy10 { pses = <&pse_pi2>; };
-&phy11 { pses = <&pse_pi3>; };
-&phy12 { pses = <&pse_pi4>; };
-&phy13 { pses = <&pse_pi5>; };
-&phy14 { pses = <&pse_pi6>; };
-&phy15 { pses = <&pse_pi7>; };

--- a/target/linux/realtek/dts/rtl8380_zyxel_gs1900-8hp-b2.dts
+++ b/target/linux/realtek/dts/rtl8380_zyxel_gs1900-8hp-b2.dts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl8380_zyxel_gs1900-8hp.dtsi"
+
+/ {
+	compatible = "zyxel,gs1900-8hp-b2", "realtek,rtl838x-soc";
+	model = "Zyxel GS1900-8HP B2 Switch";
+};
+
+&pse {
+	compatible = "zyxel,gs1900-8hp-b2-pse", "realtek,pse-mcu-gen2";
+	current-speed = <115200>;
+};

--- a/target/linux/realtek/dts/rtl8380_zyxel_gs1900-8hp.dtsi
+++ b/target/linux/realtek/dts/rtl8380_zyxel_gs1900-8hp.dtsi
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl8380_zyxel_gs1900.dtsi"
+#include "rtl8380_zyxel_gs1900_gpio.dtsi"
+
+&uart1 {
+	status = "okay";
+
+	/* PoE MCU; compatible and current-speed are set per variant */
+	pse: ethernet-pse {
+		pse-pis {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			PSE_PI(0)
+			PSE_PI(1)
+			PSE_PI(2)
+			PSE_PI(3)
+			PSE_PI(4)
+			PSE_PI(5)
+			PSE_PI(6)
+			PSE_PI(7)
+		};
+	};
+};
+
+&phy8 { pses = <&pse_pi0>; };
+&phy9 { pses = <&pse_pi1>; };
+&phy10 { pses = <&pse_pi2>; };
+&phy11 { pses = <&pse_pi3>; };
+&phy12 { pses = <&pse_pi4>; };
+&phy13 { pses = <&pse_pi5>; };
+&phy14 { pses = <&pse_pi6>; };
+&phy15 { pses = <&pse_pi7>; };

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -459,6 +459,16 @@ define Device/zyxel_gs1900-8hp-b1
 endef
 TARGET_DEVICES += zyxel_gs1900-8hp-b1
 
+define Device/zyxel_gs1900-8hp-b2
+  $(Device/zyxel_gs1900)
+  SOC := rtl8380
+  DEVICE_MODEL := GS1900-8HP
+  DEVICE_VARIANT := B2
+  ZYXEL_VERS := AAHI
+  DEVICE_PACKAGES += kmod-pse-realtek-mcu-uart
+endef
+TARGET_DEVICES += zyxel_gs1900-8hp-b2
+
 define Device/zyxel_gs1900-24-a1
   $(Device/zyxel_gs1900)
   SOC := rtl8382


### PR DESCRIPTION
This PR moves the common definitions of the ZyXEL GS1900-8HP variants to a separate include file and adds support for the B2 hardware variant.