### PR TITLE
ubox: log: check file mountpoint availability

### DIFF
--- a/package/system/ubox/Makefile
+++ b/package/system/ubox/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ubox
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/ubox.git

--- a/package/system/ubox/files/log.init
+++ b/package/system/ubox/files/log.init
@@ -54,8 +54,7 @@ start_service_file()
 
 	local mountpoint="$(procd_get_mountpoints "${log_file}")"
 
-	[ "$_BOOT" = "1" ] &&
-		[ "$mountpoint" ] &&
+	[ "$mountpoint" ] &&
 		! grep -q ".* $mountpoint " /proc/mounts &&
 		return 0
 
@@ -109,8 +108,4 @@ start_service()
 	config_foreach validate_log_daemon system start_service_daemon
 	config_foreach validate_log_section system start_service_file
 	config_foreach validate_log_section system start_service_remote
-}
-
-boot() {
-	_BOOT=1 start
 }


### PR DESCRIPTION
The file logging backend currently checks whether the configured
mountpoint is available only during boot.

When the service is started or restarted later while the mountpoint is
unavailable, the script may create the configured log directory on the
overlay filesystem and write logs to internal flash.

Always check mountpoint availability before creating the log directory and starting the file logger.
This preserves the current boot behavior while preventing unintended
directory creation when external storage is unavailable.

Tested with the log file located on external storage:

* logging works normally while the filesystem is mounted;
* no log directory is created on the overlay while it is unmounted;
* logging resumes after remounting the filesystem and starting the
  service again.

Closes #24475