### PR TITLE
mediatek: MERCUSYS MR85X: add OpenWrt UBI layout and convert to DSA

### DIFF
--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -544,6 +544,18 @@ define U-Boot/mt7981_konka_komi-a31
   DEPENDS:=+trusted-firmware-a-mt7981-spim-nand-ddr3
 endef
 
+define U-Boot/mt7981_mercusys_mr85x
+  NAME:=MERCUSYS MR85X (UBI)
+  BUILD_SUBTARGET:=filogic
+  BUILD_DEVICES:=mercusys_mr85x-ubi
+  UBOOT_CONFIG:=mt7981_mercusys_mr85x
+  UBOOT_IMAGE:=u-boot.fip
+  BL2_BOOTDEV:=spim-nand-ubi
+  BL2_SOC:=mt7981
+  BL2_DDRTYPE:=ddr3-1866
+  DEPENDS:=+trusted-firmware-a-mt7981-spim-nand-ubi-ddr3-1866
+endef
+
 define U-Boot/mt7981_netis_eap930-v1
   NAME:=netis EAP930 V1
   BUILD_SUBTARGET:=filogic
@@ -1350,6 +1362,7 @@ UBOOT_TARGETS := \
 	mt7981_imou_hx21 \
 	mt7981_jcg_q30-pro \
 	mt7981_konka_komi-a31 \
+	mt7981_mercusys_mr85x \
 	mt7981_netis_eap930-v1 \
 	mt7981_netis_n6-v2 \
 	mt7981_netis_nx30v2 \

