### PR TITLE
ramips: add support for COMFAST CF-E455AC V2

### DIFF
--- a/target/linux/ramips/dts/mt7621_comfast_cf-e455ac-v2.dts
+++ b/target/linux/ramips/dts/mt7621_comfast_cf-e455ac-v2.dts
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "comfast,cf-e455ac-v2", "mediatek,mt7621-soc";
+	model = "COMFAST CF-E455AC V2";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		/*
+		 * Three GPIO LEDs, active-high (confirmed against the stock
+		 * firmware's live GPIO/LED state):
+		 *   red:wan   gpio 13
+		 *   green:lan gpio 15
+		 *   blue:wlan gpio 16
+		 * gpio 19 is driven high by the bootloader but is not exposed
+		 * as an LED by the vendor firmware; left unconfigured.
+		 */
+
+		led_wan: wan {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_lan: lan {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	aliases {
+		label-mac-device = &gmac0;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "w25q128";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,fast-read;
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "Config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000  {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+
+					macaddr_factory_e000: macaddr@e000 {
+						compatible = "mac-base";
+						reg = <0xe000 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@50000  {
+				label = "firmware";
+				compatible = "denx,uimage";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&gpio {
+	groups = "i2c", "uart2", "uart3", "sdhci", "jtag";
+	function = "gpio";
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi_2_4_ghz: wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+		/*
+		 * MT7603 (2.4 GHz). Reads its MAC from EEPROM (&factory + 4);
+		 * do not add mac-address here or a random MAC will be used.
+		 */
+	};
+};
+
+&pcie1 {
+	wifi_5_0_ghz: wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+		/*
+		 * MT7663 (5 GHz). Reads its MAC from EEPROM (&factory + 0x8000 + 4);
+		 * do not add mac-address here or a random MAC will be used.
+		 */
+	};
+};
+
+&pcie2 {
+	status = "disabled";
+};
+
+&switch0 {
+	mediatek,mcm;
+	ports {
+		wan: port@0 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_e000 1>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		lan: port@1 {
+			status = "okay";
+			label = "lan";
+			nvmem-cells = <&macaddr_factory_e000 0>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -720,6 +720,21 @@ define Device/comfast_cf-e390ax
 endef
 TARGET_DEVICES += comfast_cf-e390ax
 
+define Device/comfast_cf-e455ac-v2
+    $(Device/dsa-migration)
+    $(Device/uimage-lzma-loader)
+    IMAGE_SIZE := 15808k
+    DEVICE_VENDOR := COMFAST
+    DEVICE_MODEL := CF-E455AC V2
+    DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
+        -uboot-envtools
+    IMAGES += factory.bin
+    IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
+        check-size | append-metadata
+    IMAGE/factory.bin := append-kernel | append-rootfs | pad-rootfs | check-size
+endef
+TARGET_DEVICES += comfast_cf-e455ac-v2
+
 define Device/comfast_cf-ew72-v2
     $(Device/dsa-migration)
     $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -58,6 +58,11 @@ wifire,s1500-nbn)
 belkin,rt1800)
 	ucidef_set_led_netdev "wan" "wan" "white:wan" "wan"
 	;;
+comfast,cf-e455ac-v2)
+	ucidef_set_led_netdev "lan" "lan" "green:lan" "lan"
+	ucidef_set_led_netdev "wan" "wan" "red:wan" "wan"
+	ucidef_set_led_wlan "wlan" "wlan" "blue:wlan" "phy0tpt"
+	;;
 cudy,ap1300-outdoor-v1)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "lan"
 	;;

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -78,6 +78,7 @@ ramips_setup_interfaces()
 		;;
 	asiarf,ap7621-001|\
 	comfast,cf-e390ax|\
+	comfast,cf-e455ac-v2|\
 	comfast,cf-ew72-v2|\
 	cudy,m1300-v2|\
 	cudy,m1800|\


### PR DESCRIPTION
COMFAST CF-E455AC V2 is a dual-band 802.11ac ceiling access point based on
MediaTek MT7621, from the same platform family as the in-tree
`comfast_cf-ew72-v2`, which was used as the device-tree template.

### Specifications
- SoC: MediaTek MT7621
- RAM: 128 MB
- Flash: 16 MB (Winbond W25Q128)
- WiFi: MT7603E (2.4 GHz) + MT7663E (5 GHz)
- Ethernet: MT7530 switch, 2× Gigabit (LAN + WAN)
- LEDs: red:wan, green:lan, blue:wlan (GPIO, active high)
- Button: reset
- Power: 802.3af PoE

### MAC addresses (factory partition)
- 2.4 GHz radio @ 0x0004
- 5 GHz radio   @ 0x8004
- LAN / label   @ 0xe000
- WAN           = LAN + 1

### Installation
Via the stock U-Boot HTTP "web failsafe" recovery: hold the reset button while
powering on, set the PC to 192.168.1.2/24, open http://192.168.1.1, and upload
the `*-squashfs-factory.bin` image.

### Testing
Built from current main for ramips/mt7621 and flashed on real hardware:
board correctly identified; both radios initialize with MAC addresses read
from the factory calibration data (no random MACs); correct 2.4/5 GHz band
assignment; LEDs, reset button, and both Ethernet ports functional;
squashfs + overlay install, configuration persists across reboots.
