### PR TITLE
ramips: fix PCIe reset GPIOs for ipTIME A8004T

### DIFF
--- a/target/linux/ramips/dts/mt7621_iptime_a8004t.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_a8004t.dts
@@ -168,6 +168,9 @@
 
 &pcie {
 	status = "okay";
+
+	reset-gpios = <&gpio 19 GPIO_ACTIVE_LOW>,
+			<&gpio 8 GPIO_ACTIVE_LOW>;
 };
 
 &pcie0 {
@@ -192,7 +195,7 @@
 
 &state_default {
 	gpio {
-		groups = "wdt", "jtag", "i2c";
+		groups = "wdt", "jtag", "i2c", "uart3";
 		function = "gpio";
 	};
 };


### PR DESCRIPTION
This fixes PCIe initialization failure after warm reboot on the ipTIME A8004T.

The issue has existed for this device for several years and was
reported as early as 2019. The problem was reproduced on a retail
ipTIME A8004T:

- Cold boot: PCIe devices initialize normally.
- Warm reboot: PCIe devices fail to initialize.

Related PCIe initialization issues have also been reported for other
MediaTek devices using mt76:

- https://github.com/openwrt/mt76/issues/421
- https://github.com/openwrt/mt76/issues/316

Those cases indicate that missing PCIe reset GPIO handling can prevent
wireless PCIe devices from being initialized correctly after reboot.

The same approach has already been applied successfully to other
MediaTek devices, such as the ZBT WG2626:

- https://github.com/openwrt/openwrt/commit/f953a1a4bfba2fa70c12bb80938aa66481a673b6
- https://github.com/openwrt/openwrt/pull/9810

The ipTIME A8004T requires two GPIO lines for PCIe reset:
- GPIO19
- GPIO8

GPIO8 is shared with UART3 and is configured for that function by
default, so it cannot be used as a GPIO until the pin state is
adjusted.

This patch follows the existing PCIe reset GPIO handling approach and
applies it to the ipTIME A8004T by adding the required reset GPIO
definitions and adjusting the pinmux state.

After this change, PCIe initialization succeeds after both cold boot
and warm reboot.

The fix has been tested successfully on a retail ipTIME A8004T.