--- a/package/boot/uboot-mediatek/patches/476-add-mercusys_mr85x.patch
+++ b/package/boot/uboot-mediatek/patches/476-add-mercusys_mr85x.patch
@@ -1,0 +1,300 @@
+--- /dev/null
++++ b/configs/mt7981_mercusys_mr85x_defconfig
+@@ -0,0 +1,97 @@
++CONFIG_ARM=y
++CONFIG_ARM_SMCCC=y
++CONFIG_SYS_HAS_NONCACHED_MEMORY=y
++CONFIG_POSITION_INDEPENDENT=y
++CONFIG_ARCH_MEDIATEK=y
++CONFIG_TEXT_BASE=0x41e00000
++CONFIG_SYS_MALLOC_F_LEN=0x4000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEFAULT_DEVICE_TREE="mt7981_mercusys-mr85x"
++CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_TARGET_MT7981=y
++CONFIG_SYS_LOAD_ADDR=0x46000000
++CONFIG_PRE_CON_BUF_ADDR=0x4007ef00
++CONFIG_DEBUG_UART_BASE=0x11002000
++CONFIG_DEBUG_UART_CLOCK=40000000
++CONFIG_DEBUG_UART=y
++CONFIG_FIT=y
++CONFIG_BOOTDELAY=30
++CONFIG_AUTOBOOT_KEYED=y
++CONFIG_AUTOBOOT_MENU_SHOW=y
++CONFIG_DEFAULT_FDT_FILE="mediatek/mt7981_mercusys-mr85x.dtb"
++CONFIG_LOGLEVEL=7
++CONFIG_PRE_CONSOLE_BUFFER=y
++CONFIG_LOG=y
++# CONFIG_BOARD_INIT is not set
++CONFIG_BOARD_LATE_INIT=y
++CONFIG_HUSH_PARSER=y
++CONFIG_SYS_PROMPT="MT7981> "
++CONFIG_CMD_CPU=y
++CONFIG_CMD_LICENSE=y
++CONFIG_CMD_BOOTMENU=y
++CONFIG_CMD_ASKENV=y
++CONFIG_CMD_ERASEENV=y
++CONFIG_CMD_ENV_FLAGS=y
++CONFIG_CMD_RNG=y
++CONFIG_CMD_STRINGS=y
++CONFIG_CMD_DM=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_MTD=y
++CONFIG_CMD_PART=y
++CONFIG_CMD_CDP=y
++CONFIG_CMD_SNTP=y
++CONFIG_CMD_CACHE=y
++CONFIG_CMD_PSTORE=y
++CONFIG_CMD_PSTORE_MEM_ADDR=0x42ff0000
++CONFIG_CMD_UUID=y
++CONFIG_CMD_HASH=y
++CONFIG_CMD_SMC=y
++CONFIG_CMD_UBI=y
++CONFIG_CMD_UBI_RENAME=y
++CONFIG_OF_EMBED=y
++CONFIG_ENV_OVERWRITE=y
++CONFIG_ENV_IS_IN_UBI=y
++CONFIG_ENV_REDUNDANT=y
++CONFIG_ENV_UBI_PART="ubi"
++CONFIG_ENV_UBI_VOLUME="ubootenv"
++CONFIG_ENV_UBI_VOLUME_REDUND="ubootenv2"
++CONFIG_ENV_RELOC_GD_ENV_ADDR=y
++CONFIG_ENV_USE_DEFAULT_ENV_TEXT_FILE=y
++CONFIG_ENV_DEFAULT_ENV_TEXT_FILE="defenvs/mercusys-mr85x_env"
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_VERSION_VARIABLE=y
++CONFIG_BUTTON=y
++CONFIG_BUTTON_GPIO=y
++CONFIG_CLK=y
++CONFIG_GPIO_HOG=y
++# CONFIG_I2C is not set
++CONFIG_LED=y
++CONFIG_LED_BLINK=y
++CONFIG_LED_GPIO=y
++# CONFIG_MMC is not set
++CONFIG_MTD=y
++CONFIG_DM_MTD=y
++CONFIG_DM_GPIO=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_MTD_UBI_FASTMAP=y
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++CONFIG_PINCTRL_MT7981=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MTK_GPIO=y
++CONFIG_MTK_POWER_DOMAIN=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_RAM=y
++CONFIG_DM_RNG=y
++CONFIG_RNG_MTK_V2=y
++CONFIG_DM_SERIAL=y
++CONFIG_SERIAL_RX_BUFFER=y
++CONFIG_MTK_SERIAL=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_MTK_SPIM=y
++CONFIG_ZSTD=y
++CONFIG_HEXDUMP=y
+--- /dev/null
++++ b/arch/arm/dts/mt7981_mercusys-mr85x.dts
+@@ -0,0 +1,160 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (c) 2026
++ * Author: Mikhail Zhilkin <csharper2005@gmail.com>
++ */
++
++/dts-v1/;
++#include "mt7981.dtsi"
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/linux-event-codes.h>
++
++/ {
++	#address-cells = <1>;
++	#size-cells = <1>;
++	model = "MERCUSYS MR85X (UBI)";
++	compatible = "mercusys,mr85x-ubi", "mediatek,mt7981";
++
++	chosen {
++		stdout-path = &uart0;
++		tick-timer = &timer0;
++	};
++
++	memory@40000000 {
++		device_type = "memory";
++		reg = <0x40000000 0x20000000>;
++	};
++
++	keys {
++		compatible = "gpio-keys";
++
++		button-0 {
++			label = "wps";
++			linux,code = <KEY_WPS_BUTTON>;
++			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
++		};
++
++		button-1 {
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-0 {
++			label = "amber:status";
++			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
++			default-state = "on";
++			u-boot,dm-pre-reloc;
++		};
++
++		led-1 {
++			label = "green:status";
++			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
++		};
++
++		led-2 {
++			label = "green:lan-0";
++			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
++		};
++
++		led-3 {
++			label = "green:lan-1";
++			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
++		};
++
++		led-4 {
++			label = "green:wan";
++			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
++		};
++
++		led-5 {
++			label = "green:lan-2";
++			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&uart0 {
++	mediatek,force-highspeed;
++	status = "okay";
++};
++
++&pio {
++	spi_flash_pins: spi0-pins-func-1 {
++		mux {
++			function = "flash";
++			groups = "spi0", "spi0_wp_hold";
++		};
++
++		conf-pu {
++			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
++			drive-strength = <MTK_DRIVE_8mA>;
++			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
++		};
++
++		conf-pd {
++			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
++			drive-strength = <MTK_DRIVE_8mA>;
++			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
++		};
++	};
++
++	spic_pins: spi1-pins-func-1 {
++		mux {
++			function = "spi";
++			groups = "spi1_1";
++		};
++	};
++
++	uart1_pins: spi1-pins-func-3 {
++		mux {
++			function = "uart";
++			groups = "uart1_2";
++		};
++	};
++};
++
++&spi0 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi_flash_pins>;
++	status = "okay";
++	must_tx;
++	enhance_timing;
++	dma_ext;
++	ipm_design;
++	support_quad;
++	tick_dly = <2>;
++	sample_sel = <0>;
++
++	spi_nand@0 {
++		compatible = "spi-nand";
++		reg = <0>;
++		spi-max-frequency = <52000000>;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "bl2";
++				reg = <0x0 0x100000>;
++			};
++
++			partition@100000 {
++				label = "ubi";
++				reg = <0x100000 0x7f00000>;
++			};
++		};
++	};
++};
++
++&watchdog {
++	status = "disabled";
++};
+--- /dev/null
++++ b/defenvs/mercusys-mr85x_env
+@@ -0,0 +1,34 @@
++loadaddr=0x46000000
++console=earlycon=uart8250,mmio32,0x11002000 console=ttyS0
++bootargs=root=/dev/fit0 rootwait
++bootcmd=run check_buttons ; run boot_production ; run boot_recovery
++bootconf=config-1
++bootdelay=0
++bootmenu_confirm_return=askenv - Press ENTER to return to menu ; bootmenu 60
++bootmenu_default=0
++bootmenu_delay=0
++bootmenu_title=      [0;34m( ( ( [1;39mOpenWrt[0;34m ) ) )
++bootmenu_0=Initialize environment=run _firstboot
++bootmenu_0d=Run default boot command=run boot_default
++bootmenu_1=Boot production system from NAND=run boot_production ; run bootmenu_confirm_return
++bootmenu_2=Boot recovery system from NAND=run boot_recovery ; run bootmenu_confirm_return
++bootmenu_3=Reboot=reset
++bootmenu_4=Reset all settings to factory defaults=run reset_factory ; reset
++boot_default=run led_boot ; run bootcmd ; run boot_recovery
++boot_production=run led_boot ; run ubi_read_production && bootm $loadaddr#$bootconf
++boot_recovery=run led_boot ; run ubi_read_recovery && bootm $loadaddr#$bootconf
++check_buttons=if button reset ; then run boot_recovery ; fi
++led_boot=led green:status off ; led amber:status on
++reset_factory=mw $loadaddr 0xff 0x1f000 ; ubi write $loadaddr ubootenv 0x1f000 ; ubi write $loadaddr ubootenv2 0x1f000 ; run ubi_remove_rootfs
++ubi_create_factory=ubi check factory || ubi create factory 0x24000 static || run ubi_format
++ubi_create_fip=ubi check fip || ubi create fip 0x100000 static || run ubi_format
++ubi_create_env=ubi check ubootenv || ubi create ubootenv 0x1f000 dynamic || run ubi_format ; ubi check ubootenv2 || ubi create ubootenv2 0x1f000 dynamic || run ubi_format
++ubi_format=ubi detach ; mtd erase ubi && ubi part ubi ; reset
++ubi_prepare_rootfs=if ubi check rootfs_data ; then else if env exists rootfs_data_max ; then ubi create rootfs_data $rootfs_data_max dynamic || ubi create rootfs_data - dynamic ; else ubi create rootfs_data - dynamic ; fi ; fi
++ubi_read_production=ubi read $loadaddr fit && iminfo $loadaddr && run ubi_prepare_rootfs
++ubi_read_recovery=ubi check recovery && ubi read $loadaddr recovery
++ubi_remove_rootfs=ubi check rootfs_data && ubi remove rootfs_data
++_init_env=setenv _init_env ; run ubi_create_env ; saveenv ; saveenv
++_firstboot=setenv _firstboot ; run ubi_create_fip ; run ubi_create_factory ; run _switch_to_menu ; run _init_env ; bootmenu
++_switch_to_menu=setenv _switch_to_menu ; setenv bootdelay 3 ; setenv bootmenu_delay 3 ; setenv bootmenu_0 $bootmenu_0d ; setenv bootmenu_0d ; run _bootmenu_update_title
++_bootmenu_update_title=setenv _bootmenu_update_title ; setenv bootmenu_title "$bootmenu_title       [33m$ver[0m"

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -41,6 +41,7 @@ h3c,magic-nx30-pro|\
 imou,hx21|\
 jcg,q30-pro|\
 konka,komi-a31|\
+mercusys,mr85x-ubi|\
 mercusys,mr90x-v1-ubi|\
 netcore,n60|\
 netcore,n60-pro|\

--- a/target/linux/mediatek/dts/mt7981b-mercusys-mr85x-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-mercusys-mr85x-common.dtsi
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+#include "mt7981b.dtsi"
+
+/ {
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_amber;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_green;
+
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x20000000>;
+		device_type = "memory";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-0 {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		button-1 {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_amber: led-0 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: led-1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		led-2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <0>;
+			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led-4 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led-5 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	rtkgsw@0 {
+		compatible = "mediatek,rtk-gsw";
+		mediatek,ethsys = <&ethsys>;
+		mediatek,mdio = <&mdio_bus>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
+		status = "okay";
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "2500base-x";
+		phy-handle = <&phy15>;
+	};
+};
+
+&mdio_bus {
+	phy15: phy@f {
+		compatible = "ethernet-phy-id03a2.a411";
+		reg = <15>;
+
+		reset-gpios = <&pio 14 GPIO_ACTIVE_LOW>;
+		reset-delay-us = <200000>;
+		reset-post-delay-us = <1000000>;
+
+		phy-mode = "2500base-x";
+		full-duplex;
+		pause;
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};

--- a/target/linux/mediatek/dts/mt7981b-mercusys-mr85x-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-mercusys-mr85x-common.dtsi
@@ -60,14 +60,14 @@
 		led-2 {
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_LAN;
-			function-enumerator = <0>;
+			function-enumerator = <1>;
 			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
 		};
 
 		led-3 {
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_LAN;
-			function-enumerator = <1>;
+			function-enumerator = <2>;
 			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
 		};
 
@@ -80,7 +80,7 @@
 		led-5 {
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_LAN;
-			function-enumerator = <2>;
+			function-enumerator = <3>;
 			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/mediatek/dts/mt7981b-mercusys-mr85x-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-mercusys-mr85x-common.dtsi
@@ -84,14 +84,6 @@
 			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
 		};
 	};
-
-	rtkgsw@0 {
-		compatible = "mediatek,rtk-gsw";
-		mediatek,ethsys = <&ethsys>;
-		mediatek,mdio = <&mdio_bus>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
-		status = "okay";
-	};
 };
 
 &eth {
@@ -114,6 +106,8 @@
 		reg = <1>;
 		phy-mode = "2500base-x";
 		phy-handle = <&phy15>;
+
+		openwrt,netdev-name = "wan";
 	};
 };
 
@@ -129,6 +123,65 @@
 		phy-mode = "2500base-x";
 		full-duplex;
 		pause;
+	};
+
+	switch@1d {
+		compatible = "realtek,rtl8365mb";
+		reg = <29>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
+
+		mdio {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			phy0: ethernet-phy@0 {
+				reg = <0>;
+			};
+
+			phy1: ethernet-phy@1 {
+				reg = <1>;
+			};
+
+			phy2: ethernet-phy@2 {
+				reg = <2>;
+			};
+		};
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "lan1";
+				phy-handle = <&phy0>;
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "lan2";
+				phy-handle = <&phy1>;
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan3";
+				phy-handle = <&phy2>;
+			};
+
+			port@6 {
+				reg = <6>;
+				label = "cpu";
+				ethernet = <&gmac0>;
+				phy-mode = "2500base-x";
+
+				fixed-link {
+					speed = <2500>;
+					full-duplex;
+					pause;
+				};
+			};
+		};
 	};
 };
 

