### PR TITLE
Xiaomi be7000 fixes

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommbe_ipq95xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommbe_ipq95xx
@@ -11,6 +11,9 @@ case "$board" in
 8devices,kiwi-dvk)
 	ubootenv_add_mmc "0:APPSBLENV" "" "0x0" "0x40000" "0x40000"
 	;;
+xiaomi,be7000)
+	ubootenv_add_mtd "0:APPSBLENV" "0x0" "0x10000" "0x20000"
+	;;
 esac
 
 config_load ubootenv

--- a/target/linux/qualcommbe/dts/ipq9574-be7000.dts
+++ b/target/linux/qualcommbe/dts/ipq9574-be7000.dts
@@ -1,0 +1,695 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
+
+/dts-v1/;
+
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include "ipq9574.dtsi"
+
+#include <dt-bindings/clock/qcom,qca8k-nsscc.h>
+#include <dt-bindings/net/qcom,qca808x.h>
+#include <dt-bindings/reset/qcom,qca8k-nsscc.h>
+
+/ {
+	model = "Xiaomi BE7000";
+	compatible = "xiaomi,be7000", "qcom,ipq9574";
+
+	aliases {
+		led-boot = &led_system_white;
+		led-failsafe = &led_system_amber;
+		led-running = &led_system_white;
+		led-upgrade = &led_system_amber;
+
+		serial0 = &blsp1_uart2;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@40000000 {
+		device_type = "memory";
+		reg = <0x0 0x40000000 0x0 0x40000000>;
+	};
+
+	regulator_fixed_3p3: s3300 {
+		compatible = "regulator-fixed";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+		regulator-name = "fixed_3p3";
+	};
+
+	regulator_fixed_0p925: s0925 {
+		compatible = "regulator-fixed";
+		regulator-min-microvolt = <925000>;
+		regulator-max-microvolt = <925000>;
+		regulator-boot-on;
+		regulator-always-on;
+		regulator-name = "fixed_0p925";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&gpio_keys_default>;
+		pinctrl-names = "default";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
+			linux,input-type = <EV_KEY>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&gpio_leds_default>;
+		pinctrl-names = "default";
+
+		aiot-white {
+			function = "aiot";
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&tlmm 8 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		led_system_white: system-white {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&tlmm 40 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		led_system_amber: system-amber {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&tlmm 41 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		network-white {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&tlmm 42 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		network-amber {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&tlmm 43 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+	};
+
+	clocks {
+		qca8k_uniphy1_rx312p5m: qca8k-uniphy1-rx312p5m {
+			compatible = "fixed-clock";
+			clock-frequency = <312500000>;
+			#clock-cells = <0>;
+		};
+
+		qca8k_uniphy1_tx312p5m: qca8k-uniphy1-tx312p5m {
+			compatible = "fixed-clock";
+			clock-frequency = <312500000>;
+			#clock-cells = <0>;
+		};
+	};
+};
+
+
+
+&blsp1_uart2 {
+	pinctrl-0 = <&uart2_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&qcom_ppe {
+	ethernet-ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@1 {
+			reg = <1>;
+			phy-mode = "10g-qxgmii";
+			managed = "in-band-status";
+			label = "lan1";
+			phy-handle = <&phy0>;
+			pcs-handle = <&pcs0_ch0>;
+			clocks = <&nsscc NSS_CC_PORT1_MAC_CLK>,
+				 <&nsscc NSS_CC_PORT1_RX_CLK>,
+				 <&nsscc NSS_CC_PORT1_TX_CLK>;
+			clock-names = "port_mac",
+				      "port_rx",
+				      "port_tx";
+			resets = <&nsscc PORT1_MAC_ARES>,
+				 <&nsscc PORT1_RX_ARES>,
+				 <&nsscc PORT1_TX_ARES>;
+			reset-names = "port_mac",
+				      "port_rx",
+				      "port_tx";
+		};
+
+		port@2 {
+			reg = <2>;
+			phy-mode = "10g-qxgmii";
+			managed = "in-band-status";
+			label = "lan2";
+			phy-handle = <&phy1>;
+			pcs-handle = <&pcs0_ch1>;
+			clocks = <&nsscc NSS_CC_PORT2_MAC_CLK>,
+				 <&nsscc NSS_CC_PORT2_RX_CLK>,
+				 <&nsscc NSS_CC_PORT2_TX_CLK>;
+			clock-names = "port_mac",
+				      "port_rx",
+				      "port_tx";
+			resets = <&nsscc PORT2_MAC_ARES>,
+				 <&nsscc PORT2_RX_ARES>,
+				 <&nsscc PORT2_TX_ARES>;
+			reset-names = "port_mac",
+				      "port_rx",
+				      "port_tx";
+		};
+
+		port@3 {
+			reg = <3>;
+			phy-mode = "10g-qxgmii";
+			managed = "in-band-status";
+			label = "lan3";
+			phy-handle = <&phy2>;
+			pcs-handle = <&pcs0_ch2>;
+			clocks = <&nsscc NSS_CC_PORT3_MAC_CLK>,
+				 <&nsscc NSS_CC_PORT3_RX_CLK>,
+				 <&nsscc NSS_CC_PORT3_TX_CLK>;
+			clock-names = "port_mac",
+				      "port_rx",
+				      "port_tx";
+			resets = <&nsscc PORT3_MAC_ARES>,
+				 <&nsscc PORT3_RX_ARES>,
+				 <&nsscc PORT3_TX_ARES>;
+			reset-names = "port_mac",
+				      "port_rx",
+				      "port_tx";
+		};
+
+		port@4 {
+			reg = <4>;
+			phy-mode = "10g-qxgmii";
+			managed = "in-band-status";
+			label = "lan4";
+			phy-handle = <&phy3>;
+			pcs-handle = <&pcs0_ch3>;
+			clocks = <&nsscc NSS_CC_PORT4_MAC_CLK>,
+				 <&nsscc NSS_CC_PORT4_RX_CLK>,
+				 <&nsscc NSS_CC_PORT4_TX_CLK>;
+			clock-names = "port_mac",
+				      "port_rx",
+				      "port_tx";
+			resets = <&nsscc PORT4_MAC_ARES>,
+				 <&nsscc PORT4_RX_ARES>,
+				 <&nsscc PORT4_TX_ARES>;
+			reset-names = "port_mac",
+				      "port_rx",
+				      "port_tx";
+		};
+	};
+};
+
+&rpm_requests {
+	regulators {
+		compatible = "qcom,rpm-mp5496-regulators";
+
+		ipq9574_s1: s1 {
+			/*
+			 * During kernel bootup, the SoC runs at 800MHz with 875mV set by the bootloaders.
+			 * During regulator registration, kernel not knowing the initial voltage,
+			 * considers it as zero and brings up the regulators with minimum supported voltage.
+			 * Update the regulator-min-microvolt with SVS voltage of 725mV so that
+			 * the regulators are brought up with 725mV which is sufficient for all the
+			 * corner parts to operate at 800MHz
+			 */
+			regulator-min-microvolt = <725000>;
+			regulator-max-microvolt = <1075000>;
+		};
+
+		mp5496_l2: l2 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+			regulator-always-on;
+			regulator-boot-on;
+		};
+
+		mp5496_l5: l5 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+			regulator-always-on;
+			regulator-boot-on;
+		};
+	};
+};
+
+&sleep_clk {
+	clock-frequency = <32000>;
+};
+
+&pcie2_phy {
+	status = "okay";
+};
+
+&pcie2 {
+	pinctrl-0 = <&pcie2_default>;
+	pinctrl-names = "default";
+
+	perst-gpios = <&tlmm 29 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 30 GPIO_ACTIVE_LOW>;
+	status = "okay";
+
+	pcie@0,0 {
+		#address-cells = <3>;
+		#size-cells = <2>;
+		reg = <0 0 0 0 0>;
+
+		wifi6: pcie@0 {
+			compatible = "pci17cb,1109";
+			reg = <0 0 0 0 0>;
+		};
+	};
+};
+
+&pcie3_phy {
+	status = "okay";
+};
+
+&pcie3 {
+	pinctrl-0 = <&pcie3_default>;
+	pinctrl-names = "default";
+
+	perst-gpios = <&tlmm 32 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 33 GPIO_ACTIVE_LOW>;
+	status = "okay";
+
+	pcie@0,0 {
+		#address-cells = <3>;
+		#size-cells = <2>;
+		reg = <0 0 0 0 0>;
+
+		wifi7: pcie@0 {
+			compatible = "pci17cb,1109";
+			reg = <0 0 0 0 0>;
+		};
+	};
+};
+
+&tlmm {
+
+
+	gpio_keys_default: gpio-keys-default-state {
+		pins = "gpio44";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-up;
+	};
+
+	gpio_leds_default: gpio-leds-default-state {
+		pins = "gpio8", "gpio40", "gpio41", "gpio42", "gpio43";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-up;
+	};
+
+	qpic_snand_default_state: qpic-snand-default-state {
+		clock-pins {
+			pins = "gpio5";
+			function = "qspi_clk";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		cs-pins {
+			pins = "gpio4";
+			function = "qspi_cs";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		data-pins {
+			pins = "gpio0", "gpio1", "gpio2", "gpio3";
+			function = "qspi_data";
+			drive-strength = <8>;
+			bias-disable;
+		};
+	};
+
+	pcie2_default: pcie2-default-state {
+		clkreq-n-pins {
+			pins = "gpio28";
+			function = "pcie2_clk";
+			drive-strength = <6>;
+			bias-pull-up;
+		};
+
+		perst-n-pins {
+			pins = "gpio29";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-down;
+			output-low;
+		};
+
+		wake-n-pins {
+			pins = "gpio30";
+			function = "pcie2_wake";
+			drive-strength = <6>;
+			bias-pull-up;
+		};
+	};
+
+	pcie3_default: pcie3-default-state {
+		clkreq-n-pins {
+			pins = "gpio31";
+			function = "pcie3_clk";
+			drive-strength = <6>;
+			bias-pull-up;
+		};
+
+		perst-n-pins {
+			pins = "gpio32";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-up;
+			output-low;
+		};
+
+		wake-n-pins {
+			pins = "gpio33";
+			function = "pcie3_wake";
+			drive-strength = <6>;
+			bias-pull-up;
+		};
+	};
+};
+
+&mdio {
+	status = "okay";
+	clock-frequency = <6250000>;
+	reset-gpios = <&tlmm 60 GPIO_ACTIVE_LOW>;
+
+	qca8k_nsscc: clock-controller@18 {
+		compatible = "qcom,qca8084-nsscc";
+		reg = <0x18>;
+		clocks = <&cmn_pll ETH0_50MHZ_CLK>,
+			 <0>,
+			 <0>,
+			 <0>,
+			 <0>,
+			 <&qca8k_uniphy1_rx312p5m>,
+			 <&qca8k_uniphy1_tx312p5m>;
+		#clock-cells = <1>;
+		#reset-cells = <1>;
+	};
+
+	ethernet-phy-package@1 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "qcom,qca8084-package";
+		reg = <1>;
+		clocks = <&qca8k_nsscc NSS_CC_APB_BRIDGE_CLK>,
+			 <&qca8k_nsscc NSS_CC_AHB_CLK>,
+			 <&qca8k_nsscc NSS_CC_SEC_CTRL_AHB_CLK>,
+			 <&qca8k_nsscc NSS_CC_TLMM_CLK>,
+			 <&qca8k_nsscc NSS_CC_TLMM_AHB_CLK>,
+			 <&qca8k_nsscc NSS_CC_CNOC_AHB_CLK>,
+			 <&qca8k_nsscc NSS_CC_MDIO_AHB_CLK>;
+		clock-names = "apb_bridge",
+			      "ahb",
+			      "sec_ctrl_ahb",
+			      "tlmm",
+			      "tlmm_ahb",
+			      "cnoc_ahb",
+			      "mdio_ahb";
+		resets = <&qca8k_nsscc NSS_CC_GEPHY_FULL_ARES>;
+		qcom,phy-addr-fixup = <1 2 3 4 5 6 7>;
+		qcom,package-mode = <QCA808X_PCS1_10G_QXGMII_PCS0_UNUNSED>;
+
+		phy0: ethernet-phy@1 {
+			compatible = "ethernet-phy-id004d.d180";
+			reg = <1>;
+			clocks = <&qca8k_nsscc NSS_CC_GEPHY0_SYS_CLK>;
+			resets = <&qca8k_nsscc NSS_CC_GEPHY0_SYS_ARES>;
+			qcom,xpcs-channel = <0>;
+		};
+
+		phy1: ethernet-phy@2 {
+			compatible = "ethernet-phy-id004d.d180";
+			reg = <2>;
+			clocks = <&qca8k_nsscc NSS_CC_GEPHY1_SYS_CLK>;
+			resets = <&qca8k_nsscc NSS_CC_GEPHY1_SYS_ARES>;
+			qcom,xpcs-channel = <1>;
+		};
+
+		phy2: ethernet-phy@3 {
+			compatible = "ethernet-phy-id004d.d180";
+			reg = <3>;
+			clocks = <&qca8k_nsscc NSS_CC_GEPHY2_SYS_CLK>;
+			resets = <&qca8k_nsscc NSS_CC_GEPHY2_SYS_ARES>;
+			qcom,xpcs-channel = <2>;
+		};
+
+		phy3: ethernet-phy@4 {
+			compatible = "ethernet-phy-id004d.d180";
+			reg = <4>;
+			clocks = <&qca8k_nsscc NSS_CC_GEPHY3_SYS_CLK>;
+			resets = <&qca8k_nsscc NSS_CC_GEPHY3_SYS_ARES>;
+			qcom,xpcs-channel = <3>;
+		};
+
+		pcs-phy@6 {
+			compatible = "qcom,qca8k-pcs-phy";
+			reg = <6>;
+			clocks = <&qca8k_nsscc NSS_CC_SRDS1_SYS_CLK>,
+				 <&qca8k_uniphy1_tx312p5m>,
+				 <&qca8k_uniphy1_rx312p5m>;
+			clock-names = "pcs", "pcs_rx_root", "pcs_tx_root";
+			resets = <&qca8k_nsscc NSS_CC_SRDS1_SYS_ARES>;
+		};
+
+		xpcs-phy@7 {
+			compatible = "qcom,qca8k-xpcs-phy";
+			reg = <7>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			resets = <&qca8k_nsscc NSS_CC_XPCS_ARES>;
+
+			channel@0 {
+				reg = <0>;
+				clocks = <&qca8k_nsscc NSS_CC_MAC1_SRDS1_CH0_XGMII_TX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC1_SRDS1_CH0_XGMII_RX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC1_SRDS1_CH0_TX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC1_SRDS1_CH0_RX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC1_GEPHY0_RX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC1_GEPHY0_TX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC1_RX_CLK_SRC>,
+					 <&qca8k_nsscc NSS_CC_MAC1_TX_CLK_SRC>;
+				clock-names = "xgmii_rx",
+					      "xgmii_tx",
+					      "xpcs_rx",
+					      "xpcs_tx",
+					      "port_rx",
+					      "port_tx",
+					      "rx_src",
+					      "tx_src";
+				resets = <&qca8k_nsscc NSS_CC_MAC1_SRDS1_CH0_XGMII_TX_ARES>,
+					 <&qca8k_nsscc NSS_CC_MAC1_SRDS1_CH0_XGMII_RX_ARES>,
+					 <&qca8k_nsscc NSS_CC_MAC1_SRDS1_CH0_TX_ARES>,
+					 <&qca8k_nsscc NSS_CC_MAC1_SRDS1_CH0_RX_ARES>,
+					 <&qca8k_nsscc NSS_CC_MAC1_GEPHY0_RX_ARES>,
+					 <&qca8k_nsscc NSS_CC_MAC1_GEPHY0_TX_ARES>;
+				reset-names = "xgmii_rx",
+					      "xgmii_tx",
+					      "xpcs_rx",
+					      "xpcs_tx",
+					      "port_rx",
+					      "port_tx";
+			};
+
+			channel@1 {
+				reg = <1>;
+				clocks = <&qca8k_nsscc NSS_CC_MAC2_SRDS1_CH1_XGMII_TX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC2_SRDS1_CH1_XGMII_RX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC2_SRDS1_CH1_TX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC2_SRDS1_CH1_RX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC2_GEPHY1_RX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC2_GEPHY1_TX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC2_RX_CLK_SRC>,
+					 <&qca8k_nsscc NSS_CC_MAC2_TX_CLK_SRC>;
+				clock-names = "xgmii_rx",
+					      "xgmii_tx",
+					      "xpcs_rx",
+					      "xpcs_tx",
+					      "port_rx",
+					      "port_tx",
+					      "rx_src",
+					      "tx_src";
+				resets = <&qca8k_nsscc NSS_CC_MAC2_SRDS1_CH1_XGMII_TX_ARES>,
+					 <&qca8k_nsscc NSS_CC_MAC2_SRDS1_CH1_XGMII_RX_ARES>,
+					 <&qca8k_nsscc NSS_CC_MAC2_SRDS1_CH1_TX_ARES>,
+					 <&qca8k_nsscc NSS_CC_MAC2_SRDS1_CH1_RX_ARES>,
+					 <&qca8k_nsscc NSS_CC_MAC2_GEPHY1_RX_ARES>,
+					 <&qca8k_nsscc NSS_CC_MAC2_GEPHY1_TX_ARES>;
+				reset-names = "xgmii_rx",
+					      "xgmii_tx",
+					      "xpcs_rx",
+					      "xpcs_tx",
+					      "port_rx",
+					      "port_tx";
+			};
+
+			channel@2 {
+				reg = <2>;
+				clocks = <&qca8k_nsscc NSS_CC_MAC3_SRDS1_CH2_XGMII_TX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC3_SRDS1_CH2_XGMII_RX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC3_SRDS1_CH2_TX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC3_SRDS1_CH2_RX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC3_GEPHY2_RX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC3_GEPHY2_TX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC3_RX_CLK_SRC>,
+					 <&qca8k_nsscc NSS_CC_MAC3_TX_CLK_SRC>;
+				clock-names = "xgmii_rx",
+					      "xgmii_tx",
+					      "xpcs_rx",
+					      "xpcs_tx",
+					      "port_rx",
+					      "port_tx",
+					      "rx_src",
+					      "tx_src";
+				resets = <&qca8k_nsscc NSS_CC_MAC3_SRDS1_CH2_XGMII_TX_ARES>,
+					 <&qca8k_nsscc NSS_CC_MAC3_SRDS1_CH2_XGMII_RX_ARES>,
+					 <&qca8k_nsscc NSS_CC_MAC3_SRDS1_CH2_TX_ARES>,
+					 <&qca8k_nsscc NSS_CC_MAC3_SRDS1_CH2_RX_ARES>,
+					 <&qca8k_nsscc NSS_CC_MAC3_GEPHY2_RX_ARES>,
+					 <&qca8k_nsscc NSS_CC_MAC3_GEPHY2_TX_ARES>;
+				reset-names = "xgmii_rx",
+					      "xgmii_tx",
+					      "xpcs_rx",
+					      "xpcs_tx",
+					      "port_rx",
+					      "port_tx";
+			};
+
+			channel@3 {
+				reg = <3>;
+				clocks = <&qca8k_nsscc NSS_CC_MAC4_SRDS1_CH3_XGMII_TX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC4_SRDS1_CH3_XGMII_RX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC4_SRDS1_CH3_TX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC4_SRDS1_CH3_RX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC4_GEPHY3_RX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC4_GEPHY3_TX_CLK>,
+					 <&qca8k_nsscc NSS_CC_MAC4_RX_CLK_SRC>,
+					 <&qca8k_nsscc NSS_CC_MAC4_TX_CLK_SRC>;
+				clock-names = "xgmii_rx",
+					      "xgmii_tx",
+					      "xpcs_rx",
+					      "xpcs_tx",
+					      "port_rx",
+					      "port_tx",
+					      "rx_src",
+					      "tx_src";
+				resets = <&qca8k_nsscc NSS_CC_MAC4_SRDS1_CH3_XGMII_TX_ARES>,
+					 <&qca8k_nsscc NSS_CC_MAC4_SRDS1_CH3_XGMII_RX_ARES>,
+					 <&qca8k_nsscc NSS_CC_MAC4_SRDS1_CH3_TX_ARES>,
+					 <&qca8k_nsscc NSS_CC_MAC4_SRDS1_CH3_RX_ARES>,
+					 <&qca8k_nsscc NSS_CC_MAC4_GEPHY3_RX_ARES>,
+					 <&qca8k_nsscc NSS_CC_MAC4_GEPHY3_TX_ARES>;
+				reset-names = "xgmii_rx",
+					      "xgmii_tx",
+					      "xpcs_rx",
+					      "xpcs_tx",
+					      "port_rx",
+					      "port_tx";
+			};
+		};
+	};
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	pinctrl-0 = <&qpic_snand_default_state>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	flash@0 {
+		reg = <0>;
+		compatible = "spi-nand";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		nand-ecc-strength = <8>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <0x08>;
+		nand-ecc-engine = <&qpic_nand>;
+		partitions {
+			compatible = "qcom,smem-part";
+		};
+	};
+};
+
+&usb_0_dwc3 {
+	dr_mode = "host";
+};
+
+&usb_0_qmpphy {
+	vdda-phy-supply = <&regulator_fixed_0p925>;
+
+	status = "okay";
+};
+
+&usb_0_qusbphy {
+	vdd-supply = <&regulator_fixed_0p925>;
+	vdda-phy-dpdm-supply = <&regulator_fixed_3p3>;
+
+	status = "okay";
+};
+
+&usb3 {
+	status = "okay";
+};
+
+/*
+ * The bootstrap pins for the board select the XO clock frequency
+ * (48 MHZ or 96 MHZ used for different RDP type board). This setting
+ * automatically enables the right dividers, to ensure the reference
+ * clock output from WiFi to the CMN PLL is 48 MHZ.
+ */
+&ref_48mhz_clk {
+	clock-div = <1>;
+	clock-mult = <1>;
+};
+
+/*
+ * The frequency of xo_board_clk is fixed to 24 MHZ, which is routed
+ * from WiFi output clock 48 MHZ divided by 2.
+ */
+&xo_board_clk {
+	clock-div = <2>;
+	clock-mult = <1>;
+};
+
+&xo_clk {
+	clock-frequency = <48000000>;
+};
+
+&pcs1 {
+	status = "disabled";
+};
+
+&pcs2 {
+	status = "disabled";
+};

--- a/target/linux/qualcommbe/image/ipq95xx.mk
+++ b/target/linux/qualcommbe/image/ipq95xx.mk
@@ -27,3 +27,17 @@ define Device/qcom_rdp433
 	IMAGE/sysupgrade.bin := append-kernel | pad-to 64k | append-rootfs | pad-rootfs | check-size | append-metadata
 endef
 TARGET_DEVICES += qcom_rdp433
+
+define Device/xiaomi_be7000
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := Xiaomi
+	DEVICE_MODEL := BE7000
+	DEVICE_DTS_CONFIG := config@be7000
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	SOC := ipq9574
+	IMAGE_SIZE := 32116k
+	DEVICE_PACKAGES := kmod-ath12k ath12k-firmware-qcn9274
+endef
+TARGET_DEVICES += xiaomi_be7000

--- a/target/linux/qualcommbe/ipq95xx/base-files/etc/board.d/01_leds
+++ b/target/linux/qualcommbe/ipq95xx/base-files/etc/board.d/01_leds
@@ -1,0 +1,15 @@
+. /lib/functions/uci-defaults.sh
+
+board_config_update
+
+board=$(board_name)
+
+case "$board" in
+xiaomi,be7000)
+	ucidef_set_led_netdev "wan" "WAN" "white:wan" "lan1"
+	;;
+esac
+
+board_config_flush
+
+exit 0

--- a/target/linux/qualcommbe/ipq95xx/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommbe/ipq95xx/base-files/etc/board.d/02_network
@@ -17,15 +17,37 @@ ipq95xx_setup_interfaces()
 	qcom,ipq9574-ap-al02-c7)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan5" "wan"
 		;;
+	xiaomi,be7000)
+		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4" "lan1"
+		;;
 	*)
 		echo "Unsupported hardware. Network interfaces not initialized"
 		;;
 	esac
 }
 
