### PR TITLE
base-files: sysupgrade: shut the network down gracefully

### DIFF
--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -450,5 +450,12 @@ else
 	[ $USE_CURR_PART -eq 1 ] && json_add_boolean use_curr_part 1
 	json_close_object
 
+	[ -x /etc/init.d/network ] && /etc/init.d/network shutdown
+
 	ubus call system sysupgrade "$(json_dump)"
+	upgrade_rc=$?
+
+	[ -x /etc/init.d/network ] && /etc/init.d/network restart
+
+	exit $upgrade_rc
 fi


### PR DESCRIPTION
Fixes https://github.com/openwrt/openwrt/issues/24461.

procd's sysupgrade path stops every service with a bare SIGTERM and never runs their
`shutdown()` hooks, unlike a reboot, which reaches them through inittab. netifd's SIGTERM
handler ends its uloop and then kills every process netifd started, so pppd never gets to
send a PADT, the peer keeps the session half open and the reconnect after the upgrade
stalls until it times out:

    netifd main.c, netifd_kill_process():
        kill(proc->uloop.pid, SIGKILL);

The hook that tears the interfaces down properly already exists, is the same one a reboot
runs on every device, and nothing on the flash path calls it:

    package/network/config/netifd/files/etc/init.d/network:
        shutdown() {
            ifdown -a
            sleep 1
        }

So the patch runs that hook from sysupgrade before the ubus handover, while netifd is
still alive, and restarts the network if the handover fails, so a rejected image cannot
leave the device unreachable. `ifup -a` would not do as the restore: it also raises
interfaces configured with `option auto 0` and leaves that flag flipped.

Measured on an ipq807x board behind a PPPoE WAN, three runs of the two commands the patch
adds, detached and with no image written, which is the rejected-image path: both returned
0, shutdown in 1 to 2 s and restart in 1 s, with `Terminating on signal 15` and
`Sent PADT` in the syslog and the WAN back up every run. I have not re-run the end-to-end
arm for this version; the table is one sysupgrade per arm, a single reading:

| teardown | pppd attempts | stall (1 sysupgrade each) |
| --- | --- | --- |
| before | 3, two ending in `Timeout waiting for PADO packets` | 71 s |
| after | 1, connects on the first PADI | 5 s |

This replaces the earlier version of the PR, which changed stage2's `skip_services`. That
loop cannot do the same job: by the time `upgraded` execs stage2, procd has already
stopped ubusd, so every `ubus call service delete` there fails with `Failed to connect to
ubus`. On the failsafe path initd execs `upgraded` in place of `/sbin/procd`, so no ubusd
runs there at all and the loop is inert. The skip list is untouched now.