--- a/target/linux/mediatek/dts/mt7981b-mercusys-mr85x-ubi.dts
+++ b/target/linux/mediatek/dts/mt7981b-mercusys-mr85x-ubi.dts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#include "mt7981b-mercusys-mr85x-common.dtsi"
+
+/ {
+	model = "MERCUSYS MR85X (UBI)";
+	compatible = "mercusys,mr85x-ubi", "mediatek,mt7981";
+
+	aliases {
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs-override = "root=/dev/fit0 rootwait";
+		rootdisk = <&ubi_rootdisk>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_8000 (0)>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	nvmem-cells = <&macaddr_factory_8000 (1)>;
+	nvmem-cell-names = "mac-address";
+};
+
+&partitions {
+	partition@0 {
+		label = "bl2";
+		reg = <0x0 0x100000>;
+		read-only;
+	};
+
+	partition@100000 {
+		reg = <0x100000 0x7f00000>;
+		compatible = "linux,ubi";
+		label = "ubi";
+
+		volumes {
+			ubi_factory: ubi-volume-factory {
+				volname = "factory";
+			};
+
+			ubi-volume-fip {
+				volname = "fip";
+			};
+
+			ubi_rootdisk: ubi-volume-fit {
+				volname = "fit";
+			};
+
+			ubi_ubootenv: ubi-volume-ubootenv {
+				volname = "ubootenv";
+			};
+
+			ubi_ubootenv2: ubi-volume-ubootenv2 {
+				volname = "ubootenv2";
+			};
+		};
+	};
+};
+
+&ubi_factory {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		eeprom_factory_0: eeprom@0 {
+			reg = <0x0 0x1000>;
+		};
+
+		macaddr_factory_8000: macaddr@8000 {
+			compatible = "mac-base";
+			reg = <0x8000 0x6>;
+			#nvmem-cell-cells = <1>;
+		};
+	};
+};
+
+&ubi_ubootenv {
+	nvmem-layout {
+		compatible = "u-boot,env-redundant-bool";
+	};
+};
+
+&ubi_ubootenv2 {
+	nvmem-layout {
+		compatible = "u-boot,env-redundant-bool";
+	};
+};
+
+&wifi {
+	status = "okay";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+
+	band@0 {
+		reg = <0>;
+
+		nvmem-cells = <&macaddr_factory_8000 (0)>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+
+		nvmem-cells = <&macaddr_factory_8000 (-1)>;
+		nvmem-cell-names = "mac-address";
+	};
+};

