### PR TITLE
build: add target SDK to index.json

### DIFF
--- a/package/Makefile
+++ b/package/Makefile
@@ -141,7 +141,9 @@ ifneq ($(CONFIG_USE_APK),)
 			--output packages.adb \
 			*.apk; \
 		$(STAGING_DIR_HOST)/bin/apk adbdump --format json packages.adb | \
-			$(SCRIPT_DIR)/make-index-json.py -f apk -a "$(ARCH_PACKAGES)" - > index.json; \
+			$(SCRIPT_DIR)/make-index-json.py -f apk -a "$(ARCH_PACKAGES)" \
+				-t "$(BOARD)$(if $(SUBTARGET),/$(SUBTARGET))" \
+				- > index.json; \
 	done
 ifdef CONFIG_JSON_CYCLONEDX_SBOM
 	@echo Creating CycloneDX package SBOMs...
@@ -163,7 +165,9 @@ else
 			$(call ERROR_MESSAGE,WARNING: Applying padding in $$d/Packages to workaround usign SHA-512 bug!); \
 			{ echo ""; echo ""; } >> Packages;; \
 		esac; \
-		$(SCRIPT_DIR)/make-index-json.py -f opkg -a "$(ARCH_PACKAGES)" Packages > index.json; \
+		$(SCRIPT_DIR)/make-index-json.py -f opkg -a "$(ARCH_PACKAGES)" \
+			-t "$(BOARD)$(if $(SUBTARGET),/$(SUBTARGET))" \
+			Packages > index.json; \
 		gzip -9nc Packages > Packages.gz; \
 	); done
 ifdef CONFIG_SIGNED_PACKAGES

--- a/scripts/make-index-json.py
+++ b/scripts/make-index-json.py
@@ -31,6 +31,8 @@ def parse_args():
                         help="Required device architecture: like 'x86_64' or 'aarch64_generic'")
     parser.add_argument("-f", "--source-format", required=True, choices=source_format,
                         help="Required source format of input: 'apk' or 'opkg'")
+    parser.add_argument("-t", "--target", default=None,
+                        help="Running target, like 'x86/64' or 'ath79/generic'")
     parser.add_argument("-m", "--manifest", action="store_true", default=False,
                         help="Print output in opkg list format, as 'package - version' pairs")
     parser.add_argument(dest="source",
@@ -100,4 +102,6 @@ if __name__ == "__main__":
             "architecture": args.architecture,
             "packages": packages,
         }
+        if args.target is not None:
+            index["target"] = args.target
         print(json.dumps(index, indent=2))


### PR DESCRIPTION
The OpenWrt build system has no mapping between a package and the SDK. Multiple SDKs may be used to create a package, however this information is nowhere available.

This information however becomes relevant when trying to rebuild an upstream package, i.e. to test reproducibility. A package is given with a specific architecture, however it's unclear which target SDK built the package.

To solve this, add the target/subtarget to the index.json. Now any downstream tooling can check the index.json file and find the corresponding target.