### PR TITLE
uboot-rockchip: enable functional second big cluster via OTP state

### DIFF
--- a/package/boot/uboot-rockchip/patches/102-rockchip-enable-good-state-big-cluster2-for-rk3582.patch
+++ b/package/boot/uboot-rockchip/patches/102-rockchip-enable-good-state-big-cluster2-for-rk3582.patch
@@ -1,0 +1,26 @@
+From 3526d76b9ffffb680e26198af424eb6a9048bf8e Mon Sep 17 00:00:00 2001
+From: xiao bo <peterwillcn@gmail.com>
+Date: Wed, 29 Jul 2026 09:58:04 +0800
+Subject: [PATCH] rockchip: enable good state big cluster2 for rk3582
+
+Enable the second big CPU cluster on RK3582 parts where OTP ip-state
+indicates the cluster is functional.
+
+Signed-off-by: xiao bo <peterwillcn@gmail.com>
+---
+ arch/arm/mach-rockchip/rk3588/rk3588.c | 4 ----
+ 1 file changed, 4 deletions(-)
+
+--- a/arch/arm/mach-rockchip/rk3588/rk3588.c
++++ b/arch/arm/mach-rockchip/rk3588/rk3588.c
+@@ -400,10 +400,6 @@ int ft_system_setup(void *blob, struct b
+ 	if (ip_state[0] & FAIL_CPU_CLUSTER2)
+ 		ip_state[0] |= FAIL_CPU_CLUSTER2;
+ 
+-	/* policy: always fail one big core cluster on rk3582 */
+-	if (!(ip_state[0] & (FAIL_CPU_CLUSTER1 | FAIL_CPU_CLUSTER2)))
+-		ip_state[0] |= FAIL_CPU_CLUSTER2;
+-
+ 	/* policy: always fail gpu on rk3582 */
+ 	ip_state[1] |= FAIL_GPU;
+ 


### PR DESCRIPTION
  Remove the hardcoded restriction that forcibly disables the second big CPU cluster on RK3582. The original code unconditionally masked the second big cluster regardless of hardware state, unnecessarily limiting performance on fully functional RK3582 SKUs with clean OTP state. After this change, cluster availability follows the factory-programmed OTP ip_state value:

- Enable the second big cluster if no hardware failure is marked in OTP
- Keep faulty clusters disabled on defective SKUs to ensure stability This change unlocks native dual big-core 

capability, improves multi-task scheduling, and boosts general throughput while retaining full hardware compatibility.

Note this change only relaxes CPU cluster policy. GPU and selected codec cores remain force-failed on RK3582. Unlike CPU cluster2, these IP blocks are officially defeatured for all RK3582 SKUs per silicon specification,rather than being subject to per-unit hardware variation recorded in OTP.

<img width="583" height="474" alt="89641cf6-0a15-4050-b947-920243e28a87" src="https://github.com/user-attachments/assets/cc7bcde8-f5ec-4c61-ba68-4cf73aef579d" />

<img width="249" height="178" alt="1a8e0c8e-9d3d-49b5-8efe-8d50e67a357d" src="https://github.com/user-attachments/assets/7e197b29-fc94-44f4-aedc-1e513f345cfd" />