--- a/target/linux/mediatek/dts/mt7981b-mercusys-mr85x.dts
+++ b/target/linux/mediatek/dts/mt7981b-mercusys-mr85x.dts
@@ -1,215 +1,45 @@
 // SPDX-License-Identifier: GPL-2.0
 
-/dts-v1/;
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/gpio/gpio.h>
+#include "mt7981b-mercusys-mr85x-common.dtsi"
 
-#include "mt7981b.dtsi"
 / {
 	model = "MERCUSYS MR85X";
 	compatible = "mercusys,mr85x", "mediatek,mt7981";
-
-	aliases {
-		led-boot = &led_status_green;
-		led-failsafe = &led_status_amber;
-		led-running = &led_status_green;
-		led-upgrade = &led_status_green;
-
-		serial0 = &uart0;
-	};
-
-	chosen {
-		stdout-path = "serial0:115200n8";
-	};
-
-	memory@40000000 {
-		reg = <0 0x40000000 0 0x20000000>;
-		device_type = "memory";
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		button-reset {
-			label = "reset";
-			linux,code = <KEY_RESTART>;
-			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
-		};
-
-		button-wps {
-			label = "wps";
-			linux,code = <KEY_WPS_BUTTON>;
-			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
-		};
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		led_status_amber: led-0 {
-			color = <LED_COLOR_ID_AMBER>;
-			function = LED_FUNCTION_STATUS;
-			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
-		};
-
-		led_status_green: led-1 {
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_STATUS;
-			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
-		};
-
-		led-2 {
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_LAN;
-			function-enumerator = <0>;
-			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
-		};
-
-		led-3 {
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_LAN;
-			function-enumerator = <1>;
-			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
-		};
-
-		led-4 {
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_WAN;
-			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
-		};
-
-		led-5 {
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_LAN;
-			function-enumerator = <2>;
-			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
-		};
-	};
-
-	rtkgsw@0 {
-		compatible = "mediatek,rtk-gsw";
-		mediatek,ethsys = <&ethsys>;
-		mediatek,mdio = <&mdio_bus>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
-		status = "okay";
-	};
 };
 
