### PR TITLE
[25.12] backport Turris MOX fixes

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mvebu
+++ b/package/boot/uboot-tools/uboot-envtools/files/mvebu
@@ -21,6 +21,9 @@ checkpoint,v-80|\
 checkpoint,v-81)
 	ubootenv_add_uci_config "/dev/mmcblk1boot0" "0x1f0000" "0x10000"
 	;;
+cznic,turris-mox)
+	ubootenv_add_uci_config "/dev/mtd2" "0x0" "0x10000" "0x10000"
+	;;
 cznic,turris-omnia)
 	idx="$(find_mtd_index u-boot-env)"
 	if [ -n "$idx" ]; then

--- a/target/linux/mvebu/cortexa53/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mvebu/cortexa53/base-files/lib/upgrade/platform.sh
@@ -43,6 +43,7 @@ methode_update_active_bootscript() {
 
 platform_check_image() {
 	case "$(board_name)" in
+	cznic,turris-mox|\
 	glinet,gl-mv1000|\
 	globalscale,espressobin|\
 	globalscale,espressobin-emmc|\
@@ -59,6 +60,7 @@ platform_check_image() {
 
 platform_do_upgrade() {
 	case "$(board_name)" in
+	cznic,turris-mox|\
 	glinet,gl-mv1000|\
 	globalscale,espressobin|\
 	globalscale,espressobin-emmc|\
@@ -117,6 +119,7 @@ platform_do_upgrade() {
 }
 platform_copy_config() {
 	case "$(board_name)" in
+	cznic,turris-mox|\
 	glinet,gl-mv1000|\
 	globalscale,espressobin|\
 	globalscale,espressobin-emmc|\

--- a/target/linux/mvebu/image/cortexa53.mk
+++ b/target/linux/mvebu/image/cortexa53.mk
@@ -6,7 +6,7 @@ define Device/cznic_turris-mox
     kmod-rtc-ds1307 kmod-i2c-pxa kmod-dsa kmod-dsa-mv88e6xxx kmod-sfp \
     kmod-phy-marvell kmod-phy-marvell-10g kmod-ath10k ath10k-board-qca988x \
     ath10k-firmware-qca988x kmod-mt7915e kmod-mt7915-firmware mwlwifi-firmware-88w8997 \
-    wpad-basic-mbedtls kmod-mwifiex-sdio
+    wpad-basic-mbedtls kmod-mwifiex-sdio kmod-btmrvl
   SOC := armada-3720
   BOOT_SCRIPT := turris-mox
 endef

--- a/target/linux/mvebu/image/cortexa53.mk
+++ b/target/linux/mvebu/image/cortexa53.mk
@@ -6,7 +6,7 @@ define Device/cznic_turris-mox
     kmod-rtc-ds1307 kmod-i2c-pxa kmod-dsa kmod-dsa-mv88e6xxx kmod-sfp \
     kmod-phy-marvell kmod-phy-marvell-10g kmod-ath10k ath10k-board-qca988x \
     ath10k-firmware-qca988x kmod-mt7915e kmod-mt7915-firmware mwlwifi-firmware-88w8997 \
-    wpad-basic-mbedtls
+    wpad-basic-mbedtls kmod-mwifiex-sdio
   SOC := armada-3720
   BOOT_SCRIPT := turris-mox
 endef

--- a/target/linux/mvebu/image/turris-mox.bootscript
+++ b/target/linux/mvebu/image/turris-mox.bootscript
@@ -1,22 +1,24 @@
 if part uuid ${devtype} ${devnum}:${distro_bootpart} bootuuid; then
 	if test "${bootfstype}" = "btrfs"; then
-		# Original BTRFS partition layout
+		# BTRFS: root and boot share the same partition via subvolumes
 		rootdev="PARTUUID=${bootuuid}"
+		rootfstype="btrfs"
 		rootflags="commit=5,subvol=@"
 		bootpath="/@/boot"
 	else
-		# OpenWrt default ext4 bootpart + rootpart layout
+		# ext4 or squashfs: boot on p1, root on p2
 		rootdev="/dev/mmcblk0p2"
-		rootflags="commit=5"
-		bootpath="/"
+		rootfstype="auto"
+		rootflags=""
+		bootpath=""
 	fi
 
 	load ${devtype} ${devnum}:${distro_bootpart} ${fdt_addr_r} ${bootpath}/armada-3720-turris-mox.dtb
 	if test "$filesize" != "0"; then
-		has_dtb=1
+		setenv has_dtb 1
 	else
 		setenv has_dtb 0
-		echo "Cannot find device tree binary!"
+		echo "Cannot find device tree binary: ${bootpath}/armada-3720-turris-mox.dtb"
 	fi
 
 	if test $has_dtb -eq 1; then
@@ -34,11 +36,11 @@ if part uuid ${devtype} ${devnum}:${distro_bootpart} bootuuid; then
 					filesize=0
 				fi
 			else
-				echo "Failed to load ${subvol}/boot/Image.lzma"
+				echo "Failed to load ${bootpath}/Image.lzma"
 			fi
 		fi
 		if test "$filesize" != "0"; then
-			setenv bootargs "earlyprintk console=ttyMV0,115200 earlycon=ar3700_uart,0xd0012000 rootfstype=${bootfstype} root=${rootdev} rootflags=${rootflags} rootwait ${contract} rw cfg80211.freg=${regdomain} ${quirks}"
+			setenv bootargs "earlyprintk console=ttyMV0,115200 earlycon=ar3700_uart,0xd0012000 rootfstype=${rootfstype} root=${rootdev} rootflags=${rootflags} rootwait ${contract} rw cfg80211.freg=${regdomain} ${quirks}"
 			booti ${kernel_addr_r} - ${fdt_addr_r}
 			echo "Booting Image failed"
 		else
@@ -46,5 +48,5 @@ if part uuid ${devtype} ${devnum}:${distro_bootpart} bootuuid; then
 		fi
 	fi
 
-	env delete bootuuid rootpart
+	env delete bootuuid
 fi

--- a/target/linux/mvebu/image/turris-mox.bootscript
+++ b/target/linux/mvebu/image/turris-mox.bootscript
@@ -40,7 +40,7 @@ if part uuid ${devtype} ${devnum}:${distro_bootpart} bootuuid; then
 			fi
 		fi
 		if test "$filesize" != "0"; then
-			setenv bootargs "earlyprintk console=ttyMV0,115200 earlycon=ar3700_uart,0xd0012000 rootfstype=${rootfstype} root=${rootdev} rootflags=${rootflags} rootwait ${contract} rw cfg80211.freg=${regdomain} ${quirks}"
+			setenv bootargs "earlyprintk console=ttyMV0,115200 earlycon=ar3700_uart,0xd0012000 rootfstype=${rootfstype} root=${rootdev} rootflags=${rootflags} rootwait ${contract} rw cfg80211.freg=${regdomain} sysctl.kernel.firmware_config.force_sysfs_fallback=0 ${quirks}"
 			booti ${kernel_addr_r} - ${fdt_addr_r}
 			echo "Booting Image failed"
 		else

--- a/target/linux/mvebu/patches-6.12/101-arm64-dts-armada-3720-turris-mox-fix-usb3-phys.patch
+++ b/target/linux/mvebu/patches-6.12/101-arm64-dts-armada-3720-turris-mox-fix-usb3-phys.patch
@@ -1,0 +1,37 @@
+From 57b95de489769259fee99a4b70f10cedc6f24641 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tom=C3=A1=C5=A1=20Macholda?= <tomas.macholda@nic.cz>
+Date: Tue, 7 Jul 2026 13:48:03 +0200
+Subject: [PATCH mvebu-dt64] arm64: dts: turris-mox: fix usb3 phys
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+After commit 00e6d608fe80b0f6 ("arm64: dts: marvell: armada-37xx: swap
+PHYs' order in USB3 controller node") swapped USB3 PHY order, USB
+initialization breaks on Turris MOX.
+
+This regression was exposed by commit 91ddf6f722084383 ("phy: marvell:
+mvebu-a3700-utmi: fix incorrect USB2_PHY_CTRL register access") which
+made USB2 devices not work at all.
+
+Fix the issue by explicitly adding all USB3 PHYs and PHY names to
+Turris MOX device-tree.
+
+Fixes: 7109d817db2e ("arm64: dts: marvell: add DTS for Turris Mox")
+Signed-off-by: Tomáš Macholda <tomas.macholda@nic.cz>
+---
+ arch/arm64/boot/dts/marvell/armada-3720-turris-mox.dts | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/arch/arm64/boot/dts/marvell/armada-3720-turris-mox.dts
++++ b/arch/arm64/boot/dts/marvell/armada-3720-turris-mox.dts
+@@ -290,7 +290,8 @@
+ 
+ &usb3 {
+ 	status = "okay";
+-	phys = <&comphy2 0>;
++	phys = <&usb2_utmi_otg_phy>, <&comphy2 0>;
++	phy-names = "usb2-phy", "usb3-phy";
+ };
+ 
+ &mdio {


### PR DESCRIPTION
Next Turris OS release is going to use OpenWrt 25.12. It would be useful to have these fixes in upstream 25.12 then.

Thanks