### PR TITLE
ppp: quote the string arguments passed to pppd

### DIFF
--- a/package/network/services/ppp/Makefile
+++ b/package/network/services/ppp/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ppp
 PKG_VERSION:=2.5.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.samba.org/pub/ppp

--- a/package/network/services/ppp/files/ppp.sh
+++ b/package/network/services/ppp/files/ppp.sh
@@ -108,6 +108,9 @@ ppp_generic_setup() {
 		norelease=""
 	fi
 
+	[ "$(set -- $reqprefix; echo $#)" -gt 1 ] && \
+		logger -p warn -t ppp "$config: ignoring extra reqprefix values"
+
 	if [ "${demand:-0}" -gt 0 ]; then
 		demand="precompiled-active-filter /etc/ppp/filter demand idle $demand"
 	else
@@ -153,9 +156,9 @@ ppp_generic_setup() {
 		${lcp_failure:+lcp-echo-interval $lcp_interval lcp-echo-failure $lcp_failure $lcp_adaptive} \
 		${ipv6:++ipv6} \
 		${autoipv6:+set AUTOIPV6=1} \
-		${reqprefix:+set REQPREFIX=$reqprefix} \
+		${reqprefix:+set "REQPREFIX=$reqprefix"} \
 		${norelease:+set NORELEASE=1} \
-		${ip6table:+set IP6TABLE=$ip6table} \
+		${ip6table:+set "IP6TABLE=$ip6table"} \
 		${peerdns:+set PEERDNS=$peerdns} \
 		${sourcefilter:+set NOSOURCEFILTER=1} \
 		${delegate:+set DELEGATE=0} \


### PR DESCRIPTION
ppp.sh expands two free-form values unquoted when it builds the pppd argument list, so the shell splits a value containing whitespace and every word after the first becomes a stray positional argument. pppd prints its usage and exits with EXIT_OPTION_ERROR when the word matches no option. The protocol handler treats that exit code as terminal and blocks the restart, so the interface stays down until the configuration changes. A bare number does not fail at all, because pppd's wildcard matcher takes it as the serial port speed.

reqprefix is declared with proto_config_add_string and carries no validation pattern. ip6table is a core interface attribute that netifd passes through as a string, and when system_resolve_rt_table() cannot parse it netifd only logs a debug message, so the raw value still reaches this argument list.

Quote both so the value survives as one element. Values without whitespace produce the same argument list as before, so no working configuration changes.

With `option reqprefix '/60 /56'` and `option ipv6 'auto'`, before:

```
pppd[6105]: unrecognized option '/56'
netifd: Interface 'pppotest' is disabled
ifstatus: "errors": [ { "subsystem": "pppoe", "code": "OPTION_ERROR" } ]
```

Same failure as #24454. `option ip6table 'my table'` hands pppd a stray `table` the same way.

A bare number takes the other path: `option reqprefix '/60 9600'` produces no error at all, because pppd's wildcard matcher takes 9600 as the serial port speed.

The `set` option takes one argument, so the shell handing it two is what pppd rejects. Quoting the expansion keeps the value together:

```
before:  set   REQPREFIX=/60   /56      three arguments, /56 arrives on its own
after:   set   REQPREFIX=/60 /56        two arguments, the space is inside the value
```

Quoting on its own would drop the extra reqprefix values without a trace, because ppp6-up expands REQPREFIX unquoted as well and forwards only the first word. The handler logs what it had to drop:

```
user.warn ppp: pppotest: ignoring extra reqprefix values
```

That counts words rather than testing for whitespace, so `option reqprefix '/60 '` stays silent: ppp6-up word splits it back to `/60` and drops nothing. The count runs in a subshell so ppp_generic_setup keeps its own argument list, which it still needs for the per-protocol options.

I read pppd's full argument list off the running process before and after and compared it byte for byte. Only a value carrying a second word behaves differently. Adding the warning changes nothing: the argument list is identical with and without it.

This does not add support for requesting more than one prefix. ppp6-up still forwards only the first word, so odhcp6c gets a single -P:

```
odhcp6c -s /lib/netifd/dhcpv6.script -P60:a62e8328 -c0004... -t120 pppoe-pppotest
```

The patch only stops the argument list from being malformed.

The ucode conversion in #23792 is not affected: ppp.uc builds the argument list as a list, so it cannot word split.

openwrt-25.12 and openwrt-24.10 carry the same ppp.sh, so the fix applies there unchanged if backported.

Tested on: Asus RT-N18U, OpenWrt SNAPSHOT r35591-d0110a25ed, pppd 2.5.3.


Fixes: d5221d5a419c ("ppp: honor ip6table for IPv6 PPP interfaces")
Fixes: 7079e456ade5 ("ppp: add reqprefix norelease ac_mac")