-&uart0 {
-	status = "okay";
-};
-
-&eth {
-	status = "okay";
-
-	mac@0 {
-		compatible = "mediatek,eth-mac";
-		reg = <0>;
-		phy-mode = "2500base-x";
-
-		fixed-link {
-			speed = <2500>;
-			full-duplex;
-			pause;
-		};
+&partitions {
+	partition@0 {
+		label = "boot";
+		reg = <0x0 0x200000>;
+		read-only;
 	};
 
-	mac@1 {
-		compatible = "mediatek,eth-mac";
-		reg = <1>;
-		phy-mode = "2500base-x";
-		phy-handle = <&phy15>;
+	partition@200000 {
+		label = "u-boot-env";
+		reg = <0x200000 0x100000>;
 	};
-};
 
-
-&mdio_bus {
-	phy15: phy@f {
-		compatible = "ethernet-phy-id03a2.a411";
-		reg = <15>;
-		reset-gpios = <&pio 14 GPIO_ACTIVE_LOW>;
-		reset-delay-us = <200000>;
-		reset-post-delay-us = <1000000>;
-		phy-mode = "2500base-x";
-		full-duplex;
-		pause;
+	partition@300000 {
+		label = "ubi0";
+		reg = <0x300000 0x3200000>;
 	};
-};
 
-&spi0 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&spi0_flash_pins>;
-	status = "okay";
-
-	spi_nand@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
-		compatible = "spi-nand";
-		reg = <0>;
-		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "boot";
-				reg = <0x00000 0x0200000>;
-				read-only;
-			};
-
-			partition@200000 {
-				label = "u-boot-env";
-				reg = <0x0200000 0x0100000>;
-			};
-
-			partition@300000 {
-				label = "ubi0";
-				reg = <0x300000 0x3200000>;
-			};
-
-			partition@3500000 {
-				label = "ubi1";
-				reg = <0x3500000 0x3200000>;
-				read-only;
-			};
-
-			partition@6700000 {
-				label = "userconfig";
-				reg = <0x6700000 0x800000>;
-				read-only;
-			};
-
-			partition@6f00000 {
-				label = "tp_data";
-				reg = <0x6f00000 0x800000>;
-				read-only;
-			};
-		};
+	partition@3500000 {
+		label = "ubi1";
+		reg = <0x3500000 0x3200000>;
+		read-only;
 	};
-};
 
-&pio {
-	spi0_flash_pins: spi0-pins {
-		mux {
-			function = "spi";
-			groups = "spi0", "spi0_wp_hold";
-		};
+	partition@6700000 {
+		label = "userconfig";
+		reg = <0x6700000 0x800000>;
+		read-only;
+	};
 
-		conf-pu {
-			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
-			drive-strength = <MTK_DRIVE_8mA>;
-			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
-		};
-
-		conf-pd {
-			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
-			drive-strength = <MTK_DRIVE_8mA>;
-			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
-		};
+	partition@6f00000 {
+		label = "tp_data";
+		reg = <0x6f00000 0x800000>;
+		read-only;
 	};
 };
 

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -176,9 +176,9 @@ mercusys,mr80x-v3)
 	;;
 mercusys,mr85x|\
 mercusys,mr85x-ubi)
