### PR TITLE
mediatek: add support for LTC Velo7 Max

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -143,7 +143,8 @@ gatonetworks,gdsp)
 glinet,gl-mt3000)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x20000"
 	;;
-jiorouter,ax6000-jidu6101)
+jiorouter,ax6000-jidu6101|\
+ltc,vl7m19k)
 	. /lib/upgrade/nand.sh
 	envubi=$(nand_find_ubi ubi)
 	envdev=/dev/$(nand_find_volume "$envubi" u-boot-env)

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -150,7 +150,8 @@ gatonetworks,gdsp)
 glinet,gl-mt3000)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x20000"
 	;;
-jiorouter,ax6000-jidu6101)
+jiorouter,ax6000-jidu6101|\
+ltc,vl7m19k)
 	. /lib/upgrade/nand.sh
 	envubi=$(nand_find_ubi ubi)
 	envdev=/dev/$(nand_find_volume "$envubi" u-boot-env)

--- a/target/linux/generic/pending-6.18/743-net-phy-realtek-reset-RTL8261N-USXGMII-SerDes-on-lin.patch
+++ b/target/linux/generic/pending-6.18/743-net-phy-realtek-reset-RTL8261N-USXGMII-SerDes-on-lin.patch
@@ -1,0 +1,206 @@
+From 7e7c098948cf877d8ebb7e7c17bfdc82a9764f3c Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Fri, 31 Jul 2026 19:13:06 +0100
+Subject: [PATCH] net: phy: realtek: reset RTL8261N USXGMII SerDes on link up
+
+The USXGMII block of the RTL8261N does not always settle by itself once
+the media side link has been established. Where it does not, the link is
+dropped again shortly afterwards while autonegotiation on the media side
+keeps completing normally, so ethtool reports negotiated speed and duplex
+while the link stays down and nothing is logged.
+
+The work-around was originally written by Bo-Cun Chen
+<bc-bocun.chen@mediatek.com> for the MediaTek SDK, which carries it as
+999-2799-net-ethernet-mtk_eth_soc-add-reseting-usxgmii-of-rtl.patch and
+applies it from mtk_mac_link_up() in the MT7988 ethernet driver. As the
+quirk is a property of the PHY rather than of the SoC it is handled here
+instead, so that the PHY also behaves on other hosts.
+
+The SDK busy-waits a flat second in the link-up path and then resets the
+block unconditionally. Poll the SerDes link status through the indirect
+register window instead and only pulse the reset while the link is down,
+from a delayed work so that the PHY state machine is never blocked.
+
+Hook it into both 10Gbps entries which share the base PHY ID. The parts
+this was observed on carry an RTL8261BE package marking while binding to
+the RTL8261N driver entry, the two being told apart solely by a vendor
+version register, so covering only one of them would be fragile.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+---
+ drivers/net/phy/realtek/phy_patch_rtl826x.c |  6 +-
+ drivers/net/phy/realtek/phy_patch_rtl826x.h |  4 +
+ drivers/net/phy/realtek/realtek.h           |  4 +
+ drivers/net/phy/realtek/realtek_main.c      | 83 +++++++++++++++++++++
+ 4 files changed, 94 insertions(+), 3 deletions(-)
+
+--- a/drivers/net/phy/realtek/realtek.h
++++ b/drivers/net/phy/realtek/realtek.h
+@@ -11,6 +11,10 @@
+ struct rtl826x_priv {
+ 	struct rtlgen_phy_patch_db *patch;
+ 	bool enable_pma_low_power:1;
++	struct phy_device *phydev;
++	struct delayed_work sds_work;
++	bool sds_work_disabled;
++	unsigned int sds_retries;
+ };
+ 
+ int rtl822x_hwmon_init(struct phy_device *phydev);
+--- a/drivers/net/phy/realtek/realtek_main.c
++++ b/drivers/net/phy/realtek/realtek_main.c
+@@ -230,6 +230,17 @@
+ #define   RTL826X_VEND1_SERDES_GLOBAL_CFG_HSI_INV	BIT(6)
+ #define   RTL826X_VEND1_SERDES_GLOBAL_CFG_HSO_INV	BIT(7)
+ 
++#define RTL826X_SDS_PAGE_LINK			0x05
++#define RTL826X_SDS_REG_LINK			0x00
++#define   RTL826X_SDS_LINK_UP			BIT(12)
++#define RTL826X_SDS_PAGE_RESET			0x20
++#define RTL826X_SDS_REG_RESET			0x02
++#define   RTL826X_SDS_RESET_ASSERT		0x40
++#define   RTL826X_SDS_RESET_RELEASE		0xc0
++
++#define RTL826X_SDS_POLL_MS			100
++#define RTL826X_SDS_MAX_RESETS			20
++
+ #define RTL826X_VEND1_PKG_MODEL			0x103
+ #define RTL826X_VEND1_VERSION_ID		0x104
+ #define   RTL826X_VEND1_VERSION_ID_VARIANT	GENMASK(2, 0)
+@@ -2524,6 +2535,70 @@ static int rtl826x_patch_db_init(struct
+ 		return rtl8264b_phy_patch_db_init(phydev);
+ }
+ 
++/* The USXGMII block does not always settle by itself once the media side
++ * link has been established. Where it does not, the link is dropped again
++ * shortly afterwards while autonegotiation keeps completing normally, so
++ * the failure is otherwise silent. Poll the SerDes link and pulse the
++ * block's reset until it comes up.
++ */
++static void rtl826x_sds_reset_work(struct work_struct *work)
++{
++	struct rtl826x_priv *priv = container_of(to_delayed_work(work),
++						 struct rtl826x_priv, sds_work);
++	struct phy_device *phydev = priv->phydev;
++	int val;
++
++	val = rtl826x_phy_patch_sds_get(phydev, RTL826X_SDS_PAGE_LINK,
++					RTL826X_SDS_REG_LINK);
++	if (val < 0)
++		return;
++
++	if (val & RTL826X_SDS_LINK_UP)
++		return;
++
++	if (++priv->sds_retries > RTL826X_SDS_MAX_RESETS) {
++		phydev_warn(phydev, "SerDes link did not come up\n");
++		return;
++	}
++
++	rtl826x_phy_patch_sds_set(phydev, RTL826X_SDS_PAGE_RESET,
++				  RTL826X_SDS_REG_RESET, RTL826X_SDS_RESET_ASSERT);
++	rtl826x_phy_patch_sds_set(phydev, RTL826X_SDS_PAGE_RESET,
++				  RTL826X_SDS_REG_RESET, RTL826X_SDS_RESET_RELEASE);
++
++	schedule_delayed_work(&priv->sds_work,
++			      msecs_to_jiffies(RTL826X_SDS_POLL_MS));
++}
++
++static void rtl826x_link_change_notify(struct phy_device *phydev)
++{
++	struct rtl826x_priv *priv = phydev->priv;
++
++	if (phydev->state != PHY_RUNNING) {
++		if (!priv->sds_work_disabled) {
++			disable_delayed_work(&priv->sds_work);
++			priv->sds_work_disabled = true;
++		}
++		return;
++	}
++
++	if (priv->sds_work_disabled) {
++		enable_delayed_work(&priv->sds_work);
++		priv->sds_work_disabled = false;
++	}
++
++	priv->sds_retries = 0;
++	mod_delayed_work(system_wq, &priv->sds_work,
++			 msecs_to_jiffies(RTL826X_SDS_POLL_MS));
++}
++
++static void rtl826x_cancel_sds_work(void *data)
++{
++	struct rtl826x_priv *priv = data;
++
++	cancel_delayed_work_sync(&priv->sds_work);
++}
++
+ static int rtl826x_probe(struct phy_device *phydev)
+ {
+ 	struct device *dev = &phydev->mdio.dev;
+@@ -2535,8 +2610,14 @@ static int rtl826x_probe(struct phy_devi
+ 		return -ENOMEM;
+ 
+ 	priv->enable_pma_low_power = device_property_read_bool(dev, "realtek,enable-pma-low-power");
++	priv->phydev = phydev;
+ 	phydev->priv = priv;
+ 
++	INIT_DELAYED_WORK(&priv->sds_work, rtl826x_sds_reset_work);
++	ret = devm_add_action_or_reset(dev, rtl826x_cancel_sds_work, priv);
++	if (ret)
++		return ret;
++
+ 	if (!priv->enable_pma_low_power)
+ 		phydev_warn(phydev, "PMA low-power suspend disabled\n");
+ 
+@@ -3337,6 +3418,7 @@ static struct phy_driver realtek_drvs[]
+ 	}, {
+ 		.name           = "RTL8261BE 10Gbps PHY",
+ 		.config_init    = rtl826x_config_init,
++		.link_change_notify = rtl826x_link_change_notify,
+ 		.probe          = rtl826x_probe,
+ 		.get_features   = rtl826x_get_features,
+ 		.suspend        = rtl826x_suspend,
+@@ -3354,6 +3436,7 @@ static struct phy_driver realtek_drvs[]
+ 	}, {
+ 		.name           = "RTL8261N 10Gbps PHY",
+ 		.config_init    = rtl826x_config_init,
++		.link_change_notify = rtl826x_link_change_notify,
+ 		.probe          = rtl826x_probe,
+ 		.get_features   = rtl826x_get_features,
+ 		.suspend        = rtl826x_suspend,
+--- a/drivers/net/phy/realtek/phy_patch_rtl826x.c
++++ b/drivers/net/phy/realtek/phy_patch_rtl826x.c
+@@ -70,7 +70,7 @@ static int rtl826x_phy_patch_wait(struct
+ 	return 0;
+ }
+ 
+-static int rtl826x_phy_patch_sds_get(struct phy_device *phydev, u32 sds_page, u32 sds_reg)
++int rtl826x_phy_patch_sds_get(struct phy_device *phydev, u32 sds_page, u32 sds_reg)
+ {
+ 	u32 sds_addr = 0x8000 + (sds_reg << 6) + sds_page;
+ 	int ret;
+@@ -86,8 +86,8 @@ static int rtl826x_phy_patch_sds_get(str
+ 	return phy_read_mmd(phydev, MDIO_MMD_VEND1, 0x142);
+ }
+ 
+-static int rtl826x_phy_patch_sds_set(struct phy_device *phydev, u32 sds_page, u32 sds_reg,
+-				     u32 data)
++int rtl826x_phy_patch_sds_set(struct phy_device *phydev, u32 sds_page, u32 sds_reg,
++			      u32 data)
+ {
+ 	u32 sds_addr = 0x8800 + (sds_reg << 6) + sds_page;
+ 	int ret;
+--- a/drivers/net/phy/realtek/phy_patch_rtl826x.h
++++ b/drivers/net/phy/realtek/phy_patch_rtl826x.h
+@@ -5,6 +5,10 @@
+ 
+ #include <linux/phy.h>
+ 
++int rtl826x_phy_patch_sds_get(struct phy_device *phydev, u32 sds_page, u32 sds_reg);
++int rtl826x_phy_patch_sds_set(struct phy_device *phydev, u32 sds_page, u32 sds_reg,
++			      u32 data);
++
+ int rtl8261n_phy_patch_db_init(struct phy_device *phydev);
+ int rtl8264b_phy_patch_db_init(struct phy_device *phydev);
+ 

--- a/target/linux/generic/pending-6.18/743-net-phy-realtek-reset-RTL8261N-USXGMII-SerDes-on-lin.patch
+++ b/target/linux/generic/pending-6.18/743-net-phy-realtek-reset-RTL8261N-USXGMII-SerDes-on-lin.patch
@@ -1,0 +1,193 @@
+From 7e7c098948cf877d8ebb7e7c17bfdc82a9764f3c Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Fri, 31 Jul 2026 19:13:06 +0100
+Subject: [PATCH] net: phy: realtek: reset RTL8261N USXGMII SerDes on link up
+
+The USXGMII block of the RTL8261N does not always settle by itself once
+the media side link has been established. Where it does not, the link is
+dropped again shortly afterwards while autonegotiation on the media side
+keeps completing normally, so ethtool reports negotiated speed and duplex
+while the link stays down and nothing is logged.
+
+The work-around was originally written by Bo-Cun Chen
+<bc-bocun.chen@mediatek.com> for the MediaTek SDK, which carries it as
+999-2799-net-ethernet-mtk_eth_soc-add-reseting-usxgmii-of-rtl.patch and
+applies it from mtk_mac_link_up() in the MT7988 ethernet driver. As the
+quirk is a property of the PHY rather than of the SoC it is handled here
+instead, so that the PHY also behaves on other hosts.
+
+The SDK busy-waits a flat second in the link-up path and then resets the
+block unconditionally. Poll the SerDes link status through the indirect
+register window instead and only pulse the reset while the link is down,
+from a delayed work so that the PHY state machine is never blocked.
+
+Hook it into both 10Gbps entries which share the base PHY ID. The parts
+this was observed on carry an RTL8261BE package marking while binding to
+the RTL8261N driver entry, the two being told apart solely by a vendor
+version register, so covering only one of them would be fragile.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+---
+ drivers/net/phy/realtek/realtek.h      |   3 +
+ drivers/net/phy/realtek/realtek_main.c | 130 +++++++++++++++++++++++++
+ 2 files changed, 133 insertions(+)
+
+--- a/drivers/net/phy/realtek/realtek.h
++++ b/drivers/net/phy/realtek/realtek.h
+@@ -11,6 +11,9 @@
+ struct rtl826x_priv {
+ 	struct rtlgen_phy_patch_db *patch;
+ 	bool enable_pma_low_power:1;
++	struct phy_device *phydev;
++	struct delayed_work sds_work;
++	unsigned int sds_retries;
+ };
+ 
+ int rtl822x_hwmon_init(struct phy_device *phydev);
+--- a/drivers/net/phy/realtek/realtek_main.c
++++ b/drivers/net/phy/realtek/realtek_main.c
+@@ -218,6 +218,17 @@
+ #define   RTL826X_VEND1_SERDES_GLOBAL_CFG_HSI_INV	BIT(6)
+ #define   RTL826X_VEND1_SERDES_GLOBAL_CFG_HSO_INV	BIT(7)
+ 
++#define RTL826X_SDS_PAGE_LINK			0x05
++#define RTL826X_SDS_REG_LINK			0x00
++#define   RTL826X_SDS_LINK_UP			BIT(12)
++#define RTL826X_SDS_PAGE_RESET			0x20
++#define RTL826X_SDS_REG_RESET			0x02
++#define   RTL826X_SDS_RESET_ASSERT		0x40
++#define   RTL826X_SDS_RESET_RELEASE		0xc0
++
++#define RTL826X_SDS_POLL_MS			100
++#define RTL826X_SDS_MAX_RESETS			20
++
+ #define RTL826X_VEND1_PKG_MODEL			0x103
+ #define RTL826X_VEND1_VERSION_ID		0x104
+ #define   RTL826X_VEND1_VERSION_ID_VARIANT	GENMASK(2, 0)
+@@ -2367,6 +2378,62 @@ static int rtl826x_patch_db_init(struct
+ 		return rtl8264b_phy_patch_db_init(phydev);
+ }
+ 
++/* The USXGMII block does not always settle by itself once the media side
++ * link has been established. Where it does not, the link is dropped again
++ * shortly afterwards while autonegotiation keeps completing normally, so
++ * the failure is otherwise silent. Poll the SerDes link and pulse the
++ * block's reset until it comes up.
++ */
++static void rtl826x_sds_reset_work(struct work_struct *work)
++{
++	struct rtl826x_priv *priv = container_of(to_delayed_work(work),
++						 struct rtl826x_priv, sds_work);
++	struct phy_device *phydev = priv->phydev;
++	int val;
++
++	val = rtl826x_phy_patch_sds_get(phydev, RTL826X_SDS_PAGE_LINK,
++					RTL826X_SDS_REG_LINK);
++	if (val < 0)
++		return;
++
++	if (val & RTL826X_SDS_LINK_UP)
++		return;
++
++	if (++priv->sds_retries > RTL826X_SDS_MAX_RESETS) {
++		phydev_warn(phydev, "SerDes link did not come up\n");
++		return;
++	}
++
++	rtl826x_phy_patch_sds_set(phydev, RTL826X_SDS_PAGE_RESET,
++				  RTL826X_SDS_REG_RESET, RTL826X_SDS_RESET_ASSERT);
++	rtl826x_phy_patch_sds_set(phydev, RTL826X_SDS_PAGE_RESET,
++				  RTL826X_SDS_REG_RESET, RTL826X_SDS_RESET_RELEASE);
++
++	schedule_delayed_work(&priv->sds_work,
++			      msecs_to_jiffies(RTL826X_SDS_POLL_MS));
++}
++
++static void rtl826x_link_change_notify(struct phy_device *phydev)
++{
++	struct rtl826x_priv *priv = phydev->priv;
++
++	if (phydev->state != PHY_RUNNING) {
++		cancel_delayed_work_sync(&priv->sds_work);
++		return;
++	}
++
++	priv->sds_retries = 0;
++	mod_delayed_work(system_wq, &priv->sds_work,
++			 msecs_to_jiffies(RTL826X_SDS_POLL_MS));
++}
++
++static void rtl826x_cancel_sds_work(void *data)
++{
++	struct rtl826x_priv *priv = data;
++
++	cancel_delayed_work_sync(&priv->sds_work);
++}
++
+ static int rtl826x_probe(struct phy_device *phydev)
+ {
+ 	struct device *dev = &phydev->mdio.dev;
+@@ -2378,8 +2445,14 @@ static int rtl826x_probe(struct phy_devi
+ 		return -ENOMEM;
+ 
+ 	priv->enable_pma_low_power = device_property_read_bool(dev, "realtek,enable-pma-low-power");
++	priv->phydev = phydev;
+ 	phydev->priv = priv;
+ 
++	INIT_DELAYED_WORK(&priv->sds_work, rtl826x_sds_reset_work);
++	ret = devm_add_action_or_reset(dev, rtl826x_cancel_sds_work, priv);
++	if (ret)
++		return ret;
++
+ 	if (!priv->enable_pma_low_power)
+ 		phydev_warn(phydev, "PMA low-power suspend disabled\n");
+ 
+@@ -3172,6 +3245,7 @@ static struct phy_driver realtek_drvs[]
+ 	}, {
+ 		.name           = "RTL8261BE 10Gbps PHY",
+ 		.config_init    = rtl826x_config_init,
++		.link_change_notify = rtl826x_link_change_notify,
+ 		.probe          = rtl826x_probe,
+ 		.get_features   = rtl826x_get_features,
+ 		.suspend        = rtl826x_suspend,
+@@ -3189,6 +3263,7 @@ static struct phy_driver realtek_drvs[]
+ 	}, {
+ 		.name           = "RTL8261N 10Gbps PHY",
+ 		.config_init    = rtl826x_config_init,
++		.link_change_notify = rtl826x_link_change_notify,
+ 		.probe          = rtl826x_probe,
+ 		.get_features   = rtl826x_get_features,
+ 		.suspend        = rtl826x_suspend,
+--- a/drivers/net/phy/realtek/phy_patch_rtl826x.c
++++ b/drivers/net/phy/realtek/phy_patch_rtl826x.c
+@@ -70,7 +70,7 @@ static int rtl826x_phy_patch_wait(struct
+ 	return 0;
+ }
+ 
+-static int rtl826x_phy_patch_sds_get(struct phy_device *phydev, u32 sds_page, u32 sds_reg)
++int rtl826x_phy_patch_sds_get(struct phy_device *phydev, u32 sds_page, u32 sds_reg)
+ {
+ 	u32 sds_addr = 0x8000 + (sds_reg << 6) + sds_page;
+ 	int ret;
+@@ -86,7 +86,7 @@ static int rtl826x_phy_patch_sds_get(str
+ 	return phy_read_mmd(phydev, MDIO_MMD_VEND1, 0x142);
+ }
+ 
+-static int rtl826x_phy_patch_sds_set(struct phy_device *phydev, u32 sds_page, u32 sds_reg,
++int rtl826x_phy_patch_sds_set(struct phy_device *phydev, u32 sds_page, u32 sds_reg,
+ 				     u32 data)
+ {
+ 	u32 sds_addr = 0x8800 + (sds_reg << 6) + sds_page;
+--- a/drivers/net/phy/realtek/phy_patch_rtl826x.h
++++ b/drivers/net/phy/realtek/phy_patch_rtl826x.h
+@@ -5,6 +5,10 @@
+ 
+ #include <linux/phy.h>
+ 
++int rtl826x_phy_patch_sds_get(struct phy_device *phydev, u32 sds_page, u32 sds_reg);
++int rtl826x_phy_patch_sds_set(struct phy_device *phydev, u32 sds_page, u32 sds_reg,
++			      u32 data);
++
+ int rtl8261n_phy_patch_db_init(struct phy_device *phydev);
+ int rtl8264b_phy_patch_db_init(struct phy_device *phydev);
+ 

--- a/target/linux/mediatek/dts/mt7988a-ltc-vl7m19k.dts
+++ b/target/linux/mediatek/dts/mt7988a-ltc-vl7m19k.dts
@@ -1,0 +1,586 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include "mt7988a.dtsi"
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+#include <dt-bindings/regulator/richtek,rt5190a-regulator.h>
+
+/ {
+	compatible = "ltc,vl7m19k", "mediatek,mt7988a";
+	model = "LTC Velo7 Max";
+
+	aliases {
+		serial0 = &serial0;
+		label-mac-device = &gmac0;
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_blue;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs = "console=ttyS0,115200n1 earlycon=uart8250,mmio32,0x11000000 pci=pcie_bus_perf";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led-power {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&pio 81 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_green: led-status-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 68 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_blue: led-status-blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 75 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_red: led-status-red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 76 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-wlan-2g {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&pio 79 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-wlan-5g {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&pio 63 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-wlan-6g {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_6GHZ;
+			gpios = <&pio 62 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-tel1-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = "tel";
+			function-enumerator = <1>;
+			gpios = <&pio 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-tel1-red {
+			color = <LED_COLOR_ID_RED>;
+			function = "tel";
+			function-enumerator = <1>;
+			gpios = <&pio 2 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-tel2-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = "tel";
+			function-enumerator = <2>;
+			gpios = <&pio 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-tel2-red {
+			color = <LED_COLOR_ID_RED>;
+			function = "tel";
+			function-enumerator = <2>;
+			gpios = <&pio 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-wps {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WPS;
+			gpios = <&pio 21 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		button-wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		button-reboot {
+			label = "reboot";
+			linux,code = <KEY_POWER2>;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c0_pins>;
+	status = "okay";
+
+	rt5190a_64: rt5190a@64 {
+		compatible = "richtek,rt5190a";
+		reg = <0x64>;
+		vin2-supply = <&rt5190_buck1>;
+		vin3-supply = <&rt5190_buck1>;
+		vin4-supply = <&rt5190_buck1>;
+
+		regulators {
+			rt5190_buck1: buck1 {
+				regulator-name = "rt5190a-buck1";
+				regulator-min-microvolt = <5090000>;
+				regulator-max-microvolt = <5090000>;
+				regulator-allowed-modes =
+				<RT5190A_OPMODE_AUTO RT5190A_OPMODE_FPWM>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+
+			buck2 {
+				regulator-name = "vcore";
+				regulator-min-microvolt = <600000>;
+				regulator-max-microvolt = <1400000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+
+			rt5190_buck3: buck3 {
+				regulator-name = "vproc";
+				regulator-min-microvolt = <600000>;
+				regulator-max-microvolt = <1400000>;
+				regulator-boot-on;
+			};
+
+			buck4 {
+				regulator-name = "rt5190a-buck4";
+				regulator-min-microvolt = <850000>;
+				regulator-max-microvolt = <850000>;
+				regulator-allowed-modes =
+				<RT5190A_OPMODE_AUTO RT5190A_OPMODE_FPWM>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+
+			ldo {
+				regulator-name = "rt5190a-ldo";
+				regulator-min-microvolt = <1200000>;
+				regulator-max-microvolt = <1200000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+		};
+	};
+};
+
+&cpu0 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cpu1 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cpu2 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cpu3 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cci {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+		spi-rx-bus-width = <4>;
+		spi-tx-bus-width = <4>;
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <256>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x400000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1e00>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@580000 {
+				label = "FIP";
+				reg = <0x580000 0x200000>;
+			};
+
+			partition@780000 {
+				label = "ubi";
+				reg = <0x780000 0xc080000>;
+				compatible = "linux,ubi";
+			};
+
+			partition@c800000 {
+				label = "config";
+				reg = <0xc800000 0xa00000>;
+				compatible = "linux,ubi";
+			};
+
+			partition@d200000 {
+				label = "config_bak";
+				reg = <0xd200000 0xa00000>;
+				compatible = "linux,ubi";
+			};
+
+			partition@dc00000 {
+				label = "data";
+				reg = <0xdc00000 0x1400000>;
+				compatible = "linux,ubi";
+			};
+		};
+	};
+};
+
+&pio {
+	pcie0_pins: pcie0-pins {
+		mux {
+			function = "pcie";
+			groups = "pcie_2l_0_pereset";
+		};
+	};
+
+	pcie1_pins: pcie1-pins {
+		mux {
+			function = "pcie";
+			groups = "pcie_2l_1_pereset";
+		};
+	};
+
+	mdio0_pins: mdio0-pins {
+		mux {
+			function = "eth";
+			groups = "mdc_mdio0";
+		};
+
+		conf {
+			groups = "mdc_mdio0";
+			drive-strength = <MTK_DRIVE_8mA>;
+		};
+	};
+
+	i2c0_pins: i2c0-g0-pins {
+		mux {
+			function = "i2c";
+			groups = "i2c0_1";
+		};
+	};
+
+	spi0_flash_pins: spi0-flash-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+	};
+
+	gbe0_led0_pins: gbe0-led0-pins {
+		mux {
+			function = "led";
+			groups = "gbe0_led0";
+		};
+	};
+
+	gbe0_led1_pins: gbe0-led1-pins {
+		mux {
+			function = "led";
+			groups = "gbe0_led1";
+		};
+	};
+
+	gbe1_led0_pins: gbe1-led0-pins {
+		mux {
+			function = "led";
+			groups = "gbe1_led0";
+		};
+	};
+
+	gbe1_led1_pins: gbe1-led1-pins {
+		mux {
+			function = "led";
+			groups = "gbe1_led1";
+		};
+	};
+
+	gbe2_led0_pins: gbe2-led0-pins {
+		mux {
+			function = "led";
+			groups = "gbe2_led0";
+		};
+	};
+
+	gbe2_led1_pins: gbe2-led1-pins {
+		mux {
+			function = "led";
+			groups = "gbe2_led1";
+		};
+	};
+
+	gbe3_led0_pins: gbe3-led0-pins {
+		mux {
+			function = "led";
+			groups = "gbe3_led0";
+		};
+	};
+
+	gbe3_led1_pins: gbe3-led1-pins {
+		mux {
+			function = "led";
+			groups = "gbe3_led1";
+		};
+	};
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio0_pins>;
+	status = "okay";
+};
+
+&serial0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&ssusb0 {
+	status = "okay";
+};
+
+&ssusb1 {
+	status = "okay";
+};
+
+&tphy {
+	status = "okay";
+};
+
+&xsphy {
+	status = "okay";
+};
+
+&mdio_bus {
+	phy6: ethernet-phy@6 {
+		reg = <6>;
+		reset-gpios = <&pio 77 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <100000>;
+		reset-deassert-us = <221000>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+	};
+
+	phy7: ethernet-phy@7 {
+		reg = <7>;
+		reset-gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <100000>;
+		reset-deassert-us = <221000>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+	};
+};
+
+&int_2p5g_phy {
+	status = "disabled";
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_4 (-2)>;
+	nvmem-cell-names = "mac-address";
+	status = "okay";
+};
+
+&gmac1 {
+	phy-mode = "usxgmii";
+	phy-connection-type = "usxgmii";
+	managed = "in-band-status";
+	phy = <&phy6>;
+	nvmem-cells = <&macaddr_factory_4 (-2)>;
+	nvmem-cell-names = "mac-address";
+	status = "okay";
+};
+
+&gmac2 {
+	phy-mode = "usxgmii";
+	phy-connection-type = "usxgmii";
+	managed = "in-band-status";
+	phy = <&phy7>;
+	nvmem-cells = <&macaddr_factory_4 (-1)>;
+	nvmem-cell-names = "mac-address";
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&gsw_port0 {
+	label = "lan0";
+};
+
+&gsw_phy0 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gbe0_led0_pins>, <&gbe0_led1_pins>;
+};
+
+&gsw_phy0_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_GREEN>;
+};
+
+&gsw_phy0_led1 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_ORANGE>;
+};
+
+&gsw_port1 {
+	label = "lan1";
+};
+
+&gsw_phy1 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gbe1_led0_pins>, <&gbe1_led1_pins>;
+};
+
+&gsw_phy1_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_GREEN>;
+};
+
+&gsw_phy1_led1 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_ORANGE>;
+};
+
+&gsw_port2 {
+	label = "lan2";
+};
+
+&gsw_phy2 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gbe2_led0_pins>, <&gbe2_led1_pins>;
+};
+
+&gsw_phy2_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_GREEN>;
+};
+
+&gsw_phy2_led1 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_ORANGE>;
+};
+
+&gsw_port3 {
+	label = "lan3";
+};
+
+&gsw_phy3 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gbe3_led0_pins>, <&gbe3_led1_pins>;
+};
+
+&gsw_phy3_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_GREEN>;
+};
+
+&gsw_phy3_led1 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_ORANGE>;
+};
+
+&pcie0 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_pins>;
+	wifi-reset-gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+	wifi-reset-msleep = <100>;
+
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+
+		wifi@0,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+			nvmem-cells = <&eeprom_factory_0>;
+			nvmem-cell-names = "eeprom";
+		};
+	};
+};
+
+&pcie1 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie1_pins>;
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -174,6 +174,19 @@ livinet,li320)
 	ucidef_set_led_netdev "wan-off" "wan-off" "red:wan" "wan" "link"
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan" "link"
 	;;
+ltc,vl7m19k)
+	ucidef_set_led_netdev "lan0-green" "LAN0" "mt7530-0:00:green:lan" "lan0" "link_1000 tx rx"
+	ucidef_set_led_netdev "lan0-orange" "LAN0" "mt7530-0:00:orange:lan" "lan0" "link_10 link_100 tx rx"
+	ucidef_set_led_netdev "lan1-green" "LAN1" "mt7530-0:01:green:lan" "lan1" "link_1000 tx rx"
+	ucidef_set_led_netdev "lan1-orange" "LAN1" "mt7530-0:01:orange:lan" "lan1" "link_10 link_100 tx rx"
+	ucidef_set_led_netdev "lan2-green" "LAN2" "mt7530-0:02:green:lan" "lan2" "link_1000 tx rx"
+	ucidef_set_led_netdev "lan2-orange" "LAN2" "mt7530-0:02:orange:lan" "lan2" "link_10 link_100 tx rx"
+	ucidef_set_led_netdev "lan3-green" "LAN3" "mt7530-0:03:green:lan" "lan3" "link_1000 tx rx"
+	ucidef_set_led_netdev "lan3-orange" "LAN3" "mt7530-0:03:orange:lan" "lan3" "link_10 link_100 tx rx"
+	ucidef_set_led_netdev "wlan2g" "WLAN2G" "green:wlan-2ghz" "phy0.0-ap0" "link tx rx"
+	ucidef_set_led_netdev "wlan5g" "WLAN5G" "green:wlan-5ghz" "phy0.1-ap0" "link tx rx"
+	ucidef_set_led_netdev "wlan6g" "WLAN6G" "green:wlan-6ghz" "phy0.2-ap0" "link tx rx"
+	;;
 mercusys,mr80x-v3|\
 mercusys,mr85x|\
 mercusys,mr85x-ubi)

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -162,6 +162,19 @@ livinet,li320)
 	ucidef_set_led_netdev "wan-off" "wan-off" "red:wan" "wan" "link"
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan" "link"
 	;;
+ltc,vl7m19k)
+	ucidef_set_led_netdev "lan0-green" "LAN0" "mt7530-0:00:green:lan" "lan0" "link_1000 tx rx"
+	ucidef_set_led_netdev "lan0-orange" "LAN0" "mt7530-0:00:orange:lan" "lan0" "link_10 link_100 tx rx"
+	ucidef_set_led_netdev "lan1-green" "LAN1" "mt7530-0:01:green:lan" "lan1" "link_1000 tx rx"
+	ucidef_set_led_netdev "lan1-orange" "LAN1" "mt7530-0:01:orange:lan" "lan1" "link_10 link_100 tx rx"
+	ucidef_set_led_netdev "lan2-green" "LAN2" "mt7530-0:02:green:lan" "lan2" "link_1000 tx rx"
+	ucidef_set_led_netdev "lan2-orange" "LAN2" "mt7530-0:02:orange:lan" "lan2" "link_10 link_100 tx rx"
+	ucidef_set_led_netdev "lan3-green" "LAN3" "mt7530-0:03:green:lan" "lan3" "link_1000 tx rx"
+	ucidef_set_led_netdev "lan3-orange" "LAN3" "mt7530-0:03:orange:lan" "lan3" "link_10 link_100 tx rx"
+	ucidef_set_led_netdev "wlan2g" "WLAN2G" "green:wlan-2ghz" "phy0.0-ap0" "link tx rx"
+	ucidef_set_led_netdev "wlan5g" "WLAN5G" "green:wlan-5ghz" "phy0.1-ap0" "link tx rx"
+	ucidef_set_led_netdev "wlan6g" "WLAN6G" "green:wlan-6ghz" "phy0.2-ap0" "link tx rx"
+	;;
 mercusys,mr80x-v3)
 	ucidef_set_led_netdev "lan1" "lan-1" "green:lan-1" "lan1" "link tx rx"
 	ucidef_set_led_netdev "lan2" "lan-2" "green:lan-2" "lan2" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -203,6 +203,9 @@ mediatek_setup_interfaces()
 	netcraze,nc-1812)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan5" "wan"
 		;;
