### PR TITLE
airoha: an7581: keep Ethernet working in W1700K recovery

### DIFF
--- a/target/linux/airoha/dts/an7581-w1700k-ubi-recovery.dts
+++ b/target/linux/airoha/dts/an7581-w1700k-ubi-recovery.dts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "an7581-w1700k-ubi.dts"
+
+/*
+ * The recovery image must remain reachable when the UBI layout is absent or
+ * damaged.  MAC addresses normally come from the factory UBI volume, and the
+ * Ethernet driver defers probing until that NVMEM provider is available.
+ * Without Ethernet the DSA switch cannot probe either, leaving no recovery
+ * interface.  Let the driver generate temporary MAC addresses in recovery;
+ * the production image continues to use the factory addresses.
+ */
+
+&gdm1 {
+	/delete-property/ nvmem-cells;
+	/delete-property/ nvmem-cell-names;
+};
+
+&gdm2 {
+	/delete-property/ nvmem-cells;
+	/delete-property/ nvmem-cell-names;
+};
+
+&gdm4 {
+	/delete-property/ nvmem-cells;
+	/delete-property/ nvmem-cell-names;
+};

--- a/target/linux/airoha/image/an7581.mk
+++ b/target/linux/airoha/image/an7581.mk
@@ -96,7 +96,7 @@ define Device/gemtek_w1700k-ubi
   DEVICE_ALT2_VENDOR := Quantum Fiber
   DEVICE_ALT2_MODEL := W1700K
   DEVICE_ALT2_VARIANT := UBI
-  DEVICE_DTS := an7581-w1700k-ubi
+  DEVICE_DTS := an7581-w1700k-ubi an7581-w1700k-ubi-recovery
   DEVICE_COMPAT_VERSION := 2.0
   DEVICE_COMPAT_MESSAGE := Partition table has been changed to cooperate \
        with the vendor bootloader with regard to the BMT/BBT partition at \
@@ -111,7 +111,7 @@ define Device/gemtek_w1700k-ubi
   KERNEL_IN_UBI := 1
   KERNEL := kernel-bin | gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 128k
+	fit lzma $$(KDIR)/image-$$(lastword $$(DEVICE_DTS)).dtb with-initrd | pad-to 128k
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
   IMAGES := sysupgrade.itb
   IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata


### PR DESCRIPTION
The W1700K Ethernet MAC addresses are provided by NVMEM cells stored in the factory UBI volume. If the UBI layout is missing or damaged, the NVMEM provider is unavailable and the Ethernet driver keeps deferring its probe. The DSA switch consequently cannot probe either, leaving the recovery image without network connectivity.

Add a recovery-specific DTS which removes the NVMEM references from the GDM interfaces. This allows the driver to generate temporary MAC addresses when booting recovery, while the production image continues to use the factory addresses.

Use the recovery DTS only for the initramfs image and keep the regular DTS for the sysupgrade image.
