### PR TITLE
ramips: add support for Ruijie RG-EG105G-V3

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/ramips
+++ b/package/boot/uboot-tools/uboot-envtools/files/ramips
@@ -34,6 +34,7 @@ allnet,all5002|\
 asiarf,ap7621-004-v3|\
 comfast,cf-ew84|\
 plasmacloud,pax1800-lite|\
+ruijie,rg-eg105g-v3|\
 yuncore,ax820)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x10000"
 	;;

--- a/target/linux/ramips/dts/mt7621_ruijie_rg-eg105g-v3.dts
+++ b/target/linux/ramips/dts/mt7621_ruijie_rg-eg105g-v3.dts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+/ {
+	compatible = "ruijie,rg-eg105g-v3", "mediatek,mt7621-soc";
+	model = "Ruijie RG-EG105G-V3";
+
+	chosen {
+		bootargs = "console=ttyS0,57600n8";
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x050000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "u-boot-env";
+				reg = <0x050000 0x010000>;
+			};
+
+			partition@60000 {
+				label = "product_info";
+				reg = <0x060000 0x010000>;
+				read-only;
+			};
+
+			partition@70000 {
+				label = "reserved";
+				reg = <0x070000 0x010000>;
+				read-only;
+			};
+
+			partition@80000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x080000 0x1f80000>;
+			};
+		};
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2767,6 +2767,14 @@ define Device/rostelecom_rt-sf-1
 endef
 TARGET_DEVICES += rostelecom_rt-sf-1
 
+define Device/ruijie_rg-eg105g-v3
+  DEVICE_VENDOR := Ruijie
+  DEVICE_MODEL := RG-EG105G-V3
+  IMAGE_SIZE := 32256k
+  DEVICE_PACKAGES := uboot-envtools
+endef
+TARGET_DEVICES += ruijie_rg-eg105g-v3
+
 define Device/ruijie_rg-ew1200g-pro-v1.1
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -289,6 +289,11 @@ ramips_setup_macs()
 		wan_mac=$(macaddr_add "$lan_mac" 8)
 		label_mac=$lan_mac
 		;;
+	ruijie,rg-eg105g-v3)
+		lan_mac=$(mtd_get_mac_ascii product_info ethaddr)
+		wan_mac=$(macaddr_add "$lan_mac" 2)
+		label_mac=$lan_mac
+		;;
 	mts,wg430223)
 		wan_mac=$(mtd_get_mac_encrypted_arcadyan "board_data")
 		label_mac=$wan_mac

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -65,6 +65,10 @@ platform_do_upgrade() {
 		dd if=/dev/mtd5 bs=1024 count=52224 >> /tmp/backup_firmware.bin
 		mtd -e firmware2 write /tmp/backup_firmware.bin firmware2
 		;;
+	ruijie,rg-eg105g-v3)
+		fw_setenv firmware_size || exit 1
+		fw_setenv firmware_crc32 || exit 1
+		;;
 	esac
 
 	case "$board" in


### PR DESCRIPTION
## Device information

* Device: Ruijie RG-EG105G-V3
* SoC: MediaTek MT7621
* RAM: 128 MiB
* Flash: 32 MiB SPI NOR
* Ethernet: 4 LAN ports and 1 WAN port through the integrated MT7530 switch

## Changes

This adds support for the Ruijie RG-EG105G-V3, including:

* Device tree and flash partition layout
* Ethernet switch and port configuration
* Factory MAC address assignment
* OpenWrt image definition
* U-Boot environment configuration
* Sysupgrade handling for the vendor firmware metadata

The vendor bootloader checks `firmware_size` and `firmware_crc32` variables stored in the U-Boot environment. These variables are cleared before sysupgrade so that firmware written by OpenWrt boots normally.

## Installation

The initial installation is performed through the U-Boot TFTP recovery interface using menu option 2 and the OpenWrt squashfs sysupgrade image renamed to `rgos.bin`.

## Tested

* U-Boot TFTP installation
* Booting from SPI flash
* All four LAN ports
* WAN port at Gigabit speed
* DHCP and routing
* LuCI
* Command-line sysupgrade
* LuCI sysupgrade
* Configuration preservation
* Factory MAC addresses