+	ltc,vl7m19k)
+		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3 eth1" eth2
+		;;
 	mediatek,mt7986a-rfb)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan6" "eth1 wan"
 		;;

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -192,6 +192,9 @@ mediatek_setup_interfaces()
 	netcraze,nc-1812)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan5" "wan"
 		;;
+	ltc,vl7m19k)
+		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3 eth1" eth2
+		;;
 	mediatek,mt7986a-rfb)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan6" "eth1 wan"
 		;;

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -130,6 +130,20 @@ update_oem_ubi_volume() {
 	ubiupdatevol "/dev/$ubidev" -s "$oem_volume_size" "$oem_volume_data"
 }
 
+# Write both volume sets used by the MediaTek SDK bootloader, so that
+# whichever of the two it ends up selecting carries the new firmware.
+mtk_dual_boot_flash_both_slots() {
+	echo "UPGRADING SECOND SLOT"
+	CI_KERNPART="kernel2"
+	CI_ROOTPART="rootfs2"
+	nand_do_flash_file "$1" || nand_do_upgrade_failed
+
+	echo "UPGRADING PRIMARY SLOT"
+	CI_KERNPART="kernel"
+	CI_ROOTPART="rootfs"
+	nand_do_flash_file "$1" || nand_do_upgrade_failed
+}
+
 platform_do_upgrade() {
 	local board=$(board_name)
 
@@ -319,15 +333,15 @@ platform_do_upgrade() {
 		CI_UBIPART="ubi0"
 		nand_do_upgrade "$1"
 		;;
+	ltc,vl7m19k)
+		mtk_dual_boot_flash_both_slots "$1"
+		# clear any marker the bootloader set after failing to verify
+		fw_setenv dual_boot.slot_0_invalid 0
+		fw_setenv dual_boot.slot_1_invalid 0
+		nand_do_upgrade_success
+		;;
 	netgear,eax17)
