### PR TITLE
[25.12] package: utils: remove dependence on peerdns to add dns servers

### DIFF
--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -253,7 +253,7 @@ _proto_mbim_setup() {
 			json_add_string proto "dhcp"
 		fi
 
-		[ "$peerdns" = 0 -a "$dhcp" != 1 ] || {
+		[ "$dhcp" != 1 ] || {
 			json_add_array dns
 			for server in $(_proto_mbim_get_field ipv4dnsserver "$mbimconfig"); do
 				json_add_string "" "$server"
@@ -298,7 +298,7 @@ _proto_mbim_setup() {
 			[ "$sourcefilter" = "0" ] && json_add_boolean sourcefilter "0"
 		fi
 
-		[ "$peerdns" = 0 -a "$dhcpv6" != 1 ] || {
+		[ "$dhcpv6" != 1 ] || {
 			json_add_array dns
 			for server in $(_proto_mbim_get_field ipv6dnsserver "$mbimconfig"); do
 				json_add_string "" "$server"

--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -455,10 +455,8 @@ proto_qmi_setup() {
 			proto_add_ipv6_prefix "${ip_6}/${ip_prefix_length}"
 			proto_add_ipv6_route "$gateway_6" "128"
 			[ "$defaultroute" = 0 ] || proto_add_ipv6_route "::0" 0 "$gateway_6" "" "" "${ip_6}/${ip_prefix_length}"
-			[ "$peerdns" = 0 ] || {
-				proto_add_dns_server "$dns1_6"
-				proto_add_dns_server "$dns2_6"
-			}
+			proto_add_dns_server "$dns1_6"
+			proto_add_dns_server "$dns2_6"
 			[ -n "$zone" ] && {
 				proto_add_data
 				json_add_string zone "$zone"
@@ -498,10 +496,8 @@ proto_qmi_setup() {
 			proto_add_ipv4_address "$ip_4" "$subnet_4"
 			proto_add_ipv4_route "$gateway_4" "128"
 			[ "$defaultroute" = 0 ] || proto_add_ipv4_route "0.0.0.0" 0 "$gateway_4"
-			[ "$peerdns" = 0 ] || {
-				proto_add_dns_server "$dns1_4"
-				proto_add_dns_server "$dns2_4"
-			}
+			proto_add_dns_server "$dns1_4"
+			proto_add_dns_server "$dns2_4"
 			[ -n "$zone" ] && {
 				proto_add_data
 				json_add_string zone "$zone"


### PR DESCRIPTION
This is required to add available dns servers in ifstatus output, required by downstream tools to receive information of the configured DNS server on the wwan interface.

Relates to https://github.com/freifunk-gluon/gluon/pull/3618

Backport to 25.12 of #21314

@blocktrron 