### PR TITLE
ramips: iptime,t5004: fix U-Boot environment size

### DIFF
--- a/target/linux/ramips/dts/mt7621_iptime_t5004.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_t5004.dts
@@ -58,7 +58,7 @@
 
 			nvmem-layout {
 				compatible = "u-boot,env";
-				env-size = <0x1000>;
+				env-size = <0x20000>;
 
 				macaddr_uboot_ethaddr: ethaddr {
 					#nvmem-cell-cells = <1>;


### PR DESCRIPTION
The U-Boot environment on ipTIME T5004 occupies a 128 KiB NAND erase block.

The existing NVMEM layout incorrectly sets env-size to 0x1000.
As a result, the u-boot,env parser calculates the CRC over only the
first 4 KiB and rejects the environment with -EINVAL.

Set env-size to 0x20000 to match the actual erase-block size.
This allows the existing NVMEM MAC address cells to be created correctly.

Tested on a retail ipTIME T5004:
- Ethernet MAC addresses are correctly provided through NVMEM.
- WAN uses the expected MAC address offset.