### PR TITLE
projectsmirrors: remove GNOME mirrors mirror.csclub.uwaterloo.ca

### DIFF
--- a/scripts/projectsmirrors.json
+++ b/scripts/projectsmirrors.json
@@ -51,8 +51,7 @@
 		"https://mirrors.ustc.edu.cn/kernel.org"
 	],
 	"@GNOME": [
-		"https://download.gnome.org/sources",
-		"https://mirror.csclub.uwaterloo.ca/gnome/sources"
+		"https://download.gnome.org/sources"
 	],
 	"@OPENWRT": [
 		"https://sources.cdn.openwrt.org",


### PR DESCRIPTION
This site no longer provide GNOME mirror services.
Link <https://mirror.csclub.uwaterloo.ca/news/2025-11-08-remove-gnome/>