### PR TITLE
realtek: board: add patch to fix boot hang

### DIFF
--- a/target/linux/realtek/patches-6.18/300-03-realtek-board-increase-fixup_fdt-buffer-to-32-KiB.patch
+++ b/target/linux/realtek/patches-6.18/300-03-realtek-board-increase-fixup_fdt-buffer-to-32-KiB.patch
@@ -1,0 +1,31 @@
+From 71db5266327ac9462e39b5cc045af1e94e18f20f Mon Sep 17 00:00:00 2001
+From: Jonas Jelonek <jelonek.jonas@gmail.com>
+Date: Sun, 2 Aug 2026 19:06:31 +0000
+Subject: [PATCH] realtek: board: increase fixup_fdt buffer to 32 KiB
+
+realtek_fixup_fdt() copies the appended device tree into a fixed
+16 KiB buffer via apply_mips_fdt_fixups()/fdt_open_into(). Some
+Realtek reference boards with richer device trees, e.g. the Linksys
+LGS352C (RTL9311), exceed that size (its packed DT is ~20.8 KiB),
+so fdt_open_into() fails with -FDT_ERR_NOSPACE and the resulting
+panic("Unable to fixup FDT: %d", err) fires before any console is
+registered. The board then silently hangs without printing
+anything at all.
+
+Bump the buffer to 32 KiB to give existing and future boards enough
+headroom.
+
+Assisted-by: Claude:claude-sonnet-5
+Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
+
+--- a/arch/mips/generic/board-realtek.c
++++ b/arch/mips/generic/board-realtek.c
+@@ -390,7 +390,7 @@ static const struct mips_fdt_fixup realt
+ 
+ static __init const void *realtek_fixup_fdt(const void *fdt, const void *match_data)
+ {
+-	static unsigned char fdt_buf[16 << 10] __initdata;
++	static unsigned char fdt_buf[32 << 10] __initdata;
+ 	int err;
+ 	
+ 	realtek_prom_init();


### PR DESCRIPTION
Credits for this go to Claude, finding the issue pretty quickly.

cc @plappermaul 

---

Add a patch to fix boot hang on some devices after 7cc31af7bdd4 ("realtek: convert to generic machine initialization"), reusing upstream's implementation of Realtek board setup. The issue came up on a Linksys LGS352C device, causing total silence and a hang after rt-loader's last line "Booting kernel from 0x80100000 ...".

While the OpenWrt downstream version operated on the plain appended device tree using a pointer, the upstream implementation copies the FDT into a 16 KiB buffer. Given the following survey, this is too small for some devices:

```
  rtl9311_linksys_lgs352c:                21278 bytes
  rtl9313_ubnt_usw-pro-xg-8-poe:          12809 bytes
  rtl9313_hasivo_f5800w-12s-plus:         13103 bytes
  rtl9313_xikestor_sks8300-12x-v1:        13630 bytes
  rtl9313_zyxel_xs1930-12f:               14488 bytes
  rtl9313_zyxel_xs1930-12hp:              15234 bytes
  rtl9313_hasivo_s1300wp-8xgt-4s-plus:    15341 bytes
```

To fix this, the patch increases the buffer size, leaving some more headroom for further outliers.

Fixes: 7cc31af7bdd4 ("realtek: convert to generic machine initialization")
Assisted-by: Claude:claude-sonnet-5

---

EDIT: Same issue happens on Plasma Cloud PSX28, fix helps too.
