### PR TITLE
omap: mark am335x series devices as BROKEN

### DIFF
--- a/package/boot/uboot-omap/Makefile
+++ b/package/boot/uboot-omap/Makefile
@@ -30,6 +30,7 @@ endef
 define U-Boot/am335x_evm
   NAME:=AM335x EVM
   BUILD_DEVICES:=ti_am335x-evm ti_am335x-bone-black
+  DEPENDS+=@BROKEN
 endef
 
 define U-Boot/omap3_beagle

--- a/target/linux/omap/image/Makefile
+++ b/target/linux/omap/image/Makefile
@@ -44,6 +44,7 @@ endef
 define Device/ti_am335x-evm
   DEVICE_VENDOR := Texas Instruments
   DEVICE_MODEL := AM335x EVM
+  BROKEN := y
 endef
 
 TARGET_DEVICES += ti_am335x-evm
@@ -52,6 +53,7 @@ define Device/ti_am335x-bone-black
   DEVICE_VENDOR := Texas Instruments
   DEVICE_MODEL := AM335x BeagleBone Black
   DEVICE_DTS := am335x-boneblack
+  BROKEN := y
 endef
 
 TARGET_DEVICES += ti_am335x-bone-black


### PR DESCRIPTION
This package has been unable to be built for several days due to u-boot SPL size limitation. Disable it until some developers can do some trim work for it.