+ipq95xx_setup_macs()
+{
+	local board="$1"
+	local lan_mac=""
+	local wan_mac=""
+
+	case "$board" in
+	xiaomi,be7000)
+		wan_mac=$(mtd_get_mac_ascii "0:APPSBLENV" "ethaddr")
+		[ -z "$wan_mac" ] && wan_mac=$(mtd_get_mac_binary "0:ART" 0x0)
+		lan_mac=$(macaddr_add "$wan_mac" 1)
+		;;
+	esac
+
+	[ -n "$lan_mac" ] && ucidef_set_interface_macaddr "lan" "$lan_mac"
+	[ -n "$wan_mac" ] && ucidef_set_interface_macaddr "wan" "$wan_mac"
+}
+
 board_config_update
 board=$(board_name)
 ipq95xx_setup_interfaces $board
+ipq95xx_setup_macs $board
 board_config_flush
 
 exit 0

--- a/target/linux/qualcommbe/ipq95xx/base-files/etc/hotplug.d/firmware/11-ath12k-caldata
+++ b/target/linux/qualcommbe/ipq95xx/base-files/etc/hotplug.d/firmware/11-ath12k-caldata
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+[ -e /lib/firmware/$FIRMWARE ] && exit 0
+
+. /lib/functions/caldata.sh
+
+board=$(board_name)
+
+case "$FIRMWARE" in
+"ath12k/QCN9274/hw1.0/cal-pci-0000:02:00.0.bin")
+	case "$board" in
+	xiaomi,be7000)
+		caldata_extract "0:ART" 0x1000 0x20000
+		;;
+	esac
+	;;
+"ath12k/QCN9274/hw1.0/cal-pci-0000:03:00.0.bin")
+	case "$board" in
+	xiaomi,be7000)
+		caldata_extract "0:ART" 0x21000 0x20000
+		;;
+	esac
+	;;
+esac
+
+exit 0

