### PR TITLE
ath79: nand: add support for Motorola NCAP-500

### DIFF
--- a/target/linux/ath79/dts/ar7242_motorola_ncap-500.dts
+++ b/target/linux/ath79/dts/ar7242_motorola_ncap-500.dts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar7242.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "motorola,ncap-500", "qca,ar7242";
+	model = "Motorola Solutions NCAP-500";
+
+	aliases {
+		led-boot = &led_green;
+		led-failsafe = &led_orange;
+		led-running = &led_green;
+		led-upgrade = &led_orange;
+		label-mac-device = &eth0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,19200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_green: green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_orange: orange {
+			color = <LED_COLOR_ID_ORANGE>;
+			function = LED_FUNCTION_FAULT;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	compatible = "motorola,ncap-500-pci", "qcom,ar7240-pci";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy24: ethernet-phy@18 {
+		reg = <0x18>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-mode = "rgmii-id";
+	phy-handle = <&phy24>;
+	pll-data = <0x06000000 0x00000101 0x00001616>;
+	nvmem-cells = <&macaddr_uboot_ethaddr>;
+	nvmem-cell-names = "mac-address";
+};
+
+&eth1 {
+	status = "disabled";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x0d0000>;
+				read-only;
+			};
+
+			partition@d0000 {
+				label = "u-boot-env";
+				reg = <0x0d0000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+
+					macaddr_uboot_ethaddr: ethaddr {
+					};
+				};
+			};
+
+			partition@e0000 {
+				label = "kernel";
+				reg = <0x0e0000 0x680000>;
+			};
+
+			partition@760000 {
+				label = "vendor-data";
+				reg = <0x760000 0x0a0000>;
+				read-only;
+			};
+		};
+	};
+
+	nand@1 {
+		compatible = "spi-nand";
+		reg = <1>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ubi";
+				reg = <0x0 0x8000000>;
+			};
+		};
+	};
+};

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -348,6 +348,22 @@ define Device/meraki_z1
 endef
 TARGET_DEVICES += meraki_z1
 
+define Device/motorola_ncap-500
+  SOC := ar7242
+  DEVICE_VENDOR := Motorola Solutions
+  DEVICE_MODEL := NCAP-500
+  DEVICE_ALT0_VENDOR := Motorola Solutions
+  DEVICE_ALT0_MODEL := AP-0621
+  KERNEL_SIZE := 6656k
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  VID_HDR_OFFSET := 2048
+  IMAGES := sysupgrade.bin factory.ubi
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  IMAGE/factory.ubi := append-ubi
+endef
+TARGET_DEVICES += motorola_ncap-500
+
 # fake rootfs is mandatory, pad-offset 129 equals (2 * uimage_header + '\0')
 define Device/netgear_ath79_nand
   DEVICE_VENDOR := NETGEAR

--- a/target/linux/ath79/nand/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/nand/base-files/etc/board.d/02_network
@@ -8,7 +8,8 @@ ath79_setup_interfaces()
 
 	case "$board" in
 	aerohive,hiveap-121|\
-	meraki,mr18)
+	meraki,mr18|\
+	motorola,ncap-500)
 		ucidef_set_interface_lan "eth0"
 		;;
 	domywifi,dw33d)

