### PR TITLE
qualcommax: ipq807x: 301w: read the port MAC addresses from ART

### DIFF
--- a/target/linux/qualcommax/dts/ipq8072-301w.dts
+++ b/target/linux/qualcommax/dts/ipq8072-301w.dts
@@ -322,6 +322,36 @@
 				label = "0:art";
 				reg = <0x370000 0x40000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_lan4: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_lan3: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+
+					macaddr_lan2: macaddr@c {
+						reg = <0xc 0x6>;
+					};
+
+					macaddr_lan1: macaddr@12 {
+						reg = <0x12 0x6>;
+					};
+
+					macaddr_10g_1: macaddr@18 {
+						reg = <0x18 0x6>;
+					};
+
+					macaddr_10g_2: macaddr@1e {
+						reg = <0x1e 0x6>;
+					};
+				};
 			};
 
 			partition@3b0000 {
@@ -466,6 +496,8 @@
 			phy-handle = <&qca8075_16>;
 			phy-mode = "qsgmii";
 			pcs-handle = <&uniphy0 0>;
+			nvmem-cells = <&macaddr_lan4>;
+			nvmem-cell-names = "mac-address";
 		};
 
 		lan3: port@2 {
@@ -474,6 +506,8 @@
 			phy-handle = <&qca8075_17>;
 			phy-mode = "qsgmii";
 			pcs-handle = <&uniphy0 1>;
+			nvmem-cells = <&macaddr_lan3>;
+			nvmem-cell-names = "mac-address";
 		};
 
 		lan2: port@3 {
@@ -482,6 +516,8 @@
 			phy-handle = <&qca8075_18>;
 			phy-mode = "qsgmii";
 			pcs-handle = <&uniphy0 2>;
+			nvmem-cells = <&macaddr_lan2>;
+			nvmem-cell-names = "mac-address";
 		};
 
 
@@ -491,6 +527,8 @@
 			phy-handle = <&qca8075_19>;
 			phy-mode = "qsgmii";
 			pcs-handle = <&uniphy0 3>;
+			nvmem-cells = <&macaddr_lan1>;
+			nvmem-cell-names = "mac-address";
 		};
 
 		port_10g_1: port@5 {
@@ -500,6 +538,8 @@
 			phy-mode = "usxgmii";
 			managed = "in-band-status";
 			pcs-handle = <&uniphy1 0>;
+			nvmem-cells = <&macaddr_10g_1>;
+			nvmem-cell-names = "mac-address";
 		};
 
 		port_10g_2: port@6 {
@@ -509,6 +549,8 @@
 			phy-mode = "usxgmii";
 			managed = "in-band-status";
 			pcs-handle = <&uniphy2 0>;
+			nvmem-cells = <&macaddr_10g_2>;
+			nvmem-cell-names = "mac-address";
 		};
 	};
 };

--- a/target/linux/qualcommax/dts/ipq8072-301w.dts
+++ b/target/linux/qualcommax/dts/ipq8072-301w.dts
@@ -322,6 +322,36 @@
 				label = "0:art";
 				reg = <0x370000 0x40000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_lan4: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_lan3: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+
+					macaddr_lan2: macaddr@c {
+						reg = <0xc 0x6>;
+					};
+
+					macaddr_lan1: macaddr@12 {
+						reg = <0x12 0x6>;
+					};
+
+					macaddr_10g_1: macaddr@18 {
+						reg = <0x18 0x6>;
+					};
+
+					macaddr_10g_2: macaddr@1e {
+						reg = <0x1e 0x6>;
+					};
+				};
 			};
 
 			partition@3b0000 {
@@ -466,6 +496,8 @@
 			phy-handle = <&qca8075_16>;
 			phy-mode = "qsgmii";
 			pcs-handle = <&uniphy0 0>;
+			nvmem-cells = <&macaddr_lan4>;
+			nvmem-cell-names = "mac-address";
 		};
 
 		lan3: port@2 {
@@ -474,6 +506,8 @@
 			phy-handle = <&qca8075_17>;
 			phy-mode = "qsgmii";
 			pcs-handle = <&uniphy0 1>;
+			nvmem-cells = <&macaddr_lan3>;
+			nvmem-cell-names = "mac-address";
 		};
 
 		lan2: port@3 {
@@ -482,6 +516,8 @@
 			phy-handle = <&qca8075_18>;
 			phy-mode = "qsgmii";
 			pcs-handle = <&uniphy0 2>;
+			nvmem-cells = <&macaddr_lan2>;
+			nvmem-cell-names = "mac-address";
 		};
 
 
@@ -491,6 +527,8 @@
 			phy-handle = <&qca8075_19>;
 			phy-mode = "qsgmii";
 			pcs-handle = <&uniphy0 3>;
+			nvmem-cells = <&macaddr_lan1>;
+			nvmem-cell-names = "mac-address";
 		};
 
 		port_10g_1: port@5 {
@@ -499,6 +537,8 @@
 			phy-handle = <&aqr113c_8>;
 			phy-mode = "usxgmii";
 			pcs-handle = <&uniphy1 0>;
+			nvmem-cells = <&macaddr_10g_1>;
+			nvmem-cell-names = "mac-address";
 		};
 
 		port_10g_2: port@6 {
@@ -507,6 +547,8 @@
 			phy-handle = <&aqr113c_0>;
 			phy-mode = "usxgmii";
 			pcs-handle = <&uniphy2 0>;
+			nvmem-cells = <&macaddr_10g_2>;
+			nvmem-cell-names = "mac-address";
 		};
 	};
 };


### PR DESCRIPTION
Since the PPE conversion the 301w brings `lan1`, `lan2`, `10g-1` and `10g-2` up with no MAC
address of their own. As DSA user ports they inherit the conduit's, so four ports and
`br-lan` all answer to the same address. Only `lan4` and `lan3` still get one patched in,
though the board names all six for the bootloader, in
`target/linux/qualcommax/dts/ipq8072-301w.dts`:

```
	ethernet0 = &lan4;
	ethernet1 = &lan3;
	ethernet2 = &lan2;
	ethernet3 = &lan1;
	ethernet4 = &port_10g_1;
	ethernet5 = &port_10g_2;
```

The addresses it hands out sit in a table at the start of `0:art`, one 6-byte slot per alias.
This describes those six slots as nvmem cells and points each port at its own, so the ports
read them whatever the bootloader does. `ipq8071-ax3600.dtsi` describes its own ART table the
same way.

@xlighting2017 hexdumped `0:art` on a 301w: slots 0 to 5 hold six consecutive addresses, the
rest of the first 48 bytes `ff`. The same unit on `r35301-d47ce71a89`, the last snapshot
before f50435627d37, brought lan4 up on slot 0 through 10g-2 on slot 5
(openwrt/openwrt#19121). That answers the open question from #24512, where this commit first
sat. It is split out here because it does not depend on that change.

I have no 301w here, so that is a user's dump and a user's boot log, not a board on my bench.
Nobody has flashed this branch on a 301w yet.

This does not change a port that works today: the nvmem cell is the last source consulted,
and an all-`ff` slot is not a valid address, so an unprovisioned port keeps the behaviour it
has now. `net/core/of_net.c, of_get_mac_address():`

```c
	ret = of_get_mac_addr(np, "mac-address", addr);
	if (!ret)
		return 0;

	ret = of_get_mac_addr(np, "local-mac-address", addr);
	if (!ret)
		return 0;

	ret = of_get_mac_addr(np, "address", addr);
	if (!ret)
		return 0;

	return of_get_mac_address_nvmem(np, addr);
```
