### PR TITLE
mtd: trx: fix endian bug in trx_fixup and trx_check

### DIFF
--- a/package/system/mtd/src/trx.c
+++ b/package/system/mtd/src/trx.c
@@ -97,8 +97,13 @@ trx_fixup(int fd, const char *name)
 		goto err;
 	}
 
+	if (STORE32_LE(trx->len) > len) {
+		fprintf(stderr, "TRX header length exceeds partition size\n");
+		goto err;
+	}
+
 	scan = ptr + offsetof(struct trx_header, flag_version);
-	trx->crc32 = crc32buf(scan, trx->len - (scan - ptr));
+	trx->crc32 = STORE32_LE(crc32buf(scan, STORE32_LE(trx->len) - (scan - ptr)));
 	msync(ptr, sizeof(struct trx_header), MS_SYNC|MS_INVALIDATE);
 	munmap(ptr, len);
 	close(bfd);
@@ -128,7 +133,7 @@ trx_check(int imagefd, const char *mtd, char *buf, int *len)
 	}
 
 	if (ntohl(trx->magic) != opt_trxmagic ||
-	    trx->len < sizeof(struct trx_header)) {
+	    STORE32_LE(trx->len) < sizeof(struct trx_header)) {
 		if (quiet < 2) {
 			fprintf(stderr, "Bad trx header\n");
 			fprintf(stderr, "This is not the correct file format; refusing to flash.\n"
@@ -144,7 +149,7 @@ trx_check(int imagefd, const char *mtd, char *buf, int *len)
 		exit(1);
 	}
 
-	if(mtdsize < trx->len) {
+	if(mtdsize < STORE32_LE(trx->len)) {
 		fprintf(stderr, "Image too big for partition: %s\n", mtd);
 		close(fd);
 		return 0;


### PR DESCRIPTION
trx->len is stored in little-endian format but read natively in trx_fixup() and trx_check(), causing a wrong length value on big-endian systems. This makes crc32buf read out of bounds in trx_fixup(), and causes incorrect size checks in trx_check(). Wrap all native reads of trx->len with STORE32_LE().