### PR TITLE
openssl: add MIPS32 AES-CTR assembly

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_VERSION:=3.5.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
 PKG_BUILD_PARALLEL:=1

--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_VERSION:=3.5.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
 PKG_BUILD_PARALLEL:=1

--- a/package/libs/openssl/patches/160-mips32-add-aes-ctr32-assembly.patch
+++ b/package/libs/openssl/patches/160-mips32-add-aes-ctr32-assembly.patch
@@ -1,0 +1,170 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gleb Pesin <dormancygrace@gmail.com>
+Date: Fri, 31 Jul 2026 12:00:00 +0000
+Subject: [PATCH] crypto: mips32: add AES CTR32 assembly path
+
+The MIPS AES assembly only exports the single-block AES core. AES-GCM
+therefore enters the full O32 function wrapper for every counter block.
+
+Add an O32 AES_ctr32_encrypt implementation which saves the register
+frame and resolves the AES table once per batch. Reuse the existing
+_mips_AES_encrypt core, handle unaligned and in-place buffers, and keep
+the private counter in network byte order as required by ctr128_f.
+
+Enable AES_CTR_ASM for MIPS32 only. The implementation uses the O32 ABI
+and is not suitable for the MIPS64 flavours.
+
+Upstream-Status: Submitted [https://github.com/openssl/openssl/pull/32133]
+Signed-off-by: Gleb Pesin <dormancygrace@gmail.com>
+
+--- a/crypto/aes/build.info
++++ b/crypto/aes/build.info
+@@ -21,9 +21,11 @@ IF[{- !$disabled{asm} -}]
+   $AESDEF_sparcv9=AES_ASM
+ 
+   $AESASM_mips32=aes_cbc.c aes-mips.S
+-  $AESDEF_mips32=AES_ASM
++  # Every asm_arch=mips32 target uses the O32 perlasm scheme, matching
++  # the AES_ctr32_encrypt emission guard in aes-mips.pl.
++  $AESDEF_mips32=AES_ASM AES_CTR_ASM
+   $AESASM_mips64=$AESASM_mips32
+-  $AESDEF_mips64=$AESDEF_mips32
++  $AESDEF_mips64=AES_ASM
+ 
+   $AESASM_s390x=aes-s390x.S
+   # aes-390x.S implements AES_ctr32_encrypt and AES_xts_[en|de]crypt
+--- a/crypto/aes/asm/aes-mips.pl
++++ b/crypto/aes/asm/aes-mips.pl
+@@ -731,6 +731,132 @@ $code.=<<___;
+ .end	AES_encrypt
+ ___
+ 
++my $CTR32_FRAMESIZE=24*$SZREG;
++my $CTR32_BLOCK_OFFSET=6*$SZREG;
++my $CTR32_COUNT_OFFSET=10*$SZREG;
++my $CTR32_IVEC_OFFSET=$CTR32_FRAMESIZE+4*$SZREG;
++
++$code.=<<___ if ($flavour =~ /o32/i);
++.align	5
++.globl	AES_ctr32_encrypt
++.ent	AES_ctr32_encrypt
++AES_ctr32_encrypt:
++	.frame	$sp,$CTR32_FRAMESIZE,$ra
++	.mask	$SAVED_REGS_MASK,-$SZREG
++	.set	noreorder
++	.cpload	$pf
++	$PTR_SUB $sp,$CTR32_FRAMESIZE
++	$REG_S	$ra,$CTR32_FRAMESIZE-1*$SZREG($sp)
++	$REG_S	$fp,$CTR32_FRAMESIZE-2*$SZREG($sp)
++	$REG_S	$s11,$CTR32_FRAMESIZE-3*$SZREG($sp)
++	$REG_S	$s10,$CTR32_FRAMESIZE-4*$SZREG($sp)
++	$REG_S	$s9,$CTR32_FRAMESIZE-5*$SZREG($sp)
++	$REG_S	$s8,$CTR32_FRAMESIZE-6*$SZREG($sp)
++	$REG_S	$s7,$CTR32_FRAMESIZE-7*$SZREG($sp)
++	$REG_S	$s6,$CTR32_FRAMESIZE-8*$SZREG($sp)
++	$REG_S	$s5,$CTR32_FRAMESIZE-9*$SZREG($sp)
++	$REG_S	$s4,$CTR32_FRAMESIZE-10*$SZREG($sp)
++	.set	reorder
++
++	# O32 passes ivec as the fifth argument on the caller's stack.
++	$REG_L	$t0,$CTR32_IVEC_OFFSET($sp)
++	$REG_S	$key,$CTR32_COUNT_OFFSET($sp) # preserve the block count
++	move	$key,$Tbl                      # key schedule for the inner core
++	$PTR_LA	$Tbl,AES_Te
++
++	# Private counter block; ctr128_f callers update ivec themselves.
++	lwl	$s0,0+$MSB($t0)
++	lwl	$s1,4+$MSB($t0)
++	lwl	$s2,8+$MSB($t0)
++	lwl	$s3,12+$MSB($t0)
++	lwr	$s0,0+$LSB($t0)
++	lwr	$s1,4+$LSB($t0)
++	lwr	$s2,8+$LSB($t0)
++	lwr	$s3,12+$LSB($t0)
++	$REG_S	$s0,$CTR32_BLOCK_OFFSET+0($sp)
++	$REG_S	$s1,$CTR32_BLOCK_OFFSET+4($sp)
++	$REG_S	$s2,$CTR32_BLOCK_OFFSET+8($sp)
++	$REG_S	$s3,$CTR32_BLOCK_OFFSET+12($sp)
++
++	$REG_L	$t0,$CTR32_COUNT_OFFSET($sp)
++	beqz	$t0,.Lctr32_done
++
++.Loop_ctr32_enc:
++	$REG_L	$s0,$CTR32_BLOCK_OFFSET+0($sp)
++	$REG_L	$s1,$CTR32_BLOCK_OFFSET+4($sp)
++	$REG_L	$s2,$CTR32_BLOCK_OFFSET+8($sp)
++	$REG_L	$s3,$CTR32_BLOCK_OFFSET+12($sp)
++
++	bal	_mips_AES_encrypt
++
++	# Load plaintext before storing, so in-place operation is safe.
++	lwl	$t0,0+$MSB($inp)
++	lwl	$t1,4+$MSB($inp)
++	lwl	$t2,8+$MSB($inp)
++	lwl	$t3,12+$MSB($inp)
++	lwr	$t0,0+$LSB($inp)
++	lwr	$t1,4+$LSB($inp)
++	lwr	$t2,8+$LSB($inp)
++	lwr	$t3,12+$LSB($inp)
++	xor	$s0,$t0
++	xor	$s1,$t1
++	xor	$s2,$t2
++	xor	$s3,$t3
++
++	swr	$s0,0+$LSB($out)
++	swr	$s1,4+$LSB($out)
++	swr	$s2,8+$LSB($out)
++	swr	$s3,12+$LSB($out)
++	swl	$s0,0+$MSB($out)
++	swl	$s1,4+$MSB($out)
++	swl	$s2,8+$MSB($out)
++	swl	$s3,12+$MSB($out)
++
++	# Increment the low 32-bit counter in big-endian byte order.
++	lbu	$t0,$CTR32_BLOCK_OFFSET+15($sp)
++	addiu	$t0,1
++	andi	$t0,0xff
++	sb	$t0,$CTR32_BLOCK_OFFSET+15($sp)
++	bnez	$t0,.Lctr32_no_carry
++	lbu	$t0,$CTR32_BLOCK_OFFSET+14($sp)
++	addiu	$t0,1
++	andi	$t0,0xff
++	sb	$t0,$CTR32_BLOCK_OFFSET+14($sp)
++	bnez	$t0,.Lctr32_no_carry
++	lbu	$t0,$CTR32_BLOCK_OFFSET+13($sp)
++	addiu	$t0,1
++	andi	$t0,0xff
++	sb	$t0,$CTR32_BLOCK_OFFSET+13($sp)
++	bnez	$t0,.Lctr32_no_carry
++	lbu	$t0,$CTR32_BLOCK_OFFSET+12($sp)
++	addiu	$t0,1
++	andi	$t0,0xff
++	sb	$t0,$CTR32_BLOCK_OFFSET+12($sp)
++
++.Lctr32_no_carry:
++	$PTR_ADD $inp,16
++	$PTR_ADD $out,16
++	$REG_L	$t0,$CTR32_COUNT_OFFSET($sp)
++	addiu	$t0,-1
++	$REG_S	$t0,$CTR32_COUNT_OFFSET($sp)
++	bnez	$t0,.Loop_ctr32_enc
++
++.Lctr32_done:
++	.set	noreorder
++	$REG_L	$ra,$CTR32_FRAMESIZE-1*$SZREG($sp)
++	$REG_L	$fp,$CTR32_FRAMESIZE-2*$SZREG($sp)
++	$REG_L	$s11,$CTR32_FRAMESIZE-3*$SZREG($sp)
++	$REG_L	$s10,$CTR32_FRAMESIZE-4*$SZREG($sp)
++	$REG_L	$s9,$CTR32_FRAMESIZE-5*$SZREG($sp)
++	$REG_L	$s8,$CTR32_FRAMESIZE-6*$SZREG($sp)
++	$REG_L	$s7,$CTR32_FRAMESIZE-7*$SZREG($sp)
++	$REG_L	$s6,$CTR32_FRAMESIZE-8*$SZREG($sp)
++	$REG_L	$s5,$CTR32_FRAMESIZE-9*$SZREG($sp)
++	$REG_L	$s4,$CTR32_FRAMESIZE-10*$SZREG($sp)
++	jr	$ra
++	$PTR_ADD $sp,$CTR32_FRAMESIZE
++.end	AES_ctr32_encrypt
++___
+ $code.=<<___;
+ .align	5
+ .ent	_mips_AES_decrypt


### PR DESCRIPTION
## What changed

- add an O32 `AES_ctr32_encrypt` loop to OpenSSL's existing MIPS AES assembly
- enable `AES_CTR_ASM` for MIPS32 while leaving the MIPS64 flavours unchanged
- bump the OpenWrt OpenSSL package release

The loop saves its register frame and resolves the AES table once per batch, then reuses the existing `_mips_AES_encrypt` core. It supports unaligned and in-place buffers and maintains the private network-order counter expected by `ctr128_f`. The private counter is above the O32 outgoing argument-save area, and the routine uses the existing perlasm register, pointer, load/store, frame-mask and address macros.

Every current OpenSSL target with `asm_arch=mips32` resolves to the O32 perlasm scheme, including the OpenWrt targets that inherit `linux-mips32`. This matches the emission guard in `aes-mips.pl`. The invariant is documented next to `AES_CTR_ASM` so a future non-O32 MIPS32 target cannot silently reference an omitted symbol.

## Why

Without `AES_ctr32_encrypt`, AES-GCM calls the full single-block O32 AES wrapper for every counter block. The added batch loop avoids that repeated ABI and table-setup overhead.

On a 580 MHz MT7620A, five alternating 1500-byte packet-style AES-GCM runs changed as follows. Both sides use the same GHASH implementation, so these numbers isolate the AES-CTR change.

| Cipher | Before | After | Change |
|---|---:|---:|---:|
| AES-128-GCM | 4.662 MB/s | 4.880 MB/s | +4.68% |
| AES-256-GCM | 4.012 MB/s | 4.169 MB/s | +3.91% |

Stock and assembly output digests matched in every run.

## Validation

- OpenWrt `git diff --check` and quilt refresh
- all OpenWrt package patches apply to OpenSSL 3.5.8 with `--fuzz=0`; complete MIPS32/musl cross-build with the OpenWrt GCC 16.2.0 toolchain passes, and the resulting `libcrypto.a` defines `AES_ctr32_encrypt` with `AES_CTR_ASM` enabled
- complete `linux-mips32` cross-build of current OpenSSL `master`
- little-endian differential AES-128/192/256 tests covering zero and multiple block counts, unaligned buffers, in-place operation and low-counter carry under `qemu-mipsel` and on a physical MT7620A
- the same differential coverage with the official OpenWrt Malta big-endian MIPS32/O32 GCC 14.4.0 toolchain under `qemu-mips`
- big-endian four-block NIST SP 800-38A AES-128-CTR known-answer test
- verified on both endiannesses that the private `ctr128_f` counter copy changes while the caller-owned IV remains unchanged
- generated object disassembly checked for the O32 frame and argument layout

## Upstream

Submitted to OpenSSL as https://github.com/openssl/openssl/pull/32133. The downstream patch header records the same link.
