### PR TITLE
ramips: mt7620: add DSA support for integrated switch

### DIFF
--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/Kconfig
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/Kconfig
@@ -56,3 +56,11 @@ config NET_RALINK_GSW_MT7620
 	def_tristate NET_RALINK_SOC
 	depends on NET_RALINK_MT7620
 endif
+
+config NET_DSA_MT7620
+	tristate "MediaTek MT7620 integrated switch DSA support"
+	depends on NET_DSA && NET_RALINK_GSW_MT7620
+	select NET_DSA_TAG_RALINK
+	help
+	  This driver provides DSA support for the seven-port switch
+	  integrated in the MediaTek MT7620 SoC.

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/Makefile
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/Makefile
@@ -15,4 +15,5 @@ ralink-eth-$(CONFIG_NET_RALINK_MT7620)	+= soc_mt7620.o
 
 obj-$(CONFIG_NET_RALINK_ESW_RT3050)		+= esw_rt3050.o
 obj-$(CONFIG_NET_RALINK_GSW_MT7620)		+= gsw_mt7620.o mt7530.o
+obj-$(CONFIG_NET_DSA_MT7620)			+= gsw_mt7620_dsa.o
 obj-$(CONFIG_NET_RALINK_SOC)			+= ralink-eth.o

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.c
@@ -29,11 +29,13 @@ void mtk_switch_w32(struct mt7620_gsw *gsw, u32 val, unsigned reg)
 {
 	iowrite32(val, gsw->base + reg);
 }
+EXPORT_SYMBOL_GPL(mtk_switch_w32);
 
 u32 mtk_switch_r32(struct mt7620_gsw *gsw, unsigned reg)
 {
 	return ioread32(gsw->base + reg);
 }
+EXPORT_SYMBOL_GPL(mtk_switch_r32);
 
 static irqreturn_t gsw_interrupt_mt7620(int irq, void *_priv)
 {
@@ -60,6 +62,22 @@ static irqreturn_t gsw_interrupt_mt7620(int irq, void *_priv)
 
 	return IRQ_HANDLED;
 }
