### PR TITLE
netfilter: add devgroup match module

### DIFF
--- a/include/netfilter.mk
+++ b/include/netfilter.mk
@@ -257,6 +257,10 @@ $(eval $(call nf_add,NFNETLINK_QUEUE,CONFIG_NETFILTER_NETLINK_QUEUE, $(P_XT)nfne
 
 $(eval $(if $(NF_KMOD),$(call nf_add,NF_CONNCOUNT,CONFIG_NETFILTER_CONNCOUNT, $(P_XT)nf_conncount),))
 
+# devgroup
+
+$(eval $(call nf_add,IPT_DEVGROUP,CONFIG_NETFILTER_XT_MATCH_DEVGROUP, $(P_XT)xt_devgroup))
+
 #
 # ebtables
 #

--- a/package/kernel/linux/modules/netfilter.mk
+++ b/package/kernel/linux/modules/netfilter.mk
@@ -1305,6 +1305,21 @@ endef
 
 $(eval $(call KernelPackage,ipt-rpfilter))
 
+define KernelPackage/ipt-devgroup
+  SUBMENU:=$(NF_MENU)
+  TITLE:=Netfilter devgroup match
+  DEPENDS:=+kmod-ipt-core
+  KCONFIG:=$(KCONFIG_IPT_DEVGROUP)
+  FILES:=$(LINUX_DIR)/net/netfilter/xt_devgroup.ko
+  AUTOLOAD:=$(call AutoProbe,xt_devgroup)
+  $(call KernelPackage/ipt)
+endef
+
+define KernelPackage/ipt-devgroup/description
+ Kernel module support for the devgroup match module
+endef
+
+$(eval $(call KernelPackage,ipt-devgroup))
 
 define KernelPackage/nft-core
   SUBMENU:=$(NF_MENU)

--- a/package/network/utils/iptables/Makefile
+++ b/package/network/utils/iptables/Makefile
@@ -470,6 +470,16 @@ define Package/iptables-mod-checksum/description
 iptables extension for the CHECKSUM calculation target
 endef
 
+define Package/iptables-mod-devgroup
+$(call Package/iptables/Module, +kmod-ipt-devgroup)
+  TITLE:=devgroup match extension
+endef
+
+define Package/iptables-mod-devgroup/description
+iptables extension for the devgroup match, which allows to match on the
+device group a network device is assigned to.
+endef
+
 define Package/ip6tables-zz-legacy
 $(call Package/iptables/Default)
   DEPENDS:=@IPV6 +kmod-ip6tables +xtables-legacy
@@ -770,6 +780,7 @@ $(eval $(call BuildPlugin,iptables-mod-nflog,$(IPT_NFLOG-m)))
 $(eval $(call BuildPlugin,iptables-mod-trace,$(IPT_DEBUG-m)))
 $(eval $(call BuildPlugin,iptables-mod-nfqueue,$(IPT_NFQUEUE-m)))
 $(eval $(call BuildPlugin,iptables-mod-checksum,$(IPT_CHECKSUM-m)))
+$(eval $(call BuildPlugin,iptables-mod-devgroup,$(IPT_DEVGROUP-m)))
 $(eval $(call BuildPackage,ip6tables-nft))
 $(eval $(call BuildPackage,ip6tables-zz-legacy))
 $(eval $(call BuildPlugin,ip6tables-extra,$(IPT_IPV6_EXTRA-m)))


### PR DESCRIPTION
The devgroup match allows to match on the device group a network device is assigned to.
