### PR TITLE
generic: backport net-dsa-realtek use devm_mutex_init for locks

### DIFF
--- a/target/linux/generic/backport-6.12/944-01-v7.2-net-dsa-realtek-rtl8365mb-use-devm_mutex_init-for-mib_lock.patch
+++ b/target/linux/generic/backport-6.12/944-01-v7.2-net-dsa-realtek-rtl8365mb-use-devm_mutex_init-for-mib_lock.patch
@@ -1,0 +1,70 @@
+From 70fd0cf29bc47882c1cb11ad4fb2881ac2c1e640 Mon Sep 17 00:00:00 2001
+From: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Date: Sun, 26 Jul 2026 22:56:08 -0300
+Subject: net: dsa: realtek: rtl8365mb: use devm_mutex_init for mib_lock
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+With CONFIG_DEBUG_MUTEXES enabled, mutex_destroy() needs to be called
+before the lock is discarded. Use devm_mutex_init() instead so the
+cleanup is handled automatically.
+
+Fixes: 4af2950c50c86 ("net: dsa: realtek-smi: add rtl8365mb subdriver for RTL8365MB-VC")
+Reviewed-by: Mieczyslaw Nalewaj <namiltd@yahoo.com>
+Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Reviewed-by: Linus Walleij <linusw@kernel.org>
+Reviewed-by: Alvin Šipraga <alvin.sipraga@analog.com>
+Link: https://patch.msgid.link/20260726-realtek_mutext-v2-1-5d62ba998791@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/realtek/rtl8365mb_main.c | 16 +++++++++++++---
+ 1 file changed, 13 insertions(+), 3 deletions(-)
+
+--- a/drivers/net/dsa/realtek/rtl8365mb_main.c
++++ b/drivers/net/dsa/realtek/rtl8365mb_main.c
+@@ -2570,16 +2570,19 @@ static void rtl8365mb_get_stats64(struct
+ 	spin_unlock(&p->stats_lock);
+ }
+ 
+-static void rtl8365mb_stats_setup(struct realtek_priv *priv)
++static int rtl8365mb_stats_setup(struct realtek_priv *priv)
+ {
+ 	struct rtl8365mb *mb = priv->chip_data;
+ 	struct dsa_switch *ds = &priv->ds;
+ 	struct dsa_port *dp;
++	int ret;
+ 
+ 	/* Per-chip global mutex to protect MIB counter access, since doing
+ 	 * so requires accessing a series of registers in a particular order.
+ 	 */
+-	mutex_init(&mb->mib_lock);
++	ret = devm_mutex_init(priv->dev, &mb->mib_lock);
++	if (ret)
++		return ret;
+ 
+ 	dsa_switch_for_each_available_port(dp, ds) {
+ 		struct rtl8365mb_port *p = &mb->ports[dp->index];
+@@ -2592,6 +2595,8 @@ static void rtl8365mb_stats_setup(struct
+ 		 */
+ 		INIT_DELAYED_WORK(&p->mib_work, rtl8365mb_stats_poll);
+ 	}
++
++	return 0;
+ }
+ 
+ static void rtl8365mb_stats_teardown(struct realtek_priv *priv)
+@@ -3174,7 +3179,12 @@ static int rtl8365mb_setup(struct dsa_sw
+ 	}
+ 
+ 	/* Start statistics counter polling */
+-	rtl8365mb_stats_setup(priv);
++	ret = rtl8365mb_stats_setup(priv);
++	if (ret) {
++		dev_err(priv->dev, "failed to setup stats: %pe\n",
++			ERR_PTR(ret));
++		goto out_teardown_irq;
++	}
+ 
+ 	return 0;
+ 

--- a/target/linux/generic/backport-6.12/944-02-v7.2-net-dsa-realtek-use-devm_mutex_init-for-regmap-lock.patch
+++ b/target/linux/generic/backport-6.12/944-02-v7.2-net-dsa-realtek-use-devm_mutex_init-for-regmap-lock.patch
@@ -1,0 +1,37 @@
+From 050e07f8765d84b4e74fae239ff7a9f29eb6869c Mon Sep 17 00:00:00 2001
+From: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Date: Sun, 26 Jul 2026 22:56:09 -0300
+Subject: net: dsa: realtek: use devm_mutex_init for regmap lock
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+With CONFIG_DEBUG_MUTEXES enabled, mutex_destroy() needs to be called
+before the lock is discarded. Use devm_mutex_init() instead so the
+cleanup is handled automatically.
+
+Fixes: 907e772f6f6de ("net: dsa: realtek: allow subdrivers to externally lock regmap")
+Reviewed-by: Mieczyslaw Nalewaj <namiltd@yahoo.com>
+Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Reviewed-by: Linus Walleij <linusw@kernel.org>
+Reviewed-by: Alvin Šipraga <alvin.sipraga@analog.com>
+Link: https://patch.msgid.link/20260726-realtek_mutext-v2-2-5d62ba998791@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/realtek/rtl83xx.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/dsa/realtek/rtl83xx.c
++++ b/drivers/net/dsa/realtek/rtl83xx.c
+@@ -156,7 +156,10 @@ rtl83xx_probe(struct device *dev,
+ 	if (!priv)
+ 		return ERR_PTR(-ENOMEM);
+ 
+-	mutex_init(&priv->map_lock);
++	ret = devm_mutex_init(dev, &priv->map_lock);
++	if (ret)
++		return ERR_PTR(ret);
++
+ 	mutex_init(&priv->vlan_lock);
+ 	mutex_init(&priv->l2_lock);
+ 

--- a/target/linux/generic/backport-6.12/944-03-v7.2-net-dsa-realtek-use-devm_mutex_init-for-vlan_lock.patch
+++ b/target/linux/generic/backport-6.12/944-03-v7.2-net-dsa-realtek-use-devm_mutex_init-for-vlan_lock.patch
@@ -1,0 +1,37 @@
+From a95f3e9b8985fc0e21bfcf727e941c1f03476927 Mon Sep 17 00:00:00 2001
+From: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Date: Sun, 26 Jul 2026 22:56:10 -0300
+Subject: net: dsa: realtek: use devm_mutex_init for vlan_lock
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+With CONFIG_DEBUG_MUTEXES enabled, mutex_destroy() needs to be called
+before the lock is discarded. Use devm_mutex_init() instead so the
+cleanup is handled automatically.
+
+Fixes: 9da2c8672f771 ("net: dsa: realtek: rtl8365mb: add VLAN support")
+Reviewed-by: Mieczyslaw Nalewaj <namiltd@yahoo.com>
+Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Reviewed-by: Linus Walleij <linusw@kernel.org>
+Reviewed-by: Alvin Šipraga <alvin.sipraga@analog.com>
+Link: https://patch.msgid.link/20260726-realtek_mutext-v2-3-5d62ba998791@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/realtek/rtl83xx.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/dsa/realtek/rtl83xx.c
++++ b/drivers/net/dsa/realtek/rtl83xx.c
+@@ -160,7 +160,10 @@ rtl83xx_probe(struct device *dev,
+ 	if (ret)
+ 		return ERR_PTR(ret);
+ 
+-	mutex_init(&priv->vlan_lock);
++	ret = devm_mutex_init(dev, &priv->vlan_lock);
++	if (ret)
++		return ERR_PTR(ret);
++
+ 	mutex_init(&priv->l2_lock);
+ 
+ 	rc.lock_arg = priv;

--- a/target/linux/generic/backport-6.12/944-04-v7.2-net-dsa-realtek-use-devm_mutex_init-for-l2_lock.patch
+++ b/target/linux/generic/backport-6.12/944-04-v7.2-net-dsa-realtek-use-devm_mutex_init-for-l2_lock.patch
@@ -1,0 +1,36 @@
+From 442ecdc83d00d6c2312541c4e0ada47e02805fcb Mon Sep 17 00:00:00 2001
+From: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Date: Sun, 26 Jul 2026 22:56:11 -0300
+Subject: net: dsa: realtek: use devm_mutex_init for l2_lock
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+With CONFIG_DEBUG_MUTEXES enabled, mutex_destroy() needs to be called
+before the lock is discarded. Use devm_mutex_init() instead so the
+cleanup is handled automatically.
+
+Fixes: 336e3e4a1ab37 ("net: dsa: realtek: rtl8365mb: add FDB support")
+Reviewed-by: Mieczyslaw Nalewaj <namiltd@yahoo.com>
+Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Reviewed-by: Linus Walleij <linusw@kernel.org>
+Reviewed-by: Alvin Šipraga <alvin.sipraga@analog.com>
+Link: https://patch.msgid.link/20260726-realtek_mutext-v2-4-5d62ba998791@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/realtek/rtl83xx.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/dsa/realtek/rtl83xx.c
++++ b/drivers/net/dsa/realtek/rtl83xx.c
+@@ -164,7 +164,9 @@ rtl83xx_probe(struct device *dev,
+ 	if (ret)
+ 		return ERR_PTR(ret);
+ 
+-	mutex_init(&priv->l2_lock);
++	ret = devm_mutex_init(dev, &priv->l2_lock);
++	if (ret)
++		return ERR_PTR(ret);
+ 
+ 	rc.lock_arg = priv;
+ 	priv->map = devm_regmap_init(dev, NULL, priv, &rc);

--- a/target/linux/generic/backport-6.18/944-01-v7.2-net-dsa-realtek-rtl8365mb-use-devm_mutex_init-for-mib_lock.patch
+++ b/target/linux/generic/backport-6.18/944-01-v7.2-net-dsa-realtek-rtl8365mb-use-devm_mutex_init-for-mib_lock.patch
@@ -1,0 +1,70 @@
+From 70fd0cf29bc47882c1cb11ad4fb2881ac2c1e640 Mon Sep 17 00:00:00 2001
+From: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Date: Sun, 26 Jul 2026 22:56:08 -0300
+Subject: net: dsa: realtek: rtl8365mb: use devm_mutex_init for mib_lock
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+With CONFIG_DEBUG_MUTEXES enabled, mutex_destroy() needs to be called
+before the lock is discarded. Use devm_mutex_init() instead so the
+cleanup is handled automatically.
+
+Fixes: 4af2950c50c86 ("net: dsa: realtek-smi: add rtl8365mb subdriver for RTL8365MB-VC")
+Reviewed-by: Mieczyslaw Nalewaj <namiltd@yahoo.com>
+Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Reviewed-by: Linus Walleij <linusw@kernel.org>
+Reviewed-by: Alvin Šipraga <alvin.sipraga@analog.com>
+Link: https://patch.msgid.link/20260726-realtek_mutext-v2-1-5d62ba998791@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/realtek/rtl8365mb_main.c | 16 +++++++++++++---
+ 1 file changed, 13 insertions(+), 3 deletions(-)
+
+--- a/drivers/net/dsa/realtek/rtl8365mb_main.c
++++ b/drivers/net/dsa/realtek/rtl8365mb_main.c
+@@ -2571,16 +2571,19 @@ static void rtl8365mb_get_stats64(struct
+ 	spin_unlock(&p->stats_lock);
+ }
+ 
+-static void rtl8365mb_stats_setup(struct realtek_priv *priv)
++static int rtl8365mb_stats_setup(struct realtek_priv *priv)
+ {
+ 	struct rtl8365mb *mb = priv->chip_data;
+ 	struct dsa_switch *ds = &priv->ds;
+ 	struct dsa_port *dp;
++	int ret;
+ 
+ 	/* Per-chip global mutex to protect MIB counter access, since doing
+ 	 * so requires accessing a series of registers in a particular order.
+ 	 */
+-	mutex_init(&mb->mib_lock);
++	ret = devm_mutex_init(priv->dev, &mb->mib_lock);
++	if (ret)
++		return ret;
+ 
+ 	dsa_switch_for_each_available_port(dp, ds) {
+ 		struct rtl8365mb_port *p = &mb->ports[dp->index];
+@@ -2593,6 +2596,8 @@ static void rtl8365mb_stats_setup(struct
+ 		 */
+ 		INIT_DELAYED_WORK(&p->mib_work, rtl8365mb_stats_poll);
+ 	}
++
++	return 0;
+ }
+ 
+ static void rtl8365mb_stats_teardown(struct realtek_priv *priv)
+@@ -3175,7 +3180,12 @@ static int rtl8365mb_setup(struct dsa_sw
+ 	}
+ 
+ 	/* Start statistics counter polling */
+-	rtl8365mb_stats_setup(priv);
++	ret = rtl8365mb_stats_setup(priv);
++	if (ret) {
++		dev_err(priv->dev, "failed to setup stats: %pe\n",
++			ERR_PTR(ret));
++		goto out_teardown_irq;
++	}
+ 
+ 	return 0;
+ 

--- a/target/linux/generic/backport-6.18/944-02-v7.2-net-dsa-realtek-use-devm_mutex_init-for-regmap-lock.patch
+++ b/target/linux/generic/backport-6.18/944-02-v7.2-net-dsa-realtek-use-devm_mutex_init-for-regmap-lock.patch
@@ -1,0 +1,37 @@
+From 050e07f8765d84b4e74fae239ff7a9f29eb6869c Mon Sep 17 00:00:00 2001
+From: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Date: Sun, 26 Jul 2026 22:56:09 -0300
+Subject: net: dsa: realtek: use devm_mutex_init for regmap lock
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+With CONFIG_DEBUG_MUTEXES enabled, mutex_destroy() needs to be called
+before the lock is discarded. Use devm_mutex_init() instead so the
+cleanup is handled automatically.
+
+Fixes: 907e772f6f6de ("net: dsa: realtek: allow subdrivers to externally lock regmap")
+Reviewed-by: Mieczyslaw Nalewaj <namiltd@yahoo.com>
+Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Reviewed-by: Linus Walleij <linusw@kernel.org>
+Reviewed-by: Alvin Šipraga <alvin.sipraga@analog.com>
+Link: https://patch.msgid.link/20260726-realtek_mutext-v2-2-5d62ba998791@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/realtek/rtl83xx.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/dsa/realtek/rtl83xx.c
++++ b/drivers/net/dsa/realtek/rtl83xx.c
+@@ -156,7 +156,10 @@ rtl83xx_probe(struct device *dev,
+ 	if (!priv)
+ 		return ERR_PTR(-ENOMEM);
+ 
+-	mutex_init(&priv->map_lock);
++	ret = devm_mutex_init(dev, &priv->map_lock);
++	if (ret)
++		return ERR_PTR(ret);
++
+ 	mutex_init(&priv->vlan_lock);
+ 	mutex_init(&priv->l2_lock);
+ 

--- a/target/linux/generic/backport-6.18/944-03-v7.2-net-dsa-realtek-use-devm_mutex_init-for-vlan_lock.patch
+++ b/target/linux/generic/backport-6.18/944-03-v7.2-net-dsa-realtek-use-devm_mutex_init-for-vlan_lock.patch
@@ -1,0 +1,37 @@
+From a95f3e9b8985fc0e21bfcf727e941c1f03476927 Mon Sep 17 00:00:00 2001
+From: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Date: Sun, 26 Jul 2026 22:56:10 -0300
+Subject: net: dsa: realtek: use devm_mutex_init for vlan_lock
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+With CONFIG_DEBUG_MUTEXES enabled, mutex_destroy() needs to be called
+before the lock is discarded. Use devm_mutex_init() instead so the
+cleanup is handled automatically.
+
+Fixes: 9da2c8672f771 ("net: dsa: realtek: rtl8365mb: add VLAN support")
+Reviewed-by: Mieczyslaw Nalewaj <namiltd@yahoo.com>
+Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Reviewed-by: Linus Walleij <linusw@kernel.org>
+Reviewed-by: Alvin Šipraga <alvin.sipraga@analog.com>
+Link: https://patch.msgid.link/20260726-realtek_mutext-v2-3-5d62ba998791@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/realtek/rtl83xx.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/dsa/realtek/rtl83xx.c
++++ b/drivers/net/dsa/realtek/rtl83xx.c
+@@ -160,7 +160,10 @@ rtl83xx_probe(struct device *dev,
+ 	if (ret)
+ 		return ERR_PTR(ret);
+ 
+-	mutex_init(&priv->vlan_lock);
++	ret = devm_mutex_init(dev, &priv->vlan_lock);
++	if (ret)
++		return ERR_PTR(ret);
++
+ 	mutex_init(&priv->l2_lock);
+ 
+ 	rc.lock_arg = priv;

--- a/target/linux/generic/backport-6.18/944-04-v7.2-net-dsa-realtek-use-devm_mutex_init-for-l2_lock.patch
+++ b/target/linux/generic/backport-6.18/944-04-v7.2-net-dsa-realtek-use-devm_mutex_init-for-l2_lock.patch
@@ -1,0 +1,36 @@
+From 442ecdc83d00d6c2312541c4e0ada47e02805fcb Mon Sep 17 00:00:00 2001
+From: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Date: Sun, 26 Jul 2026 22:56:11 -0300
+Subject: net: dsa: realtek: use devm_mutex_init for l2_lock
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+With CONFIG_DEBUG_MUTEXES enabled, mutex_destroy() needs to be called
+before the lock is discarded. Use devm_mutex_init() instead so the
+cleanup is handled automatically.
+
+Fixes: 336e3e4a1ab37 ("net: dsa: realtek: rtl8365mb: add FDB support")
+Reviewed-by: Mieczyslaw Nalewaj <namiltd@yahoo.com>
+Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Reviewed-by: Linus Walleij <linusw@kernel.org>
+Reviewed-by: Alvin Šipraga <alvin.sipraga@analog.com>
+Link: https://patch.msgid.link/20260726-realtek_mutext-v2-4-5d62ba998791@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/realtek/rtl83xx.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/dsa/realtek/rtl83xx.c
++++ b/drivers/net/dsa/realtek/rtl83xx.c
+@@ -164,7 +164,9 @@ rtl83xx_probe(struct device *dev,
+ 	if (ret)
+ 		return ERR_PTR(ret);
+ 
+-	mutex_init(&priv->l2_lock);
++	ret = devm_mutex_init(dev, &priv->l2_lock);
++	if (ret)
++		return ERR_PTR(ret);
+ 
+ 	rc.lock_arg = priv;
+ 	priv->map = devm_regmap_init(dev, NULL, priv, &rc);


### PR DESCRIPTION
Backport four upstream commits that convert mutex_init() calls to devm_mutex_init() in the Realtek DSA driver family. With CONFIG_DEBUG_MUTEXES enabled, mutex_destroy() must be called before a mutex is discarded; using the devm variant handles this cleanup automatically and avoids leaking a warning on driver removal/failure.

Added patches (applied to both backport-6.12 and backport-6.18):
- 944-01: net: dsa: realtek: rtl8365mb: use devm_mutex_init for mib_lock
- 944-02: net: dsa: realtek: use devm_mutex_init for regmap lock
- 944-03: net: dsa: realtek: use devm_mutex_init for vlan_lock
- 944-04: net: dsa: realtek: use devm_mutex_init for l2_lock