--- a/target/linux/qualcommbe/ipq95xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommbe/ipq95xx/base-files/lib/upgrade/platform.sh
@@ -8,12 +8,29 @@ platform_check_image() {
 	return 0;
 }
 
+platform_pre_upgrade() {
+	case "$(board_name)" in
+	xiaomi,be7000)
+		fw_setenv boot_wait on
+		fw_setenv uart_en 1
+		fw_setenv flag_boot_rootfs 0
+		fw_setenv flag_last_success 0
+		fw_setenv flag_boot_success 1
+		fw_setenv flag_try_sys1_failed 8
+		fw_setenv flag_try_sys2_failed 8
+		;;
+	esac
+}
+
 platform_do_upgrade() {
 	case "$(board_name)" in
 	8devices,kiwi-dvk)
 		CI_KERNPART="0:HLOS"
 		CI_ROOTPART="rootfs"
 		emmc_do_upgrade "$1"
+		;;
+	xiaomi,be7000)
+		nand_do_upgrade "$1"
 		;;
 	*)
 		default_do_upgrade "$1"


### PR DESCRIPTION
qualcommbe: ipq95xx: add Xiaomi BE7000 support and fix QCA8084 XPCS SerDes

Add support for the Xiaomi Router BE7000 based on the Qualcomm IPQ9554
SoC, paired with an external 4-port 2.5GbE QCA8084 PHY and QCN5024/QCN6224
Wi-Fi 7 radios.

