### PR TITLE
realtek: arch: add rtl960x compatibles

### DIFF
--- a/target/linux/realtek/patches-6.18/300-02-enhance-realtek-board-setup.patch
+++ b/target/linux/realtek/patches-6.18/300-02-enhance-realtek-board-setup.patch
@@ -375,7 +375,7 @@ Signed-off-by: Markus Stockhausen <markus.stockhausen@gmx.de>
  
  	if (fdt_check_header(fdt))
  		panic("Corrupt DT");
-@@ -69,11 +409,28 @@ static __init const void *realtek_fixup_
+@@ -69,11 +409,32 @@ static __init const void *realtek_fixup_
  }
  
  static const struct of_device_id realtek_of_match[] __initconst = {
@@ -396,6 +396,10 @@ Signed-off-by: Markus Stockhausen <markus.stockhausen@gmx.de>
 +	{ .compatible = "realtek,rtl9312-soc" },
 +	{ .compatible = "realtek,rtl9313-soc" },
 +	{ .compatible = "realtek,rtl931x-soc" },
++	{ .compatible = "realtek,rtl8198d-soc" },
++	{ .compatible = "realtek,rtl9607-soc" },
++	{ .compatible = "realtek,rtl9607c-soc" },
++	{ .compatible = "realtek,rtl960x-soc" },
  	{}
  };
  


### PR DESCRIPTION
When the realtek target was converted to generic machine initialization in https://github.com/openwrt/openwrt/pull/24390, the rtl960x were not included into of_device_id compatibles.
 
Fix this by adding the rtl960x compatibles and all relevant chip variants. Booting with https://github.com/openwrt/openwrt/pull/20064 changes works now.

<details>

<summary>Working bootlog</summary>