-	ucidef_set_led_switch "lan0" "lan-0" "green:lan-0" "switch0" "0x01"
-	ucidef_set_led_switch "lan1" "lan-1" "green:lan-1" "switch0" "0x02"
-	ucidef_set_led_switch "lan2" "lan-2" "green:lan-2" "switch0" "0x04"
+	ucidef_set_led_switch "lan1" "lan-1" "green:lan-1" "switch0" "0x01"
+	ucidef_set_led_switch "lan2" "lan-2" "green:lan-2" "switch0" "0x02"
+	ucidef_set_led_switch "lan3" "lan-3" "green:lan-3" "switch0" "0x04"
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "eth1" "link tx rx"
 	;;
 mercusys,mr90x-v1|\

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -168,18 +168,13 @@ livinet,li320)
 	ucidef_set_led_netdev "wan-off" "wan-off" "red:wan" "wan" "link"
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan" "link"
 	;;
-mercusys,mr80x-v3)
+mercusys,mr80x-v3|\
+mercusys,mr85x|\
+mercusys,mr85x-ubi)
 	ucidef_set_led_netdev "lan1" "lan-1" "green:lan-1" "lan1" "link tx rx"
 	ucidef_set_led_netdev "lan2" "lan-2" "green:lan-2" "lan2" "link tx rx"
 	ucidef_set_led_netdev "lan3" "lan-3" "green:lan-3" "lan3" "link tx rx"
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan" "link tx rx"
-	;;
-mercusys,mr85x|\
-mercusys,mr85x-ubi)
-	ucidef_set_led_switch "lan1" "lan-1" "green:lan-1" "switch0" "0x01"
-	ucidef_set_led_switch "lan2" "lan-2" "green:lan-2" "switch0" "0x02"
-	ucidef_set_led_switch "lan3" "lan-3" "green:lan-3" "switch0" "0x04"
-	ucidef_set_led_netdev "wan" "wan" "green:wan" "eth1" "link tx rx"
 	;;
 mercusys,mr90x-v1|\
 mercusys,mr90x-v1-ubi)

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -174,7 +174,8 @@ mercusys,mr80x-v3)
 	ucidef_set_led_netdev "lan3" "lan-3" "green:lan-3" "lan3" "link tx rx"
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan" "link tx rx"
 	;;
