### PR TITLE
mediatek: filogic: fix support for D-Link AQUILA PRO AI M60 sold in multi packs

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-dlink-aquila-pro-ai-m60-a1.dts
+++ b/target/linux/mediatek/dts/mt7986a-dlink-aquila-pro-ai-m60-a1.dts
@@ -18,7 +18,6 @@
 		led-failsafe = &led_status_red;
 		led-running = &led_status_white;
 		led-upgrade = &led_status_blue;
-		label-mac-device = &gmac0;
 	};
 
 	chosen {
@@ -61,8 +60,6 @@
 		reg = <0>;
 		phy-mode = "2500base-x";
 
-		nvmem-cells = <&macaddr_odm 1>;
-		nvmem-cell-names = "mac-address";
 		fixed-link {
 			speed = <2500>;
 			full-duplex;
@@ -75,8 +72,6 @@
 		reg = <1>;
 		phy-mode = "2500base-x";
 		phy-handle = <&phy6>;
-		nvmem-cells = <&macaddr_odm 0>;
-		nvmem-cell-names = "mac-address";
 		label = "internet";
 	};
 
@@ -273,19 +268,6 @@
 				label = "Odm";
 				reg = <0x6980000 0x40000>;
 				read-only;
-
-				nvmem-layout {
-					compatible = "fixed-layout";
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					macaddr_odm: macaddr@81 {
-						compatible = "mac-base";
-						reg = <0x81 0x6>;
-						#nvmem-cell-cells = <1>;
-					};
-				};
-
 			};
 
 			partition@69c0000 {
@@ -311,28 +293,11 @@
 };
 
 &wifi {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
 	pinctrl-names = "default";
 	pinctrl-0 = <&wf_2g_5g_pins>;
-
-
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";
-
-	band@0 {
-		/* 2.4 GHz */
-		reg = <0>;
-		nvmem-cells = <&macaddr_odm 2>;
-		nvmem-cell-names = "mac-address";
-	};
-	band@1 {
-		/* 5 GHz */
-		reg = <1>;
-		nvmem-cells = <&macaddr_odm 5>;
-		nvmem-cell-names = "mac-address";
-	};
 };
 
 &uart0 {

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -121,6 +121,18 @@ case "$board" in
 		addr=$(mtd_get_mac_binary "Odm" 0x81)
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
 		;;
+	dlink,aquila-pro-ai-m60-a1)
+		# multi-pack units (M60-2/M60-3) carry a '-' (0x2d) at offset 0x4d
+		# and store MAC at offset 0x83
+		odm=$(find_mtd_part "Odm")
+		if [ "$(hexdump -n 1 -v -s 0x4d -e '1 "%02x"' "$odm")" = "2d" ]; then
+			addr=$(get_mac_binary "$odm" 0x83)
+		else
+			addr=$(get_mac_binary "$odm" 0x81)
+		fi
+		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $addr 5 > /sys${DEVPATH}/macaddress
+		;;
 	glinet,gl-mt6000|\
 	glinet,gl-x3000|\
 	glinet,gl-xe3000)

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -28,6 +28,21 @@ preinit_set_mac_address() {
 		ip link set dev eth0 address "$addr"
 		ip link set dev eth1 address "$addr"
 		;;
+	dlink,aquila-pro-ai-m60-a1)
+		# multi-pack units (M60-2/M60-3) carry a '-' (0x2d) at offset 0x4d
+		# and store MAC at offset 0x83
+		odm=$(find_mtd_part "Odm")
+		if [ "$(hexdump -n 1 -v -s 0x4d -e '1 "%02x"' "$odm")" = "2d" ]; then
+			wan_mac=$(get_mac_binary "$odm" 0x83)
+		else
+			wan_mac=$(get_mac_binary "$odm" 0x81)
+		fi
+		ip link set dev lan1 address "$(macaddr_add "$wan_mac" 1)"
+		ip link set dev lan2 address "$(macaddr_add "$wan_mac" 1)"
+		ip link set dev lan3 address "$(macaddr_add "$wan_mac" 1)"
+		ip link set dev lan4 address "$(macaddr_add "$wan_mac" 1)"
+		ip link set dev internet address "$wan_mac"
+		;;
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\
 	tplink,archer-ax80-v1-eu|\


### PR DESCRIPTION
D-Link AQUILA PRO AI M60 is sold as single device and also in pack of 2 or 3 devices
Device MAC is stored on  'Odm' partition but for M60-2 and M60-3 devices offset change.
This change moves MAC setup from .dts to userspace to allow M60 M60-2 M60-3 MAC detection.

OEM and OpenWrt share same MAC table:

WAN = Odm = label -1
LAN1-4 = eth0  = label
WiFi 2.4G = Odm+2
WiFi 5G = Odm+5

Fixes: https://github.com/openwrt/openwrt/commit/b3ce08e0b6fa6780bf7ee295a1f176c053b1100b ("mediatek: filogic: Add support for D-Link AQUILA PRO AI M60")

note:
`eth0` stays random due to interface is up before preinit script.
this suppress #23902 which use fixed address and will cause regression on single packed device 