### PR TITLE
bcm53xx: fix sysupgrade config loss / mt7622: drop unused file_type variable

### DIFF
--- a/target/linux/bcm53xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/bcm53xx/base-files/lib/upgrade/platform.sh
@@ -237,7 +237,7 @@ platform_do_upgrade_nand_trx() {
 	}
 
 	# Firmwares without UBI image should be flashed "normally"
-	local root_type=$(identify $dir/root)
+	local root_type=$(identify "$dir/root" "cat")
 	[ "$root_type" != "ubi" ] && {
 		echo "Provided firmware doesn't use UBI for rootfs."
 		return

--- a/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
@@ -3,7 +3,6 @@ RAMFS_COPY_BIN='fitblk fit_check_sign'
 
 platform_do_upgrade() {
 	local board=$(board_name)
-	local file_type=$(identify $1)
 
 	case "$board" in
 	bananapi,bpi-r64|\


### PR DESCRIPTION
Since 24.10.0-rc1 a bcm53xx NAND device always comes back at factory defaults after a flash, as if `-n` had been passed.

The UBI check fails and sysupgrade falls back to a raw whole image write, which cannot carry `sysupgrade.tgz` into the new `rootfs_data`.

Affects bcm53xx NAND devices flashed with a trx based image.

The fix lives in the firmware doing the flashing, so upgrading from an affected build loses the config one last time. Every upgrade from a fixed build onwards keeps it.

Build tested on main with kernel 6.18, Asus RT-N18U, three consecutive sysupgrades, config preserved every time.

The second commit removes a dead file_type assignment in mt7622, the only other caller still on the old identify argument order after 715634e6d144. It is included here because both commits clean up callers left stale by the same change; the review bot requested it during review.

The first commit can be backported to openwrt-24.10 and openwrt-25.12.

Fixes: https://github.com/openwrt/openwrt/issues/21024
Fixes: https://github.com/openwrt/openwrt/issues/21655