### PR TITLE
mediatek: filogic: add support for ipTIME AX6000M

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-iptime-ax6000m.dts
+++ b/target/linux/mediatek/dts/mt7986a-iptime-ax6000m.dts
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+
+#include "mt7986a.dtsi"
+
+/ {
+	model = "ipTIME AX6000M";
+	compatible = "iptime,ax6000m", "mediatek,mt7986a";
+
+	aliases {
+		serial0 = &uart0;
+		label-mac-device = &wan;
+		led-boot = &led_cpu;
+		led-failsafe = &led_cpu;
+		led-running = &led_cpu;
+		led-upgrade = &led_cpu;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x20000000>;
+		device_type = "memory";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-0 {
+			label = "wps";
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+
+		button-1 {
+			label = "reset";
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_cpu: led-0 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_CPU;
+			gpios = <&pio 22 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led-2 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&pio 2 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+};
+
+&pio {
+	spi_flash_pins: spi-flash-pins-33-to-38 {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+
+	wf_2g_5g_pins: wf_2g_5g-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_2g", "wf_5g";
+		};
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+			       "WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+			       "WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+			       "WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+			       "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+			       "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+			       "WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <MTK_DRIVE_4mA>;
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_flash_pins>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x6e00000>;
+			};
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 3>;
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		reset-delay-us = <50000>;
+		reset-post-delay-us = <20000>;
+	};
+};
+
+&mdio {
+	switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <0x1f>;
+		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		reset-assert-us = <10000>;
+		reset-deassert-us = <10000>;
+
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			wan: port@0 {
+				reg = <0>;
+				label = "wan";
+				nvmem-cell-names = "mac-address";
+				nvmem-cells = <&macaddr_factory_4 1>;
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "lan4";
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan3";
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan2";
+			};
+
+			port@4 {
+				reg = <4>;
+				label = "lan1";
+			};
+
+			port@6 {
+				reg = <6>;
+				label = "cpu";
+				ethernet = <&gmac0>;
+				phy-mode = "2500base-x";
+
+				fixed-link {
+					speed = <2500>;
+					full-duplex;
+					pause;
+				};
+			};
+		};
+	};
+};
+
+&wifi {
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+	pinctrl-names = "default";
+	pinctrl-0 = <&wf_2g_5g_pins>;
+	status = "okay";
+};
+
+&trng {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&ssusb {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -144,7 +144,8 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $base_mac 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $base_mac 3 > /sys${DEVPATH}/macaddress
 		;;
-	iptime,ax3000q)
+	iptime,ax3000q|\
+	iptime,ax6000m)
 		addr=$(mtd_get_mac_binary "Factory" 0x4)
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $addr > /sys${DEVPATH}/macaddress
 		;;

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2120,6 +2120,23 @@ define Device/iptime_ax3000m
 endef
 TARGET_DEVICES += iptime_ax3000m
 
+define Device/iptime_ax6000m
+  DEVICE_VENDOR := ipTIME
+  DEVICE_MODEL := AX6000M
+  DEVICE_DTS := mt7986a-iptime-ax6000m
+  DEVICE_DTS_DIR := ../dts
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 32768k
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGES := factory.bin sysupgrade.bin
+  IMAGE/factory.bin := sysupgrade-tar | append-metadata | check-size | iptime-crc32 ax6000m
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
+endef
+TARGET_DEVICES += iptime_ax6000m
+
 define Device/iptime_ax7800m-6e
   DEVICE_VENDOR := ipTIME
   DEVICE_MODEL := AX7800M-6E


### PR DESCRIPTION
This PR is based on the work done by @saeheeryu in #22387.

Add support for the ipTIME AX6000M, a MediaTek MT7986-based dual-band WiFi 6 router with SPI-NAND, NMBM, and UBI.

Specification
-------------
- SoC       : MediaTek MT7986AV quad-core ARM Cortex-A53 2GHz
- RAM       : DDR3 512Mbytes, Nanya NT5CC256M16ER-EK
- Flash     : 128Mbytes NAND Flash, ESMT F50L1G41LB SPI-NAND
- WLAN      : MediaTek MT7975N, MediaTek MT7975PN
  - 2.4GHz  : b/g/n/ax, Multi User MIMO
  - 5GHz    : a/n/ac/ax, Multi User MIMO
- Ethernet  : 10/100/1000 Mbps x4, LAN (Mediatek MT7531AE)
              10/100/1000 Mbps x1, WAN
- Buttons   : WPS, Reset
- USB       : 1x USB 3.0 (MediaTek MT7986AV peripheral)
- LEDs      : 1x CPU (Amber, GPIO-controlled)
              1x Wi-Fi 5GHz (Amber, GPIO-controlled)
              1x Wi-Fi 2.4GHz (Amber, GPIO-controlled)
              4x LAN activity (Amber, Switch-controlled)
              1x WAN activity (Amber, Switch-controlled)
- Power     : 12VDC, 2A (Center positive polarity)

MAC address
-----------
| Interface | MAC | Calculation |
| --- | --- | --- |
| WLAN 2.4G | 58:86:94:xx:xx:xx | base |
| WLAN 5G | 5A:86:94:xx:xx:xx | base with LA Bit Set |
| WAN | 58:86:94:xx:xx:xx | base + 1 |
| LAN       | 58:86:94:xx:xx:xx | base + 3 |

The WLAN 2.4G MAC address (base) was found in 'Factory' partition, 0x4

Installation
------------
- Initial install via U-Boot recovery using `mtkupgrade`
- Sysupgrade supported after OpenWrt installation
- Stock web UI installation is not supported

1. Download the OEM recovery software (ipTIME Firmware Wizard (11ac)) from the manufacturer's website
2. Download the *squashfs-factory.bin file from the OpenWrt website
3. Press a reset button, and power up the router (keep pressing the reset button)
4. Wait more than 10 seconds until the CPU LED stop blinking
5. Connect the router (LAN port) to the PC
6. Run the OEM recovery software and follow the instructions
7. Select the *squashfs-factory.bin file during the router recovery process
8. Wait for the router to boot from *squashfs-factory.bin

Note: The router will automatically reboot if no file is uploaded within 55 seconds.