### PR TITLE
qualcommax: qca_edma: give the DSA conduit a stable MAC address

### DIFF
--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
@@ -11,6 +11,7 @@
 #include <linux/module.h>
 #include <linux/of.h>
 #include <linux/of_address.h>
+#include <linux/of_net.h>
 #include <linux/of_platform.h>
 #include <linux/property.h>
 #include <linux/regmap.h>
@@ -1116,6 +1117,42 @@ static const struct regmap_config edma_regmap_cfg = {
 	.val_bits = 32,
 };
 
+/*
+ * The conduit is a DMA engine behind the switch and has no address of its
+ * own, so boards describe none: fall back to the switch this conduit serves,
+ * whose ports carry the board's addresses either from DT or patched in by
+ * the bootloader. DSA user ports without one of their own inherit whatever
+ * ends up here.
+ */
+static int edma_get_mac_address(struct net_device *netdev,
+				struct device_node *np)
+{
+	struct device_node *cpu_port;
+	int ret;
+
+	ret = of_get_ethdev_address(np, netdev);
+	if (!ret || ret == -EPROBE_DEFER)
+		return ret;
+
+	for_each_node_with_property(cpu_port, "ethernet") {
+		struct device_node *conduit __free(device_node) =
+			of_parse_phandle(cpu_port, "ethernet", 0);
+
+		if (conduit != np)
+			continue;
+
+		for_each_available_child_of_node_scoped(cpu_port->parent, port) {
+			ret = of_get_ethdev_address(port, netdev);
+			if (!ret || ret == -EPROBE_DEFER) {
+				of_node_put(cpu_port);
+				return ret;
+			}
+		}
+	}
+
+	return -ENODEV;
+}
+
 static int edma_probe(struct platform_device *pdev)
 {
 	struct clk_bulk_data *clks;
@@ -1158,6 +1195,12 @@ static int edma_probe(struct platform_device *pdev)
 	priv->pdev = pdev;
 	priv->soc = device_get_match_data(dev);
 
+	ret = edma_get_mac_address(netdev, dev->of_node);
+	if (ret == -EPROBE_DEFER)
+		return dev_err_probe(dev, ret, "failed to get MAC address\n");
+	if (ret)
+		eth_hw_addr_random(netdev);
+
 	ret = edma_page_pool_create(priv);
 	if (ret)
 		return ret;
@@ -1168,7 +1211,6 @@ static int edma_probe(struct platform_device *pdev)
 
 	SET_NETDEV_DEV(netdev, dev);
 	netdev->dev.of_node = dev->of_node;
-	eth_hw_addr_random(netdev);
 	netdev->netdev_ops = &edma_netdev_ops;
 	netdev->features = NETIF_F_GRO;
 	netdev->pcpu_stat_type = NETDEV_PCPU_STAT_TSTATS;


### PR DESCRIPTION
`edma_probe()` calls `eth_hw_addr_random()` unconditionally, so the conduit's MAC changes on every boot — and any DSA user port without a `mac-address` of its own inherits it.

The conduit is a DMA engine sitting behind the switch and has no address of its own, which is why no board describes one for it. So take the address from the switch this conduit serves: every board's CPU port already declares `ethernet = <&edma>`, and its sibling ports carry the board's addresses. That covers boards whose port addresses live in DT and boards where the bootloader patches them in through the `ethernetN` aliases — the latter could not be fixed by adding anything to DT, since the address only exists at runtime. Nothing has to be added per board.

Verified on an AX3600 (ipq8071): `eth0` comes up as `28:d1:27:fc:78:5a` on every boot, the address in the `0:art` cell that the WAN port uses, instead of a fresh random one each time.

@Ansuel @robimarko
