### PR TITLE
qualcommax: qca_ppe: take both XLT indices before programming a VLAN

### DIFF
--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_vlan.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_vlan.c
@@ -231,18 +231,21 @@ int qca_ppe_port_vlan_add(struct dsa_switch *ds, int port,
 			return -ENOSPC;
 	}
 
-	entry->ports |= BIT(port);
-
 	if (entry->xlt_idx < 0) {
 		idx = ppe_xlt_idx_alloc(priv);
-		if (idx < 0) {
-			entry->ports &= ~BIT(port);
-			if (!entry->ports)
-				ppe_vlan_free(priv, entry);
-			return -ENOSPC;
-		}
+		if (idx < 0)
+			goto err_free_entry;
 		entry->xlt_idx = idx;
 	}
+
+	if (pvid && entry->xlt_pvid_idx < 0) {
+		idx = ppe_xlt_idx_alloc(priv);
+		if (idx < 0)
+			goto err_free_entry;
+		entry->xlt_pvid_idx = idx;
+	}
+
+	entry->ports |= BIT(port);
 
 	ppe_xlt_rule_set(priv, entry->xlt_idx,
 			 entry->ports | BIT(QCA_PPE_CPU_PORT), vid, false);
@@ -256,12 +259,6 @@ int qca_ppe_port_vlan_add(struct dsa_switch *ds, int port,
 		priv->port_pvid[port] = vid;
 		entry->pvid_ports |= BIT(port);
 
-		if (entry->xlt_pvid_idx < 0) {
-			idx = ppe_xlt_idx_alloc(priv);
-			if (idx < 0)
-				return -ENOSPC;
-			entry->xlt_pvid_idx = idx;
-		}
 		ppe_xlt_rule_set(priv, entry->xlt_pvid_idx,
 				 entry->pvid_ports, 0, true);
 		ppe_xlt_action_set(priv, entry->xlt_pvid_idx, entry->vsi,
@@ -277,6 +274,11 @@ int qca_ppe_port_vlan_add(struct dsa_switch *ds, int port,
 	ppe_vlan_members_update(priv, entry);
 
 	return 0;
+
+err_free_entry:
+	if (!entry->ports)
+		ppe_vlan_free(priv, entry);
+	return -ENOSPC;
 }
 
 int qca_ppe_port_vlan_del(struct dsa_switch *ds, int port,


### PR DESCRIPTION
`qca_ppe_port_vlan_add()` allocates two XLT indices. The first failure is rolled
back - the port is dropped from the entry and the entry freed if that emptied it.
The second, for the pvid rule, returned `-ENOSPC` having already written
`PPE_PORT_DEF_CVID` for the port, set `priv->port_pvid[port]` and added the port
to `entry->pvid_ports`.

DSA does not call `port_vlan_del()` after a failed `port_vlan_add()`, so none of
that was undone: the port kept a pvid in hardware that the driver's own state said
it did not have, and the next `ppe_vlan_pvid_update()` acted on a `pvid_ports` mask
including a port that was never programmed.

Take both indices before anything is programmed. Both failures then share the
rollback that already exists, and there is no half-written state to undo.

Not reachable today: `PPE_VSI_MAX * 2 == PPE_XLT_TBL_NUM`, so any arrangement that
exhausts the XLT pool has already given every entry its pvid index. That is an
accident of two constants rather than an invariant - raising `PPE_VSI_MAX` without
raising `PPE_XLT_TBL_NUM` opens it.