-		echo "UPGRADING SECOND SLOT"
-		CI_KERNPART="kernel2"
-		CI_ROOTPART="rootfs2"
-		nand_do_flash_file "$1" || nand_do_upgrade_failed
-		echo "UPGRADING PRIMARY SLOT"
-		CI_KERNPART="kernel"
-		CI_ROOTPART="rootfs"
-		nand_do_flash_file "$1" || nand_do_upgrade_failed
+		mtk_dual_boot_flash_both_slots "$1"
 		nand_do_upgrade_success
 		;;
 	tplink,fr365-v1|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -130,6 +130,20 @@ update_oem_ubi_volume() {
 	ubiupdatevol "/dev/$ubidev" -s "$oem_volume_size" "$oem_volume_data"
 }
 
+# Write both volume sets used by the MediaTek SDK bootloader, so that
+# whichever of the two it ends up selecting carries the new firmware.
+mtk_dual_boot_flash_both_slots() {
+	echo "UPGRADING SECOND SLOT"
+	CI_KERNPART="kernel2"
+	CI_ROOTPART="rootfs2"
+	nand_do_flash_file "$1" || nand_do_upgrade_failed
+
+	echo "UPGRADING PRIMARY SLOT"
+	CI_KERNPART="kernel"
+	CI_ROOTPART="rootfs"
+	nand_do_flash_file "$1" || nand_do_upgrade_failed
+}
+
 platform_do_upgrade() {
 	local board=$(board_name)
 
@@ -317,15 +331,15 @@ platform_do_upgrade() {
 		CI_UBIPART="ubi0"
 		nand_do_upgrade "$1"
 		;;
+	ltc,vl7m19k)
+		mtk_dual_boot_flash_both_slots "$1"
+		# clear any marker the bootloader set after failing to verify
+		fw_setenv dual_boot.slot_0_invalid 0
+		fw_setenv dual_boot.slot_1_invalid 0
+		nand_do_upgrade_success
+		;;
 	netgear,eax17)
