### PR TITLE
netifd: dhcp: add vendorid_hex option for raw hex option 60

### DIFF
--- a/package/network/config/netifd/Makefile
+++ b/package/network/config/netifd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netifd
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/netifd.git

--- a/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
+++ b/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
@@ -17,6 +17,7 @@ proto_dhcp_init_config() {
 	proto_config_add_string clientid
 	proto_config_add_string sendclientid
 	proto_config_add_string vendorid
+	proto_config_add_string vendorid_hex
 	proto_config_add_boolean 'broadcast:bool'
 	proto_config_add_boolean 'norelease:bool'
 	proto_config_add_string 'reqopts:list(string)'
@@ -59,8 +60,8 @@ proto_dhcp_setup() {
 	local config="$1"
 	local iface="$2"
 
-	local ipaddr hostname clientid sendclientid vendorid broadcast norelease reqopts defaultreqopts iface6rd sendopts delegate zone6rd zone mtu6rd customroutes classlessroute timeout retry tryagain
-	json_get_vars ipaddr hostname clientid sendclientid vendorid broadcast norelease reqopts defaultreqopts iface6rd delegate zone6rd zone mtu6rd customroutes classlessroute timeout retry tryagain
+	local ipaddr hostname clientid sendclientid vendorid vendorid_hex broadcast norelease reqopts defaultreqopts iface6rd sendopts delegate zone6rd zone mtu6rd customroutes classlessroute timeout retry tryagain
+	json_get_vars ipaddr hostname clientid sendclientid vendorid vendorid_hex broadcast norelease reqopts defaultreqopts iface6rd delegate zone6rd zone mtu6rd customroutes classlessroute timeout retry tryagain
 
 	local opt dhcpopts
 	for opt in $reqopts; do
@@ -97,7 +98,17 @@ proto_dhcp_setup() {
 			;;
 	esac
 	[ -n "${clientid##-C}" ] && clientid="-x 0x3d:$clientid"
-	[ -n "$vendorid" ] && append dhcpopts "-x 0x3c:$(echo -n "$vendorid" | hexdump -ve '1/1 "%02x"')"
+	[ -n "$vendorid_hex" ] && {
+		vendorid_hex="$(hexdump_2hex "$vendorid_hex")"
+		[ -z "$vendorid_hex" ] && {
+			logger -p warn -t dhcp "$iface: ignoring invalid vendorid_hex value"
+		}
+	}
+	if [ -n "$vendorid_hex" ]; then
+		append dhcpopts "-x 0x3c:$vendorid_hex"
+	elif [ -n "$vendorid" ]; then
+		append dhcpopts "-x 0x3c:$(echo -n "$vendorid" | hexdump -ve '1/1 "%02x"')"
+	fi
 	[ -n "$iface6rd" ] && proto_export "IFACE6RD=$iface6rd"
 	[ "$iface6rd" != 0 -a -f /lib/netifd/proto/6rd.sh ] && append dhcpopts "-O 212"
 	[ -n "$zone6rd" ] && proto_export "ZONE6RD=$zone6rd"


### PR DESCRIPTION
Currently, the `vendorid` option in `dhcp.sh` treats input values as standard ASCII strings and converts each character into its hex representation using `hexdump`. 

However, some ISPs require custom DHCP Option 60 values sent in raw hexadecimal format (e.g., binary payload or pre-encoded hex sequence like `00001f39014d...`). Passing such raw hex strings into the existing `vendorid` option results in double hex encoding (e.g., ASCII `'0'` converted to `30`).

This PR introduces a new UCI option `vendorid_hex` for the DHCP protocol handler:
- Allows users to specify raw hex strings directly for Option 60 (`-x 0x3c:<hex>`).
- Retains backwards compatibility with the existing string-based `vendorid` option.
- Handles conflict resolution by prioritizing `vendorid_hex` over `vendorid` if both are specified.
- Maintains compatibility with the existing duplicate Option 60 suppression logic (`emptyvendorid=1`).

Once this PR is merged, I will submit a corresponding PR to the openwrt/luci repository to add support for the vendorid_hex option in the Web UI.