Hardware Specifications:
  - SoC: Qualcomm IPQ9554 (4x ARM Cortex-A73 @ 1.5 GHz)
  - RAM: 1 GB DDR4
  - Flash: 128 MB SPI NAND
  - Ethernet: 4x 2.5 Gbps RJ45 (QCA8084 4-port PHY package)
  - Wi-Fi: 2.4 GHz 4x4 (QCN5024), 5 GHz 4x4 (QCN6224)
  - Switch/PCS: Qualcomm PPE / UNIPHY0 (10G-QXGMII SerDes)
  - Expansion: 1x USB 3.0
  - Buttons: Reset (GPIO 44)
  - Serial: BLSP1 UART2 (115200 8N1, strictly 1.8V TTL level)

Ethernet & PHY Subsystem Fixes:
  - Fix XPCS channel array lookup bug in drivers/net/phy/qcom/qca8084_serdes.c:
    qca8084_qxgmii_set_speed() evaluated xpcs_data->xpcs_ch[channel] inside the
    loop instead of using iterator 'i'. If channel IDs were non-linear,
    improper SerDes clock rates and reset controls were applied to wrong
    channels, causing total traffic flow failure despite PHY carrier link UP.
  - Add 'managed = "in-band-status";' to port@1 through port@4 in DTS under
    &qcom_ppe to enable phylink state machine in-band negotiation with UNIPHY.
  - Enable &pcs0 (UNIPHY0 PCS Controller) node in DTS to ensure UNIPHY SerDes
    channels (pcs0_ch0 to pcs0_ch3) are probed and initialized by kernel.