```
[    0.000000] Linux version 6.18.39 (binguy@binpc) (mips-openwrt-linux-musl-gcc (OpenWrt GCC 14.4.0 r35006+617-a9b5937015) 14.4.0, GNU ld (GNU Binutils) 2.46.1) #0 SMP Sat Aug  1 09:51:19 2026
[    0.000000] printk: legacy bootconsole [early0] enabled
[    0.000000] CPU0 revision is: 0001a120 (MIPS interAptiv (multi))
[    0.000000] Realtek RTL9607C subtype 18 rev B (6831) SoC with 256 MB
[    0.000000] Adding initrd info from environment
[    0.000000] MIPS: machine is BT-PON BT-G711AX
[    0.000000] earlycon: ns16550a0 at MMIO 0x18002000 (options '115200n8')
[    0.000000] printk: legacy bootconsole [ns16550a0] enabled
[    0.000000] Initrd not found or empty - disabling initrd
[    0.000000] OF: reserved mem: Reserved memory: No reserved-memory node in the DT
[    0.000000] VPE topology {2,2} total 4
[    0.000000] Primary instruction cache 64kB, VIPT, 4-way, linesize 32 bytes.
[    0.000000] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.000000] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    0.000000] Zone ranges:
[    0.000000]   Normal   [mem 0x0000000000000000-0x000000000fffffff]
[    0.000000]   HighMem  empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000000000-0x000000000fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x000000000fffffff]
[    0.000000] percpu: Embedded 12 pages/cpu s18704 r8192 d22256 u49152
[    0.000000] pcpu-alloc: s18704 r8192 d22256 u49152 alloc=12*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 [0] 2 [0] 3 
[    0.000000] Kernel command line: earlycon
[    0.000000] printk: log buffer data + meta data: 131072 + 409600 = 540672 bytes
[    0.000000] Dentry cache hash table entries: 32768 (order: 5, 131072 bytes, linear)
[    0.000000] Inode-cache hash table entries: 16384 (order: 4, 65536 bytes, linear)
[    0.000000] Writing ErrCtl register=00000000
[    0.000000] Readback ErrCtl register=00000000
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 65536
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] SLUB: HWalign=32, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000]  Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] RCU Tasks Trace: Setting shift to 2 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=4.
[    0.000000] NR_IRQS: 256
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.000000] rtl83xx-clk: initialized, CPU 1150 MHz, MEM 666 MHz (16 Bit DDR3), LXB 200 MHz
[    0.000000] No 'frequency' property in DT, using default.
[    0.000000] clocksource: realtek_otto_timer: mask: 0xfffffff max_cycles: 0xfffffff, max_idle_ns: 38225208801 ns
[    0.000002] sched_clock: 28 bits at 3125kHz, resolution 320ns, wraps every 42949672800ns
[    0.009235] Calibrating delay loop... 761.03 BogoMIPS (lpj=3805184)
[    0.056047] pid_max: default: 32768 minimum: 301
[    0.069382] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.077559] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.100808] rcu: Hierarchical SRCU implementation.
[    0.106181] rcu:     Max phase no-delay instances is 1000.
[    0.113619] smp: Bringing up secondary CPUs ...
[    0.120028] Primary instruction cache 64kB, VIPT, 4-way, linesize 32 bytes.
[    0.120063] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.120074] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    0.120160] CPU1 revision is: 0001a120 (MIPS interAptiv (multi))
[    0.146353] Counter synchronization [CPU#0 -> CPU#1]:
[    0.181367] Measured 3 cycles counter warp between CPUs
[    0.183804] Primary instruction cache 64kB, VIPT, 4-way, linesize 32 bytes.
[    0.183842] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.183853] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    0.183900] CPU2 revision is: 0001a120 (MIPS interAptiv (multi))
[    0.218911] Counter synchronization [CPU#0 -> CPU#2]:
[    0.259731] Measured 2 cycles counter warp between CPUs
[    0.261398] Primary instruction cache 64kB, VIPT, 4-way, linesize 32 bytes.
[    0.261426] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.261437] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    0.261494] CPU3 revision is: 0001a120 (MIPS interAptiv (multi))
[    0.287696] Counter synchronization [CPU#0 -> CPU#3]: passed
[    0.329430] smp: Brought up 1 node, 4 CPUs
[    0.335952] Memory: 239452K/262144K available (8419K kernel code, 652K rwdata, 1752K rodata, 7472K init, 245K bss, 21312K reserved, 0K cma-reserved, 0K highmem)
[    0.355680] posixtimers hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.364186] futex hash table entries: 1024 (32768 bytes on 1 NUMA nodes, total 32 KiB, linear).
[    0.378821] pinctrl core: initialized pinctrl subsystem
[    0.387325] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.394569] thermal_sys: Registered thermal governor 'step_wise'
[    0.394896] FPU Affinity set after 15220 emulations
[    0.426616] clocksource: Switched to clocksource realtek_otto_timer
[    0.441723] NET: Registered PF_INET protocol family
[    0.447543] IP idents hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.456770] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.466140] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.474833] TCP established hash table entries: 2048 (order: 1, 8192 bytes, linear)
[    0.483451] TCP bind hash table entries: 2048 (order: 3, 32768 bytes, linear)
[    0.491578] TCP: Hash tables configured (established 2048 bind 2048)
[    0.499414] MPTCP token hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.507917] UDP hash table entries: 256 (order: 2, 14336 bytes, linear)
[    0.515365] UDP-Lite hash table entries: 256 (order: 2, 14336 bytes, linear)
[    0.524312] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.532826] workingset: timestamp_bits=14 max_order=16 bucket_order=2
[    0.545612] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.552294] jffs2: version 2.2 (NAND) (SUMMARY) (ZLIB) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.574478] pinctrl-single 1b000038.pinmux: 96 pins, size 12
[    0.701199] Serial: 8250/16550 driver, 2 ports, IRQ sharing disabled
[    0.710131] printk: legacy console [ttyS0] disabled
[    0.716243] 18002000.uart: ttyS0 at MMIO 0x18002000 (irq = 23, base_baud = 12500000) is a 16550A
[    0.726165] printk: legacy console [ttyS0] enabled
[    0.726165] printk: legacy console [ttyS0] enabled
[    0.736943] printk: legacy bootconsole [early0] disabled
[    0.736943] printk: legacy bootconsole [early0] disabled
[    0.749109] printk: legacy bootconsole [ns16550a0] disabled
[    0.749109] printk: legacy bootconsole [ns16550a0] disabled
[    0.790090] brd: module loaded
[    0.795487] spi-nand spi0.0: Winbond SPI NAND was found.
[    0.801555] spi-nand spi0.0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
[    0.810917] 5 fixed-partitions partitions found on MTD device spi0.0
[    0.818062] Creating 5 MTD partitions on "spi0.0":
[    0.823403] 0x000000000000-0x0000000e0000 : "u-boot"
[    0.830626] 0x0000000e0000-0x000000100000 : "u-boot-env"
[    0.838728] 0x000000100000-0x000000120000 : "u-boot-env2"
[    0.847627] 0x000000120000-0x000000140000 : "static_conf"
[    0.855533] 0x000000140000-0x000007d80000 : "ubi"
[    0.962674] i2c_dev: i2c /dev entries driver
[    0.971536] NET: Registered PF_INET6 protocol family
[    0.983551] Segment Routing with IPv6
[    0.987875] In-situ OAM (IOAM) with IPv6
[    0.992378] NET: Registered PF_PACKET protocol family
[    0.998190] 8021q: 802.1Q VLAN Support v1.8
[    1.037384] UBI: auto-attach mtd4
[    1.041127] ubi0: attaching mtd4
[    1.918275] ubi0: scanning is finished
[    1.978889] ubi0: attached mtd4 (name "ubi", size 124 MiB)
[    1.985136] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
[    1.992841] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
[    2.000426] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
[    2.008201] ubi0: good PEBs: 994, bad PEBs: 0, corrupted PEBs: 0
[    2.014899] ubi0: user volume: 5, internal volumes: 1, max. volumes count: 128
[    2.022959] ubi0: max/mean erase counter: 7/2, WL threshold: 4096, image sequence number: 1312284411
[    2.033182] ubi0: available PEBs: 303, total reserved PEBs: 691, PEBs reserved for bad PEB handling: 20
[    2.043739] ubi0: background thread "ubi_bgt0d" started, PID 367
[    2.043931] clk: Disabling unused clocks
[    2.089744] Freeing unused kernel image (initmem) memory: 7472K
[    2.096382] This architecture does not have kernel memory protection.
[    2.103593] Run /init as init process
[    2.107687]   with arguments:
[    2.110986]     /init
[    2.113512]   with environment:
[    2.117023]     HOME=/
[    2.119645]     TERM=linux
[    2.453149] init: Console is alive
[    2.457947] init: - watchdog -
[    2.472733] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    2.481454] gpio_button_hotplug: loading out-of-tree module taints kernel.
[    2.494545] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    2.513118] init: - preinit -
[    2.906661] random: crng init done
BusyBox v1.38.0 (2026-05-13 02:19:59 UTC) multi-call binary.

Usage: basename FILE [SUFFIX] | -a FILE... | -s SUFFIX FILE...

Strip directory path and SUFFIX from FILE

        -a              All arguments are FILEs
        -s SUFFIX       Remove SUFFIX (implies -a)
Cannot parse config file '/etc/fw_env.config': No such file or directory
Failed to find NVMEM device
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level
cfg016cb7
cfg02a9ad
grep: /etc/fw_env.config: No such file or directory
grep: /etc/fw_sys.config: No such file or directory
- generating board file -
[    7.756709] procd: - early -
[    7.760306] procd: - watchdog -
[    8.351128] procd: - watchdog -
[    8.355028] procd: - ubus -
[    8.413564] procd: - init -
Please press Enter to activate this console.
[    8.846836] kmodloader: loading kernel modules from /etc/modules.d/*
[    8.925295] kmodloader: done loading kernel modules from /etc/modules.d/*
[    9.795997] urngd: v1.0.2 started.



BusyBox v1.38.0 (2026-05-13 02:19:59 UTC) built-in shell (ash)

  _______                     ________        __
 |       |.-----.-----.-----.|  |  |  |.----.|  |_
 |   -   ||  _  |  -__|     ||  |  |  ||   _||   _|
 |_______||   __|_____|__|__||________||__|  |____|
          |__| W I R E L E S S   F R E E D O M
 -----------------------------------------------------
 OpenWrt SNAPSHOT, r35006+617-a9b5937015
 -----------------------------------------------------

 === WARNING! =====================================
 There is no root password defined on this device!
 Use the "passwd" command to set up a new password
 in order to prevent unauthorized SSH logins.
 --------------------------------------------------

root@OpenWrt:~# 

```

</details>