### PR TITLE
scripts: feeds: support per-feed --post_update hook flag

### DIFF
--- a/scripts/feeds
+++ b/scripts/feeds
@@ -74,6 +74,10 @@ sub parse_file($$) {
 			}
 		}
 
+		if (defined $flags && $flags =~ /(?:^|\s)--post_update(?:\s|$)/) {
+			die "Feed '$name' in '$fname' line $line: --post_update requires =<script>\n";
+		}
+
 		if ($type eq "include") {
 			parse_file($urls, $existing) or
 			    die "Unable to open included file '$urls'";
@@ -257,6 +261,10 @@ sub update_feed_via($$$$$$$$) {
 	if ($m->{'post_update'}) {
 		my $cmd = $m->{'post_update'};
 		system("cd '$localpath'; $cmd") == 0 or return 1;
+	}
+	if (defined(my $hook = $flags->{'post_update'})) {
+		system($hook, $name, $localpath) == 0 or
+			die "Feed '$name': --post_update hook '$hook' failed\n";
 	}
 
 	return 0;


### PR DESCRIPTION
### Problem

Downstream trees frequently need to run custom logic after a feed is fetched or refreshed — apply a locally-maintained patch series on top of an upstream feed, generate provenance/SBOM data, stage overlay files into the feed, etc. Today there is no extension point for this, so each downstream carries a private patch to `scripts/feeds` that inserts a single `system(...)` call at the same spot and hardcodes a path to its own script.

### Change

Extend the existing `feeds.conf` flag syntax with an opt-in `--post_update=<script>` flag. After a feed's per-VCS `post_update` step, if the flag is set on the feed's source line, run the script with the feed name and local path as arguments. Non-zero exit fails the update. Absent flag preserves current behavior.

```
src-git  --post_update=scripts/apply-overlay.sh packages URL
src-cpy  --force --post_update=scripts/stage-core.sh core ../core
src-link vendor ../vendor
```

Flags must appear between `src-<type>` and the feed name — that is the only position the feed-line parser (regex at `scripts/feeds:58`) recognises the `--<word>=<value>` flag run. Three lines in `scripts/feeds`; no schema or grammar change (the existing parser already accepts `--<word>=<value>`).

### Why this shape

- **Per-feed script, not one global hook.** Each feed can have distinct behavior without downstreams building a global if/else dispatcher.
- **Configuration in `feeds.conf`.** Feed-related settings live next to the feed definition rather than in the environment or a magic directory. Consistent with how `--force` already works.
- **No on-disk footprint.** No `feeds.d/` directory to invent; important for consumers who take openwrt as a git subtree, where extra tracked or untracked files complicate merges.
- **Backward compatible.** Flag unset ⇒ zero behavior change.

### Testing

Tested against a tree with five feeds (`src-git`, `src-cpy`, `src-link`, with and without `--force`). Each line was given a `--post_update=<script>` pointing at the same downstream helper. On a clean `feeds/` directory, `feeds update -a` invoked the hook once per feed with the expected `<feed_name> <feed_path>` arguments after the per-VCS post_update ran. A hook returning non-zero correctly failed the enclosing update. Removing the flag from a line reverted that feed to unhooked behavior with the rest still hooking.
