### PR TITLE
tools: elfutils: fix uio header inclusion

### DIFF
--- a/tools/elfutils/patches/006-Fix-build-on-aarch64-musl.patch
+++ b/tools/elfutils/patches/006-Fix-build-on-aarch64-musl.patch
@@ -1,0 +1,44 @@
+From 578f370c7e7a9f056aefa062b34590b0aa13bce5 Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Tue, 15 Aug 2017 17:27:30 +0800
+Subject: [PATCH] Fix build on aarch64/musl
+
+Errors
+
+error: redefinition
+ of 'struct iovec'
+ struct iovec { void *iov_base; size_t iov_len; };
+        ^
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Rebase to 0.170
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+
+---
+ backends/aarch64_initreg.c | 2 +-
+ backends/arm_initreg.c     | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+--- a/backends/aarch64_initreg.c
++++ b/backends/aarch64_initreg.c
+@@ -33,7 +33,7 @@
+ #include "system.h"
+ #include <assert.h>
+ #if defined(__aarch64__) && defined(__linux__)
+-# include <linux/uio.h>
++# include <sys/uio.h>
+ # include <sys/user.h>
+ # include <sys/ptrace.h>
+ # include <asm/ptrace.h>
+--- a/backends/arm_initreg.c
++++ b/backends/arm_initreg.c
+@@ -38,7 +38,7 @@
+ #endif
+ 
+ #ifdef __aarch64__
+-# include <linux/uio.h>
++# include <sys/uio.h>
+ # include <sys/user.h>
+ # include <sys/ptrace.h>
+ /* Deal with old glibc defining user_pt_regs instead of user_regs_struct.  */


### PR DESCRIPTION
Fixes arm64 build failures by replacing <linux/uio.h> with POSIX <sys/uio.h>
to avoid header redefinition conflicts.

```
In file included from aarch64_initreg.c:36:
/usr/include/linux/uio.h:17:8: error: redefinition of 'struct iovec'
   17 | struct iovec
      |        ^~~~~
In file included from /usr/include/aarch64-linux-gnu/bits/fcntl-linux.h:38,
                 from /usr/include/aarch64-linux-gnu/bits/fcntl.h:55,
                 from /usr/include/fcntl.h:35,
                 from ../libgnu/fcntl.h:74,
                 from ../libgnu/unistd.h:117,
                 from /usr/include/aarch64-linux-gnu/bits/sigstksz.h:24,
                 from /usr/include/signal.h:328,
                 from ../libgnu/signal.h:52,
                 from /usr/include/aarch64-linux-gnu/sys/param.h:28,
                 from ../lib/system.h:47:
/usr/include/aarch64-linux-gnu/bits/types/struct_iovec.h:26:8: note: originally defined here
   26 | struct iovec
      |        ^~~~~
make[5]: *** [Makefile:2507: aarch64_initreg.o] Error 1
make[4]: *** [Makefile:2216: all-recursive] Error 1
make[3]: *** [Makefile:2123: all] Error 2
```