### PR TITLE
mtd mtdsplit-fit: fix reading fit header from wrong offset

### DIFF
--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_fit.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_fit.c
@@ -300,7 +300,7 @@ mtdsplit_fit_parse(struct mtd_info *mtd,
 	} else {
 		/* Search for rootfs_data after FIT external data */
 		fit = kzalloc(fit_size, GFP_KERNEL);
-		ret = mtd_read(mtd, offset, fit_size + offset_start, &retlen, fit);
+		ret = mtd_read(mtd, offset + offset_start, fit_size, &retlen, fit);
 		if (ret) {
 			pr_err("read error in \"%s\" at offset 0x%llx\n",
 			       mtd->name, (unsigned long long) offset);

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_fit.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_fit.c
@@ -198,7 +198,6 @@ mtdsplit_fit_parse(struct mtd_info *mtd,
 	const char *cmdline_match = NULL;
 	struct fdt_header hdr;
 	size_t hdr_len, retlen;
-	size_t offset;
 	u32 offset_start = 0;
 	size_t fit_offset, fit_size;
 	size_t rootfs_offset, rootfs_size;
@@ -218,11 +217,13 @@ mtdsplit_fit_parse(struct mtd_info *mtd,
 	hdr_len = sizeof(struct fdt_header);
 
 	/* Parse the MTD device & search for the FIT image location */
-	for (offset = 0; offset + offset_start + hdr_len <= mtd->size; offset += mtd->erasesize) {
-		ret = mtd_read(mtd, offset + offset_start, hdr_len, &retlen, (void*) &hdr);
+	for (fit_offset = offset_start;
+	     fit_offset + hdr_len <= mtd->size;
+	     fit_offset += mtd->erasesize) {
+		ret = mtd_read(mtd, fit_offset, hdr_len, &retlen, (void*) &hdr);
 		if (ret) {
 			pr_err("read error in \"%s\" at offset 0x%llx\n",
-			       mtd->name, (unsigned long long) offset);
+			       mtd->name, (unsigned long long) fit_offset);
 			return ret;
 		}
 
@@ -234,7 +235,7 @@ mtdsplit_fit_parse(struct mtd_info *mtd,
 		/* Check the magic - see if this is a FIT image */
 		if (be32_to_cpu(hdr.magic) != OF_DT_HEADER) {
 			pr_debug("no valid FIT image found in \"%s\" at offset %llx\n",
-				 mtd->name, (unsigned long long) offset);
+				 mtd->name, (unsigned long long) fit_offset);
 			continue;
 		}
 
@@ -248,7 +249,6 @@ mtdsplit_fit_parse(struct mtd_info *mtd,
 		return -ENOENT;
 	}
 
-	fit_offset = offset;
 	fit_size = be32_to_cpu(hdr.totalsize);
 
 	if (fit_size == 0) {
@@ -269,7 +269,7 @@ mtdsplit_fit_parse(struct mtd_info *mtd,
 		enum mtdsplit_part_type type;
 
 		/* Search for the rootfs partition after the FIT image */
-		ret = mtd_find_rootfs_from(mtd, fit_offset + fit_size + offset_start, mtd->size,
+		ret = mtd_find_rootfs_from(mtd, fit_offset + fit_size, mtd->size,
 					   &rootfs_offset, &type);
 		if (ret) {
 			pr_info("no rootfs found after FIT image in \"%s\"\n",
@@ -300,10 +300,10 @@ mtdsplit_fit_parse(struct mtd_info *mtd,
 	} else {
 		/* Search for rootfs_data after FIT external data */
 		fit = kzalloc(fit_size, GFP_KERNEL);
-		ret = mtd_read(mtd, offset + offset_start, fit_size, &retlen, fit);
+		ret = mtd_read(mtd, fit_offset, fit_size, &retlen, fit);
 		if (ret) {
 			pr_err("read error in \"%s\" at offset 0x%llx\n",
-			       mtd->name, (unsigned long long) offset);
+			       mtd->name, (unsigned long long) fit_offset);
 			return ret;
 		}
 


### PR DESCRIPTION
The fit header starts at offset_start, so starting reading it from this offset, instead of adding offset_start to the read size.
