### PR TITLE
realtek: dsa: rtl931x: downgrade print_matrix to debug

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl931x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl931x.c
@@ -456,8 +456,8 @@ void rtldsa_931x_print_matrix(void)
 
 	for (int i = 0; i < 64; i++) {
 		rtl_table_read(r, i);
-		pr_info("> %08x %08x\n", sw_r32(rtl_table_data(r, 0)),
-			sw_r32(rtl_table_data(r, 1)));
+		pr_debug("> %08x %08x\n", sw_r32(rtl_table_data(r, 0)),
+			 sw_r32(rtl_table_data(r, 1)));
 	}
 	rtl_table_release(r);
 }


### PR DESCRIPTION
Downgrade rtldsa_931x_print_matrix from pr_info to pr_debug to reduce the massive amount printed during boot (64 lines). There doesn't seem any benefit right now for keeping this at info level. And RTL931X is the only variant that uses info-level print right now, all others already user pr_debug.

Debug output can be activated individually for people who need this for testing/debugging.