-		echo "UPGRADING SECOND SLOT"
-		CI_KERNPART="kernel2"
-		CI_ROOTPART="rootfs2"
-		nand_do_flash_file "$1" || nand_do_upgrade_failed
-		echo "UPGRADING PRIMARY SLOT"
-		CI_KERNPART="kernel"
-		CI_ROOTPART="rootfs"
-		nand_do_flash_file "$1" || nand_do_upgrade_failed
+		mtk_dual_boot_flash_both_slots "$1"
 		nand_do_upgrade_success
 		;;
 	tplink,fr365-v1|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2445,6 +2445,22 @@ define Device/livinet_li320
 endef
 TARGET_DEVICES += livinet_li320
 
+define Device/ltc_vl7m19k
+  DEVICE_VENDOR := LTC
+  DEVICE_MODEL := Velo7 Max
+  DEVICE_ALT0_VENDOR := Tozed Kangwei
+  DEVICE_ALT0_MODEL := ZLT W19B6VM
+  DEVICE_DTS := mt7988a-ltc-vl7m19k
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7996-firmware kmod-phy-realtek kmod-usb3 \
+	mt7988-wo-firmware rtl826x-firmware
+  KERNEL = kernel-bin | lzma | \
+	fit-with-netgear-top-level-rootfs-node lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  SUPPORTED_DEVICES += mediatek,mt7988a-dsa-10g-spim-snand
+endef
+TARGET_DEVICES += ltc_vl7m19k
+
 define Device/mediatek_mt7981-rfb
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MT7981 rfb

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2336,6 +2336,22 @@ define Device/livinet_li320
 endef
 TARGET_DEVICES += livinet_li320
 
