### PR TITLE
build: do not rebuild tools in SDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,9 @@ else
 # Include the test suite Makefile if it exists
 -include tests/Makefile
 
+ifeq ($(SDK),)
 $(toolchain/stamp-compile): $(tools/stamp-compile) $(if $(CONFIG_BUILDBOT),toolchain_rebuild_check)
+endif
 $(target/stamp-compile): $(toolchain/stamp-compile) $(tools/stamp-compile) $(BUILD_DIR)/.prepared
 $(package/stamp-compile): $(target/stamp-compile) $(package/stamp-cleanup)
 $(package/stamp-install): $(package/stamp-compile)

--- a/toolchain/Makefile
+++ b/toolchain/Makefile
@@ -86,7 +86,10 @@ endif
 
 $(curdir)/install: $(curdir)/compile
 
+ifeq ($(SDK),)
 $(eval $(call stampfile,$(curdir),toolchain,compile,$(TOOLCHAIN_DIR)/stamp/.gcc_final_installed,,$(TOOLCHAIN_DIR)))
 $(eval $(call stampfile,$(curdir),toolchain,check,$(TMP_DIR)/.build))
+endif
+
 $(eval $(call subdir,$(curdir)))
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -236,6 +236,10 @@ $(curdir)/ := .config prereq
 $(curdir)/install: $(curdir)/compile
 
 tools_enabled = $(foreach tool,$(sort $(tools-y) $(tools-)),$(if $(filter $(tool),$(tools-y)),y,n))
+
+ifeq ($(SDK),)
 $(eval $(call stampfile,$(curdir),tools,compile,,_$(subst $(space),,$(tools_enabled)),$(STAGING_DIR_HOST)))
 $(eval $(call stampfile,$(curdir),tools,check,$(TMP_DIR)/.build,,$(STAGING_DIR_HOST)))
+endif
+
 $(eval $(call subdir,$(curdir)))


### PR DESCRIPTION
This is a much simpler alternative to previous suggestion, which I believe is an equivalent fix
Fixes: #7299 
maybe-fixes: #24273 
Closes: #10255


A long-standing problem with the SDK is that tools can rebuild due to the lack of a stamp file. This can cause ABI mismatch, as the new binaries are built against a different libc than is packaged.

The SDK Makefile defines Make variable $(SDK)
which can be used as a condition to prevent this.
Each stage in a build has the stampfile of the previous stage as a prerequisite for building, such as $(tools/stamp-compile). By blocking the definition of those variables,
the stamp file path is never defined, so that prerequisite expands to nothing.

These files are not directly included in the SDK,
but they are imported through the "base" feed
along with the packages in the main openwrt repo.

Also, for consistency, block the rule that is defined using the toolchain stamp file, so as to not have a blank rule.

As usual, it is still possible to rebuild some tools, but after this it is no longer automatic
as a result of including the main repo tools targets in the form of stamp file definitions within the feeds.
