### PR TITLE
ramips: add support for BUFFALO WEX-1800AX4

### DIFF
--- a/target/linux/ramips/dts/mt7621_buffalo_wex-1800ax4.dts
+++ b/target/linux/ramips/dts/mt7621_buffalo_wex-1800ax4.dts
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "buffalo,wex-1800ax4", "mediatek,mt7621-soc";
+	model = "Buffalo WEX-1800AX4";
+
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_orange;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8 ubi.block=0,rootfs root=/dev/ubiblock0_0";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_orange: led-0 {
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_ORANGE>;
+			function = LED_FUNCTION_POWER;
+		};
+
+		/* Wi-Fi upstream (AP-Extender) */
+		led-1 {
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+		};
+
+		led_power_green: led-2 {
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+		};
+
+		led-3 {
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WPS;
+		};
+
+		/* Wi-Fi upstream (AP-Extender) */
+		led-4 {
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_ORANGE>;
+			function = LED_FUNCTION_WAN;
+		};
+
+		/* Wi-Fi downstream (Extender-Client) */
+		led-5 {
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-wps {
+			label = "wps";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		/*
+		 * Wi-Fi bands between AP and extender
+		 * - AUTO (GPIO:high): 2.4GHz or 5GHz
+		 * - 5GHz (GPIO:low) : only 5GHz
+		 */
+		switch-auto {
+			label = "auto";
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_bdata_mac 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+	pinctrl-0 = <&nand_pins>;
+	pinctrl-names = "default";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "u-boot-env";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x80000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
+				precal_factory_e10: precal@e10 {
+					reg = <0xe10 0x19c10>;
+				};
+			};
+		};
+
+		/* stock: "Kernel" */
+		partition@180000 {
+			label = "kernel";
+			reg = <0x180000 0x1800000>;
+		};
+
+		partition@1980000 {
+			label = "Kernel2";
+			reg = <0x1980000 0x1800000>;
+		};
+
+		partition@3180000 {
+			label = "glbcfg";
+			reg = <0x3180000 0x200000>;
+			read-only;
+		};
+
+		partition@3380000 {
+			label = "board_data";
+			reg = <0x3380000 0x200000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "ascii-eq-delim-env";
+
+				macaddr_bdata_mac: mac {
+					compatible = "mac-base";
+					#nvmem-cell-cells = <1>;
+				};
+			};
+		};
+
+		/* stock: "User_data" */
+		partition@3580000 {
+			label = "ubi";
+			reg = <0x3580000 0x1800000>;
+		};
+
+		partition@4d80000 {
+			label = "glbcfg2";
+			reg = <0x4d80000 0x200000>;
+			read-only;
+		};
+
+		partition@4f80000 {
+			label = "board_data2";
+			reg = <0x4f80000 0x200000>;
+			read-only;
+		};
+	};
+};
+
+/*
+ * pcie0: MT7915D HIF (14c3,7916)
+ * pcie1: MT7915D     (14c3,7915)
+ */
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>, <&precal_factory_e10>;
+		nvmem-cell-names = "eeprom", "precal";
+		mediatek,disable-radar-background;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		band@0 {
+			reg = <0>;
+			nvmem-cells = <&macaddr_bdata_mac 1>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		band@1 {
+			reg = <1>;
+			nvmem-cells = <&macaddr_bdata_mac 8>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&pcie2 {
+	status = "disabled";
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag", "uart3", "wdt";
+		function = "gpio";
+	};
+};
+
+&usb_phy {
+	status = "disabled";
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -620,6 +620,21 @@ define Device/belkin_rt1800
 endef
 TARGET_DEVICES += belkin_rt1800
 
+define Device/buffalo_wex-1800ax4
+  $(Device/dsa-migration)
+  DEVICE_VENDOR := Buffalo
+  DEVICE_MODEL := WEX-1800AX4
+  KERNEL_SIZE := 8192k
+  KERNEL_LOADADDR := 0x82000000
+  KERNEL := kernel-bin | relocate-kernel $(loadaddr-y) | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  IMAGE/sysupgrade.bin := \
+	buffalo-trx 0x38315841 $(KDIR)/tmp/$$(DEVICE_NAME).null | \
+	sysupgrade-tar kernel=$$$$@ | append-metadata
+  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+endef
+TARGET_DEVICES += buffalo_wex-1800ax4
+
 define Device/buffalo_wsr-1166dhp
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -46,6 +46,7 @@ ramips_setup_interfaces()
 	arcadyan,we410443|\
 	asus,rp-ac56|\
 	asus,rp-ac87|\
+	buffalo,wex-1800ax4|\
 	cudy,ap1300-outdoor-v1|\
 	dlink,dap-1620-b1|\
 	dlink,dap-x1860-a1|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -83,6 +83,7 @@ platform_do_upgrade() {
 	beeline,smartbox-turbo|\
 	beeline,smartbox-turbo-plus|\
 	belkin,rt1800|\
+	buffalo,wex-1800ax4|\
 	dlink,covr-x1860-a1|\
 	dlink,dap-x1860-a1|\
 	dlink,dir-1360-a1|\


### PR DESCRIPTION
BUFFALO WEX-1800AX4 is a 2.4/5 GHz band 11ax (Wi-Fi 6) Wi-Fi/Mesh Extender, based on MT7621A.

Specification:

- SoC            : MediaTek MT7621A
- RAM            : DDR3L 256 MiB (Winbond W632GU6NB-11)
- Flash          : RAW-NAND 128 MiB (KIOXIA TC58BVG0S3HTA00)
- WLAN           : 2.4/5 GHz 2T2R (MediaTek MT7915D)
- Ethernet       : 1x 10/100/1000 Mbps
  - switch       : MediaTek MT7530 (SoC)
- LEDs/Keys(GPIO): 6x/3x
- UART           : through-hole on PCB (J4)
  - assignment   : 3.3V, GND, TX, RX from tri-angle marking
  - settings     : 115200n8
- Power          : 100 VAC (50/60 Hz), 0.2 A (Max. 11.3 W)
  - ac/dc board  : F12W-120100SP-0P REV:05

Flash instruction using initramfs image:

1. Prepare a TFTP server with 192.168.11.2
2. Rename an initramfs image to "linux.trx-recovery" and put it to the TFTP directory
3. Hold the WPS button and power on WEX-1800AX4, release after 7~ seconds
4. The bootloader automatically downloads the initramfs image and boots with it
5. After booting, upload a sysupgrade image to the device and perform sysupgrade with it
6. Wait ~120 seconds to complete flashing

Notes:

- WEX-1800AX4 has 2x OS images ("Kernel"/"Kernel2"), but the second one is only for buckup and not used for booting.

  image handling on the bootloader:

  - "Kernel" is broken   : "Kernel2" --(copy)--> "Kernel"
  - "Kernel2" is broken  : "Kernel" --(copy)--> "Kernel2"
  - "Kernel" != "Kernel2": "Kernel" --(copy)--> "Kernel2"

- Any BMT feature on the NAND chip are not enabled on the stock bootloader and stock firmware.

MAC Addresses:

LAN    : 68:E1:DC:xx:xx:40 (board_data, "mac" (text))
2.4 GHz: 68:E1:DC:xx:xx:41
5 GHz  : 68:E1:DC:xx:xx:48
