### PR TITLE
qualcommax: qca_ppe: fix the port scheduler TDM enqueue interlock

### DIFF
--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
@@ -381,7 +381,7 @@ static void ppe_tdm_init(struct qca_ppe_priv *priv)
 			     FIELD_PREP(PPE_PSCH_ENS_PORT, psch[i].en_port) |
 			     FIELD_PREP(PPE_PSCH_DES_PORT, psch[i].de_port));
 
-		prev_de_port = BIT(psch[i].de_port);
+		prev_de_port = psch[i].de_port;
 	}
 
 	regmap_write(priv->regmap, PPE_TM_TDM_DEPTH,


### PR DESCRIPTION
Each port scheduler TDM tick carries a dequeue port, an enqueue port and an enqueue port bitmap. The bitmap must permit every port **except** the one dequeued on this tick and the one dequeued on the previous tick, so an enqueue cannot touch a port's scheduler state while a dequeue is still working on it. The comment above the loop states that rule correctly.

`prev_de_port` is seeded as a **port number** and read back as a port number, but assigned as a **mask**:

```c
prev_de_port = psch[psch_num - 1].de_port;              /* port number */
for (i = 0; i < psch_num; i++) {
        u8 bmp = ~(BIT(prev_de_port) | BIT(psch[i].de_port));   /* read as a port number */
        ...
        prev_de_port = BIT(psch[i].de_port);            /* <-- assigned as a MASK */
}
```

So every tick after the first computes `BIT(BIT(de_port))`.

### Worked example, IPQ8074

Tick 0 dequeues port 0, tick 1 dequeues port 5, tick 11 dequeues port 6, tick 12 dequeues port 2.

**Tick 1** — `prev_de_port` was set to `BIT(0)` = 1 instead of 0:

```
correct   ~(BIT(0) | BIT(5)) = ~0x21 = 0xDE   blocks ports 0 and 5
computed  ~(BIT(1) | BIT(5)) = ~0x22 = 0xDD   blocks ports 1 and 5
```

Port 0 was dequeued on the previous tick and is now permitted; port 1 is blocked for no reason.

**Tick 12** — `prev_de_port` was set to `BIT(6)` = 64, so the shift is out of range (on arm64 `1UL << 64` shifts by `64 & 63` = 0):

```
correct   ~(BIT(6) | BIT(2)) = ~0x44 = 0xBB   blocks ports 2 and 6
computed  ~(BIT(0) | BIT(2)) = ~0x05 = 0xFA   blocks ports 0 and 2
```

Both computed values are what the hardware actually reads back. Across the table, **49 of the 50 ticks permit enqueue on the previous tick's dequeue port**. Only tick 0 is right, because it uses the seed from before the loop.

### Why this is the right value

qca-ssdk does not compute the bitmap at all — it ships it per tick as a constant in `port_scheduler0_tbl` (IPQ807x) and `cppe_port_scheduler0_tbl` (IPQ60xx) and writes it straight to `PSCH_TDM_CFG_TBL.ENS_PORT_BITMAP`. With the assignment fixed, the loop reproduces both tables exactly: 50/50 ticks on IPQ8074 and 50/50 on IPQ6018.

Verified on hardware, AX3600 and DL-WRX36: `ens`/`des` already matched ssdk on all 50 ticks; the bitmaps matched on 1 of 50 before the change and 50 of 50 after.

@Ansuel @robimarko