--- a/target/linux/ath79/patches-6.18/319-MIPS-pci-ar724x-add-motorola-ncap-500-quirk.patch
+++ b/target/linux/ath79/patches-6.18/319-MIPS-pci-ar724x-add-motorola-ncap-500-quirk.patch
@@ -1,0 +1,81 @@
+From 2cebbeca77ae9e30529cdbaebe937a8bfb35ee0e Mon Sep 17 00:00:00 2001
+From: Vít Kazík <catelixor@proton.me>
+Date: Thu, 30 Jul 2026 02:29:28 +0200
+Subject: [PATCH] MIPS: pci-ar724x: add Motorola NCAP-500 quirk
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Without this the card never comes up.
+
+Add a PCIe endpoint reset sequence and apply application
+control settings required to initialize the PCIe bus on the
+Atheros AR7242 SoC for the Motorola NCAP-500 board.
+
+Signed-off-by: Vít Kazík <catelixor@proton.me>
+---
+ arch/mips/pci/pci-ar724x.c | 39 ++++++++++++++++++++++++++++----------
+ 1 file changed, 29 insertions(+), 10 deletions(-)
+
+--- a/arch/mips/pci/pci-ar724x.c
++++ b/arch/mips/pci/pci-ar724x.c
+@@ -17,6 +17,7 @@
+ #include <asm/mach-ath79/ar71xx_regs.h>
+ #include <linux/of_irq.h>
+ #include <linux/of_pci.h>
++#include <linux/of.h>
+ 
+ #define AR724X_PCI_REG_APP		0x00
+ #define AR724X_PCI_REG_RESET		0x18
+@@ -371,15 +372,32 @@ static void ar724x_pci_hw_init(struct ar
+ 		ath79_pll_wr(AR724X_PLL_REG_PCIE_CONFIG, ppl);
+ 	}
+ 
+-	/* deassert the reset state of the PCIE endpoint */
+-	rst = __raw_readl(apc->ctrl_base + AR724X_PCI_REG_RESET);
+-	rst |= AR724X_PCI_RESET_EP_RESET_L;
+-	__raw_writel(rst, apc->ctrl_base + AR724X_PCI_REG_RESET);
+-
+-	/* set PCIE Application Control to ready */
+-	app = __raw_readl(apc->ctrl_base + AR724X_PCI_REG_APP);
+-	app |= AR724X_PCI_APP_LTSSM_ENABLE;
+-	__raw_writel(app, apc->ctrl_base + AR724X_PCI_REG_APP);
++	if (of_device_is_compatible(apc->np, "motorola,ncap-500-pci")) {
++		/* Motorola NCAP-500: PCIe endpoint reset sequence */
++		rst = __raw_readl(apc->ctrl_base + AR724X_PCI_REG_RESET);
++		rst &= ~AR724X_PCI_RESET_EP_RESET_L;
++		__raw_writel(rst, apc->ctrl_base + AR724X_PCI_REG_RESET);
++		msleep(100);
++		rst |= AR724X_PCI_RESET_EP_RESET_L;
++		__raw_writel(rst, apc->ctrl_base + AR724X_PCI_REG_RESET);
++		msleep(100);
++
++		/*
++		 * Motorola NCAP-500: apply PCIe application control settings
++		 * 0x1ffc1 is a value from the U-Boot.
++		 */
++		__raw_writel(0x1ffc1, apc->ctrl_base + AR724X_PCI_REG_APP);
++	} else {
++		/* deassert the reset state of the PCIE endpoint */
++		rst = __raw_readl(apc->ctrl_base + AR724X_PCI_REG_RESET);
++		rst |= AR724X_PCI_RESET_EP_RESET_L;
++		__raw_writel(rst, apc->ctrl_base + AR724X_PCI_REG_RESET);
++
++		/* set PCIE Application Control to ready */
++		app = __raw_readl(apc->ctrl_base + AR724X_PCI_REG_APP);
++		app |= AR724X_PCI_APP_LTSSM_ENABLE;
++		__raw_writel(app, apc->ctrl_base + AR724X_PCI_REG_APP);
++	}
+ 
+ 	/* wait up to 100ms for PHY link up */
+ 	do {
+@@ -436,7 +454,8 @@ static int ar724x_pci_probe(struct platf
+ 	 * Do the full PCIE Root Complex Initialization Sequence if the PCIe
+ 	 * host controller is in reset.
+ 	 */
+-	if (reset_control_status(apc->hc_reset))
++	if (reset_control_status(apc->hc_reset) ||
++	    of_device_is_compatible(apc->np, "motorola,ncap-500-pci"))
+ 		ar724x_pci_hw_init(apc);
+ 
+ 	apc->link_up = ar724x_pci_check_link(apc);

--- a/target/linux/generic/pending-6.18/418-mtd-spinand-micron-add-MT29F1G01AAADD.patch
+++ b/target/linux/generic/pending-6.18/418-mtd-spinand-micron-add-MT29F1G01AAADD.patch
@@ -1,0 +1,58 @@
+From 72789601b55d103a28b6e8e259f3db1d31af0289 Mon Sep 17 00:00:00 2001
+From: Vít Kazík <catelixor@proton.me>
+Date: Thu, 30 Jul 2026 02:26:50 +0200
+Subject: [PATCH] kernel: mtd: spinand: add support for Micron MT29F1G01AAADD
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add support for the Micron MT29F1G01AAADD (M68A) SPI NAND chip.
+
+Signed-off-by: Vít Kazík <catelixor@proton.me>
+---
+ drivers/mtd/nand/spi/micron.c | 27 +++++++++++++++++++++++++++
+ 1 file changed, 27 insertions(+)
+
+--- a/drivers/mtd/nand/spi/micron.c
++++ b/drivers/mtd/nand/spi/micron.c
+@@ -134,6 +134,23 @@ static const struct mtd_ooblayout_ops mi
+ 	.free = micron_4_ooblayout_free,
+ };
+ 
++static int micron_m68a_ooblayout_free(struct mtd_info *mtd, int section,
++				      struct mtd_oob_region *region)
++{
++	if (section >= 4)
++		return -ERANGE;
++
++	region->offset = (section * 16) + 2;
++	region->length = 6;
++
++	return 0;
++}
++
++static const struct mtd_ooblayout_ops micron_m68a_ooblayout = {
++	.ecc = micron_4_ooblayout_ecc,
++	.free = micron_m68a_ooblayout_free,
++};
++
+ static int micron_select_target(struct spinand_device *spinand,
+ 				unsigned int target)
+ {
+@@ -404,6 +421,16 @@ static const struct spinand_info micron_
+ 		     SPINAND_ECCINFO(&micron_8_ooblayout,
+ 				     micron_8_ecc_get_status),
+ 		     SPINAND_SELECT_TARGET(micron_select_target)),
++	/* M68A 1Gb 3.3V */
++	SPINAND_INFO("MT29F1G01AAADD",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0x12),
++		     NAND_MEMORG(1, 2048, 64, 64, 1024, 20, 2, 1, 1),
++		     NAND_ECCREQ(4, 512),
++		     SPINAND_INFO_OP_VARIANTS(&x4_read_cache_variants,
++					      &x1_write_cache_variants,
++					      &x1_update_cache_variants),
++		     0,
++		     SPINAND_ECCINFO(&micron_m68a_ooblayout, NULL)),
+ 	/* M69A 2Gb 3.3V */
+ 	SPINAND_INFO("MT29F2G01AAAED",
+ 		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0x9F),


