### PR TITLE
scripts/feeds: install feed targets with 'install -a'

### DIFF
--- a/scripts/feeds
+++ b/scripts/feeds
@@ -726,10 +726,15 @@ sub install {
 	if($opts{a}) {
 		foreach my $f (@feeds) {
 			if (!defined($opts{p}) or $opts{p} eq $f->[1]) {
-				printf "Installing all packages from feed %s.\n", $f->[1];
+				printf "Installing all packages and targets from feed %s.\n", $f->[1];
 				get_feed($f->[1]);
 				foreach my $name (sort { lc($a) cmp lc($b) } keys %$feed_src) {
 					install_src($feed, $name, exists($opts{f})) == 0 or $ret = 1;
+					get_feed($f->[1]);
+				}
+				foreach my $name (sort { lc($a) cmp lc($b) } keys %$feed_target) {
+					next if $feed_target->{$name}{subtarget};
+					install_target($feed, $name, exists($opts{f})) == 0 or $ret = 1;
 					get_feed($f->[1]);
 				}
 			}
@@ -927,7 +932,7 @@ Commands:
 
 	install [options] <package>: Install a package
 	Options:
-	    -a :           Install all packages from all feeds or from the specified feed using the -p option.
+	    -a :           Install all packages and targets from all feeds or from the specified feed using the -p option.
 	    -p <feedname>: Prefer this feed when installing packages.
 	    -d <y|m|n>:    Set default for newly installed packages.
 	    -f :           Install will be forced even if the package exists in core OpenWrt (override)


### PR DESCRIPTION
Since commit ebc36ebb2349 ("scripts/feeds: install targets to `target/linux/feeds` and support overriding") feeds may host targets in addition to packages, installed on demand with `feeds install <target>`. However `feeds install -a` still only iterates `$feed_src`, so top-level targets shipped by a feed are silently skipped and users must invoke a second `feeds install <name>` for each feed target.

Extend the `-a` code path to also loop over `$feed_target` after the package loop. Subtarget entries share their parent's `Source-Makefile` and would trigger `Path already exists` errors in `do_install_target`, so skip anything marked as a subtarget — the parent symlink already brings the subtargets along.

The existing core-target override guard in `install_target` (skip with a warning unless the feed was declared with `--force`, or `-f` is passed) is preserved, so `feeds install -a` will not silently replace an in-tree target.

### Testing

Tested against a tree that hosts an out-of-tree target in a `src-link` feed (one top-level target plus 9 subtargets). Before the patch `feeds install -a` left `target/linux/feeds/` empty; a separate `feeds install <target>` was required. After the patch a fresh `feeds install -a` prints `Installing target '<name>'` and creates the correct `target/linux/feeds/<name> -> ../../../feeds/<feed>/target/linux/<name>` symlink, subtarget entries are filtered out (no "Path already exists" spam), and a second invocation is a clean no-op.
