### PR TITLE
realtek: eth: remove locking from ndo_open()

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.18/drivers/net/ethernet/rtl838x_eth.c
@@ -918,30 +918,25 @@ static int rteth_open(struct net_device *dev)
 	struct rteth_ctrl *ctrl = netdev_priv(dev);
 	int ret;
 
-	pr_debug("%s called: RX rings %d(length %d), TX rings %d(length %d)\n",
-		 __func__, RTETH_RX_RINGS, RTETH_RX_RING_SIZE, RTETH_TX_RINGS, RTETH_TX_RING_SIZE);
+	ctrl->r->hw_reset(ctrl);
+	ctrl->r->set_hol(ctrl);
+	rteth_setup_cpu_rx_rings(ctrl);
+	ret = rteth_setup_ring_buffer(ctrl);
+	if (ret)
+		return ret;
 
-	scoped_guard(spinlock_irqsave, &ctrl->lock) {
-		ctrl->r->hw_reset(ctrl);
-		ctrl->r->set_hol(ctrl);
-		rteth_setup_cpu_rx_rings(ctrl);
-		ret = rteth_setup_ring_buffer(ctrl);
-		if (ret)
-			return ret;
+	if (ctrl->r->setup_notify_ring_buffer)
+		ctrl->r->setup_notify_ring_buffer(ctrl);
 
-		if (ctrl->r->setup_notify_ring_buffer)
-			ctrl->r->setup_notify_ring_buffer(ctrl);
+	rteth_hw_ring_setup(ctrl);
+	phylink_start(ctrl->phylink);
 
-		rteth_hw_ring_setup(ctrl);
-		phylink_start(ctrl->phylink);
+	for (int i = 0; i < RTETH_RX_RINGS; i++)
+		napi_enable(&ctrl->rx_info[i].napi);
 
-		for (int i = 0; i < RTETH_RX_RINGS; i++)
-			napi_enable(&ctrl->rx_info[i].napi);
-
-		ctrl->r->hw_init(ctrl);
-		ctrl->r->hw_en_rxtx(ctrl);
-		netif_tx_start_all_queues(dev);
-	}
+	ctrl->r->hw_init(ctrl);
+	ctrl->r->hw_en_rxtx(ctrl);
+	netif_tx_start_all_queues(dev);
 
 	return 0;
 }


### PR DESCRIPTION
ndo_open() runs under rtnl_lock() nevertheless the driver adds its own locking and disables interrupts. Additionally it sleeps inside some of the sub functions. This leads to spurious errors:

```
[   11.233001] BUG: sleeping function called from invalid context at kernel/locking/mutex.c:271
[   11.233029] in_atomic(): 1, irqs_disabled(): 0, non_block: 0, pid: 710, name: ip
[   11.233040] preempt_count: ffffffff, expected: 0
[   11.233055] CPU: 0 UID: 0 PID: 710 Comm: ip Tainted: G        W  O        6.18.39 #0 NONE
[   11.233082] Hardware name: Hasivo S1100W-8XGT-SE
[   11.233290] Call Trace:
[   11.233294] [<80112108>] show_stack+0x28/0xf0
[   11.233337] [<8010bb78>] dump_stack_lvl+0x70/0xb0
[   11.233378] [<80168b80>] __might_resched+0x144/0x15c
[   11.233417] [<808f2b6c>] mutex_lock+0x20/0x6c
[   11.233451] [<80669ad8>] __dev_open+0x14c/0x230
[   11.233493] [<80669c00>] netif_open+0x44/0x94
[   11.233512] [<8066e51c>] dev_open+0x40/0x78
```

Remove that anti-pattern.