-mercusys,mr85x)
+mercusys,mr85x|\
+mercusys,mr85x-ubi)
 	ucidef_set_led_switch "lan0" "lan-0" "green:lan-0" "switch0" "0x01"
 	ucidef_set_led_switch "lan1" "lan-1" "green:lan-1" "switch0" "0x02"
 	ucidef_set_led_switch "lan2" "lan-2" "green:lan-2" "switch0" "0x04"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -207,7 +207,8 @@ mediatek_setup_interfaces()
 	mediatek,mt7988a-rfb)
 		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3 eth2" eth1
 		;;
-	mercusys,mr85x)
+	mercusys,mr85x|\
+	mercusys,mr85x-ubi)
 		ucidef_add_switch "switch0" "0:lan0" "1:lan1" "2:lan2" "6@eth0"
 		ucidef_set_interfaces_lan_wan "eth0.1 eth0.2 eth0.3" eth1
 		;;

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -67,6 +67,8 @@ mediatek_setup_interfaces()
 	keenetic,kn-3711|\
 	keenetic,kn-3811|\
 	livinet,li320|\
+	mercusys,mr85x|\
+	mercusys,mr85x-ubi|\
 	netis,n6-v2|\
 	netis,nx32u|\
 	qihoo,360t7|\
@@ -206,11 +208,6 @@ mediatek_setup_interfaces()
 		;;
 	mediatek,mt7988a-rfb)
 		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3 eth2" eth1
-		;;
-	mercusys,mr85x|\
-	mercusys,mr85x-ubi)
-		ucidef_add_switch "switch0" "0:lan0" "1:lan1" "2:lan2" "6@eth0"
-		ucidef_set_interfaces_lan_wan "eth0.1 eth0.2 eth0.3" eth1
 		;;
 	mercusys,mr90x-v1|\
 	mercusys,mr90x-v1-ubi)

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/05_compat-version
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/05_compat-version
@@ -11,6 +11,7 @@ case "$(board_name)" in
 	bananapi,bpi-r4|\
 	bananapi,bpi-r4-2g5|\
 	bananapi,bpi-r4-poe|\