+
+#if IS_ENABLED(CONFIG_NET_DSA_MT7620)
+static irqreturn_t gsw_interrupt_mt7620_dsa(int irq, void *data)
+{
+	struct mt7620_gsw *gsw = data;
+	u32 status;
+
+	status = mtk_switch_r32(gsw, GSW_REG_ISR);
+	if (!status)
+		return IRQ_NONE;
+
+	mtk_switch_w32(gsw, status, GSW_REG_ISR);
+
+	return IRQ_HANDLED;
+}
+#endif
 
 static void gsw_reset_ephy(struct mt7620_gsw *gsw)
 {
@@ -199,7 +217,8 @@ static void mt7620_mac_init(struct mt7620_gsw *gsw)
 	mtk_switch_w32(gsw, val, GSW_REG_GMACCR);
 
 	/* Enable MIB stats */
-	mtk_switch_w32(gsw, mtk_switch_r32(gsw, GSW_REG_MIB_CNT_EN) | (1 << 1), GSW_REG_MIB_CNT_EN);
+	mtk_switch_w32(gsw, mtk_switch_r32(gsw, GSW_REG_MIB_CNT_EN) |
+		       GSW_MIB_CNT_EN, GSW_REG_MIB_CNT_EN);
 }
 
 static const struct of_device_id mediatek_gsw_match[] = {
@@ -216,6 +235,7 @@ int mtk_gsw_init(struct fe_priv *priv)
 	struct platform_device *pdev;
 	struct mt7620_gsw *gsw;
 	const __be32 *id;
+	bool dsa_switch;
 	int ret;
 	u8 val;
 
@@ -249,16 +269,61 @@ int mtk_gsw_init(struct fe_priv *priv)
 	else
 		gsw->ephy_base = 0;
 
+	dsa_switch = priv->dsa_switch;
+
 	mt7620_mac_init(gsw);
+
+	/*
+	 * DSA uses phylib polling for the user PHYs. Mask the legacy switch
+	 * interrupt before enabling the PHYs, otherwise an unhandled link-state
+	 * change can continuously assert the GSW interrupt line.
+	 */
+	if (dsa_switch) {
+#if IS_ENABLED(CONFIG_NET_DSA_MT7620)
+		mtk_switch_w32(gsw, ~0, GSW_REG_IMR);
+		mtk_switch_w32(gsw, mtk_switch_r32(gsw, GSW_REG_ISR),
+			       GSW_REG_ISR);
+
+		/*
+		 * Claim the interrupt once, but leave it disabled because
+		 * phylib polls the user PHYs. Unlike the legacy handler, this
+		 * does not retain fe_priv across deferred Ethernet probes.
+		 */
+		if (gsw->irq && !gsw->dsa_irq_claimed) {
+			ret = devm_request_irq(&pdev->dev, gsw->irq,
+					       gsw_interrupt_mt7620_dsa,
+					       IRQF_NO_AUTOEN,
+					       "gsw-dsa", gsw);
+			if (ret) {
+				dev_err(&pdev->dev,
+					"failed to request DSA switch IRQ\n");
+				put_device(&pdev->dev);
+				return ret;
+			}
+
+			gsw->dsa_irq_claimed = true;
+		}
+#else
+		put_device(&pdev->dev);
+		return -ENODEV;
+#endif
+	}
 
 	mt7620_ephy_init(gsw);
 
-	if (gsw->irq) {
+	/*
+	 * DSA phylink manages the user PHYs. Do not install the legacy switch
+	 * interrupt handler for a DSA switch: a deferred DSA probe would leave
+	 * that handler attached to the switch device with a stale fe_priv
+	 * argument after the Ethernet probe is rolled back.
+	 */
+	if (gsw->irq && !dsa_switch) {
 		ret = devm_request_irq(&pdev->dev, gsw->irq, gsw_interrupt_mt7620, 0,
 				  "gsw", priv);
 		if (ret) {
+			dev_err(&pdev->dev,
+				"failed to request switch IRQ\n");
 			put_device(&pdev->dev);
-			dev_err(&pdev->dev, "Failed to request irq");
 			return ret;
 		}
 		mtk_switch_w32(gsw, ~PORT_IRQ_ST_CHG, GSW_REG_IMR);
@@ -267,6 +332,60 @@ int mtk_gsw_init(struct fe_priv *priv)
 	put_device(&pdev->dev);
 	return 0;
 }
+
+#if IS_ENABLED(CONFIG_NET_DSA_MT7620)
+int mt7620_gsw_dsa_device_register(struct mt7620_gsw *gsw,
+				   struct device *parent)
+{
+	struct platform_device *dsa_dev;
+	int ret;
+
+	if (gsw->dsa_dev)
+		return 0;
+
+	/*
+	 * The switch registers from the Ethernet driver's probe, but its
+	 * register block belongs to a separate platform device. Give DSA a
+	 * bound child of the Ethernet device so the conduit device link is
+	 * removed before the Ethernet supplier is unbound.
+	 *
+	 * Keep the child registered while the modular DSA driver is not loaded
+	 * yet. The platform bus binds it when the module becomes available.
+	 */
+	dsa_dev = platform_device_alloc("mt7620-dsa", PLATFORM_DEVID_AUTO);
+	if (!dsa_dev)
+		return -ENOMEM;
+
+	dsa_dev->dev.parent = parent;
+	dsa_dev->dev.of_node = of_node_get(gsw->dev->of_node);
+	platform_set_drvdata(dsa_dev, gsw);
+
+	ret = device_set_driver_override(&dsa_dev->dev, "mt7620-dsa");
+	if (ret)
+		goto err_put_device;
+
+	ret = platform_device_add(dsa_dev);
+	if (ret)
+		goto err_put_device;
+
+	gsw->dsa_dev = dsa_dev;
+
+	return 0;
+
+err_put_device:
+	platform_device_put(dsa_dev);
+	return ret;
+}
+
+void mt7620_gsw_dsa_device_unregister(struct mt7620_gsw *gsw)
+{
+	if (!gsw->dsa_dev)
+		return;
+
+	platform_device_unregister(gsw->dsa_dev);
+	gsw->dsa_dev = NULL;
+}
+#endif
 
 static int mt7620_gsw_probe(struct platform_device *pdev)
 {
@@ -281,6 +400,7 @@ static int mt7620_gsw_probe(struct platform_device *pdev)
 		return PTR_ERR(gsw->base);
 
 	gsw->dev = &pdev->dev;
+	mutex_init(&gsw->reg_mutex);
 
 	gsw->irq = platform_get_irq(pdev, 0);
 

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.h
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.h
@@ -12,10 +12,16 @@
  *   Copyright (C) 2013-2015 Michael Lee <igvtee@gmail.com>
  */
 
+#include <linux/mutex.h>
 #include <linux/reset.h>
+#include <linux/workqueue.h>
 
 #ifndef _RALINK_GSW_MT7620_H__
 #define _RALINK_GSW_MT7620_H__
+
+struct dsa_switch;
+struct fe_priv;
+struct platform_device;
 
 #define GSW_REG_PHY_TIMEOUT	(5 * HZ)
 
@@ -25,6 +31,7 @@
 #define GSW_NUM_VIDS		4096
 #define GSW_NUM_PORTS		7
 #define GSW_PORT6		6
+#define GSW_NUM_MIB_COUNTERS	13
 
 #define GSW_MDIO_ACCESS		BIT(31)
 #define GSW_MDIO_READ		BIT(19)
@@ -33,7 +40,8 @@
 #define GSW_MDIO_ADDR_SHIFT	20
 #define GSW_MDIO_REG_SHIFT	25
 
-#define GSW_REG_MIB_CNT_EN	0x4000
+#define GSW_REG_MIB_CNT_EN	0x4800
+#define GSW_MIB_CNT_EN		GENMASK(30, 24)
 
 #define GSW_REG_PORT_PMCR(x)	(0x3000 + (x * 0x100))
 #define GSW_REG_PORT_STATUS(x)	(0x3008 + (x * 0x100))
@@ -100,20 +108,63 @@ enum {
 	GSW_ATTR_PORT_UNTAG,
 };
 
+struct mt7620_gsw_vlan {
+	u16 vid;
+	u8 members;
+	u8 untagged;
+	bool valid;
+};
+
 struct mt7620_gsw {
 	struct device		*dev;
 	struct reset_control	*rst_ephy;
 	void __iomem		*base;
+	/* Serializes switch register read-modify-write operations. */
+	struct mutex		reg_mutex;
 	int			irq;
+#if IS_ENABLED(CONFIG_NET_DSA_MT7620)
+	struct dsa_switch	*ds;
+	struct platform_device	*dsa_dev;
+	bool			dsa_irq_claimed;
+#endif
 	bool			ephy_disable;
 	bool			port4_ephy;
 	unsigned long int	autopoll;
 	u16			ephy_base;
+#if IS_ENABLED(CONFIG_NET_DSA_MT7620)
+	u16			pvid[GSW_NUM_PORTS];
+	struct mt7620_gsw_vlan	vlans[GSW_NUM_VLANS];
+	struct delayed_work	mib_work;
+	unsigned long		mib_active_ports;
+	u8			mib_port_intervals;
+	/* Protects the software-extended MIB counter state. */
+	spinlock_t		mib_lock;
+	bool			mib_initialized;
+	u32			mib_last[GSW_NUM_PORTS][GSW_NUM_MIB_COUNTERS];
+	u64			mib_stats[GSW_NUM_PORTS][GSW_NUM_MIB_COUNTERS];
+#endif
 };
 
 void mtk_switch_w32(struct mt7620_gsw *gsw, u32 val, unsigned reg);
 u32 mtk_switch_r32(struct mt7620_gsw *gsw, unsigned reg);
 int mtk_gsw_init(struct fe_priv *priv);
+#if IS_ENABLED(CONFIG_NET_DSA_MT7620)
+int mt7620_gsw_dsa_device_register(struct mt7620_gsw *gsw,
+				   struct device *parent);
+void mt7620_gsw_dsa_device_unregister(struct mt7620_gsw *gsw);
+#else
+static inline int
+mt7620_gsw_dsa_device_register(struct mt7620_gsw *gsw,
+			       struct device *parent)
+{
+	return -ENODEV;
+}
+
+static inline void
+mt7620_gsw_dsa_device_unregister(struct mt7620_gsw *gsw)
+{
+}
+#endif
 
 int mt7620_mdio_write(struct mii_bus *bus, int phy_addr, int phy_reg, u16 val);
 int mt7620_mdio_read(struct mii_bus *bus, int phy_addr, int phy_reg);

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620_dsa.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620_dsa.c
@@ -1,0 +1,1371 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * DSA support for the switch embedded in the MediaTek MT7620 SoC.
+ */
+
+#include <linux/bitfield.h>
+#include <linux/ethtool.h>
+#include <linux/if_bridge.h>
+#include <linux/if_vlan.h>
+#include <linux/iopoll.h>
+#include <linux/netdevice.h>
+#include <linux/of.h>
+#include <linux/phy.h>
+#include <linux/platform_device.h>
+#include <net/dsa.h>
+#include <net/switchdev.h>
+
+#include "gsw_mt7620.h"
+
+#define MT7620_DSA_NUM_PORTS		7
+#define MT7620_DSA_CPU_PORT		6
+#define MT7620_DSA_USER_PORTS		GENMASK(4, 0)
+#define MT7620_DSA_ALL_PORTS		GENMASK(6, 0)
+
+#define MT7620_GSW_SSC(p)		(0x2000 + ((p) * 0x100))
+#define MT7620_GSW_PCR(p)		(0x2004 + ((p) * 0x100))
+#define MT7620_GSW_PSC(p)		(0x200c + ((p) * 0x100))
+#define MT7620_GSW_PVC(p)		(0x2010 + ((p) * 0x100))
+#define MT7620_GSW_PPBV1(p)		(0x2014 + ((p) * 0x100))
+
+#define MT7620_GSW_VTCR			0x0090
+#define MT7620_GSW_VAWD1		0x0094
+#define MT7620_GSW_VAWD2		0x0098
+#define MT7620_GSW_VTIM(slot)		(0x0100 + (((slot) / 2) * 4))
+
+#define MT7620_GSW_ATA1			0x0074
+#define MT7620_GSW_ATA2			0x0078
+#define MT7620_GSW_ATWD			0x007c
+#define MT7620_GSW_ATC			0x0080
+#define MT7620_GSW_TSRA1		0x0084
+#define MT7620_GSW_TSRA2		0x0088
+#define MT7620_GSW_ATRD			0x008c
+#define MT7620_GSW_MFC			0x0010
+#define MT7620_GSW_AAC			0x00a0
+#define MT7620_GSW_MIB_BASE(p)		(0x4000 + ((p) * 0x100))
+
+#define MT7620_MFC_BC_FFP		GENMASK(31, 24)
+#define MT7620_MFC_UNM_FFP		GENMASK(23, 16)
+#define MT7620_MFC_UNU_FFP		GENMASK(15, 8)
+
+#define MT7620_AAC_AGE_CNT		GENMASK(19, 12)
+#define MT7620_AAC_AGE_CNT_MAX		0xff
+#define MT7620_AAC_AGE_UNIT		GENMASK(11, 0)
+#define MT7620_AAC_AGE_UNIT_MAX		0xfff
+
+#define MT7620_ATA2_IVL			BIT(15)
+#define MT7620_ATA2_FID			GENMASK(14, 12)
+#define MT7620_ATA2_VID			GENMASK(11, 0)
+
+#define MT7620_ATWD_AGE			GENMASK(31, 24)
+#define MT7620_ATWD_PORT_MAP		GENMASK(11, 4)
+#define MT7620_ATWD_STATUS		GENMASK(3, 2)
+
+#define MT7620_ATC_BUSY			BIT(15)
+#define MT7620_ATC_SEARCH_END		BIT(14)
+#define MT7620_ATC_SEARCH_HIT		BIT(13)
+#define MT7620_ATC_INVALID		BIT(12)
+#define MT7620_ATC_MATCH		GENMASK(11, 8)
+
+#define MT7620_FDB_READ			0
+#define MT7620_FDB_WRITE		1
+#define MT7620_FDB_FLUSH		2
+#define MT7620_FDB_START		4
+#define MT7620_FDB_NEXT			5
+
+#define MT7620_FDB_EMPTY		0
+#define MT7620_FDB_STATIC		3
+#define MT7620_FDB_ENTRIES		2048
+#define MT7620_FDB_MATCH_ALL_MAC	0
+#define MT7620_FDB_MATCH_DYNAMIC_MAC	4
+
+#define MT7620_VTCR_BUSY		BIT(31)
+#define MT7620_VTCR_FUNC		GENMASK(15, 12)
+#define MT7620_VTCR_INDEX		GENMASK(3, 0)
+
+#define MT7620_VTCR_READ		0
+#define MT7620_VTCR_WRITE		1
+
+#define MT7620_VAWD1_IVL_MAC		BIT(30)
+#define MT7620_VAWD1_VTAG_EN		BIT(28)
+#define MT7620_VAWD1_PORT_MEM		GENMASK(23, 16)
+#define MT7620_VAWD1_FID		GENMASK(3, 1)
+#define MT7620_VAWD1_VALID		BIT(0)
+
+#define MT7620_VLAN_FID_BRIDGED		1
+
+#define MT7620_VAWD2_EGRESS(p, mode)	((mode) << ((p) * 2))
+
+#define MT7620_VLAN_EGRESS_UNTAG	0
+#define MT7620_VLAN_EGRESS_TAG		2
+
+#define MT7620_PCR_MATRIX		GENMASK(23, 16)
+#define MT7620_PCR_PORT_VLAN		GENMASK(1, 0)
+
+#define MT7620_PORT_MATRIX_MODE		0
+#define MT7620_PORT_FALLBACK_MODE	1
+#define MT7620_PORT_SECURITY_MODE	3
+
+#define MT7620_PSC_SA_DIS		BIT(4)
+
+#define MT7620_PVC_EG_TAG		GENMASK(10, 8)
+#define MT7620_PVC_VLAN_ATTR		GENMASK(7, 6)
+#define MT7620_PVC_ACCEPT_FRAME		GENMASK(1, 0)
+#define MT7620_PVC_EG_TAG_CONSISTENT	1
+#define MT7620_PVC_EG_TAG_DISABLED	0
+#define MT7620_PVC_VLAN_USER		0
+#define MT7620_PVC_VLAN_TRANSPARENT	3
+#define MT7620_PVC_ACCEPT_ALL		0
+#define MT7620_PVC_ACCEPT_TAGGED	1
+#define MT7620_PVC_PORT_SPEC_TAG	BIT(5)
+
+#define MT7620_PPBV1_PVID		GENMASK(11, 0)
+
+#define MT7620_STP_DISABLED		0
+#define MT7620_STP_BLOCKING		1
+#define MT7620_STP_LEARNING		2
+#define MT7620_STP_FORWARDING		3
+
+#define MT7620_MAX_FRAME_LEN		2048
+#define MT7620_MAX_MTU			(MT7620_MAX_FRAME_LEN - VLAN_ETH_HLEN - \
+					 ETH_FCS_LEN)
+
+/*
+ * At minimum-sized line-rate traffic, the 16-bit packet counters wrap in
+ * about 440 ms on the 100BASE-T user ports and 44 ms on the 1000BASE-T CPU
+ * port. Sample the CPU port every 20 ms and the full port set every tenth
+ * tick (200 ms), keeping both well inside their wrap intervals.
+ */
+#define MT7620_MIB_CPU_INTERVAL		msecs_to_jiffies(20)
+#define MT7620_MIB_PORT_INTERVALS	10
+
+enum mt7620_gsw_mib_id {
+	MT7620_MIB_TX_GOOD_PACKETS,
+	MT7620_MIB_TX_BAD_PACKETS,
+	MT7620_MIB_TX_BAD_BYTES,
+	MT7620_MIB_TX_BYTES,
+	MT7620_MIB_TX_DROPPED,
+	MT7620_MIB_RX_GOOD_PACKETS,
+	MT7620_MIB_RX_BAD_PACKETS,
+	MT7620_MIB_RX_BAD_BYTES,
+	MT7620_MIB_RX_BYTES,
+	MT7620_MIB_RX_CTRL_DROPPED,
+	MT7620_MIB_RX_INGRESS_DROPPED,
+	MT7620_MIB_RX_ARL_DROPPED,
+	MT7620_MIB_RX_FILTERED,
+};
+
+struct mt7620_gsw_mib_desc {
+	u16 offset;
+	u8 shift;
+	u32 mask;
+	const char *name;
+};
+
+static const struct mt7620_gsw_mib_desc mt7620_gsw_mibs[] = {
+	[MT7620_MIB_TX_GOOD_PACKETS] = {
+		0x10, 0, U16_MAX, "tx_good_packets"
+	},
+	[MT7620_MIB_TX_BAD_PACKETS] = {
+		0x10, 16, U16_MAX, "tx_bad_packets"
+	},
+	[MT7620_MIB_TX_BAD_BYTES] = {
+		0x14, 0, U32_MAX, "tx_bad_bytes"
+	},
+	[MT7620_MIB_TX_BYTES] = {
+		0x18, 0, U32_MAX, "tx_good_bytes"
+	},
+	[MT7620_MIB_TX_DROPPED] = {
+		0x1c, 0, U16_MAX, "tx_dropped"
+	},
+	[MT7620_MIB_RX_GOOD_PACKETS] = {
+		0x20, 0, U16_MAX, "rx_good_packets"
+	},
+	[MT7620_MIB_RX_BAD_PACKETS] = {
+		0x20, 16, U16_MAX, "rx_bad_packets"
+	},
+	[MT7620_MIB_RX_BAD_BYTES] = {
+		0x24, 0, U32_MAX, "rx_bad_bytes"
+	},
+	[MT7620_MIB_RX_BYTES] = {
+		0x28, 0, U32_MAX, "rx_good_bytes"
+	},
+	[MT7620_MIB_RX_CTRL_DROPPED] = {
+		0x2c, 16, U16_MAX, "rx_ctrl_dropped"
+	},
+	[MT7620_MIB_RX_INGRESS_DROPPED] = {
+		0x2c, 0, U16_MAX, "rx_ingress_dropped"
+	},
+	[MT7620_MIB_RX_ARL_DROPPED] = {
+		0x30, 16, U16_MAX, "rx_arl_dropped"
+	},
+	[MT7620_MIB_RX_FILTERED] = {
+		0x30, 0, U16_MAX, "rx_filtered"
+	},
+};
+
+static_assert(ARRAY_SIZE(mt7620_gsw_mibs) == GSW_NUM_MIB_COUNTERS);
+
+struct mt7620_gsw_fdb {
+	u8 mac[ETH_ALEN];
+	u16 vid;
+	u8 port_mask;
+	bool noarp;
+};
+
+static void mt7620_gsw_mib_update(struct mt7620_gsw *gsw,
+				  unsigned long ports)
+{
+	u32 raw[GSW_NUM_PORTS][GSW_NUM_MIB_COUNTERS];
+	int port, i;
+
+	for_each_set_bit(port, &ports, MT7620_DSA_NUM_PORTS) {
+		for (i = 0; i < GSW_NUM_MIB_COUNTERS; i++) {
+			const struct mt7620_gsw_mib_desc *mib =
+				&mt7620_gsw_mibs[i];
+
+			raw[port][i] = (mtk_switch_r32(gsw,
+				MT7620_GSW_MIB_BASE(port) + mib->offset) >>
+				mib->shift) & mib->mask;
+		}
+	}
+
+	spin_lock_bh(&gsw->mib_lock);
+	for_each_set_bit(port, &ports, MT7620_DSA_NUM_PORTS) {
+		for (i = 0; i < GSW_NUM_MIB_COUNTERS; i++) {
+			if (gsw->mib_initialized)
+				gsw->mib_stats[port][i] += (raw[port][i] -
+					gsw->mib_last[port][i]) &
+					mt7620_gsw_mibs[i].mask;
+			gsw->mib_last[port][i] = raw[port][i];
+		}
+	}
+	gsw->mib_initialized = true;
+	spin_unlock_bh(&gsw->mib_lock);
+}
+
+static void mt7620_gsw_mib_work(struct work_struct *work)
+{
+	struct mt7620_gsw *gsw =
+		container_of(to_delayed_work(work), struct mt7620_gsw, mib_work);
+	unsigned long ports = BIT(MT7620_DSA_CPU_PORT);
+
+	if (++gsw->mib_port_intervals == MT7620_MIB_PORT_INTERVALS) {
+		ports = MT7620_DSA_ALL_PORTS;
+		gsw->mib_port_intervals = 0;
+	}
+
+	mt7620_gsw_mib_update(gsw, ports);
+	if (READ_ONCE(gsw->mib_active_ports))
+		schedule_delayed_work(&gsw->mib_work,
+				      MT7620_MIB_CPU_INTERVAL);
+}
+
+static void mt7620_gsw_rmw(struct mt7620_gsw *gsw, u32 reg, u32 mask,
+			   u32 set)
+{
+	mutex_lock(&gsw->reg_mutex);
+	mtk_switch_w32(gsw, (mtk_switch_r32(gsw, reg) & ~mask) |
+		       (set & mask), reg);
+	mutex_unlock(&gsw->reg_mutex);
+}
+
+static void mt7620_gsw_rmw_locked(struct mt7620_gsw *gsw, u32 reg, u32 mask,
+				  u32 set)
+{
+	mtk_switch_w32(gsw, (mtk_switch_r32(gsw, reg) & ~mask) |
+		       (set & mask), reg);
+}
+
+static int mt7620_gsw_poll_busy(struct mt7620_gsw *gsw, u32 reg, u32 busy)
+{
+	u32 val;
+
+	return read_poll_timeout(mtk_switch_r32, val, !(val & busy), 20, 20000,
+				 false, gsw, reg);
+}
+
+static int mt7620_gsw_vlan_cmd_locked(struct mt7620_gsw *gsw, u8 cmd,
+				      u8 slot)
+{
+	int ret;
+
+	mtk_switch_w32(gsw, MT7620_VTCR_BUSY |
+		       FIELD_PREP(MT7620_VTCR_FUNC, cmd) |
+		       FIELD_PREP(MT7620_VTCR_INDEX, slot), MT7620_GSW_VTCR);
+
+	ret = mt7620_gsw_poll_busy(gsw, MT7620_GSW_VTCR,
+				   MT7620_VTCR_BUSY);
+	if (ret)
+		dev_err(gsw->dev, "VLAN table command timed out\n");
+
+	return ret;
+}
+
+static void mt7620_gsw_vlan_set_vid_locked(struct mt7620_gsw *gsw, int slot,
+					   u16 vid)
+{
+	u32 mask = GENMASK(11, 0);
+	u32 shift = (slot & 1) * 12;
+
+	mt7620_gsw_rmw_locked(gsw, MT7620_GSW_VTIM(slot), mask << shift,
+			      (vid & mask) << shift);
+}
+
+static int mt7620_gsw_vlan_write_locked(struct mt7620_gsw *gsw, int slot)
+{
+	struct mt7620_gsw_vlan *vlan = &gsw->vlans[slot];
+	u32 vawd1 = 0;
+	u32 vawd2 = 0;
+	int port;
+
+	if (vlan->valid && vlan->members) {
+		vawd1 = MT7620_VAWD1_IVL_MAC | MT7620_VAWD1_VTAG_EN |
+			FIELD_PREP(MT7620_VAWD1_PORT_MEM, vlan->members) |
+			FIELD_PREP(MT7620_VAWD1_FID,
+				   MT7620_VLAN_FID_BRIDGED) |
+			MT7620_VAWD1_VALID;
+
+		for (port = 0; port < MT7620_DSA_NUM_PORTS; port++) {
+			u32 mode;
+
+			if (!(vlan->members & BIT(port)))
+				continue;
+
+			mode = vlan->untagged & BIT(port) ?
+			       MT7620_VLAN_EGRESS_UNTAG :
+			       MT7620_VLAN_EGRESS_TAG;
+			vawd2 |= MT7620_VAWD2_EGRESS(port, mode);
+		}
+	}
+
+	mtk_switch_w32(gsw, vawd1, MT7620_GSW_VAWD1);
+	mtk_switch_w32(gsw, vawd2, MT7620_GSW_VAWD2);
+
+	return mt7620_gsw_vlan_cmd_locked(gsw, MT7620_VTCR_WRITE, slot);
+}
+
+static int mt7620_gsw_vlan_find_locked(struct mt7620_gsw *gsw, u16 vid)
+{
+	int slot;
+
+	for (slot = 0; slot < GSW_NUM_VLANS; slot++)
+		if (gsw->vlans[slot].valid && gsw->vlans[slot].vid == vid)
+			return slot;
+
+	return -ENOENT;
+}
+
+static int mt7620_gsw_vlan_alloc_locked(struct mt7620_gsw *gsw, u16 vid)
+{
+	int slot;
+
+	for (slot = 0; slot < GSW_NUM_VLANS; slot++) {
+		if (gsw->vlans[slot].valid)
+			continue;
+
+		gsw->vlans[slot].valid = true;
+		gsw->vlans[slot].vid = vid;
+		mt7620_gsw_vlan_set_vid_locked(gsw, slot, vid);
+
+		return slot;
+	}
+
+	return -ENOSPC;
+}
+
+static int mt7620_gsw_fdb_cmd_match_locked(struct mt7620_gsw *gsw, u8 cmd,
+					   u8 match, u32 *response)
+{
+	u32 val;
+	int ret;
+
+	val = MT7620_ATC_BUSY | FIELD_PREP(MT7620_ATC_MATCH, match) | cmd;
+	mtk_switch_w32(gsw, val, MT7620_GSW_ATC);
+
+	ret = mt7620_gsw_poll_busy(gsw, MT7620_GSW_ATC, MT7620_ATC_BUSY);
+	if (ret) {
+		dev_err(gsw->dev, "FDB command timed out\n");
+		return ret;
+	}
+
+	val = mtk_switch_r32(gsw, MT7620_GSW_ATC);
+	if (cmd == MT7620_FDB_READ && val & MT7620_ATC_INVALID)
+		return -EINVAL;
+
+	if (response)
+		*response = val;
+
+	return 0;
+}
+
+static int mt7620_gsw_fdb_cmd_locked(struct mt7620_gsw *gsw, u8 cmd,
+				     u32 *response)
+{
+	return mt7620_gsw_fdb_cmd_match_locked(gsw, cmd,
+					       MT7620_FDB_MATCH_ALL_MAC,
+					       response);
+}
+
+static void mt7620_gsw_fdb_write_locked(struct mt7620_gsw *gsw, u16 vid,
+					u8 port_mask, const u8 *mac,
+					u8 aging, u8 status)
+{
+	u32 ata1;
+	u32 ata2;
+	u32 atwd;
+
+	ata1 = mac[0] << 24 | mac[1] << 16 | mac[2] << 8 | mac[3];
+	ata2 = mac[4] << 24 | mac[5] << 16 | MT7620_ATA2_IVL |
+	       FIELD_PREP(MT7620_ATA2_FID, MT7620_VLAN_FID_BRIDGED) |
+	       FIELD_PREP(MT7620_ATA2_VID, vid);
+	atwd = FIELD_PREP(MT7620_ATWD_AGE, aging) |
+	       FIELD_PREP(MT7620_ATWD_PORT_MAP, port_mask) |
+	       FIELD_PREP(MT7620_ATWD_STATUS, status);
+
+	mtk_switch_w32(gsw, ata1, MT7620_GSW_ATA1);
+	mtk_switch_w32(gsw, ata2, MT7620_GSW_ATA2);
+	mtk_switch_w32(gsw, atwd, MT7620_GSW_ATWD);
+}
+
+static void mt7620_gsw_fdb_read_locked(struct mt7620_gsw *gsw,
+				       struct mt7620_gsw_fdb *fdb)
+{
+	u32 tsra1 = mtk_switch_r32(gsw, MT7620_GSW_TSRA1);
+	u32 tsra2 = mtk_switch_r32(gsw, MT7620_GSW_TSRA2);
+	u32 atrd = mtk_switch_r32(gsw, MT7620_GSW_ATRD);
+
+	fdb->mac[0] = tsra1 >> 24;
+	fdb->mac[1] = tsra1 >> 16;
+	fdb->mac[2] = tsra1 >> 8;
+	fdb->mac[3] = tsra1;
+	fdb->mac[4] = tsra2 >> 24;
+	fdb->mac[5] = tsra2 >> 16;
+	fdb->vid = FIELD_GET(MT7620_ATA2_VID, tsra2);
+	fdb->port_mask = FIELD_GET(MT7620_ATWD_PORT_MAP, atrd);
+	fdb->noarp = FIELD_GET(MT7620_ATWD_STATUS, atrd) ==
+		     MT7620_FDB_STATIC;
+}
+
+static void mt7620_gsw_set_port_matrix(struct mt7620_gsw *gsw, int port,
+				       u8 matrix)
+{
+	mt7620_gsw_rmw(gsw, MT7620_GSW_PCR(port), MT7620_PCR_MATRIX,
+		       FIELD_PREP(MT7620_PCR_MATRIX, matrix));
+}
+
+static bool mt7620_gsw_is_forwarding(struct dsa_port *dp, int port, u8 state)
+{
+	if (port >= 0 && dp->index == (unsigned int)port)
+		return state == BR_STATE_FORWARDING;
+
+	return dp->stp_state == BR_STATE_FORWARDING;
+}
+
+static void mt7620_gsw_update_matrices(struct dsa_switch *ds, int port,
+				       u8 state)
+{
+	struct mt7620_gsw *gsw = ds->priv;
+	struct dsa_port *dp, *other_dp;
+
+	dsa_switch_for_each_user_port(dp, ds) {
+		u8 matrix = BIT(MT7620_DSA_CPU_PORT);
+
+		if (mt7620_gsw_is_forwarding(dp, port, state)) {
+			dsa_switch_for_each_user_port(other_dp, ds) {
+				if (dp == other_dp)
+					continue;
+				if (!mt7620_gsw_is_forwarding(other_dp, port,
+							      state))
+					continue;
+				if (dsa_port_bridge_same(dp, other_dp))
+					matrix |= BIT(other_dp->index);
+			}
+		}
+
+		mt7620_gsw_set_port_matrix(gsw, dp->index, matrix);
+	}
+}
+
+static void mt7620_gsw_recalc_matrices(struct dsa_switch *ds)
+{
+	mt7620_gsw_update_matrices(ds, -1, 0);
+}
+
+static int mt7620_gsw_setup(struct dsa_switch *ds)
+{
+	struct mt7620_gsw *gsw = ds->priv;
+	int port, slot;
+
+	ds->mtu_enforcement_ingress = true;
+	ds->ageing_time_min = 1000;
+	ds->ageing_time_max = 256 * 4096 * 1000;
+
+	for (port = 0; port < ds->num_ports; port++) {
+		mt7620_gsw_rmw(gsw, MT7620_GSW_PCR(port),
+			       MT7620_PCR_MATRIX | MT7620_PCR_PORT_VLAN, 0);
+		mt7620_gsw_rmw(gsw, MT7620_GSW_PSC(port),
+			       MT7620_PSC_SA_DIS, MT7620_PSC_SA_DIS);
+		mt7620_gsw_rmw(gsw, MT7620_GSW_PVC(port),
+			       MT7620_PVC_EG_TAG | MT7620_PVC_VLAN_ATTR |
+			       MT7620_PVC_ACCEPT_FRAME |
+			       MT7620_PVC_PORT_SPEC_TAG,
+			       FIELD_PREP(MT7620_PVC_EG_TAG,
+					  MT7620_PVC_EG_TAG_CONSISTENT) |
+			       FIELD_PREP(MT7620_PVC_VLAN_ATTR,
+					  MT7620_PVC_VLAN_TRANSPARENT) |
+			       FIELD_PREP(MT7620_PVC_ACCEPT_FRAME,
+					  MT7620_PVC_ACCEPT_ALL));
+		mt7620_gsw_rmw(gsw, MT7620_GSW_PPBV1(port),
+			       MT7620_PPBV1_PVID, 0);
+	}
+
+	mt7620_gsw_set_port_matrix(gsw, MT7620_DSA_CPU_PORT,
+				   MT7620_DSA_USER_PORTS);
+	mt7620_gsw_rmw(gsw, MT7620_GSW_PSC(MT7620_DSA_CPU_PORT),
+		       MT7620_PSC_SA_DIS, 0);
+	mt7620_gsw_rmw(gsw, MT7620_GSW_MFC,
+		       MT7620_MFC_BC_FFP | MT7620_MFC_UNM_FFP |
+		       MT7620_MFC_UNU_FFP,
+		       FIELD_PREP(MT7620_MFC_BC_FFP,
+				  BIT(MT7620_DSA_CPU_PORT)) |
+		       FIELD_PREP(MT7620_MFC_UNM_FFP,
+				  BIT(MT7620_DSA_CPU_PORT)) |
+		       FIELD_PREP(MT7620_MFC_UNU_FFP,
+				  BIT(MT7620_DSA_CPU_PORT)));
+
+	mutex_lock(&gsw->reg_mutex);
+	memset(gsw->pvid, 0, sizeof(gsw->pvid));
+	memset(gsw->vlans, 0, sizeof(gsw->vlans));
+	for (slot = 0; slot < GSW_NUM_VLANS; slot++) {
+		mt7620_gsw_vlan_set_vid_locked(gsw, slot, 0);
+		if (mt7620_gsw_vlan_write_locked(gsw, slot)) {
+			mutex_unlock(&gsw->reg_mutex);
+			return -ETIMEDOUT;
+		}
+	}
+	if (mt7620_gsw_fdb_cmd_locked(gsw, MT7620_FDB_FLUSH, NULL)) {
+		mutex_unlock(&gsw->reg_mutex);
+		return -ETIMEDOUT;
+	}
+	mutex_unlock(&gsw->reg_mutex);
+
+	memset(gsw->mib_last, 0, sizeof(gsw->mib_last));
+	memset(gsw->mib_stats, 0, sizeof(gsw->mib_stats));
+	gsw->mib_initialized = false;
+	gsw->mib_active_ports = 0;
+	gsw->mib_port_intervals = 0;
+	mt7620_gsw_mib_update(gsw, MT7620_DSA_ALL_PORTS);
+
+	return 0;
+}
+
+static void mt7620_gsw_teardown(struct dsa_switch *ds)
+{
+	struct mt7620_gsw *gsw = ds->priv;
+
+	cancel_delayed_work_sync(&gsw->mib_work);
+}
+
+static enum dsa_tag_protocol
+mt7620_gsw_get_tag_protocol(struct dsa_switch *ds, int port,
+			    enum dsa_tag_protocol mp)
+{
+	return DSA_TAG_PROTO_RALINK;
+}
+
+static int mt7620_gsw_port_enable(struct dsa_switch *ds, int port,
+				  struct phy_device *phy)
+{
+	struct mt7620_gsw *gsw = ds->priv;
+	bool start_mib;
+
+	if (dsa_is_user_port(ds, port)) {
+		mt7620_gsw_set_port_matrix(gsw, port,
+					   BIT(MT7620_DSA_CPU_PORT));
+		start_mib = !READ_ONCE(gsw->mib_active_ports);
+		set_bit(port, &gsw->mib_active_ports);
+		if (start_mib)
+			schedule_delayed_work(&gsw->mib_work,
+					      MT7620_MIB_CPU_INTERVAL);
+	}
+
+	return 0;
+}
+
+static void mt7620_gsw_port_disable(struct dsa_switch *ds, int port)
+{
+	struct mt7620_gsw *gsw = ds->priv;
+
+	if (dsa_is_user_port(ds, port)) {
+		mt7620_gsw_set_port_matrix(gsw, port, 0);
+		clear_bit(port, &gsw->mib_active_ports);
+		if (!READ_ONCE(gsw->mib_active_ports)) {
+			cancel_delayed_work_sync(&gsw->mib_work);
+			mt7620_gsw_mib_update(gsw, MT7620_DSA_ALL_PORTS);
+		}
+	}
+}
+
+static int mt7620_gsw_port_max_mtu(struct dsa_switch *ds, int port)
+{
+	return MT7620_MAX_MTU;
+}
+
+static int mt7620_gsw_port_change_mtu(struct dsa_switch *ds, int port,
+				      int new_mtu)
+{
+	/*
+	 * mt7620_mac_init() configures the switch for its maximum 2 KiB frame
+	 * size. There is no per-port MTU register to update.
+	 */
+	return 0;
+}
+
+static void mt7620_gsw_port_stp_state_set(struct dsa_switch *ds, int port,
+					  u8 state)
+{
+	struct mt7620_gsw *gsw = ds->priv;
+	u32 mask = 0;
+	u32 val = 0;
+	u8 hw_state;
+	int fid;
+
+	switch (state) {
+	case BR_STATE_DISABLED:
+		hw_state = MT7620_STP_DISABLED;
+		break;
+	case BR_STATE_BLOCKING:
+	case BR_STATE_LISTENING:
+		hw_state = MT7620_STP_BLOCKING;
+		break;
+	case BR_STATE_LEARNING:
+		hw_state = MT7620_STP_LEARNING;
+		break;
+	case BR_STATE_FORWARDING:
+		hw_state = MT7620_STP_FORWARDING;
+		break;
+	default:
+		return;
+	}
+
+	for (fid = 0; fid < 8; fid++) {
+		mask |= GENMASK(1, 0) << (fid * 2);
+		val |= hw_state << (fid * 2);
+	}
+
+	mt7620_gsw_rmw(gsw, MT7620_GSW_SSC(port), mask, val);
+	/* DSA updates dp->stp_state only after this callback returns. */
+	mt7620_gsw_update_matrices(ds, port, state);
+}
+
+static int
+mt7620_gsw_port_pre_bridge_flags(struct dsa_switch *ds, int port,
+				 struct switchdev_brport_flags flags,
+				 struct netlink_ext_ack *extack)
+{
+	if (flags.mask & ~(BR_LEARNING | BR_FLOOD | BR_MCAST_FLOOD |
+			   BR_BCAST_FLOOD)) {
+		NL_SET_ERR_MSG_MOD(extack, "Unsupported bridge port flag");
+		return -EOPNOTSUPP;
+	}
+
+	return 0;
+}
+
+static int
+mt7620_gsw_port_bridge_flags(struct dsa_switch *ds, int port,
+			     struct switchdev_brport_flags flags,
+			     struct netlink_ext_ack *extack)
+{
+	struct mt7620_gsw *gsw = ds->priv;
+
+	if (flags.mask & BR_LEARNING)
+		mt7620_gsw_rmw(gsw, MT7620_GSW_PSC(port),
+			       MT7620_PSC_SA_DIS,
+			       flags.val & BR_LEARNING ? 0 :
+			       MT7620_PSC_SA_DIS);
+
+	if (flags.mask & BR_FLOOD)
+		mt7620_gsw_rmw(gsw, MT7620_GSW_MFC,
+			       FIELD_PREP(MT7620_MFC_UNU_FFP, BIT(port)),
+			       flags.val & BR_FLOOD ?
+			       FIELD_PREP(MT7620_MFC_UNU_FFP, BIT(port)) : 0);
+
+	if (flags.mask & BR_MCAST_FLOOD)
+		mt7620_gsw_rmw(gsw, MT7620_GSW_MFC,
+			       FIELD_PREP(MT7620_MFC_UNM_FFP, BIT(port)),
+			       flags.val & BR_MCAST_FLOOD ?
+			       FIELD_PREP(MT7620_MFC_UNM_FFP, BIT(port)) : 0);
+
+	if (flags.mask & BR_BCAST_FLOOD)
+		mt7620_gsw_rmw(gsw, MT7620_GSW_MFC,
+			       FIELD_PREP(MT7620_MFC_BC_FFP, BIT(port)),
+			       flags.val & BR_BCAST_FLOOD ?
+			       FIELD_PREP(MT7620_MFC_BC_FFP, BIT(port)) : 0);
+
+	return 0;
+}
+
+static int mt7620_gsw_port_bridge_join(struct dsa_switch *ds, int port,
+				       struct dsa_bridge bridge,
+				       bool *tx_fwd_offload,
+				       struct netlink_ext_ack *extack)
+{
+	struct mt7620_gsw *gsw = ds->priv;
+
+	mt7620_gsw_rmw(gsw, MT7620_GSW_PCR(port),
+		       MT7620_PCR_PORT_VLAN,
+		       FIELD_PREP(MT7620_PCR_PORT_VLAN,
+				  MT7620_PORT_FALLBACK_MODE));
+	mt7620_gsw_recalc_matrices(ds);
+
+	return 0;
+}
+
+static void mt7620_gsw_port_bridge_leave(struct dsa_switch *ds, int port,
+					 struct dsa_bridge bridge)
+{
+	struct mt7620_gsw *gsw = ds->priv;
+
+	mt7620_gsw_recalc_matrices(ds);
+	mt7620_gsw_rmw(gsw, MT7620_GSW_PCR(port),
+		       MT7620_PCR_PORT_VLAN,
+		       FIELD_PREP(MT7620_PCR_PORT_VLAN,
+				  MT7620_PORT_MATRIX_MODE));
+}
+
+static int
+mt7620_gsw_port_vlan_filtering(struct dsa_switch *ds, int port,
+			       bool vlan_filtering,
+			       struct netlink_ext_ack *extack)
+{
+	struct mt7620_gsw *gsw = ds->priv;
+	struct dsa_port *dp;
+	bool cpu_vlan_filtering = vlan_filtering;
+	u32 pcr_mode;
+	u32 pvc;
+
+	dsa_switch_for_each_user_port(dp, ds) {
+		if (dp->index == port)
+			continue;
+		if (dsa_port_is_vlan_filtering(dp)) {
+			cpu_vlan_filtering = true;
+			break;
+		}
+	}
+
+	mutex_lock(&gsw->reg_mutex);
+
+	if (vlan_filtering) {
+		pcr_mode = MT7620_PORT_SECURITY_MODE;
+		pvc = FIELD_PREP(MT7620_PVC_VLAN_ATTR,
+				 MT7620_PVC_VLAN_USER) |
+		      FIELD_PREP(MT7620_PVC_EG_TAG,
+				 MT7620_PVC_EG_TAG_DISABLED) |
+		      FIELD_PREP(MT7620_PVC_ACCEPT_FRAME,
+				 gsw->pvid[port] ?
+				 MT7620_PVC_ACCEPT_ALL :
+				 MT7620_PVC_ACCEPT_TAGGED);
+
+		mt7620_gsw_rmw_locked(gsw, MT7620_GSW_PPBV1(port),
+				      MT7620_PPBV1_PVID,
+				      FIELD_PREP(MT7620_PPBV1_PVID,
+						 gsw->pvid[port]));
+	} else {
+		pcr_mode = dsa_port_bridge_dev_get(dsa_to_port(ds, port)) ?
+			   MT7620_PORT_FALLBACK_MODE :
+			   MT7620_PORT_MATRIX_MODE;
+		pvc = FIELD_PREP(MT7620_PVC_VLAN_ATTR,
+				 MT7620_PVC_VLAN_TRANSPARENT) |
+		      FIELD_PREP(MT7620_PVC_EG_TAG,
+				 MT7620_PVC_EG_TAG_CONSISTENT) |
+		      FIELD_PREP(MT7620_PVC_ACCEPT_FRAME,
+				 MT7620_PVC_ACCEPT_ALL);
+
+		mt7620_gsw_rmw_locked(gsw, MT7620_GSW_PPBV1(port),
+				      MT7620_PPBV1_PVID, 0);
+	}
+
+	mt7620_gsw_rmw_locked(gsw, MT7620_GSW_PCR(port),
+			      MT7620_PCR_PORT_VLAN,
+			      FIELD_PREP(MT7620_PCR_PORT_VLAN, pcr_mode));
+	mt7620_gsw_rmw_locked(gsw, MT7620_GSW_PVC(port),
+			      MT7620_PVC_VLAN_ATTR | MT7620_PVC_EG_TAG |
+			      MT7620_PVC_ACCEPT_FRAME, pvc);
+	mt7620_gsw_rmw_locked(gsw, MT7620_GSW_PVC(MT7620_DSA_CPU_PORT),
+			      MT7620_PVC_VLAN_ATTR,
+			      FIELD_PREP(MT7620_PVC_VLAN_ATTR,
+					 cpu_vlan_filtering ?
+					 MT7620_PVC_VLAN_USER :
+					 MT7620_PVC_VLAN_TRANSPARENT));
+
+	mutex_unlock(&gsw->reg_mutex);
+
+	return 0;
+}
+
+static int
+mt7620_gsw_port_vlan_add(struct dsa_switch *ds, int port,
+			 const struct switchdev_obj_port_vlan *vlan,
+			 struct netlink_ext_ack *extack)
+{
+	struct mt7620_gsw *gsw = ds->priv;
+	struct mt7620_gsw_vlan old_vlan;
+	bool allocated = false;
+	int slot;
+	int ret;
+
+	if (!vlan->vid || vlan->vid >= VLAN_VID_MASK)
+		return -EINVAL;
+
+	mutex_lock(&gsw->reg_mutex);
+
+	slot = mt7620_gsw_vlan_find_locked(gsw, vlan->vid);
+	if (slot < 0) {
+		slot = mt7620_gsw_vlan_alloc_locked(gsw, vlan->vid);
+		if (slot < 0) {
+			NL_SET_ERR_MSG_MOD(extack,
+					   "MT7620 has only 16 VLAN table entries");
+			ret = slot;
+			goto out;
+		}
+		allocated = true;
+	}
+
+	old_vlan = gsw->vlans[slot];
+	gsw->vlans[slot].members |= BIT(port);
+	if (dsa_is_cpu_port(ds, port))
+		gsw->vlans[slot].untagged &= ~BIT(port);
+	else if (vlan->flags & BRIDGE_VLAN_INFO_UNTAGGED)
+		gsw->vlans[slot].untagged |= BIT(port);
+	else
+		gsw->vlans[slot].untagged &= ~BIT(port);
+
+	ret = mt7620_gsw_vlan_write_locked(gsw, slot);
+	if (ret) {
+		if (allocated) {
+			memset(&gsw->vlans[slot], 0,
+			       sizeof(gsw->vlans[slot]));
+			mt7620_gsw_vlan_set_vid_locked(gsw, slot, 0);
+		} else {
+			gsw->vlans[slot] = old_vlan;
+		}
+		goto out;
+	}
+
+	if (vlan->flags & BRIDGE_VLAN_INFO_PVID) {
+		gsw->pvid[port] = vlan->vid;
+		mt7620_gsw_rmw_locked(gsw, MT7620_GSW_PVC(port),
+				      MT7620_PVC_ACCEPT_FRAME,
+				      FIELD_PREP(MT7620_PVC_ACCEPT_FRAME,
+						 MT7620_PVC_ACCEPT_ALL));
+
+		if (dsa_port_is_vlan_filtering(dsa_to_port(ds, port)))
+			mt7620_gsw_rmw_locked(gsw, MT7620_GSW_PPBV1(port),
+					      MT7620_PPBV1_PVID,
+					      FIELD_PREP(MT7620_PPBV1_PVID,
+							 vlan->vid));
+	} else if (vlan->vid && gsw->pvid[port] == vlan->vid) {
+		gsw->pvid[port] = 0;
+
+		if (dsa_port_is_vlan_filtering(dsa_to_port(ds, port)))
+			mt7620_gsw_rmw_locked(gsw, MT7620_GSW_PVC(port),
+					      MT7620_PVC_ACCEPT_FRAME,
+					      FIELD_PREP(MT7620_PVC_ACCEPT_FRAME,
+							 MT7620_PVC_ACCEPT_TAGGED));
+
+		mt7620_gsw_rmw_locked(gsw, MT7620_GSW_PPBV1(port),
+				      MT7620_PPBV1_PVID, 0);
+	}
+
+out:
+	mutex_unlock(&gsw->reg_mutex);
+
+	return ret;
+}
+
+static int
+mt7620_gsw_port_vlan_del(struct dsa_switch *ds, int port,
+			 const struct switchdev_obj_port_vlan *vlan)
+{
+	struct mt7620_gsw *gsw = ds->priv;
+	struct mt7620_gsw_vlan old_vlan;
+	int slot;
+	int ret = 0;
+
+	mutex_lock(&gsw->reg_mutex);
+
+	slot = mt7620_gsw_vlan_find_locked(gsw, vlan->vid);
+	if (slot < 0)
+		goto out;
+
+	old_vlan = gsw->vlans[slot];
+	gsw->vlans[slot].members &= ~BIT(port);
+	gsw->vlans[slot].untagged &= ~BIT(port);
+	if (!gsw->vlans[slot].members)
+		gsw->vlans[slot].valid = false;
+
+	ret = mt7620_gsw_vlan_write_locked(gsw, slot);
+	if (ret) {
+		gsw->vlans[slot] = old_vlan;
+		goto out;
+	}
+
+	if (!gsw->vlans[slot].valid) {
+		gsw->vlans[slot].vid = 0;
+		mt7620_gsw_vlan_set_vid_locked(gsw, slot, 0);
+	}
+
+	if (gsw->pvid[port] == vlan->vid) {
+		gsw->pvid[port] = 0;
+
+		if (dsa_port_is_vlan_filtering(dsa_to_port(ds, port)))
+			mt7620_gsw_rmw_locked(gsw, MT7620_GSW_PVC(port),
+					      MT7620_PVC_ACCEPT_FRAME,
+					      FIELD_PREP(MT7620_PVC_ACCEPT_FRAME,
+							 MT7620_PVC_ACCEPT_TAGGED));
+
+		mt7620_gsw_rmw_locked(gsw, MT7620_GSW_PPBV1(port),
+				      MT7620_PPBV1_PVID, 0);
+	}
+
+out:
+	mutex_unlock(&gsw->reg_mutex);
+
+	return ret;
+}
+
+static int
+mt7620_gsw_port_fdb_add(struct dsa_switch *ds, int port,
+			const unsigned char *addr, u16 vid,
+			struct dsa_db db)
+{
+	struct mt7620_gsw *gsw = ds->priv;
+	u32 response;
+	int ret;
+
+	mutex_lock(&gsw->reg_mutex);
+	mt7620_gsw_fdb_write_locked(gsw, vid, BIT(port), addr, 0xff,
+				    MT7620_FDB_STATIC);
+	ret = mt7620_gsw_fdb_cmd_locked(gsw, MT7620_FDB_WRITE, &response);
+	if (!ret && response & MT7620_ATC_INVALID)
+		ret = -ENOSPC;
+	mutex_unlock(&gsw->reg_mutex);
+
+	return ret;
+}
+
+static int
+mt7620_gsw_port_fdb_del(struct dsa_switch *ds, int port,
+			const unsigned char *addr, u16 vid,
+			struct dsa_db db)
+{
+	struct mt7620_gsw *gsw = ds->priv;
+	int ret;
+
+	mutex_lock(&gsw->reg_mutex);
+	mt7620_gsw_fdb_write_locked(gsw, vid, BIT(port), addr, 0,
+				    MT7620_FDB_EMPTY);
+	ret = mt7620_gsw_fdb_cmd_locked(gsw, MT7620_FDB_WRITE, NULL);
+	mutex_unlock(&gsw->reg_mutex);
+
+	return ret;
+}
+
+static int
+mt7620_gsw_port_fdb_dump(struct dsa_switch *ds, int port,
+			 dsa_fdb_dump_cb_t *cb, void *data)
+{
+	struct mt7620_gsw_fdb fdb = {};
+	struct mt7620_gsw *gsw = ds->priv;
+	int count = MT7620_FDB_ENTRIES;
+	u32 response;
+	int ret;
+
+	mutex_lock(&gsw->reg_mutex);
+
+	ret = mt7620_gsw_fdb_cmd_locked(gsw, MT7620_FDB_START, &response);
+	if (ret)
+		goto out;
+
+	do {
+		if (response & MT7620_ATC_SEARCH_HIT) {
+			mt7620_gsw_fdb_read_locked(gsw, &fdb);
+			if (fdb.port_mask & BIT(port)) {
+				ret = cb(fdb.mac, fdb.vid, fdb.noarp, data);
+				if (ret)
+					break;
+			}
+		}
+
+		if (response & MT7620_ATC_SEARCH_END)
+			break;
+
+		ret = mt7620_gsw_fdb_cmd_locked(gsw, MT7620_FDB_NEXT,
+						&response);
+	} while (!ret && --count);
+
+out:
+	mutex_unlock(&gsw->reg_mutex);
+
+	return ret;
+}
+
+static void mt7620_gsw_port_fast_age(struct dsa_switch *ds, int port)
+{
+	struct mt7620_gsw *gsw = ds->priv;
+
+	/*
+	 * The switch cannot combine its source-port match with its dynamic-MAC
+	 * match. Flush all dynamic MAC entries to preserve static entries.
+	 */
+	mutex_lock(&gsw->reg_mutex);
+	mt7620_gsw_fdb_cmd_match_locked(gsw, MT7620_FDB_FLUSH,
+					MT7620_FDB_MATCH_DYNAMIC_MAC, NULL);
+	mutex_unlock(&gsw->reg_mutex);
+}
+
+static int
+mt7620_gsw_port_mdb_add(struct dsa_switch *ds, int port,
+			const struct switchdev_obj_port_mdb *mdb,
+			struct dsa_db db)
+{
+	struct mt7620_gsw_fdb fdb = {};
+	struct mt7620_gsw *gsw = ds->priv;
+	u8 port_mask = 0;
+	u32 response;
+	int ret;
+
+	mutex_lock(&gsw->reg_mutex);
+
+	mt7620_gsw_fdb_write_locked(gsw, mdb->vid, 0, mdb->addr, 0,
+				    MT7620_FDB_EMPTY);
+	if (!mt7620_gsw_fdb_cmd_locked(gsw, MT7620_FDB_READ, NULL)) {
+		mt7620_gsw_fdb_read_locked(gsw, &fdb);
+		port_mask = fdb.port_mask;
+	}
+
+	port_mask |= BIT(port);
+	mt7620_gsw_fdb_write_locked(gsw, mdb->vid, port_mask, mdb->addr,
+				    0xff, MT7620_FDB_STATIC);
+	ret = mt7620_gsw_fdb_cmd_locked(gsw, MT7620_FDB_WRITE, &response);
+	if (!ret && response & MT7620_ATC_INVALID)
+		ret = -ENOSPC;
+
+	mutex_unlock(&gsw->reg_mutex);
+
+	return ret;
+}
+
+static int
+mt7620_gsw_port_mdb_del(struct dsa_switch *ds, int port,
+			const struct switchdev_obj_port_mdb *mdb,
+			struct dsa_db db)
+{
+	struct mt7620_gsw_fdb fdb = {};
+	struct mt7620_gsw *gsw = ds->priv;
+	u8 port_mask = 0;
+	int ret;
+
+	mutex_lock(&gsw->reg_mutex);
+
+	mt7620_gsw_fdb_write_locked(gsw, mdb->vid, 0, mdb->addr, 0,
+				    MT7620_FDB_EMPTY);
+	if (!mt7620_gsw_fdb_cmd_locked(gsw, MT7620_FDB_READ, NULL)) {
+		mt7620_gsw_fdb_read_locked(gsw, &fdb);
+		port_mask = fdb.port_mask;
+	}
+
+	port_mask &= ~BIT(port);
+	mt7620_gsw_fdb_write_locked(gsw, mdb->vid, port_mask, mdb->addr,
+				    0xff, port_mask ? MT7620_FDB_STATIC :
+				    MT7620_FDB_EMPTY);
+	ret = mt7620_gsw_fdb_cmd_locked(gsw, MT7620_FDB_WRITE, NULL);
+
+	mutex_unlock(&gsw->reg_mutex);
+
+	return ret;
+}
+
+static int mt7620_gsw_set_ageing_time(struct dsa_switch *ds,
+				      unsigned int msecs)
+{
+	struct mt7620_gsw *gsw = ds->priv;
+	unsigned int secs = DIV_ROUND_CLOSEST(msecs, 1000);
+	unsigned int best_error = UINT_MAX;
+	unsigned int age_count = 0;
+	unsigned int age_unit = 0;
+	unsigned int count;
+
+	/*
+	 * The hardware period is (AGE_CNT + 1) * (AGE_UNIT + 1) seconds.
+	 * Find the closest representation across the two register fields.
+	 */
+	for (count = 0; count <= MT7620_AAC_AGE_CNT_MAX; count++) {
+		unsigned int duration;
+		unsigned int error;
+		unsigned int unit;
+
+		unit = DIV_ROUND_CLOSEST(secs, count + 1);
+		if (!unit || unit > MT7620_AAC_AGE_UNIT_MAX + 1)
+			continue;
+
+		duration = (count + 1) * unit;
+		error = abs_diff(secs, duration);
+		if (error < best_error) {
+			best_error = error;
+			age_count = count;
+			age_unit = unit - 1;
+		}
+
+		if (!error)
+			break;
+	}
+
+	mt7620_gsw_rmw(gsw, MT7620_GSW_AAC,
+		       MT7620_AAC_AGE_CNT | MT7620_AAC_AGE_UNIT,
+		       FIELD_PREP(MT7620_AAC_AGE_CNT, age_count) |
+		       FIELD_PREP(MT7620_AAC_AGE_UNIT, age_unit));
+
+	return 0;
+}
+
+static void mt7620_gsw_get_strings(struct dsa_switch *ds, int port,
+				   u32 stringset, u8 *data)
+{
+	int i;
+
+	if (stringset != ETH_SS_STATS)
+		return;
+
+	for (i = 0; i < ARRAY_SIZE(mt7620_gsw_mibs); i++)
+		ethtool_puts(&data, mt7620_gsw_mibs[i].name);
+}
+
+static int mt7620_gsw_get_sset_count(struct dsa_switch *ds, int port,
+				     int stringset)
+{
+	if (stringset != ETH_SS_STATS)
+		return 0;
+
+	return ARRAY_SIZE(mt7620_gsw_mibs);
+}
+
+static void mt7620_gsw_get_ethtool_stats(struct dsa_switch *ds, int port,
+					 u64 *data)
+{
+	struct mt7620_gsw *gsw = ds->priv;
+
+	spin_lock_bh(&gsw->mib_lock);
+	memcpy(data, gsw->mib_stats[port], sizeof(gsw->mib_stats[port]));
+	spin_unlock_bh(&gsw->mib_lock);
+}
+
+static void mt7620_gsw_get_stats64(struct dsa_switch *ds, int port,
+				   struct rtnl_link_stats64 *stats)
+{
+	struct mt7620_gsw *gsw = ds->priv;
+
+	spin_lock_bh(&gsw->mib_lock);
+	stats->tx_packets = gsw->mib_stats[port][MT7620_MIB_TX_GOOD_PACKETS];
+	stats->tx_bytes = gsw->mib_stats[port][MT7620_MIB_TX_BYTES] -
+			  stats->tx_packets * ETH_FCS_LEN;
+	stats->tx_errors = gsw->mib_stats[port][MT7620_MIB_TX_BAD_PACKETS];
+	stats->tx_dropped = gsw->mib_stats[port][MT7620_MIB_TX_DROPPED];
+	stats->rx_packets = gsw->mib_stats[port][MT7620_MIB_RX_GOOD_PACKETS];
+	stats->rx_bytes = gsw->mib_stats[port][MT7620_MIB_RX_BYTES] -
+			  stats->rx_packets * ETH_FCS_LEN;
+	stats->rx_errors = gsw->mib_stats[port][MT7620_MIB_RX_BAD_PACKETS];
+	stats->rx_dropped =
+		gsw->mib_stats[port][MT7620_MIB_RX_CTRL_DROPPED] +
+		gsw->mib_stats[port][MT7620_MIB_RX_INGRESS_DROPPED] +
+		gsw->mib_stats[port][MT7620_MIB_RX_ARL_DROPPED] +
+		gsw->mib_stats[port][MT7620_MIB_RX_FILTERED];
+	spin_unlock_bh(&gsw->mib_lock);
+}
+
+static int mt7620_gsw_pmcr_speed(int speed)
+{
+	switch (speed) {
+	case SPEED_10:
+		return 0;
+	case SPEED_100:
+		return 1;
+	case SPEED_1000:
+		return 2;
+	default:
+		return -EINVAL;
+	}
+}
+
+static void mt7620_gsw_mac_config(struct phylink_config *config,
+				  unsigned int mode,
+				  const struct phylink_link_state *state)
+{
+}
+
+static void mt7620_gsw_mac_link_down(struct phylink_config *config,
+				     unsigned int mode,
+				     phy_interface_t interface)
+{
+	struct dsa_port *dp = dsa_phylink_to_port(config);
+	struct mt7620_gsw *gsw = dp->ds->priv;
+
+	if (dsa_is_cpu_port(dp->ds, dp->index))
+		return;
+
+	mt7620_gsw_rmw(gsw, GSW_REG_PORT_PMCR(dp->index),
+		       PMCR_FORCE | PMCR_LINK, PMCR_FORCE);
+}
+
+static void mt7620_gsw_mac_link_up(struct phylink_config *config,
+				   struct phy_device *phydev,
+				   unsigned int mode,
+				   phy_interface_t interface,
+				   int speed, int duplex,
+				   bool tx_pause, bool rx_pause)
+{
+	struct dsa_port *dp = dsa_phylink_to_port(config);
+	struct mt7620_gsw *gsw = dp->ds->priv;
+	u32 val;
+	int hw_speed;
+
+	if (dsa_is_cpu_port(dp->ds, dp->index))
+		return;
+
+	hw_speed = mt7620_gsw_pmcr_speed(speed);
+	if (hw_speed < 0)
+		return;
+
+	val = PMCR_IPG | PMCR_MAC_MODE | PMCR_FORCE | PMCR_TX_EN |
+	      PMCR_RX_EN | PMCR_BACKOFF | PMCR_BACKPRES | PMCR_LINK |
+	      PMCR_SPEED(hw_speed);
+
+	if (duplex == DUPLEX_FULL)
+		val |= PMCR_DUPLEX;
+	if (tx_pause)
+		val |= PMCR_TX_FC;
+	if (rx_pause)
+		val |= PMCR_RX_FC;
+
+	mtk_switch_w32(gsw, val, GSW_REG_PORT_PMCR(dp->index));
+}
+
+static const struct phylink_mac_ops mt7620_gsw_phylink_mac_ops = {
+	.mac_config	= mt7620_gsw_mac_config,
+	.mac_link_down	= mt7620_gsw_mac_link_down,
+	.mac_link_up	= mt7620_gsw_mac_link_up,
+};
+
+static void mt7620_gsw_phylink_get_caps(struct dsa_switch *ds, int port,
+					struct phylink_config *config)
+{
+	bitmap_zero(config->supported_interfaces, PHY_INTERFACE_MODE_MAX);
+	config->mac_capabilities = MAC_SYM_PAUSE | MAC_ASYM_PAUSE;
+
+	/*
+	 * Port 5 is an external MAC whose pinmux and PHY mode are
+	 * board-specific. It matches neither case below and is therefore
+	 * left without a supported interface until a DSA device tree
+	 * describes it.
+	 */
+	if (port >= 0 && BIT(port) & MT7620_DSA_USER_PORTS) {
+		__set_bit(PHY_INTERFACE_MODE_MII,
+			  config->supported_interfaces);
+		config->mac_capabilities |= MAC_10HD | MAC_10FD |
+					    MAC_100HD | MAC_100FD;
+	} else if (port == MT7620_DSA_CPU_PORT) {
+		phy_interface_set_rgmii(config->supported_interfaces);
+		config->mac_capabilities |= MAC_10HD | MAC_10FD |
+					    MAC_100HD | MAC_100FD |
+					    MAC_1000FD;
+	}
+}
+
+static const struct dsa_switch_ops mt7620_gsw_dsa_ops = {
+	.get_tag_protocol	= mt7620_gsw_get_tag_protocol,
+	.setup			= mt7620_gsw_setup,
+	.teardown		= mt7620_gsw_teardown,
+	.port_enable		= mt7620_gsw_port_enable,
+	.port_disable		= mt7620_gsw_port_disable,
+	.port_max_mtu		= mt7620_gsw_port_max_mtu,
+	.port_change_mtu	= mt7620_gsw_port_change_mtu,
+	.port_bridge_join	= mt7620_gsw_port_bridge_join,
+	.port_bridge_leave	= mt7620_gsw_port_bridge_leave,
+	.port_pre_bridge_flags	= mt7620_gsw_port_pre_bridge_flags,
+	.port_bridge_flags	= mt7620_gsw_port_bridge_flags,
+	.port_stp_state_set	= mt7620_gsw_port_stp_state_set,
+	.port_vlan_filtering	= mt7620_gsw_port_vlan_filtering,
+	.port_vlan_add		= mt7620_gsw_port_vlan_add,
+	.port_vlan_del		= mt7620_gsw_port_vlan_del,
+	.port_fdb_add		= mt7620_gsw_port_fdb_add,
+	.port_fdb_del		= mt7620_gsw_port_fdb_del,
+	.port_fdb_dump		= mt7620_gsw_port_fdb_dump,
+	.port_fast_age		= mt7620_gsw_port_fast_age,
+	.port_mdb_add		= mt7620_gsw_port_mdb_add,
+	.port_mdb_del		= mt7620_gsw_port_mdb_del,
+	.set_ageing_time	= mt7620_gsw_set_ageing_time,
+	.get_strings		= mt7620_gsw_get_strings,
+	.get_sset_count		= mt7620_gsw_get_sset_count,
+	.get_ethtool_stats	= mt7620_gsw_get_ethtool_stats,
+	.get_stats64		= mt7620_gsw_get_stats64,
+	.phylink_get_caps	= mt7620_gsw_phylink_get_caps,
+};
+
+static int mt7620_gsw_dsa_probe(struct platform_device *pdev)
+{
+	struct mt7620_gsw *gsw = platform_get_drvdata(pdev);
+	struct dsa_switch *ds;
+	int ret;
+
+	if (gsw->ds)
+		return 0;
+
+	ds = devm_kzalloc(&pdev->dev, sizeof(*ds), GFP_KERNEL);
+	if (!ds)
+		return -ENOMEM;
+
+	ds->dev = &pdev->dev;
+	ds->priv = gsw;
+	ds->ops = &mt7620_gsw_dsa_ops;
+	ds->phylink_mac_ops = &mt7620_gsw_phylink_mac_ops;
+	ds->num_ports = MT7620_DSA_NUM_PORTS;
+
+	spin_lock_init(&gsw->mib_lock);
+	INIT_DELAYED_WORK(&gsw->mib_work, mt7620_gsw_mib_work);
+
+	ret = dsa_register_switch(ds);
+	if (ret) {
+		dev_err_probe(gsw->dev, ret, "failed to register DSA switch\n");
+		return ret;
+	}
+
+	gsw->ds = ds;
+
+	return 0;
+}
+
+static void mt7620_gsw_dsa_remove(struct platform_device *pdev)
+{
+	struct mt7620_gsw *gsw = platform_get_drvdata(pdev);
+
+	if (!gsw->ds)
+		return;
+
+	dsa_unregister_switch(gsw->ds);
+	gsw->ds = NULL;
+}
+
+static struct platform_driver mt7620_gsw_dsa_driver = {
+	.probe = mt7620_gsw_dsa_probe,
+	.remove = mt7620_gsw_dsa_remove,
+	.driver = {
+		.name = "mt7620-dsa",
+	},
+};
+module_platform_driver(mt7620_gsw_dsa_driver);
+MODULE_ALIAS("platform:mt7620-dsa");
+MODULE_AUTHOR("Gleb Pesin <dormancygrace@gmail.com>");
+MODULE_DESCRIPTION("DSA driver for the MediaTek MT7620 integrated switch");
+MODULE_LICENSE("GPL");

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mdio.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mdio.c
@@ -250,10 +250,11 @@ int fe_mdio_init(struct fe_priv *priv)
 	if (err)
 		goto err_free_bus;
 
+	of_node_put(mii_np);
 	return 0;
 
 err_free_bus:
-	kfree(priv->mii_bus);
+	mdiobus_free(priv->mii_bus);
 err_put_node:
 	of_node_put(mii_np);
 err_no_bus:
@@ -268,6 +269,6 @@ void fe_mdio_cleanup(struct fe_priv *priv)
 		return;
 
 	mdiobus_unregister(priv->mii_bus);
-	put_device(&priv->mii_bus->dev);
-	kfree(priv->mii_bus);
+	mdiobus_free(priv->mii_bus);
+	priv->mii_bus = NULL;
 }

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mdio_mt7620.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mdio_mt7620.c
@@ -14,6 +14,7 @@
 
 #include <linux/module.h>
 #include <linux/kernel.h>
+#include <linux/iopoll.h>
 #include <linux/types.h>
 
 #include "mtk_eth_soc.h"
@@ -22,17 +23,17 @@
 
 static int mt7620_mii_busy_wait(struct mt7620_gsw *gsw)
 {
-	unsigned long t_start = jiffies;
+	u32 val;
+	int ret;
 
-	while (1) {
-		if (!(mtk_switch_r32(gsw, MT7620A_GSW_REG_PIAC) & GSW_MDIO_ACCESS))
-			return 0;
-		if (time_after(jiffies, t_start + GSW_REG_PHY_TIMEOUT))
-			break;
-	}
+	ret = readl_poll_timeout_atomic(gsw->base + MT7620A_GSW_REG_PIAC,
+					val, !(val & GSW_MDIO_ACCESS), 0,
+					jiffies_to_usecs(GSW_REG_PHY_TIMEOUT));
+	if (!ret)
+		return 0;
 
-	dev_err(gsw->dev, "mdio: MDIO timeout\n");
-	return -1;
+	dev_err(gsw->dev, "mdio: MDIO timeout (PIAC %#x)\n", val);
+	return ret;
 }
 
 u32 _mt7620_mii_write(struct mt7620_gsw *gsw, u32 phy_addr,

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -43,6 +43,7 @@
 
 #if IS_ENABLED(CONFIG_NET_DSA)
 #include <net/dsa.h>
+#include <net/dst_metadata.h>
 #endif
 
 #if defined(CONFIG_SOC_MT7620)
@@ -94,6 +95,52 @@ static const u16 fe_reg_table_default[FE_REG_COUNT] = {
 	[FE_REG_FE_RST_GL] = FE_FE_RST_GL,
 };
 
+#if IS_ENABLED(CONFIG_NET_DSA)
+static void fe_dsa_metadata_free(void *data)
+{
+	struct fe_priv *priv = data;
+	int port;
+
+	for (port = 0; port < ARRAY_SIZE(priv->dsa_meta); port++) {
+		if (!priv->dsa_meta[port])
+			continue;
+
+		dst_release(&priv->dsa_meta[port]->dst);
+		priv->dsa_meta[port] = NULL;
+	}
+}
+
+static int fe_dsa_metadata_init(struct fe_priv *priv)
+{
+	struct metadata_dst *md_dst;
+	int err;
+	int port;
+
+	for (port = 0; port < ARRAY_SIZE(priv->dsa_meta); port++) {
+		md_dst = metadata_dst_alloc(0, METADATA_HW_PORT_MUX,
+					    GFP_KERNEL);
+		if (!md_dst) {
+			fe_dsa_metadata_free(priv);
+			return -ENOMEM;
+		}
+
+		md_dst->u.port_info.port_id = port;
+		priv->dsa_meta[port] = md_dst;
+	}
+
+	err = devm_add_action_or_reset(priv->dev, fe_dsa_metadata_free, priv);
+	if (err)
+		return err;
+
+	return 0;
+}
+#endif
+
+static void fe_of_node_put(void *data)
+{
+	of_node_put(data);
+}
+
 static const u16 *fe_reg_table = fe_reg_table_default;
 
 struct fe_work_t {
@@ -137,13 +184,27 @@ void fe_m32(struct fe_priv *eth, u32 clear, u32 set, unsigned reg)
 
 static void fe_reset_fe(struct fe_priv *priv)
 {
-	if (!priv->resets)
+	if (!priv->rst_fe && !priv->rst_esw)
 		return;
 
-	reset_control_assert(priv->resets);
+	reset_control_assert(priv->rst_fe);
+	reset_control_assert(priv->rst_esw);
 	usleep_range(60, 120);
-	reset_control_deassert(priv->resets);
+	reset_control_deassert(priv->rst_fe);
+	reset_control_deassert(priv->rst_esw);
 	usleep_range(1000, 1200);
+}
+
+static void fe_reset_dma(struct fe_priv *priv)
+{
+	if (!priv->rst_fe)
+		return;
+
+	reset_control_assert(priv->rst_fe);
+	usleep_range(60, 120);
+	reset_control_deassert(priv->rst_fe);
+	usleep_range(1000, 1200);
+	priv->fe_needs_reinit = true;
 }
 
 static inline void fe_int_disable(u32 mask)
@@ -689,6 +750,21 @@ static int fe_tx_map_dma(struct sk_buff *skb, struct net_device *dev,
 		priv->soc->tx_dma(&st.txd);
 	else
 		st.txd.txd4 = TX_DMA_DESP4_DEF;
+
+#if IS_ENABLED(CONFIG_NET_DSA)
+	if (netdev_uses_dsa(dev) &&
+	    dev->dsa_ptr->tag_ops->proto == DSA_TAG_PROTO_RALINK) {
+		struct metadata_dst *md_dst = skb_metadata_dst(skb);
+
+		if (md_dst && md_dst->type == METADATA_HW_PORT_MUX &&
+		    md_dst->u.port_info.port_id <= MT7620_TX_DMA_LAST_PORT) {
+			st.txd.txd4 &= ~MT7620_TX_DMA_FP_BMAP;
+			st.txd.txd4 |= FIELD_PREP(MT7620_TX_DMA_FP_BMAP,
+				BIT(md_dst->u.port_info.port_id));
+		}
+	}
+#endif
+
 	st.def_txd4 = st.txd.txd4;
 
 	/* TX Checksum offload */
@@ -981,11 +1057,24 @@ static int fe_poll_rx(struct napi_struct *napi, int budget,
 			goto replace_desc;
 		}
 		skb_put(skb, pktlen);
+
 		if (trxd.rxd4 & checksum_bit)
 			skb->ip_summed = CHECKSUM_UNNECESSARY;
 		else
 			skb_checksum_none_assert(skb);
 		skb->protocol = eth_type_trans(skb, netdev);
+
+#if IS_ENABLED(CONFIG_NET_DSA)
+		if (netdev_uses_dsa(netdev) &&
+		    netdev->dsa_ptr->tag_ops->proto == DSA_TAG_PROTO_RALINK) {
+			unsigned int port;
+
+			port = FIELD_GET(MT7620_RX_DMA_SP, trxd.rxd4);
+			if (port < ARRAY_SIZE(priv->dsa_meta) &&
+			    priv->dsa_meta[port])
+				skb_dst_set_noref(skb, &priv->dsa_meta[port]->dst);
+		}
+#endif
 
 		if (netdev->features & NETIF_F_HW_VLAN_CTAG_RX &&
 		    RX_DMA_VID(trxd.rxd3))
@@ -1264,15 +1353,10 @@ void fe_csum_config(struct fe_priv *priv)
 	fe_rxcsum_config((dev->features & NETIF_F_RXCSUM));
 }
 
-static int fe_hw_init(struct net_device *dev)
+static void fe_hw_config(struct net_device *dev)
 {
 	struct fe_priv *priv = netdev_priv(dev);
-	int i, err;
-
-	err = devm_request_irq(priv->dev, dev->irq, fe_handle_irq, 0,
-			       dev_name(priv->dev), dev);
-	if (err)
-		return err;
+	int i;
 
 	if (priv->soc->set_mac)
 		priv->soc->set_mac(priv, dev->dev_addr);
@@ -1298,7 +1382,19 @@ static int fe_hw_init(struct net_device *dev)
 		fe_reg_w32(1, FE_REG_FE_RST_GL);
 		fe_reg_w32(0, FE_REG_FE_RST_GL);
 	}
+}
 
+static int fe_hw_init(struct net_device *dev)
+{
+	struct fe_priv *priv = netdev_priv(dev);
+	int err;
+
+	err = devm_request_irq(priv->dev, dev->irq, fe_handle_irq, 0,
+			       dev_name(priv->dev), dev);
+	if (err)
+		return err;
+
+	fe_hw_config(dev);
 	return 0;
 }
 
@@ -1308,6 +1404,11 @@ static int fe_open(struct net_device *dev)
 	unsigned long flags;
 	u32 val;
 	int err;
+
+	if (priv->fe_needs_reinit) {
+		fe_hw_config(dev);
+		priv->fe_needs_reinit = false;
+	}
 
 	err = fe_init_dma(priv);
 	if (err) {
@@ -1325,10 +1426,11 @@ static int fe_open(struct net_device *dev)
 
 	spin_unlock_irqrestore(&priv->page_lock, flags);
 
-	if (priv->phy)
+	if (priv->phy && !priv->dsa_switch)
 		priv->phy->start(priv);
 
-	if (priv->soc->has_carrier && priv->soc->has_carrier(priv))
+	if (priv->dsa_switch ||
+	    (priv->soc->has_carrier && priv->soc->has_carrier(priv)))
 		netif_carrier_on(dev);
 
 	napi_enable(&priv->rx_napi);
@@ -1343,12 +1445,13 @@ static int fe_stop(struct net_device *dev)
 	struct fe_priv *priv = netdev_priv(dev);
 	unsigned long flags;
 	int i;
+	u32 dma_cfg;
 
 	netif_tx_disable(dev);
 	fe_int_disable(priv->soc->tx_int | priv->soc->rx_int);
 	napi_disable(&priv->rx_napi);
 
-	if (priv->phy)
+	if (priv->phy && !priv->dsa_switch)
 		priv->phy->stop(priv);
 
 	spin_lock_irqsave(&priv->page_lock, flags);
@@ -1366,6 +1469,12 @@ static int fe_stop(struct net_device *dev)
 			continue;
 		}
 		break;
+	}
+
+	dma_cfg = fe_reg_r32(FE_REG_PDMA_GLO_CFG);
+	if (dma_cfg & (FE_TX_DMA_BUSY | FE_RX_DMA_BUSY)) {
+		netdev_warn(dev, "DMA did not stop, resetting frame engine\n");
+		fe_reset_dma(priv);
 	}
 
 	fe_free_dma(priv);
@@ -1402,7 +1511,7 @@ static void fe_reset_phy(struct fe_priv *priv)
 	gpiod_set_value(phy_reset, 0);
 }
 