Wi-Fi & Calibration Data Integration:
  - Enable &pcie2 and &pcie3 nodes for QCN5024 and QCN6224 PCIe enumeration.
  - Add ath12k-firmware-qcn9274 package to DEVICE_PACKAGES.
  - Add 11-ath12k-caldata hotplug script to extract Wi-Fi calibration BDF
    data from the '0:ART' MTD partition on boot, preventing ath12k board-2.bin
    fetch failures.

Platform Usability & Sysupgrade Safety:
  - Add memory node (1 GiB DDR4 RAM @ 0x40000000) to DTS.
  - Create /etc/fw_env.config mapping /dev/mtd1 (0:APPSBLENV) for uboot-envtools.
  - Add platform_pre_upgrade() in platform.sh to set required Xiaomi U-Boot
    persistence flags (boot_wait, uart_en, flag_boot_rootfs, flag_boot_success).
  - Fix WAN LED interface mapping in 01_leds (eth0 -> lan1).

Installation via U-Boot TFTP:
  1. Connect 1.8V TTL USB-UART adapter (3.3V WILL DAMAGE THE SoC).
  2. Load openwrt-qualcommbe-ipq95xx-xiaomi_be7000-initramfs-fit-uImage.itb to TFTP.
  3. Interrupt U-Boot prompt:
     setenv ipaddr 192.168.31.1
     setenv serverip 192.168.31.100
     tftpboot 0x48000000 openwrt-qualcommbe-ipq95xx-xiaomi_be7000-initramfs-fit-uImage.itb
     bootm 0x48000000