+	mercusys,mr85x|\
 	routerich,ax3000|\
 	zbtlink,zbt-z8102ax-v2)
 		ucidef_set_compat_version "1.1"

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -166,6 +166,7 @@ platform_do_upgrade() {
 	konka,komi-a31|\
 	mediatek,mt7981-rfb|\
 	mediatek,mt7988a-rfb|\
+	mercusys,mr85x-ubi|\
 	mercusys,mr90x-v1-ubi|\
 	netis,eap930-v1|\
 	netis,n6-v2|\
@@ -412,6 +413,7 @@ platform_check_image() {
 	konka,komi-a31|\
 	mediatek,mt7981-rfb|\
 	mediatek,mt7988a-rfb|\
+	mercusys,mr85x-ubi|\
 	mercusys,mr90x-v1-ubi|\
 	nokia,ea0326gmp|\
 	netis,eap930-v1|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2613,9 +2613,8 @@ define Device/mercusys_mr85x-common
   DEVICE_VENDOR := MERCUSYS
   DEVICE_MODEL := MR85X
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware \
-	mt7981-wo-firmware kmod-phy-airoha-en8811h swconfig \
-	kmod-switch-rtl8367s
+  DEVICE_PACKAGES := kmod-dsa-rtl8365mb kmod-mt7915e \
+	kmod-mt7981-firmware kmod-phy-airoha-en8811h mt7981-wo-firmware
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 128k
   PAGESIZE := 2048
@@ -2625,6 +2624,9 @@ define Device/mercusys_mr85x
   DEVICE_DTS := mt7981b-mercusys-mr85x
   $(call Device/mercusys_mr85x-common)
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_COMPAT_VERSION := 1.1
+  DEVICE_COMPAT_MESSAGE := Ethernet port names have been updated due to \
+	DSA conversion.
 endef
 TARGET_DEVICES += mercusys_mr85x
 

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2609,18 +2609,45 @@ define Device/mercusys_mr80x-v3
 endef
 TARGET_DEVICES += mercusys_mr80x-v3
 
-define Device/mercusys_mr85x
+define Device/mercusys_mr85x-common
   DEVICE_VENDOR := MERCUSYS
   DEVICE_MODEL := MR85X
-  DEVICE_DTS := mt7981b-mercusys-mr85x
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-phy-airoha-en8811h swconfig kmod-switch-rtl8367s
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware \
+	mt7981-wo-firmware kmod-phy-airoha-en8811h swconfig \
+	kmod-switch-rtl8367s
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 128k
   PAGESIZE := 2048
+endef
+
+define Device/mercusys_mr85x
+  DEVICE_DTS := mt7981b-mercusys-mr85x
+  $(call Device/mercusys_mr85x-common)
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += mercusys_mr85x
+
+define Device/mercusys_mr85x-ubi
+  DEVICE_VARIANT := (UBI)
+  DEVICE_DTS := mt7981b-mercusys-mr85x-ubi
+  $(call Device/mercusys_mr85x-common)
+  KERNEL_IN_UBI := 1
+  UBOOTENV_IN_UBI := 1
+  IMAGES := sysupgrade.itb
+  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
+  KERNEL := kernel-bin | lzma
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | \
+	pad-to 64k
+  IMAGE/sysupgrade.itb := append-kernel | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | \
+	append-metadata
+  ARTIFACTS := bl31-uboot.fip preloader.bin
+  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot mercusys_mr85x
+  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ubi-ddr3-1866
+endef
+TARGET_DEVICES += mercusys_mr85x-ubi
 
 define Device/mercusys_mr90x-v1
   DEVICE_VENDOR := MERCUSYS

--- a/target/linux/mediatek/modules.mk
+++ b/target/linux/mediatek/modules.mk
@@ -56,18 +56,3 @@ define KernelPackage/phy-mediatek-2p5g/description
 endef
 
 $(eval $(call KernelPackage,phy-mediatek-2p5g))
-
-
-define KernelPackage/switch-rtl8367s
-  SUBMENU:=Network Devices
-  TITLE:=Realtek RTL8367S switch support
-  KCONFIG:= \
-	CONFIG_RTL8367S_GSW \
-	CONFIG_SWCONFIG=y
-  DEPENDS:=@TARGET_mediatek +kmod-swconfig
-  FILES:= \
-	$(LINUX_DIR)/drivers/net/phy/rtk/rtl8367s_gsw.ko
-  AUTOLOAD:=$(call AutoProbe,rtl8367s_gsw,1)
-endef
-
-$(eval $(call KernelPackage,switch-rtl8367s))


### PR DESCRIPTION
This commit adds OpenWrt U-Boot (UBI) layout support for MERCUSYS MR85X.

```
Stock bootloader UBI size: 50 MiB
OpenWrt U-Boot UBI size:  127 MiB
```

A note about U-Boot network support https://github.com/openwrt/openwrt/pull/24435#issuecomment-5168292471

<img width="590" height="590" alt="image" src="https://github.com/user-attachments/assets/189476e6-77df-450b-892b-1d44a1361fa3" />