-static int __init fe_init(struct net_device *dev)
+static int fe_init(struct net_device *dev)
 {
 	struct fe_priv *priv = netdev_priv(dev);
 	int err;
@@ -1417,17 +1526,19 @@ static int __init fe_init(struct net_device *dev)
 
 	fe_reset_phy(priv);
 
-	err = fe_mdio_init(priv);
-	if (err)
-		return err;
+	if (!priv->dsa_switch) {
+		err = fe_mdio_init(priv);
+		if (err)
+			return err;
+	}
 
-	if (priv->soc->port_init)
+	if (priv->soc->port_init && !priv->dsa_switch)
 		for_each_child_of_node_scoped(priv->dev->of_node, port)
 			if (of_device_is_compatible(port, "mediatek,eth-port") &&
 			    of_device_is_available(port))
 				priv->soc->port_init(priv, port);
 
-	if (priv->phy) {
+	if (priv->phy && !priv->dsa_switch) {
 		err = priv->phy->connect(priv);
 		if (err)
 			goto err_phy_disconnect;
@@ -1437,13 +1548,14 @@ static int __init fe_init(struct net_device *dev)
 	if (err)
 		goto err_phy_disconnect;
 
-	if ((priv->flags & FE_FLAG_HAS_SWITCH) && priv->soc->switch_config)
+	if ((priv->flags & FE_FLAG_HAS_SWITCH) && priv->soc->switch_config &&
+	    !priv->dsa_switch)
 		priv->soc->switch_config(priv);
 
 	return 0;
 
 err_phy_disconnect:
-	if (priv->phy)
+	if (priv->phy && !priv->dsa_switch)
 		priv->phy->disconnect(priv);
 	fe_mdio_cleanup(priv);
 
@@ -1454,7 +1566,7 @@ static void fe_uninit(struct net_device *dev)
 {
 	struct fe_priv *priv = netdev_priv(dev);
 
-	if (priv->phy)
+	if (priv->phy && !priv->dsa_switch)
 		priv->phy->disconnect(priv);
 	fe_mdio_cleanup(priv);
 
@@ -1579,6 +1691,7 @@ static int fe_probe(struct platform_device *pdev)
 {
 	struct fe_soc_data *soc;
 	struct net_device *netdev;
+	struct device_node *ports_np;
 	struct fe_priv *priv;
 	struct clk *sysclk;
 	int err, napi_weight;
@@ -1624,10 +1737,19 @@ static int fe_probe(struct platform_device *pdev)
 
 	priv = netdev_priv(netdev);
 	spin_lock_init(&priv->page_lock);
-	priv->resets = devm_reset_control_array_get_optional_exclusive(&pdev->dev);
-	if (IS_ERR(priv->resets)) {
-		dev_err(&pdev->dev, "Failed to get resets for FE and ESW cores: %pe\n", priv->resets);
-		return PTR_ERR(priv->resets);
+	priv->rst_fe =
+		devm_reset_control_get_optional_exclusive(&pdev->dev, "fe");
+	if (IS_ERR(priv->rst_fe)) {
+		dev_err(&pdev->dev, "failed to get FE reset: %pe\n",
+			priv->rst_fe);
+		return PTR_ERR(priv->rst_fe);
+	}
+	priv->rst_esw =
+		devm_reset_control_get_optional_exclusive(&pdev->dev, "esw");
+	if (IS_ERR(priv->rst_esw)) {
+		dev_err(&pdev->dev, "failed to get ESW reset: %pe\n",
+			priv->rst_esw);
+		return PTR_ERR(priv->rst_esw);
 	}
 
 	if (soc->init_data)
@@ -1665,6 +1787,27 @@ static int fe_probe(struct platform_device *pdev)
 		dev_err(&pdev->dev, "failed to read switch phandle\n");
 		return -ENODEV;
 	}
+	if (priv->switch_np) {
+		err = devm_add_action_or_reset(&pdev->dev, fe_of_node_put,
+					       priv->switch_np);
+		if (err)
+			return err;
+
+		ports_np = of_get_available_child_by_name(priv->switch_np,
+							  "ports");
+		priv->dsa_switch = !!ports_np;
+		of_node_put(ports_np);
+		if (priv->dsa_switch &&
+		    (!(priv->flags & FE_FLAG_HAS_SWITCH) ||
+		     !soc->switch_config)) {
+			dev_err(&pdev->dev,
+				"DSA switch requested on unsupported SoC\n");
+			return -ENODEV;
+		}
+	}
+	if (priv->switch_np && !priv->rst_fe && !priv->rst_esw)
+		dev_warn(&pdev->dev,
+			 "no \"fe\"/\"esw\" reset-names, hardware not reset\n");
 
 	priv->netdev = netdev;
 	priv->dev = &pdev->dev;
@@ -1675,6 +1818,15 @@ static int fe_probe(struct platform_device *pdev)
 	priv->tx_ring.tx_ring_size = NUM_DMA_DESC;
 	priv->rx_ring.rx_ring_size = NUM_DMA_DESC;
 	INIT_WORK(&priv->pending_work, fe_pending_work);
+
+	if (priv->dsa_switch) {
+#if IS_ENABLED(CONFIG_NET_DSA)
+		err = fe_dsa_metadata_init(priv);
+		if (err)
+			return err;
+#endif
+		netif_keep_dst(netdev);
+	}
 
 	napi_weight = 16;
 	if (priv->flags & FE_FLAG_NAPI_WEIGHT) {
@@ -1693,10 +1845,27 @@ static int fe_probe(struct platform_device *pdev)
 
 	platform_set_drvdata(pdev, netdev);
 
+	if (priv->dsa_switch) {
+		err = fe_mdio_init(priv);
+		if (err)
+			goto err_clear_drvdata;
+
+		err = priv->soc->switch_config(priv);
+		if (err)
+			goto err_mdio_cleanup;
+	}
+
 	netif_info(priv, probe, netdev, "mediatek frame engine at 0x%08lx, irq %d\n",
 		   netdev->base_addr, netdev->irq);
 
 	return 0;
+
+err_mdio_cleanup:
+	fe_mdio_cleanup(priv);
+err_clear_drvdata:
+	platform_set_drvdata(pdev, NULL);
+
+	return err;
 }
 
 static void fe_remove(struct platform_device *pdev)
@@ -1704,7 +1873,8 @@ static void fe_remove(struct platform_device *pdev)
 	struct net_device *dev = platform_get_drvdata(pdev);
 	struct fe_priv *priv = netdev_priv(dev);
 
-	netif_napi_del(&priv->rx_napi);
+	if (priv->soc->switch_cleanup)
+		priv->soc->switch_cleanup(priv);
 
 	cancel_work_sync(&priv->pending_work);
 

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.h
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.h
@@ -306,6 +306,7 @@ enum fe_work_flag {
 #define RX_DMA_VID(_x)		((_x) & 0xffff)
 /* rxd4 */
 #define RX_DMA_L4VALID		BIT(30)
+#define MT7620_RX_DMA_SP	GENMASK(21, 19)
 
 struct fe_rx_dma {
 	unsigned int rxd1;
@@ -334,6 +335,8 @@ struct fe_rx_dma {
 #define TX_DMA_UDF		BIT(20)
 #define TX_DMA_CHKSUM		(0x7 << 29)
 #define TX_DMA_TSO		BIT(28)
+#define MT7620_TX_DMA_FP_BMAP	GENMASK(27, 20)
+#define MT7620_TX_DMA_LAST_PORT	5
 
 /* frame engine counters */
 #define FE_PPE_AC_BCNT0		(FE_CMTABLE_OFFSET + 0x00)
@@ -352,6 +355,7 @@ struct fe_tx_dma {
 } __packed __aligned(4);
 
 struct fe_priv;
+struct metadata_dst;
 
 struct fe_phy {
 	/* make sure that phy operations are atomic */
@@ -379,6 +383,7 @@ struct fe_soc_data {
 	void (*tx_dma)(struct fe_tx_dma *txd);
 	int (*switch_init)(struct fe_priv *priv);
 	int (*switch_config)(struct fe_priv *priv);
+	void (*switch_cleanup)(struct fe_priv *priv);
 	void (*port_init)(struct fe_priv *priv, struct device_node *port);
 	int (*has_carrier)(struct fe_priv *priv);
 	int (*mdio_init)(struct fe_priv *priv);
@@ -479,8 +484,9 @@ struct fe_priv {
 	struct fe_phy			*phy;
 	struct mii_bus			*mii_bus;
 	struct phy_device		*phy_dev;
+	struct metadata_dst		*dsa_meta[8];
+	bool				dsa_switch;
 	u32				phy_flags;
-
 	int				link[8];
 
 	struct fe_hw_stats		*hw_stats;
@@ -488,7 +494,9 @@ struct fe_priv {
 	struct work_struct		pending_work;
 	DECLARE_BITMAP(pending_flags, FE_FLAG_MAX);
 
-	struct reset_control		*resets;
+	struct reset_control		*rst_fe;
+	struct reset_control		*rst_esw;
+	bool				fe_needs_reinit;
 	struct mtk_foe_entry		*foe_table;
 	dma_addr_t			foe_table_phys;
 	struct flow_offload __rcu	**foe_flow_table;

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_mt7620.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_mt7620.c
@@ -30,7 +30,6 @@
 #define MT7620_L4_VALID		BIT(23)
 
 #define MT7620_TX_DMA_UDF	BIT(15)
-#define TX_DMA_FP_BMAP		((0xff) << 19)
 
 #define CDMA_ICS_EN		BIT(2)
 #define CDMA_UCS_EN		BIT(1)
@@ -82,6 +81,9 @@ static int mt7620_gsw_config(struct fe_priv *priv)
 	struct mt7620_gsw *gsw = (struct mt7620_gsw *) priv->soc->swpriv;
 	u32 val;
 
+	if (priv->dsa_switch)
+		return mt7620_gsw_dsa_device_register(gsw, priv->dev);
+
 	/* is the mt7530 internal or external */
 	if (priv->mii_bus && mdiobus_get_phy(priv->mii_bus, 0x1f)) {
 		mt7530_probe(priv->dev, gsw->base, NULL, 0);
@@ -105,6 +107,14 @@ static int mt7620_gsw_config(struct fe_priv *priv)
 	}
 
 	return 0;
+}
+
+static void mt7620_gsw_cleanup(struct fe_priv *priv)
+{
+	struct mt7620_gsw *gsw = (struct mt7620_gsw *)priv->soc->swpriv;
+
+	if (gsw)
+		mt7620_gsw_dsa_device_unregister(gsw);
 }
 
 static void mt7620_set_mac(struct fe_priv *priv, const unsigned char *mac)
@@ -349,6 +359,7 @@ static struct fe_soc_data mt7620_data = {
 	.tx_dma = mt7620_tx_dma,
 	.switch_init = mtk_gsw_init,
 	.switch_config = mt7620_gsw_config,
+	.switch_cleanup = mt7620_gsw_cleanup,
 	.port_init = mt7620_port_init,
 	.reg_table = mt7620_reg_table,
 	.pdma_glo_cfg = FE_PDMA_SIZE_16DWORDS,

--- a/target/linux/ramips/modules.mk
+++ b/target/linux/ramips/modules.mk
@@ -113,6 +113,26 @@ endef
 
 $(eval $(call KernelPackage,dma-ralink))
 
+define KernelPackage/dsa-mt7620
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=MediaTek MT7620 integrated switch DSA support
+  DEPENDS:=@TARGET_ramips_mt7620 +kmod-dsa
+  CONFLICTS:=swconfig
+  KCONFIG:= \
+	CONFIG_NET_DSA_MT7620 \
+	CONFIG_NET_DSA_TAG_RALINK
+  FILES:= \
+	$(LINUX_DIR)/drivers/net/ethernet/ralink/gsw_mt7620_dsa.ko \
+	$(LINUX_DIR)/net/dsa/tag_ralink.ko
+  AUTOLOAD:=$(call AutoProbe,tag_ralink gsw_mt7620_dsa)
+endef
+
+define KernelPackage/dsa-mt7620/description
+ DSA support for the switch integrated in the MediaTek MT7620 SoC.
+endef
+
+$(eval $(call KernelPackage,dsa-mt7620))
+
 define KernelPackage/hsdma-mtk
   SUBMENU:=Other modules
   TITLE:=MediaTek HSDMA Engine

--- a/target/linux/ramips/patches-6.18/761-net-dsa-add-ralink-metadata-tagger.patch
+++ b/target/linux/ramips/patches-6.18/761-net-dsa-add-ralink-metadata-tagger.patch
@@ -1,0 +1,172 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gleb Pesin <dormancygrace@gmail.com>
+Date: Wed, 29 Jul 2026 20:00:00 +0000
+Subject: [PATCH] net: dsa: add Ralink DMA metadata tagger
+
+The MT7620 frame engine can force the destination switch port through the
+TX DMA descriptor and reports the source switch port through the RX DMA
+descriptor.
+
+Add a DSA tagger which passes the destination port to the conduit driver as
+hardware-port metadata on TX. The conduit driver supplies the same metadata
+from the RX descriptor, so no in-band tag is needed in either direction.
+
+The conduit driver is responsible for translating METADATA_HW_PORT_MUX into
+the frame-engine TX descriptor's forced-port bitmap.
+
+Protocol value 32 is target-local. The ipq40xx, qualcommax and realtek
+patchsets use the same value for protocols built on mutually exclusive
+targets.
+
+Signed-off-by: Gleb Pesin <dormancygrace@gmail.com>
+---
+ include/net/dsa.h       |   2 ++
+ net/dsa/Kconfig         |  10 ++++++
+ net/dsa/Makefile        |   1 +
+ net/dsa/tag_ralink.c    |  94 +++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 107 insertions(+)
+
+--- a/include/net/dsa.h
++++ b/include/net/dsa.h
+@@ -57,6 +57,7 @@ struct tc_action;
+ #define DSA_TAG_PROTO_BRCM_LEGACY_FCS_VALUE	29
+ #define DSA_TAG_PROTO_MXL862_VALUE		30
+ #define DSA_TAG_PROTO_MXL862_8021Q_VALUE	31
++#define DSA_TAG_PROTO_RALINK_VALUE		32
+ 
+ enum dsa_tag_protocol {
+ 	DSA_TAG_PROTO_NONE		= DSA_TAG_PROTO_NONE_VALUE,
+@@ -91,6 +92,7 @@ enum dsa_tag_protocol {
+ 	DSA_TAG_PROTO_VSC73XX_8021Q	= DSA_TAG_PROTO_VSC73XX_8021Q_VALUE,
+ 	DSA_TAG_PROTO_MXL862		= DSA_TAG_PROTO_MXL862_VALUE,
+ 	DSA_TAG_PROTO_MXL862_8021Q	= DSA_TAG_PROTO_MXL862_8021Q_VALUE,
++	DSA_TAG_PROTO_RALINK		= DSA_TAG_PROTO_RALINK_VALUE,
+ };
+ 
+ struct dsa_switch;
+--- a/net/dsa/Kconfig
++++ b/net/dsa/Kconfig
+@@ -151,6 +151,16 @@ config NET_DSA_TAG_QCA
+ 	  Say Y or M if you want to enable support for tagging frames for
+ 	  the Qualcomm Atheros QCA8K switches.
+ 
++config NET_DSA_TAG_RALINK
++	tristate "Tag driver for Ralink embedded switches"
++	help
++	  Say Y or M if you want to enable support for Ralink SoCs whose
++	  frame engine selects the TX switch port through a DMA descriptor
++	  and reports the RX source port through a DMA descriptor.
++
++	  The Ethernet conduit driver must exchange DSA hardware-port
++	  metadata with the DMA descriptors in both directions.
++
+ config NET_DSA_TAG_RTL4_A
+ 	tristate "Tag driver for Realtek 4 byte protocol A tags"
+ 	help
+--- a/net/dsa/Makefile
++++ b/net/dsa/Makefile
+@@ -34,6 +34,7 @@ obj-$(CONFIG_NET_DSA_TAG_NONE) += tag_no
+ obj-$(CONFIG_NET_DSA_TAG_OCELOT) += tag_ocelot.o
+ obj-$(CONFIG_NET_DSA_TAG_OCELOT_8021Q) += tag_ocelot_8021q.o
+ obj-$(CONFIG_NET_DSA_TAG_QCA) += tag_qca.o
++obj-$(CONFIG_NET_DSA_TAG_RALINK) += tag_ralink.o
+ obj-$(CONFIG_NET_DSA_TAG_RTL4_A) += tag_rtl4_a.o
+ obj-$(CONFIG_NET_DSA_TAG_RTL8_4) += tag_rtl8_4.o
+ obj-$(CONFIG_NET_DSA_TAG_RZN1_A5PSW) += tag_rzn1_a5psw.o
+--- /dev/null
++++ b/net/dsa/tag_ralink.c
+@@ -0,0 +1,94 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/* Ralink DMA metadata DSA tag support */
++
++#include <net/dst_metadata.h>
++
++#include "tag.h"
++
++#define RALINK_NAME		"ralink"
++
++struct ralink_tagger_data {
++	unsigned int num_ports;
++	struct metadata_dst *meta[];
++};
++
++static struct sk_buff *ralink_tag_xmit(struct sk_buff *skb,
++				       struct net_device *dev)
++{
++	struct dsa_port *dp = dsa_user_to_port(dev);
++	struct ralink_tagger_data *data = dp->ds->tagger_data;
++
++	skb_dst_drop(skb);
++	skb_dst_set_noref(skb, &data->meta[dp->index]->dst);
++
++	return skb;
++}
++
++static struct sk_buff *ralink_tag_rcv(struct sk_buff *skb,
++				      struct net_device *dev)
++{
++	dev_err_ratelimited(&dev->dev,
++			    "RX frame arrived without hardware-port metadata\n");
++	return NULL;
++}
++
++static int ralink_tag_connect(struct dsa_switch *ds)
++{
++	struct ralink_tagger_data *data;
++	struct metadata_dst *md_dst;
++	int port;
++
++	data = kzalloc(struct_size(data, meta, ds->num_ports), GFP_KERNEL);
++	if (!data)
++		return -ENOMEM;
++
++	data->num_ports = ds->num_ports;
++	for (port = 0; port < ds->num_ports; port++) {
++		md_dst = metadata_dst_alloc(0, METADATA_HW_PORT_MUX,
++					    GFP_KERNEL);
++		if (!md_dst)
++			goto err_free;
++
++		md_dst->u.port_info.port_id = port;
++		data->meta[port] = md_dst;
++	}
++
++	ds->tagger_data = data;
++
++	return 0;
++
++err_free:
++	while (port--)
++		dst_release(&data->meta[port]->dst);
++	kfree(data);
++
++	return -ENOMEM;
++}
++
++static void ralink_tag_disconnect(struct dsa_switch *ds)
++{
++	struct ralink_tagger_data *data = ds->tagger_data;
++	int port;
++
++	for (port = 0; port < data->num_ports; port++)
++		dst_release(&data->meta[port]->dst);
++
++	kfree(data);
++	ds->tagger_data = NULL;
++}
++
++static const struct dsa_device_ops ralink_netdev_ops = {
++	.name		= RALINK_NAME,
++	.proto		= DSA_TAG_PROTO_RALINK,
++	.connect	= ralink_tag_connect,
++	.disconnect	= ralink_tag_disconnect,
++	.xmit		= ralink_tag_xmit,
++	.rcv		= ralink_tag_rcv,
++};
++
++MODULE_AUTHOR("Gleb Pesin <dormancygrace@gmail.com>");
++MODULE_DESCRIPTION("DSA tag driver for Ralink embedded switches");
++MODULE_LICENSE("GPL");
++MODULE_ALIAS_DSA_TAG_DRIVER(DSA_TAG_PROTO_RALINK, RALINK_NAME);
++
++module_dsa_tag_driver(ralink_netdev_ops);


### PR DESCRIPTION
## Summary

Add common DSA support for the seven-port switch integrated in MT7620 while preserving the existing swconfig path for device trees without a `ports` node.

This PR deliberately migrates no individual boards. A board opts into DSA by describing the switch ports in DT and including `kmod-dsa-mt7620` in `DEVICE_PACKAGES`; existing MT7620 devices continue using swconfig without building DSA or switchdev support.

The data path uses the frame engine's descriptor metadata rather than an in-frame tag: TXD4 carries the forced egress bitmap and RXD4 reports the ingress source port. A ramips-local Ralink metadata tagger exchanges that information through `METADATA_HW_PORT_MUX`.

## Series

1. Add the ramips-local MT7620 DMA metadata DSA tagger.
2. Add the MT7620 DSA driver with bridge isolation/STP, VLAN filtering, FDB/MDB offload, ageing, flood controls, phylink, 2026-byte MTU support, and extended hardware MIB counters. Package the driver and tagger as an optional per-device kmod which conflicts with swconfig.

The DSA instance is owned by a bound child of the frame-engine device. This gives the managed conduit device link the correct lifetime across driver unbind/reprobe. The series also fixes MDIO/frame-engine cleanup for deferred probes and reprobes.

The FE-only reset in `fe_stop()` is deliberately limited to the teardown path where DMA did not quiesce before its rings are freed. It does not address stale network state across a system restart; that separate condition is handled by #24724.

## Testing

The unchanged DSA code was functionally tested on an MT7620N rev 2 eco 6 using a local, intentionally unsubmitted D-Link DWR-921 C1 DT migration:

- identical-image `sysupgrade -n`, runtime Ethernet-driver unbind/rebind, and a hard power cycle;
- VLAN-aware hardware bridging with VLAN 100 untagged on one user port and tagged on another, including hardware FDB learning;
- 2000-byte and 2026-byte DF traffic; 2001 at MTU 2000 and MTU 2027 were rejected at the expected boundaries;
- four-stream bidirectional iperf3 at 93.4/93.9 Mbit/s receiver throughput on 100BASE-T;
- FDB/MDB add/delete, STP states, bridge ageing, unicast/multicast/broadcast flood controls, and hardware MIB accounting;
- modular DSA driver/tagger build and package contents; the DSA test rootfs contains `kmod-dsa-mt7620` and no `swconfig`;
- a swconfig-only ZBT-WE826 configuration keeps `NET_DSA`, `NET_DSA_MT7620`, `NET_DSA_TAG_RALINK`, and `NET_SWITCHDEV` disabled;
- an independent TP-Link Archer C5 v4 test found no regression with its external RTL8367S DSA switch and RTL8_4t tagger.

The current two-commit series was also applied to `namiltd/openwrt#138` and built from a clean tree. Its package manifest and 6,750,503-byte sysupgrade image remained identical; only the initramfs build metadata changed. The integrated-switch module is not selected by that external-switch profile.

The earlier warm-reboot matrix included the reset change now split into #24724. Warm-reboot recovery is therefore not claimed by this DSA PR alone.

## Related work

- Original MT7620 DSA discussion and patch: https://lists.infradead.org/pipermail/openwrt-devel/2021-December/037379.html
- External-switch DSA prerequisites: #23933
- MT7620 jumbo-frame prerequisite: #24242
- Direct-call stability fixes split from the original series: #24723
- Warm-restart network reset split from the original series: #24724

Hardware flow offload/PPE support is intentionally outside this PR.