+define Device/ltc_vl7m19k
+  DEVICE_VENDOR := LTC
+  DEVICE_MODEL := Velo7 Max
+  DEVICE_ALT0_VENDOR := Tozed Kangwei
+  DEVICE_ALT0_MODEL := ZLT W19B6VM
+  DEVICE_DTS := mt7988a-ltc-vl7m19k
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7996-firmware kmod-phy-realtek kmod-usb3 \
+	mt7988-wo-firmware rtl826x-firmware
+  KERNEL = kernel-bin | lzma | \
+	fit-with-netgear-top-level-rootfs-node lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  SUPPORTED_DEVICES += mediatek,mt7988a-dsa-10g-spim-snand
+endef
+TARGET_DEVICES += ltc_vl7m19k
+
 define Device/mediatek_mt7981-rfb
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MT7981 rfb

--- a/target/linux/realtek/patches-6.18/024-02-v7.1-net-phy-realtek-add-RTL8224-pair-order-support.patch
+++ b/target/linux/realtek/patches-6.18/024-02-v7.1-net-phy-realtek-add-RTL8224-pair-order-support.patch
@@ -54,7 +54,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  #define RTL8366RB_POWER_SAVE			0x15
  #define RTL8366RB_POWER_SAVE_ON			BIT(12)
  
