### PR TITLE
kernel: add pvpanic modules, enable on x86 and armsr

### DIFF
--- a/package/kernel/linux/modules/virt.mk
+++ b/package/kernel/linux/modules/virt.mk
@@ -75,6 +75,29 @@ endef
 $(eval $(call KernelPackage,kvm-amd))
 
 
+define KernelPackage/pvpanic
+  SUBMENU:=Virtualization
+  TITLE:=QEMU pvpanic device support
+  DEPENDS:=@TARGET_x86||TARGET_armsr @PCI_SUPPORT
+  KCONFIG:= \
+	CONFIG_PVPANIC=y \
+	CONFIG_PVPANIC_MMIO \
+	CONFIG_PVPANIC_PCI
+  FILES:= \
+	$(LINUX_DIR)/drivers/misc/pvpanic/pvpanic.ko \
+	$(LINUX_DIR)/drivers/misc/pvpanic/pvpanic-mmio.ko \
+	$(LINUX_DIR)/drivers/misc/pvpanic/pvpanic-pci.ko
+  AUTOLOAD:=$(call AutoProbe,pvpanic-mmio pvpanic-pci)
+endef
+
+define KernelPackage/pvpanic/description
+  Support for the QEMU -device pvpanic device exposed through ACPI QEMU0001
+  and an I/O port, and for the -device pvpanic-pci PCI device.
+endef
+
+$(eval $(call KernelPackage,pvpanic))
+
+
 define KernelPackage/vfio
   SUBMENU:=Virtualization
   TITLE:=VFIO Non-Privileged userspace driver framework

--- a/target/linux/armsr/Makefile
+++ b/target/linux/armsr/Makefile
@@ -12,7 +12,7 @@ FEATURES+=cpiogz ext4 ramdisk squashfs targz vmdk
 KERNEL_PATCHVER:=6.18
 include $(INCLUDE_DIR)/target.mk
 
-DEFAULT_PACKAGES += mkf2fs e2fsprogs
+DEFAULT_PACKAGES += mkf2fs e2fsprogs kmod-pvpanic
 # blkid used for resolving PARTUUID
 # in sysupgrade. vfat required for
 # mounting ESP partition

--- a/target/linux/x86/64/target.mk
+++ b/target/linux/x86/64/target.mk
@@ -1,6 +1,8 @@
 ARCH:=x86_64
 BOARDNAME:=x86_64
 
+DEFAULT_PACKAGES += kmod-pvpanic
+
 define Target/Description
         Build images for 64 bit systems including virtualized guests.
 endef

--- a/target/linux/x86/generic/target.mk
+++ b/target/linux/x86/generic/target.mk
@@ -2,6 +2,8 @@ BOARDNAME:=Generic
 CPU_TYPE :=pentium4
 FEATURES += audio pci pcie usb
 
+DEFAULT_PACKAGES += kmod-pvpanic
+
 define Target/Description
 	Build firmware images for modern x86 based boards with CPUs
 	supporting at least the Intel Pentium 4 instruction set with


### PR DESCRIPTION
QEMU's pvpanic device lets a guest report kernel panic events to the host.
OpenWrt ships no driver for it today, so from outside a panicking guest looks
identical to a hung one.

This adds `kmod-pvpanic` (shared core plus the MMIO and PCI transports) and
enables it by default on x86/64, x86/generic and armsr. These images are
commonly run as QEMU/KVM guests. The modules only bind when a matching QEMU
device is present. The existing board-wide x86 default for
`kmod-button-hotplug` uses the same device-presence reasoning.

## Validation

| Target | Result |
|---|---|
| x86/64 | builds; `kmod-pvpanic - 6.18.39-r1` in the image manifest |
| armsr/armv8 | builds; same package in the manifest |
| armsr/armv7 | metadata only: package selected, `CONFIG_PCI_SUPPORT=y` |

All three `.ko` files land in `drivers/misc/pvpanic/` on both built targets.
armv7 was not built.

## Size impact

Flash, measured by rebuilding each target from the same tree with the package
deselected (x86 manifest 148 to 147 packages):

| Target | squashfs rootfs | package `.apk` | modules unpacked |
|---|---|---|---|
| x86/64 | +3420 B | 5413 B | 23512 B |
| armsr/armv8 | +2320 B | 4932 B | 19128 B |

RAM, with all three modules loaded:

```
pvpanic         12288  2 pvpanic_pci,pvpanic_mmio
pvpanic_mmio    12288  0
pvpanic_pci     12288  0
```

:warning: **36 KiB** resident, page-rounded. `AutoProbe` loads both transports at boot, so
**this is paid even where no pvpanic device is present**

Image sizes are not bit-reproducible here; rebuilding an unchanged config
moved them by 23 to 337 B, so read the flash deltas as approximate to a few
hundred bytes.

## x86 end-to-end panic test

Booted the x86-64 squashfs combined-EFI image from this branch under QEMU q35
with `-device pvpanic`:

1. Confirmed the driver actually bound:
   `/sys/bus/platform/devices/QEMU0001:00/driver` resolves to `pvpanic-mmio`
2. Injected a panic with `echo c > /proc/sysrq-trigger`
3. Host received QMP `GUEST_PANICKED`; guest serial showed
   `Kernel panic - not syncing: sysrq triggered crash`

Negative control on the same image: a clean `reboot` produced one QMP `RESET`
and no `GUEST_PANICKED`.

## Note for review

`pvpanic-mmio` needs `HAS_IOMEM && (ACPI || OF)`. bcm47xx has neither, so
Kconfig drops the module and the package's unconditional `FILES` list fails
the build. CI run 30615355138 caught this. The package therefore remains gated
by target: `DEPENDS:=@TARGET_x86||TARGET_armsr @PCI_SUPPORT`.

All four x86 subtargets set `CONFIG_ACPI=y`, so the package builds across the
whole x86 target. geode and legacy users can select it by hand, while the
default install is declared only for x86/64 and x86/generic after review
feedback. Other targets can be added once someone validates pvpanic there.