### PR DESCRIPTION
Add support for the Motorola Solutions NCAP-500 access point based on Atheros AR7242 SoC.

Hardware:

* SoC: Atheros AR7242
* RAM: 64 MB (46V32M16)
* Flash:
  * 8 MB SPI NOR (Macronix MX25L6445EMI-10G)
  * 128 MB SPI NAND (Micron MT29F1G01AAADDH4)
* Ethernet: 1x RJ-45 10/100/1000 Mbps (Broadcom BCM54610C1KMLG)
* Wi-Fi: 1x Mini-PCIe slot (2.4/5 GHz 2x2 MIMO Atheros AR9280 802.11a/b/g/n card)
* Antennas: 2x external antenna connectors (RP-SMA)
* Console: 1x RJ-45 RS-232 (19200 8N1, SIPEX 3232EC)
* Power: 802.3af PoE-in via ethernet or 48 V DC via 2 pin connector
* LEDs: 1x green, 1x orange
* Buttons: 1x reset

U-Boot ENVs:

	bootdelay=2
	baudrate=19200
	mem=57M
	mfg_hardware_type=ncap
	ethact=eth0
	ethaddr=REDACTED
	mfg_serial_number=REDACTED
	base_mint_id=0x1A
	mfg_hardware_model=AP-0621-60020-EU
	mfg_hardware_version=A
	mfg_date=2014/05/17
	mfg_country_code=EU
	filesize=1D5A400
	fileaddr=80100000
	gatewayip=192.168.1.1
	netmask=255.255.255.0
	ipaddr=192.168.1.50
	serverip=192.168.1.100
	bootcmd=bootx
	stdin=serial
	stdout=serial
	stderr=serial

MAC address:

	There is one ethernet MAC address stored in the u-boot-env partition.
	The WLAN MAC address is stored on the WLAN card.

Installation:
Console access is necessary.

	Interrupt U-Boot by pressing key when countdown shows up.
	Transfer the initramfs image via TFTP and boot it:
	tftpboot 0x82000000 openwrt-ath79-nand-motorola_ncap-500-initramfs-kernel.bin
	bootm 0x82000000

	Make a backup of the original firmware(run from PC, nanddump requires mtd-utils):
	ssh root@192.168.1.1 "cat /dev/mtd2" > motorola_original_nor_kernel_dump.bin
	ssh root@192.168.1.1 "nanddump -n -o /dev/mtd4" > motorola_original_nand_dump.bin

	Sysupgrade from initramfs doesn't work, because of limited RAM. Flash manually.

	From PC:
	extract kernel file from openwrt-ath79-nand-motorola_ncap-500-squashfs-sysupgrade.bin
	scp -O kernel root@192.168.1.1:/tmp/kernel

	From console:
	mtd erase kernel
	mtd write /tmp/kernel kernel
	rm /tmp/kernel

	From PC:
	scp -O openwrt-ath79-nand-motorola_ncap-500-squashfs-factory.ubi root@192.168.1.1:/tmp/factory.ubi

	From console:
	ubidetach -m 4
	ubiformat /dev/mtd4 -y -f /tmp/factory.ubi

	reboot

Return to stock firmware:
Use the backup of original firmware made before flashing OpenWrt

Tested on 2 devices:

	Gigabit ethernet
	2.4 and 5 GHz AP mode
	Mini-PCIe slot (tested with original card only)
	LEDs
	UBIFS overlay and persistence after reboot
	Reset button
	Serial Console
	LuCI and sysupgrade through LuCI