-@@ -2048,6 +2051,66 @@ static int rtl8224_cable_test_get_status
+@@ -2059,6 +2062,66 @@ static int rtl8224_cable_test_get_status
  	return rtl8224_cable_test_report(phydev, finished);
  }
  
@@ -121,7 +121,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  static bool rtlgen_supports_2_5gbps(struct phy_device *phydev)
  {
  	int val;
-@@ -3252,6 +3315,8 @@ static struct phy_driver realtek_drvs[]
+@@ -3333,6 +3396,8 @@ static struct phy_driver realtek_drvs[]
  		PHY_ID_MATCH_EXACT(0x001ccad0),
  		.name		= "RTL8224 2.5Gbps PHY",
  		.flags		= PHY_POLL_CABLE_TEST,

--- a/target/linux/realtek/patches-6.18/024-02-v7.1-net-phy-realtek-add-RTL8224-pair-order-support.patch
+++ b/target/linux/realtek/patches-6.18/024-02-v7.1-net-phy-realtek-add-RTL8224-pair-order-support.patch
@@ -54,7 +54,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  #define RTL8366RB_POWER_SAVE			0x15
  #define RTL8366RB_POWER_SAVE_ON			BIT(12)
  
-@@ -1891,6 +1894,66 @@ static int rtl8224_cable_test_get_status
+@@ -1902,6 +1905,66 @@ static int rtl8224_cable_test_get_status
  	return rtl8224_cable_test_report(phydev, finished);
  }
  
