### PR TITLE
[24.10] ath79: wndap360: make it usable

### DIFF
--- a/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
@@ -11,7 +11,7 @@
 	model = "Netgear WNDAP360";
 
 	chosen {
-		/delete-property/ bootargs;
+		bootargs = "console=ttyS0,9600";
 	};
 
 	aliases {

--- a/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
@@ -10,6 +10,10 @@
 	compatible = "netgear,wndap360", "qca,ar7161";
 	model = "Netgear WNDAP360";
 
+	chosen {
+		/delete-property/ bootargs;
+	};
+
 	aliases {
 		led-boot = &led_power_orange;
 		led-failsafe = &led_power_orange;

--- a/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
@@ -17,12 +17,18 @@
 	aliases {
 		led-boot = &led_power_orange;
 		led-failsafe = &led_power_orange;
-		led-running = &led_power_orange;
+		led-running = &led_power_green;
 		led-upgrade = &led_power_orange;
 	};
 
 	leds {
 		compatible = "gpio-leds";
+
+		led_power_green: power_green {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
 
 		led_power_orange: power_orange {
 			function = LED_FUNCTION_POWER;

--- a/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
@@ -19,6 +19,7 @@
 		led-failsafe = &led_power_orange;
 		led-running = &led_power_green;
 		led-upgrade = &led_power_orange;
+		label-mac-device = &ath9k0;
 	};
 
 	leds {
@@ -80,7 +81,7 @@
 	phy-mode = "rgmii";
 	phy-handle = <&phy1>;
 
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_120c 10>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -131,17 +132,9 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
-					macaddr_art_0: macaddr@0 {
-						reg = <0x0 0x6>;
-					};
-
 					macaddr_art_120c: macaddr@120c {
-						reg = <0x120c 0x6>;
-					};
-
-					macaddr_art_520c: macaddr@520c {
 						compatible = "mac-base";
-						reg = <0x520c 0x6>;
+						reg = <0x120c 0x6>;
 						#nvmem-cell-cells = <1>;
 					};
 
@@ -164,7 +157,7 @@
 	ath9k0: wifi@11,0 {
 		compatible = "pci168c,0029";
 		reg = <0x8800 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_120c>, <&calibration_art_1000>;
+		nvmem-cells = <&macaddr_art_120c 0>, <&calibration_art_1000>;
 		nvmem-cell-names = "mac-address", "calibration";
 		#gpio-cells = <2>;
 		gpio-controller;
@@ -173,7 +166,7 @@
 	ath9k1: wifi@12,0 {
 		compatible = "pci168c,0029";
 		reg = <0x9000 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_520c 1>, <&calibration_art_5000>;
+		nvmem-cells = <&macaddr_art_120c 8>, <&calibration_art_5000>;
 		nvmem-cell-names = "mac-address", "calibration";
 		#gpio-cells = <2>;
 		gpio-controller;

--- a/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
@@ -69,6 +69,8 @@
 &eth0 {
 	status = "okay";
 
+	pll-data = <0x11110000 0x00001099 0x00991099>;
+
 	phy-mode = "rgmii";
 	phy-handle = <&phy1>;
 

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2214,8 +2214,9 @@ define Device/netgear_wndap360
   DEVICE_PACKAGES := kmod-owl-loader
   IMAGE_SIZE := 7744k
   BLOCKSIZE := 256k
-  KERNEL := kernel-bin | append-dtb | gzip | uImage gzip
-  KERNEL_INITRAMFS := kernel-bin | append-dtb | uImage none
+  LOADER_TYPE := bin
+  KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | uImage none
+  KERNEL_INITRAMFS := $$(KERNEL)
   IMAGES := sysupgrade.bin
   IMAGE/sysupgrade.bin := append-kernel | pad-to 64k | append-rootfs | pad-rootfs | \
 	check-size | append-metadata

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2213,13 +2213,12 @@ define Device/netgear_wndap360
   DEVICE_MODEL := WNDAP360
   DEVICE_PACKAGES := kmod-owl-loader
   IMAGE_SIZE := 7744k
-  BLOCKSIZE := 256k
   LOADER_TYPE := bin
   KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | uImage none
   KERNEL_INITRAMFS := $$(KERNEL)
   IMAGES := sysupgrade.bin
-  IMAGE/sysupgrade.bin := append-kernel | pad-to 64k | append-rootfs | pad-rootfs | \
-	check-size | append-metadata
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs | check-size | append-metadata
 endef
 TARGET_DEVICES += netgear_wndap360
 

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2211,6 +2211,7 @@ define Device/netgear_wndap360
   $(Device/netgear_generic)
   SOC := ar7161
   DEVICE_MODEL := WNDAP360
+  DEVICE_PACKAGES := kmod-owl-loader
   IMAGE_SIZE := 7744k
   BLOCKSIZE := 256k
   KERNEL := kernel-bin | append-dtb | gzip | uImage gzip


### PR DESCRIPTION
Because of bootloader limitations, squashfs cannot be used directly and lzma-loader must be used.

Currently, gzip is used and creates a broken image with not enough space to create overlayfs at runtime:

https://downloads.openwrt.org/releases/24.10.8/targets/ath79/generic/openwrt-24.10.8-ath79-generic-netgear_wndap360-squashfs-sysupgrade.bin

Backport everything from master to have a working image even on 24.10.