### PR TITLE
realtek: eth: bound the CPU port packet length and follow the MTU

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.18/drivers/net/ethernet/rtl838x_eth.c
@@ -38,11 +38,14 @@
 
 #define NOTIFY_EVENTS			10
 #define NOTIFY_BLOCKS			10
+
 #define RX_TRUNCATE_EN_93XX		BIT(6)
 #define RX_TRUNCATE_EN_83XX		BIT(4)
 #define TX_PAD_EN_838X			BIT(5)
 
 #define SKB_MTU				1600
+/* Ethernet header, two stacked VLAN tags (802.1ad QinQ) and FCS */
+#define RTETH_FRAME_OVERHEAD		(ETH_HLEN + 2 * VLAN_HLEN + ETH_FCS_LEN)
 /* TODO: change this to 1568 after fragment handling has been tested in the wild */
 #define SKB_FRAG_SIZE			400
 #define SKB_PAD				MAX(32, L1_CACHE_BYTES)
@@ -559,11 +562,63 @@ static void rteth_hw_ring_setup(struct rteth_ctrl *ctrl)
 			     offsetof(struct rteth_tx_data, ring));
 }
 
+/*
+ * Three limits bound the frames exchanged with the CPU port, and each family spreads them
+ * over registers of its own, whose length fields are named after the block holding them:
+ * what the driver receives is transmitted by the switch, but received by the NIC.
+ *
+ * - the DMA truncation length cuts a frame short. It still reaches the CPU, carrying only
+ *   as many bytes as the field allows, so switch it off and leave the length to the others.
+ * - the largest frame the switch hands to the CPU, which drops the longer ones. Both
+ *   measured on an RTL9303 by lowering one at a time while frames of growing size were
+ *   sent into a user port.
+ * - the largest frame the switch takes from the CPU. Longan keeps it in the port register
+ *   of the CPU port, Maple in a register of its own, the others in a second field of the
+ *   register above.
+ */
+static void rteth_838x_set_max_packet_length(struct rteth_ctrl *ctrl, int len)
+{
+	regmap_update_bits(ctrl->map, RTETH_838X_DMA_IF_PKT_RX_FLTR_CTRL, GENMASK(13, 0), len);
+	regmap_update_bits(ctrl->map, RTETH_838X_DMA_IF_PKT_TX_FLTR_CTRL, GENMASK(13, 0), len);
+	regmap_clear_bits(ctrl->map, ctrl->r->dma_if_ctrl, RX_TRUNCATE_EN_83XX);
+}
+
+static void rteth_839x_set_max_packet_length(struct rteth_ctrl *ctrl, int len)
+{
+	regmap_update_bits(ctrl->map, RTETH_839X_DMA_IF_PKT_FLTR_CTRL,
+			   GENMASK(27, 14) | GENMASK(13, 0),
+			   FIELD_PREP(GENMASK(27, 14), len) | FIELD_PREP(GENMASK(13, 0), len));
+	regmap_clear_bits(ctrl->map, ctrl->r->dma_if_ctrl, RX_TRUNCATE_EN_83XX);
+}
+
+static void rteth_930x_set_max_packet_length(struct rteth_ctrl *ctrl, int len)
+{
+	regmap_update_bits(ctrl->map, RTETH_930X_MAC_L2_CPU_MAX_LEN_CTRL, GENMASK(13, 0), len);
+	regmap_update_bits(ctrl->map, RTETH_930X_MAC_L2_PORT_MAX_LEN_CTRL,
+			   GENMASK(27, 14) | GENMASK(13, 0),
+			   FIELD_PREP(GENMASK(27, 14), len) | FIELD_PREP(GENMASK(13, 0), len));
+	regmap_clear_bits(ctrl->map, ctrl->r->dma_if_ctrl, RX_TRUNCATE_EN_93XX);
+}
+
+static void rteth_931x_set_max_packet_length(struct rteth_ctrl *ctrl, int len)
+{
+	regmap_update_bits(ctrl->map, RTETH_931X_MAC_L2_CPU_MAX_LEN_CTRL,
+			   GENMASK(27, 14) | GENMASK(13, 0),
+			   FIELD_PREP(GENMASK(27, 14), len) | FIELD_PREP(GENMASK(13, 0), len));
+	regmap_clear_bits(ctrl->map, ctrl->r->dma_if_ctrl, RX_TRUNCATE_EN_93XX);
+}
+
+static void rteth_set_max_packet_length(struct rteth_ctrl *ctrl)
+{
+	ctrl->r->set_max_packet_length(ctrl, ctrl->dev->mtu + RTETH_FRAME_OVERHEAD);
+}
+
 static void rteth_838x_hw_en_rxtx(struct rteth_ctrl *ctrl)
 {
-	/* Truncate RX buffer to SKB_MTU bytes, pad TX */
-	regmap_write(ctrl->map, ctrl->r->dma_if_ctrl,
-		     (SKB_MTU << 16) | RX_TRUNCATE_EN_83XX | TX_PAD_EN_838X);
+	/* Pad TX */
+	regmap_write(ctrl->map, ctrl->r->dma_if_ctrl, TX_PAD_EN_838X);
+
+	rteth_set_max_packet_length(ctrl);
 
 	rteth_enable_all_rx_irqs(ctrl);
 
@@ -586,8 +641,7 @@ static void rteth_838x_hw_en_rxtx(struct rteth_ctrl *ctrl)
 
 static void rteth_839x_hw_en_rxtx(struct rteth_ctrl *ctrl)
 {
-	/* Setup CPU-Port: RX Buffer */
-	regmap_write(ctrl->map, ctrl->r->dma_if_ctrl, (SKB_MTU << 5) | RX_TRUNCATE_EN_83XX);
+	rteth_set_max_packet_length(ctrl);
 
 	rteth_enable_all_rx_irqs(ctrl);
 
@@ -610,8 +664,7 @@ static void rteth_839x_hw_en_rxtx(struct rteth_ctrl *ctrl)
 
 static void rteth_930x_hw_en_rxtx(struct rteth_ctrl *ctrl)
 {
-	/* Setup CPU-Port: RX Buffer truncated at SKB_MTU Bytes */
-	regmap_write(ctrl->map, ctrl->r->dma_if_ctrl, (SKB_MTU << 16) | RX_TRUNCATE_EN_93XX);
+	rteth_set_max_packet_length(ctrl);
 
 	rteth_enable_all_rx_irqs(ctrl);
 
@@ -627,8 +680,7 @@ static void rteth_930x_hw_en_rxtx(struct rteth_ctrl *ctrl)
 
 static void rteth_931x_hw_en_rxtx(struct rteth_ctrl *ctrl)
 {
-	/* Setup CPU-Port: RX Buffer truncated at SKB_MTU Bytes */
-	regmap_write(ctrl->map, ctrl->r->dma_if_ctrl, (SKB_MTU << 16) | RX_TRUNCATE_EN_93XX);
+	rteth_set_max_packet_length(ctrl);
 
 	rteth_enable_all_rx_irqs(ctrl);
 
@@ -1600,6 +1652,7 @@ static const struct rteth_config rteth_838x_cfg = {
 	.hw_stop = &rteth_838x_hw_stop,
 	.hw_reset = &rteth_838x_hw_reset,
 	.init_mac = &rteth_838x_init_mac,
+	.set_max_packet_length = rteth_838x_set_max_packet_length,
 	.netdev_ops = &rteth_838x_netdev_ops,
 };
 
@@ -1645,6 +1698,7 @@ static const struct rteth_config rteth_839x_cfg = {
 	.hw_stop = &rteth_839x_hw_stop,
 	.hw_reset = &rteth_839x_hw_reset,
 	.init_mac = &rteth_839x_init_mac,
+	.set_max_packet_length = rteth_839x_set_max_packet_length,
 	.setup_notify_ring_buffer = &rteth_839x_setup_notify_ring_buffer,
 	.netdev_ops = &rteth_839x_netdev_ops,
 };
@@ -1692,6 +1746,7 @@ static const struct rteth_config rteth_930x_cfg = {
 	.hw_stop = &rteth_930x_hw_stop,
 	.hw_reset = &rteth_93xx_hw_reset,
 	.init_mac = &rteth_930x_init_mac,
+	.set_max_packet_length = rteth_930x_set_max_packet_length,
 	.netdev_ops = &rteth_930x_netdev_ops,
 };
 
@@ -1738,6 +1793,7 @@ static const struct rteth_config rteth_931x_cfg = {
 	.hw_stop = &rteth_931x_hw_stop,
 	.hw_reset = &rteth_93xx_hw_reset,
 	.init_mac = &rteth_931x_init_mac,
+	.set_max_packet_length = rteth_931x_set_max_packet_length,
 	.netdev_ops = &rteth_931x_netdev_ops,
 };
 

--- a/target/linux/realtek/files-6.18/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.18/drivers/net/ethernet/rtl838x_eth.c
@@ -43,9 +43,13 @@
 #define RX_TRUNCATE_EN_83XX		BIT(4)
 #define TX_PAD_EN_838X			BIT(5)
 
-#define SKB_MTU				1600
 /* Ethernet header, two stacked VLAN tags (802.1ad QinQ) and FCS */
 #define RTETH_FRAME_OVERHEAD		(ETH_HLEN + 2 * VLAN_HLEN + ETH_FCS_LEN)
+/* Largest frame each family switches, as its datasheet and DSA rmon range have it */
+#define RTETH_838X_MAX_FRAME		10000
+#define RTETH_839X_MAX_FRAME		12288
+#define RTETH_930X_MAX_FRAME		12288
+#define RTETH_931X_MAX_FRAME		12288
 /* TODO: change this to 1568 after fragment handling has been tested in the wild */
 #define SKB_FRAG_SIZE			400
 #define SKB_PAD				MAX(32, L1_CACHE_BYTES)
@@ -441,12 +445,15 @@ static void rteth_nic_reset(struct rteth_ctrl *ctrl, int reset_mask)
 	msleep(100);
 }
 
+static void rteth_83xx_set_hol(struct rteth_ctrl *ctrl)
+{
+	/* Free floating rings without space tracking */
+	regmap_write(ctrl->map, ctrl->r->dma_if_rx_ring_size, 0);
+}
+
 static void rteth_838x_hw_reset(struct rteth_ctrl *ctrl)
 {
 	rteth_nic_reset(ctrl, 0xc);
-
-	/* Free floating rings without space tracking */
-	regmap_write(ctrl->map, ctrl->r->dma_if_rx_ring_size, 0);
 }
 
 static void rteth_839x_hw_reset(struct rteth_ctrl *ctrl)
@@ -472,32 +479,36 @@ static void rteth_839x_hw_reset(struct rteth_ctrl *ctrl)
 	/* Restore notification settings: on RTL838x these bits are null */
 	regmap_update_bits(ctrl->map, ctrl->r->dma_if_intr_msk, 7 << 20, int_saved & (7 << 20));
 	regmap_write(ctrl->map, RTL839X_DMA_IF_NBUF_BASE_DESC_ADDR_CTRL, nbuf);
-
-	/* Free floating rings without space tracking */
-	regmap_write(ctrl->map, ctrl->r->dma_if_rx_ring_size, 0);
 }
 
-static void rteth_93xx_hw_reset(struct rteth_ctrl *ctrl)
+static void rteth_93xx_set_hol(struct rteth_ctrl *ctrl)
 {
 	/*
 	 * The counter registers track the number of packets that are allowed to be appended to
 	 * the ring buffer. On RTL93xx a ring overflow must be avoided at all cost. Defensively
 	 * calculate the space by anticipating that only fully filled packets are received.
 	 */
-	int max_frame_size = SKB_MTU + ETH_HLEN + ETH_FCS_LEN + VLAN_HLEN + 4;
+	int max_frame_size = ctrl->dev->mtu + RTETH_FRAME_OVERHEAD;
 	int frags_per_pkt = DIV_ROUND_UP(max_frame_size, SKB_FRAG_SIZE);
 	int cnt = min(RTETH_RX_RING_SIZE / frags_per_pkt, 0x3ff);
 
-	rteth_nic_reset(ctrl, 0x6);
-
-	/* Setup Head of Line */
 	for (int ring = 0; ring < RTETH_RX_RINGS; ring++) {
 		int shift = (ring % 3) * 10;
 		int reg = (ring / 3) * 4;
-		u32 v;
 
 		regmap_update_bits(ctrl->map, ctrl->r->dma_if_rx_ring_size + reg,
 				   0x3ff << shift, cnt << shift);
+	}
+}
+
+static void rteth_93xx_hw_reset(struct rteth_ctrl *ctrl)
+{
+	rteth_nic_reset(ctrl, 0x6);
+
+	for (int ring = 0; ring < RTETH_RX_RINGS; ring++) {
+		int reg = (ring / 3) * 4;
+		u32 v;
+
 		/* clear counters by simply writing the current register values back */
 		regmap_read(ctrl->map, ctrl->r->dma_if_rx_ring_cntr + reg, &v);
 		regmap_write(ctrl->map, ctrl->r->dma_if_rx_ring_cntr + reg, v);
@@ -912,6 +923,7 @@ static int rteth_open(struct net_device *dev)
 
 	scoped_guard(spinlock_irqsave, &ctrl->lock) {
 		ctrl->r->hw_reset(ctrl);
+		ctrl->r->set_hol(ctrl);
 		rteth_setup_cpu_rx_rings(ctrl);
 		ret = rteth_setup_ring_buffer(ctrl);
 		if (ret)
@@ -1022,6 +1034,41 @@ static int rteth_stop(struct net_device *dev)
 	rteth_free_tx_buffers(ctrl);
 	rteth_free_rx_buffers(ctrl);
 	netif_tx_stop_all_queues(dev);
+
+	return 0;
+}
+
+static int rteth_change_mtu(struct net_device *dev, int mtu)
+{
+	struct rteth_ctrl *ctrl = netdev_priv(dev);
+	bool grow = mtu > dev->mtu;
+
+	/* A frame of that size must still fit into the linear part and fragments of a single skb */
+	if (mtu + RTETH_FRAME_OVERHEAD > (MAX_SKB_FRAGS + 1) * SKB_FRAG_SIZE)
+		return -EINVAL;
+
+	WRITE_ONCE(dev->mtu, mtu);
+
+	/* Opening the interface programs both limits from the MTU, so leave the hardware alone */
+	if (!netif_running(dev))
+		return 0;
+
+	netdev_warn(dev, "changing the MTU may have unexpected effects under high receive load\n");
+
+	/*
+	 * A larger MTU buys a smaller budget, so hand the rings their new limit before the
+	 * switch may deliver larger frames, and the other way around when the MTU shrinks.
+	 * Hold the lock, so rteth_tx_timeout() cannot reprogram the same registers in between.
+	 */
+	scoped_guard(spinlock_irqsave, &ctrl->lock) {
+		if (grow)
+			ctrl->r->set_hol(ctrl);
+
+		rteth_set_max_packet_length(ctrl);
+
+		if (!grow)
+			ctrl->r->set_hol(ctrl);
+	}
 
 	return 0;
 }
@@ -1611,6 +1658,7 @@ static int rteth_setup_tc(struct net_device *dev, enum tc_setup_type type, void 
 static const struct net_device_ops rteth_838x_netdev_ops = {
 	.ndo_open = rteth_open,
 	.ndo_stop = rteth_stop,
+	.ndo_change_mtu = rteth_change_mtu,
 	.ndo_start_xmit = rteth_start_xmit,
 	.ndo_set_mac_address = rteth_set_mac_address,
 	.ndo_validate_addr = eth_validate_addr,
@@ -1623,6 +1671,7 @@ static const struct net_device_ops rteth_838x_netdev_ops = {
 
 static const struct rteth_config rteth_838x_cfg = {
 	.cpu_port = RTETH_838X_CPU_PORT,
+	.max_mtu = RTETH_838X_MAX_FRAME - RTETH_FRAME_OVERHEAD,
 	.rx_rings = 8,
 	.tx_rx_enable = 0xc,
 	.tx_trigger_mask = BIT(1),
@@ -1652,6 +1701,7 @@ static const struct rteth_config rteth_838x_cfg = {
 	.hw_stop = &rteth_838x_hw_stop,
 	.hw_reset = &rteth_838x_hw_reset,
 	.init_mac = &rteth_838x_init_mac,
+	.set_hol = rteth_83xx_set_hol,
 	.set_max_packet_length = rteth_838x_set_max_packet_length,
 	.netdev_ops = &rteth_838x_netdev_ops,
 };
@@ -1659,6 +1709,7 @@ static const struct rteth_config rteth_838x_cfg = {
 static const struct net_device_ops rteth_839x_netdev_ops = {
 	.ndo_open = rteth_open,
 	.ndo_stop = rteth_stop,
+	.ndo_change_mtu = rteth_change_mtu,
 	.ndo_start_xmit = rteth_start_xmit,
 	.ndo_set_mac_address = rteth_set_mac_address,
 	.ndo_validate_addr = eth_validate_addr,
@@ -1671,6 +1722,7 @@ static const struct net_device_ops rteth_839x_netdev_ops = {
 
 static const struct rteth_config rteth_839x_cfg = {
 	.cpu_port = RTETH_839X_CPU_PORT,
+	.max_mtu = RTETH_839X_MAX_FRAME - RTETH_FRAME_OVERHEAD,
 	.rx_rings = 8,
 	.tx_rx_enable = 0xc,
 	.tx_trigger_mask = BIT(1),
@@ -1698,6 +1750,7 @@ static const struct rteth_config rteth_839x_cfg = {
 	.hw_stop = &rteth_839x_hw_stop,
 	.hw_reset = &rteth_839x_hw_reset,
 	.init_mac = &rteth_839x_init_mac,
+	.set_hol = rteth_83xx_set_hol,
 	.set_max_packet_length = rteth_839x_set_max_packet_length,
 	.setup_notify_ring_buffer = &rteth_839x_setup_notify_ring_buffer,
 	.netdev_ops = &rteth_839x_netdev_ops,
@@ -1706,6 +1759,7 @@ static const struct rteth_config rteth_839x_cfg = {
 static const struct net_device_ops rteth_930x_netdev_ops = {
 	.ndo_open = rteth_open,
 	.ndo_stop = rteth_stop,
+	.ndo_change_mtu = rteth_change_mtu,
 	.ndo_start_xmit = rteth_start_xmit,
 	.ndo_set_mac_address = rteth_set_mac_address,
 	.ndo_validate_addr = eth_validate_addr,
@@ -1718,6 +1772,7 @@ static const struct net_device_ops rteth_930x_netdev_ops = {
 
 static const struct rteth_config rteth_930x_cfg = {
 	.cpu_port = RTETH_930X_CPU_PORT,
+	.max_mtu = RTETH_930X_MAX_FRAME - RTETH_FRAME_OVERHEAD,
 	.rx_rings = 32,
 	.tx_rx_enable = 0x30,
 	.tx_trigger_mask = GENMASK(3, 2),
@@ -1746,6 +1801,7 @@ static const struct rteth_config rteth_930x_cfg = {
 	.hw_stop = &rteth_930x_hw_stop,
 	.hw_reset = &rteth_93xx_hw_reset,
 	.init_mac = &rteth_930x_init_mac,
+	.set_hol = rteth_93xx_set_hol,
 	.set_max_packet_length = rteth_930x_set_max_packet_length,
 	.netdev_ops = &rteth_930x_netdev_ops,
 };
@@ -1753,6 +1809,7 @@ static const struct rteth_config rteth_930x_cfg = {
 static const struct net_device_ops rteth_931x_netdev_ops = {
 	.ndo_open = rteth_open,
 	.ndo_stop = rteth_stop,
+	.ndo_change_mtu = rteth_change_mtu,
 	.ndo_start_xmit = rteth_start_xmit,
 	.ndo_set_mac_address = rteth_set_mac_address,
 	.ndo_validate_addr = eth_validate_addr,
@@ -1765,6 +1822,7 @@ static const struct net_device_ops rteth_931x_netdev_ops = {
 
 static const struct rteth_config rteth_931x_cfg = {
 	.cpu_port = RTETH_931X_CPU_PORT,
+	.max_mtu = RTETH_931X_MAX_FRAME - RTETH_FRAME_OVERHEAD,
 	.rx_rings = 32,
 	.tx_rx_enable = 0x30,
 	.tx_trigger_mask = GENMASK(3, 2),
@@ -1793,6 +1851,7 @@ static const struct rteth_config rteth_931x_cfg = {
 	.hw_stop = &rteth_931x_hw_stop,
 	.hw_reset = &rteth_93xx_hw_reset,
 	.init_mac = &rteth_931x_init_mac,
+	.set_hol = rteth_93xx_set_hol,
 	.set_max_packet_length = rteth_931x_set_max_packet_length,
 	.netdev_ops = &rteth_931x_netdev_ops,
 };
@@ -1892,7 +1951,7 @@ static int rteth_probe(struct platform_device *pdev)
 
 	dev->ethtool_ops = &rteth_ethtool_ops;
 	dev->min_mtu = ETH_ZLEN;
-	dev->max_mtu = SKB_MTU;
+	dev->max_mtu = ctrl->r->max_mtu;
 	dev->features = NETIF_F_RXCSUM;
 	dev->hw_features = NETIF_F_RXCSUM;
 	dev->netdev_ops = ctrl->r->netdev_ops;

--- a/target/linux/realtek/files-6.18/drivers/net/ethernet/rtl838x_eth.h
+++ b/target/linux/realtek/files-6.18/drivers/net/ethernet/rtl838x_eth.h
@@ -194,6 +194,7 @@ struct rteth_frag;
 
 struct rteth_config {
 	int cpu_port;
+	int max_mtu;
 	int rx_rings;
 	int tx_rx_enable;
 	int tx_trigger_mask;
@@ -222,6 +223,7 @@ struct rteth_config {
 	void (*hw_stop)(struct rteth_ctrl *ctrl);
 	void (*hw_reset)(struct rteth_ctrl *ctrl);
 	int (*init_mac)(struct rteth_ctrl *ctrl);
+	void (*set_hol)(struct rteth_ctrl *ctrl);
 	void (*set_max_packet_length)(struct rteth_ctrl *ctrl, int len);
 	void (*setup_notify_ring_buffer)(struct rteth_ctrl *ctrl);
 	void (*update_counter)(struct rteth_ctrl *ctrl, int ring, int released);

--- a/target/linux/realtek/files-6.18/drivers/net/ethernet/rtl838x_eth.h
+++ b/target/linux/realtek/files-6.18/drivers/net/ethernet/rtl838x_eth.h
@@ -11,6 +11,8 @@
 #define RTETH_838X_DMA_IF_CTRL			(0x9f58)
 #define RTETH_838X_DMA_IF_INTR_MSK		(0x9f50)
 #define RTETH_838X_DMA_IF_INTR_STS		(0x9f54)
+#define RTETH_838X_DMA_IF_PKT_RX_FLTR_CTRL	(0x6b10)
+#define RTETH_838X_DMA_IF_PKT_TX_FLTR_CTRL	(0xaa6c)
 #define RTETH_838X_DMA_IF_RX_RING_CNTR		(0xb7e8)
 #define RTETH_838X_DMA_IF_RX_RING_SIZE		(0xb7e4)
 #define RTETH_838X_DMA_RX_BASE			(0x9f00)
@@ -30,6 +32,7 @@
 #define RTETH_839X_DMA_IF_CTRL			(0x786c)
 #define RTETH_839X_DMA_IF_INTR_MSK		(0x7864)
 #define RTETH_839X_DMA_IF_INTR_STS		(0x7868)
+#define RTETH_839X_DMA_IF_PKT_FLTR_CTRL		(0x1000)
 #define RTETH_839X_DMA_IF_RX_RING_CNTR		(0x603c)
 #define RTETH_839X_DMA_IF_RX_RING_SIZE		(0x6038)
 #define RTETH_839X_DMA_RX_BASE			(0x780c)
@@ -55,7 +58,9 @@
 #define RTETH_930X_DMA_TX_BASE			(0xe000)
 #define RTETH_930X_MAC_FORCE_MODE_CTRL		(0xca1c + RTETH_930X_CPU_PORT * 4)
 #define RTETH_930X_MAC_L2_ADDR_CTRL		(0xc714)
+#define RTETH_930X_MAC_L2_CPU_MAX_LEN_CTRL	(0xa3a0)
 #define RTETH_930X_MAC_L2_PORT_CTRL		(0x3268 + RTETH_930X_CPU_PORT * 64)
+#define RTETH_930X_MAC_L2_PORT_MAX_LEN_CTRL	(0x326c + RTETH_930X_CPU_PORT * 64)
 #define RTETH_930X_QM_RSN2CPUQID_CTRL_0		(0xa344)
 #define RTETH_930X_QM_RSN2CPUQID_CTRL_CNT	11
 #define RTETH_930X_RMA_CTRL_0			(0x9e60)
@@ -72,6 +77,7 @@
 #define RTETH_931X_DMA_TX_BASE			(0x0900)
 #define RTETH_931X_MAC_FORCE_MODE_CTRL		(0x0dcc + RTETH_931X_CPU_PORT * 4)
 #define RTETH_931X_MAC_L2_ADDR_CTRL		(0x135c)
+#define RTETH_931X_MAC_L2_CPU_MAX_LEN_CTRL	(0x1368)
 #define RTETH_931X_MAC_L2_PORT_CTRL		(0x6000 + RTETH_931X_CPU_PORT * 128)
 #define RTETH_931X_QM_RSN2CPUQID_CTRL_0		(0xa9f4)
 #define RTETH_931X_QM_RSN2CPUQID_CTRL_CNT	14
@@ -216,6 +222,7 @@ struct rteth_config {
 	void (*hw_stop)(struct rteth_ctrl *ctrl);
 	void (*hw_reset)(struct rteth_ctrl *ctrl);
 	int (*init_mac)(struct rteth_ctrl *ctrl);
+	void (*set_max_packet_length)(struct rteth_ctrl *ctrl, int len);
 	void (*setup_notify_ring_buffer)(struct rteth_ctrl *ctrl);
 	void (*update_counter)(struct rteth_ctrl *ctrl, int ring, int released);
 	const struct net_device_ops *netdev_ops;


### PR DESCRIPTION
Two commits. The first programs the switch registers that bound the frames exchanged with
the CPU port from the conduit MTU, where they used to keep whatever the bootloader left, and
turns the DMA truncation off so an oversized frame is dropped rather than delivered cut
short. The second adds a `change_mtu` operation that keeps those limits, and the RTL93xx
head of line budget, following the MTU at runtime.

Split out of #24400 as requested; that series will be rebased on top of this one.

Hardware: RTL9303 (Hasivo S1100W-8XGT-SE), RTL8264B PHY, USXGMII SerDes mode.
Baseline: current main.

| conduit MTU | 1504 (idle) | 1000 | 7174 |
|---|---|---|---|
| packet length programmed | 1530 | 1026 | 7200 |
| packets per ring | 32 | 42 | 7 |

The previous static sizing programmed 25 packets per ring at every MTU. A 1046 byte frame
passes at MTU 1504, is dropped at MTU 1000, whose limit of 1026 it exceeds, and passes again
once the MTU is back; a 102 byte one is answered five times out of five at every step. With
the interface down the hardware is left alone and the change is applied when it comes up.

Known limit: `dev->max_mtu` is the chip maximum of the family, while the operation refuses
anything above an MTU of 7174, which is what the linear part and the fragments of a single
skb hold at 400 bytes each. Raising `SKB_FRAG_SIZE` past its TODO lifts that towards the
hardware limit.

Second known limit: on an MTU decrease the head of line budget grows while the ring may still
hold frames of the previous size, so the ordering narrows that window rather than closing it;
every accepted change logs a warning for it. Open question in the comment below.

Not tested on RTL838x/839x/931x, where the register offsets come from the svanheule.net maps
and only the build is covered. Those boards program the new registers at every interface
open, not only when the MTU changes, so testing from their owners is welcome.

*Bench testing and analysis assisted by Claude Opus 5 (Anthropic AI).*