@@ -121,7 +121,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  static bool rtlgen_supports_2_5gbps(struct phy_device *phydev)
  {
  	int val;
-@@ -3087,6 +3150,8 @@ static struct phy_driver realtek_drvs[]
+@@ -3160,6 +3223,8 @@ static struct phy_driver realtek_drvs[]
  		PHY_ID_MATCH_EXACT(0x001ccad0),
  		.name		= "RTL8224 2.5Gbps PHY",
  		.flags		= PHY_POLL_CABLE_TEST,

--- a/target/linux/realtek/patches-6.18/024-04-v7.1-net-phy-realtek-add-RTL8224-polarity-support.patch
+++ b/target/linux/realtek/patches-6.18/024-04-v7.1-net-phy-realtek-add-RTL8224-polarity-support.patch
@@ -32,7 +32,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  
  #define RTL8366RB_POWER_SAVE			0x15
  #define RTL8366RB_POWER_SAVE_ON			BIT(12)
-@@ -2099,9 +2100,40 @@ static int rtl8224_mdi_config_order(stru
+@@ -2110,9 +2111,40 @@ static int rtl8224_mdi_config_order(stru
  					  order ? BIT(port_offset) : 0);
  }
  

--- a/target/linux/realtek/patches-6.18/024-04-v7.1-net-phy-realtek-add-RTL8224-polarity-support.patch
+++ b/target/linux/realtek/patches-6.18/024-04-v7.1-net-phy-realtek-add-RTL8224-polarity-support.patch
@@ -32,7 +32,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  
  #define RTL8366RB_POWER_SAVE			0x15
  #define RTL8366RB_POWER_SAVE_ON			BIT(12)
-@@ -1942,9 +1943,40 @@ static int rtl8224_mdi_config_order(stru
+@@ -1953,9 +1954,40 @@ static int rtl8224_mdi_config_order(stru
  					  order ? BIT(port_offset) : 0);
  }
  

--- a/target/linux/realtek/patches-6.18/030-v7.2-net-phy-realtek-support-MDI-swapping-for-RTL8226-CG.patch
+++ b/target/linux/realtek/patches-6.18/030-v7.2-net-phy-realtek-support-MDI-swapping-for-RTL8226-CG.patch
@@ -60,7 +60,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  #define RTL8366RB_POWER_SAVE			0x15
  #define RTL8366RB_POWER_SAVE_ON			BIT(12)
  
-@@ -1404,6 +1419,144 @@ static int rtl822x_init_phycr1(struct ph
+@@ -1415,6 +1430,144 @@ static int rtl822x_init_phycr1(struct ph
  				      mask, val);
  }
  
@@ -205,7 +205,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  static int rtl822x_set_serdes_option_mode(struct phy_device *phydev, bool gen1)
  {
  	bool has_2500, has_sgmii;
-@@ -3231,6 +3384,7 @@ static struct phy_driver realtek_drvs[]
+@@ -3312,6 +3465,7 @@ static struct phy_driver realtek_drvs[]
  		.soft_reset	= rtl822x_c45_soft_reset,
  		.get_features	= rtl822x_c45_get_features,
  		.config_aneg	= rtl822x_c45_config_aneg,

--- a/target/linux/realtek/patches-6.18/030-v7.2-net-phy-realtek-support-MDI-swapping-for-RTL8226-CG.patch
+++ b/target/linux/realtek/patches-6.18/030-v7.2-net-phy-realtek-support-MDI-swapping-for-RTL8226-CG.patch
@@ -60,7 +60,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  #define RTL8366RB_POWER_SAVE			0x15
  #define RTL8366RB_POWER_SAVE_ON			BIT(12)
  
-@@ -1392,6 +1407,144 @@ static int rtl822x_init_phycr1(struct ph
+@@ -1403,6 +1418,144 @@ static int rtl822x_init_phycr1(struct ph
  				      mask, val);
  }
  
@@ -205,7 +205,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  static int rtl822x_set_serdes_option_mode(struct phy_device *phydev, bool gen1)
  {
  	bool has_2500, has_sgmii;
-@@ -3074,6 +3227,7 @@ static struct phy_driver realtek_drvs[]
+@@ -3147,6 +3300,7 @@ static struct phy_driver realtek_drvs[]
  		.soft_reset	= rtl822x_c45_soft_reset,
  		.get_features	= rtl822x_c45_get_features,
  		.config_aneg	= rtl822x_c45_config_aneg,

--- a/target/linux/realtek/patches-6.18/743-net-realtek-serdes-configuration.patch
+++ b/target/linux/realtek/patches-6.18/743-net-realtek-serdes-configuration.patch
@@ -42,7 +42,7 @@
  #define RTL8221B_PHYCR1				0xa430
  #define RTL8221B_PHYCR1_ALDPS_EN		BIT(2)
  #define RTL8221B_PHYCR1_ALDPS_XTAL_OFF_EN	BIT(12)
-@@ -2071,6 +2106,147 @@ exit:
+@@ -2082,6 +2117,147 @@ exit:
  	return ret;
  }
  
@@ -190,7 +190,7 @@
  static int rtl8224_mdi_config_order(struct phy_device *phydev)
  {
  	struct device_node *np = phydev->mdio.dev.of_node;
-@@ -2125,6 +2301,10 @@ static int rtl8224_config_init(struct ph
+@@ -2136,6 +2312,10 @@ static int rtl8224_config_init(struct ph
  {
  	int ret;
  

--- a/target/linux/realtek/patches-6.18/743-net-realtek-serdes-configuration.patch
+++ b/target/linux/realtek/patches-6.18/743-net-realtek-serdes-configuration.patch
@@ -42,7 +42,7 @@
  #define RTL8221B_PHYCR1				0xa430
  #define RTL8221B_PHYCR1_ALDPS_EN		BIT(2)
  #define RTL8221B_PHYCR1_ALDPS_XTAL_OFF_EN	BIT(12)
-@@ -2228,6 +2263,147 @@ exit:
+@@ -2239,6 +2274,147 @@ exit:
  	return ret;
  }
  
@@ -190,7 +190,7 @@
  static int rtl8224_mdi_config_order(struct phy_device *phydev)
  {
  	struct device_node *np = phydev->mdio.dev.of_node;
-@@ -2282,6 +2458,10 @@ static int rtl8224_config_init(struct ph
+@@ -2293,6 +2469,10 @@ static int rtl8224_config_init(struct ph
  {
  	int ret;
  


### PR DESCRIPTION
Adds support for the LTC Velo7 Max, an MT7988A based Wi-Fi 7 router, together with the PHY fix its 10G ports turned out to need.

## Hardware

| | |
|---|---|
| SoC | MediaTek MT7988A, 4x Cortex-A73 @ 1.8 GHz |
| RAM | 1/4/8 GiB DDR4 (2x ESMT M16U4G16256A in FCC documents) |
| Flash | 256 MiB Winbond W25N02KV SPI-NAND, managed by NMBM |
| WiFi | MediaTek MT7996 802.11be tri-band (2.4/5/6 GHz), attached to both 2-lane PCIe interfaces |
| Ethernet | 4x 1GbE from the built-in switch, 2x 10GbE via Realtek RTL8261BE using USXGMII |
| USB | 2x USB 3.0 Type-A |
| Buttons | Reset, WPS, Reboot |
| LEDs | Power, Status (RGB), WLAN 2.4/5/6 GHz, WPS, TEL1 and TEL2 (each red and green), plus dual LEDs on all six RJ-45 sockets |
| UART | 115200 8N1, unpopulated 3-pin 2.54mm header on the bottom edge of the board, which stands vertically. The pins are RX, GND, TX, the middle one carrying no label |
| Power | 12 VDC 3 A, barrel connector |

Also sold as the Tozed Kangwei ZLT W19B6VM. FCC ID `2A5LO-VL7M19K`.

eMMC and two telephony SLICs with their RJ-12 sockets are unpopulated on this variant and hence not described.

The serial console has been tested and works as-is; only the header pins themselves need fitting, which pogo pins can avoid too.

The LEDs of the two 10G RJ-45 sockets are left in the default behaviour of the RTL8261BE. The PHY driver offers no means of controlling them, and the part very likely has more LED outputs than the two used per socket, with neither the selection nor the order of them known, so they cannot be described in the device tree at this point.

## `kernel: net: phy: realtek: USXGMII bring-up work-around`

The USXGMII block of the RTL8261N does not always settle once the media side link has been established. Where it does not, the link is brought up and then dropped again shortly afterwards, while autonegotiation on the media side keeps completing normally. `ethtool` therefore reports negotiated speed and duplex next to `Link: no`, and nothing at all is logged.

MediaTek carry a work-around for exactly this in their SDK, written by Bo-Cun Chen, applied from `mtk_mac_link_up()` in the MT7988 ethernet driver. As the quirk is a property of the PHY rather than of the SoC, it is carried in the Realtek driver here instead so that the PHY also behaves on other hosts.

The SDK busy-waits a flat second in the link-up path and then resets the block unconditionally. This version instead polls the SerDes link status through the PHY's indirect register window and only pulses the reset while the link is still down, from a delayed work so that the PHY state machine is never blocked.

It is hooked into both 10 Gbps driver entries which share the base PHY ID. The parts this was observed on carry an `RTL8261BE` package marking while binding to the `RTL8261N` driver entry, the two being told apart solely by a vendor version register, so covering only one of them would be fragile.

## `mediatek: add support for LTC Velo7 Max`

### MAC addresses

| | Source |
|---|---|
| LAN | Factory 0x4, minus 2 |
| WAN | Factory 0x4, minus 1 |
| WLAN | Factory 0x4, 0xa and 0x2c0 |

Only the three WLAN addresses are stored in flash, as part of the MT7996 EEPROM. Both Ethernet addresses are derived from the first of them by subtraction, which is how the vendor firmware assigns them. Also matching the vendor firmware, the built-in switch and the 10G LAN port share the LAN address, and the default network configuration bridges `lan0`-`lan3` with `eth1` for LAN and uses `eth2` for WAN, so an existing configuration survives the switch to OpenWrt.

### Bootloader

MediaTek U-Boot using the SDK dual-boot scheme: two sets of UBI volumes, `kernel`/`rootfs` and `kernel2`/`rootfs2`, selected by the U-Boot environment variable `dual_boot.current_slot`. The environment itself lives in the `u-boot-env` UBI volume rather than in a raw MTD partition. U-Boot verifies the kernel FIT and, separately, a hash over the squashfs which it takes from a top-level `rootfs` node of that FIT, falling back to the other slot should either check fail.

`platform_do_upgrade()` therefore writes both volume sets, so that whichever slot the bootloader selects carries the new firmware, and clears any invalid marker left behind by an earlier failed boot. The flashing half is shared with `netgear,eax17`, which uses the same scheme.

### Installation

The vendor firmware is itself OpenWrt based and its `sysupgrade` accepts the OpenWrt image directly.
⚠️***It is patched to not reboot unless `-R` is passed and then just halts/hangs after flashing has completed*** ⚠️, and it always writes to whichever slot is currently inactive:

```
sysupgrade -R openwrt-mediatek-filogic-ltc_vl7m19k-squashfs-sysupgrade.bin
```

The vendor sysupgrade preserves `rootfs_data` no matter what, so run `firstboot` once OpenWrt has come up in order to discard the vendor overlay.

