### PR TITLE
[25.12] mediatek: fix 2.5G PHY MCU CSR base address in mt7988.dtsi

### DIFF
--- a/target/linux/mediatek/patches-6.12/173-dts-mt7988a-Add-built-in-ethernet-phy-firmware-node.patch
+++ b/target/linux/mediatek/patches-6.12/173-dts-mt7988a-Add-built-in-ethernet-phy-firmware-node.patch
@@ -19,7 +19,7 @@ Signed-off-by: Sky Huang <skylake.huang@mediatek.com>
 +		phyfw: phy-firmware@f000000 {
 +			compatible = "mediatek,2p5gphy-fw";
 +			reg = <0 0x0f100000 0 0x20000>,
-+			      <0 0x0f0f0018 0 0x20>;
++			      <0 0x0f0f0000 0 0x20>;
 +		};
 +
  		usb@11190000 {

--- a/target/linux/mediatek/patches-6.12/186-arm64-dts-mt7988a-complete-dtsi.patch
+++ b/target/linux/mediatek/patches-6.12/186-arm64-dts-mt7988a-complete-dtsi.patch
@@ -123,7 +123,7 @@ Work-in-progress patch to complete mt7988a.dtsi
  			compatible = "mediatek,mt7981-i2c";
  			reg = <0 0x11003000 0 0x1000>,
 @@ -425,7 +512,7 @@
- 			      <0 0x0f0f0018 0 0x20>;
+ 			      <0 0x0f0f0000 0 0x20>;
  		};
  
 -		usb@11190000 {

--- a/target/linux/mediatek/patches-6.12/700-net-phy-mediatek-Add-2.5Gphy-firmware-dt-bindings-an.patch
+++ b/target/linux/mediatek/patches-6.12/700-net-phy-mediatek-Add-2.5Gphy-firmware-dt-bindings-an.patch
@@ -40,7 +40,7 @@ Signed-off-by: Sky Huang <skylake.huang@mediatek.com>
 +  reg:
 +    items:
 +      - description: pmb firmware load address
-+      - description: firmware trigger register
++      - description: MCU CSR base address
 +
 +required:
 +  - compatible
@@ -53,7 +53,7 @@ Signed-off-by: Sky Huang <skylake.huang@mediatek.com>
 +    phyfw: phy-firmware@f000000 {
 +      compatible = "mediatek,2p5gphy-fw";
 +      reg = <0 0x0f100000 0 0x20000>,
-+            <0 0x0f0f0018 0 0x20>;
++            <0 0x0f0f0000 0 0x20>;
 +    };
 --- a/MAINTAINERS
 +++ b/MAINTAINERS


### PR DESCRIPTION
The second reg entry of the phy-firmware node holds the wrong address. The driver adds MD32_EN_CFG (0x18) to it, but the node already contains the register address including that offset, so the access ends up at 0x0f0f0030. The mainline driver and the Mediatek SDK both use 0x0f0f0000 as the MCU CSR base.

Without this fix, loading the PHY firmware occasionally hangs on MT7988 when the interface is brought up for the first time after a cold boot, causing the watchdog to trigger a reboot.

For reference:
https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/net/phy/mediatek/mtk-2p5ge.c?h=v6.18.40#n18
https://github.com/openwrt/openwrt/blob/openwrt-25.12/target/linux/mediatek/patches-6.12/701-net-phy-mediatek-add-driver-for-built-in-2.5G-ethern.patch#L145
