### PR TITLE
realtek: pcs: RTL931x RX calibration

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3120,6 +3120,16 @@ static void rtpcs_931x_sds_clear_symerr(struct rtpcs_serdes *sds,
 	}
 }
 
+static int rtpcs_931x_sds_rxeq_leq_set_adapt(struct rtpcs_serdes *sds, bool enable)
+{
+	return rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xd, 7, 7, enable ? 0x0 : 0x1);
+}
+
+static int rtpcs_931x_sds_rxeq_leq_set_coef(struct rtpcs_serdes *sds, unsigned int gain)
+{
+	return rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xd, 6, 2, gain);
+}
+
 /**
  * rtpcs_931x_sds_reset_leq_dfe() - Reset LEQ + DFE to a baseline.
  *
@@ -3149,6 +3159,16 @@ static int rtpcs_931x_sds_reset_leq_dfe(struct rtpcs_serdes *sds)
 	rtpcs_sds_write(sds, PAGE_ANA_10G_EXT, 0x12, 0xaaa); /* [11:8] VTHN | [7:4] VTHP */
 
 	return 0;
+}
+
+/*
+ * Disable DFE auto-adapt on the companion 5G analog block before
+ * calibrating this lane's 10G LEQ/DFE. Used by the vendor SDK's
+ * PHY-attached and PCB-adapt calibration paths.
+ */
+static int rtpcs_931x_sds_dfe_disable_5g(struct rtpcs_serdes *sds)
+{
+	return rtpcs_sds_write_bits(sds, PAGE_ANA_5G0, 0xf, 12, 6, 0x7f);
 }
 
 static int rtpcs_931x_sds_power(struct rtpcs_serdes *sds, bool power_on)
@@ -3210,7 +3230,6 @@ static int rtpcs_931x_sds_activate(struct rtpcs_serdes *sds)
 	return rtpcs_931x_sds_power(sds, true);
 }
 
-__maybe_unused
 static void rtpcs_931x_sds_rx_reset(struct rtpcs_serdes *sds)
 {
 	if (sds->type != RTPCS_SDS_TYPE_10G)
@@ -3227,6 +3246,29 @@ static void rtpcs_931x_sds_rx_reset(struct rtpcs_serdes *sds)
 	rtpcs_sds_write(sds, PAGE_ANA_MISC, 0x0, 0xc30);
 
 	msleep(50);
+}
+
+/*
+ * rtpcs_931x_sds_rxcal_leq_adapt() - RX calibration for PHY-attached ports.
+ *
+ * Vendor SDK: _phy_rtl9310_leq_adapt(). Used whenever the port has an
+ * external PHY attached, regardless of hw_mode - the PHY performs its own
+ * equalization, so this only resets LEQ and releases it back into
+ * auto-adapt. No TAP/VTH involvement.
+ */
+static void rtpcs_931x_sds_rxcal_leq_adapt(struct rtpcs_serdes *sds)
+{
+	rtpcs_931x_sds_rxeq_leq_set_coef(sds, 0);
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xd, 1, 0, 0x0);   /* undocumented */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xd, 13, 13, 0x0); /* undocumented */
+
+	rtpcs_931x_sds_dfe_disable_5g(sds);
+
+	rtpcs_931x_sds_rxeq_leq_set_adapt(sds, false);
+	rtpcs_931x_sds_rx_reset(sds);
+	msleep(10);
+	rtpcs_931x_sds_rxeq_leq_set_adapt(sds, true);
+	msleep(100);
 }
 
 static int rtpcs_931x_sds_get_pll_select(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type *pll)
@@ -3576,6 +3618,30 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 	/* Gating as mentioned above, deactivated here for non-10G and XSGMII */
 	if (!is_10g || hw_mode == RTPCS_SDS_MODE_XSGMII)
 		rtpcs_sds_write_bits(sds, DIGI_1(PAGE_WDIG), 0x1, 0, 0, 0x0);
+
+	return 0;
+}
+
+/*
+ * rtpcs_931x_sds_post_config() - RX calibration, run after power-up.
+ *
+ * Vendor SDK: _phy_rtl9310_rxCali(). Dispatches by attachment, mirroring
+ * the SDK's own split into separate calibration paths per attachment.
+ */
+static int rtpcs_931x_sds_post_config(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode)
+{
+	if (sds->type != RTPCS_SDS_TYPE_10G)
+		return 0;
+
+	switch (sds->attachment) {
+	case RTPCS_SDS_ATTACH_PHY:
+		rtpcs_931x_sds_rxcal_leq_adapt(sds);
+		break;
+
+	default:
+		/* TODO: fiber/DAC RX calibration */
+		break;
+	}
 
 	return 0;
 }
@@ -4284,6 +4350,7 @@ static const struct rtpcs_sds_ops rtpcs_931x_sds_ops = {
 	.config_hw_mode		= rtpcs_931x_sds_config_hw_mode,
 	.set_hw_mode		= rtpcs_931x_sds_set_mode,
 	.config_attachment	= rtpcs_931x_sds_config_attachment,
+	.post_config		= rtpcs_931x_sds_post_config,
 };
 
 static const struct rtpcs_config rtpcs_931x_cfg = {

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3089,6 +3089,11 @@ static int rtpcs_931x_sds_fiber_get_symerr(struct rtpcs_serdes *sds,
 	return symerr;
 }
 
+static bool rtpcs_931x_sds_10gr_link_up(struct rtpcs_serdes *sds)
+{
+	return rtpcs_sds_read_bits(sds, PAGE_TGR_STD_1, 0x0, 12, 12) == 1;
+}
+
 static void rtpcs_931x_sds_clear_symerr(struct rtpcs_serdes *sds,
 					enum rtpcs_sds_mode hw_mode)
 {
@@ -3438,6 +3443,7 @@ static void rtpcs_931x_sds_rxcal_fiber_adapt(struct rtpcs_serdes *sds)
 	unsigned int vth_p = 0, vth_n = 0, sum_p = 0, sum_n = 0;
 	struct device *dev = sds->ctrl->dev;
 	int i, samples = 0, symerr = -1;
+	bool link_up = false;
 
 	dev_dbg(dev, "SerDes %u fiber RX calibration...\n", sds->id);
 	/* per-port calibration offset in the SDK, kept 0 here */
@@ -3488,18 +3494,28 @@ static void rtpcs_931x_sds_rxcal_fiber_adapt(struct rtpcs_serdes *sds)
 		rtpcs_931x_sds_clear_symerr(sds, RTPCS_SDS_MODE_10GBASER);
 		msleep(300);
 		symerr = rtpcs_931x_sds_fiber_get_symerr(sds, RTPCS_SDS_MODE_10GBASER);
+		link_up = rtpcs_931x_sds_10gr_link_up(sds);
+		dev_dbg(dev, "SerDes %u symErr check %d: linkUp=%d symErr=0x%x\n", sds->id,
+			i + 1, link_up, symerr);
 
-		dev_dbg(dev, "SerDes %u symErr check %d: 0x%x\n", sds->id, i + 1, symerr);
-
-		if (symerr >= 0 && symerr <= 5) {
+		/*
+		 * symErr also reads 0 with no signal at all, not just a clean
+		 * link - don't trust it without link_up confirming there's
+		 * actually something being decoded.
+		 */
+		if (link_up && symerr >= 0 && symerr <= 5) {
 			dev_dbg(dev, "SerDes %u fiber RX calibration OK (check %d)\n",
 				sds->id, i + 1);
 			return;
 		}
 	}
 
-	dev_warn(dev, "SerDes %u fiber RX calibration failed after %d symErr checks\n",
-		 sds->id, i);
+	if (link_up)
+		dev_dbg(dev, "SerDes %u fiber RX calibration: symErr still 0x%x after %d checks, link up anyway\n",
+			sds->id, symerr, i);
+	else
+		dev_warn(dev, "SerDes %u fiber RX calibration failed after %d symErr checks\n",
+			 sds->id, i);
 }
 
 static int rtpcs_931x_sds_get_pll_select(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type *pll)

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3066,7 +3066,6 @@ static int rtpcs_931x_sds_op_xsg_write(struct rtpcs_serdes *sds, enum rtpcs_page
 				     value);
 }
 
-__maybe_unused
 static int rtpcs_931x_sds_fiber_get_symerr(struct rtpcs_serdes *sds,
 					   enum rtpcs_sds_mode hw_mode)
 {
@@ -3120,6 +3119,33 @@ static void rtpcs_931x_sds_clear_symerr(struct rtpcs_serdes *sds,
 	}
 }
 
+/*
+ * rtpcs_931x_sds_set_debug() - Route a coefficient's debug readback.
+ *
+ * Vendor SDK: _phy_rtl9310_dbg_set(). Selects which lane of the even/odd
+ * pair feeds the shared WDIG debug readback register, then selects
+ * dbg_sel within that lane. Must run before reading any rxeq_*_get().
+ *
+ * Note: This needs to be locked to avoid adjacent SerDes interfering with
+ * 	 those settings and produce inconsistent results. Currently, this is
+ * 	 achieved by the global PCS lock.
+ */
+static int rtpcs_931x_sds_set_debug(struct rtpcs_serdes *sds, unsigned int dbg_sel)
+{
+	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
+	int ret;
+
+	ret = rtpcs_sds_write(even_sds, PAGE_WDIG, 0x2, (sds == even_sds) ? 0x4b : 0x4c);
+	if (ret < 0)
+		return ret;
+
+	ret = rtpcs_sds_write_bits(sds, PAGE_ANA_COM, 0x0, 2, 2, 0x1);
+	if (ret < 0)
+		return ret;
+
+	return rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x15, 11, 10, dbg_sel);
+}
+
 static int rtpcs_931x_sds_rxeq_leq_set_adapt(struct rtpcs_serdes *sds, bool enable)
 {
 	return rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xd, 7, 7, enable ? 0x0 : 0x1);
@@ -3128,6 +3154,96 @@ static int rtpcs_931x_sds_rxeq_leq_set_adapt(struct rtpcs_serdes *sds, bool enab
 static int rtpcs_931x_sds_rxeq_leq_set_coef(struct rtpcs_serdes *sds, unsigned int gain)
 {
 	return rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xd, 6, 2, gain);
+}
+
+static int rtpcs_931x_sds_rxeq_tap_set_value(struct rtpcs_serdes *sds, unsigned int tap_id,
+					     int tap_even, int tap_odd)
+{
+	int ret;
+
+	switch (tap_id) {
+	case 0:
+		return rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1c, 5, 0,
+					    rtpcs_sign_mag_encode(tap_even, 5));
+	case 1:
+		ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1d, 5, 0,
+					   rtpcs_sign_mag_encode(tap_even, 5));
+		if (!ret)
+			ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1d, 11, 6,
+						   rtpcs_sign_mag_encode(tap_odd, 5));
+		return ret;
+	case 2:
+		ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1f, 5, 0,
+					   rtpcs_sign_mag_encode(tap_even, 5));
+		if (!ret)
+			ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1f, 11, 6,
+						   rtpcs_sign_mag_encode(tap_odd, 5));
+		return ret;
+	case 3:
+		ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0, 5, 0,
+					   rtpcs_sign_mag_encode(tap_even, 5));
+		if (!ret)
+			ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0, 11, 6,
+						   rtpcs_sign_mag_encode(tap_odd, 5));
+		return ret;
+	case 4:
+		ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x1, 5, 0,
+					   rtpcs_sign_mag_encode(tap_even, 5));
+		if (!ret)
+			ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x1, 11, 6,
+						   rtpcs_sign_mag_encode(tap_odd, 5));
+		return ret;
+	default:
+		return -EINVAL;
+	}
+}
+
+static int rtpcs_931x_sds_rxeq_tap_set_adapt(struct rtpcs_serdes *sds, unsigned int tap_id,
+					     bool enable)
+{
+	if (tap_id > 4)
+		return -EINVAL;
+
+	/* manual-mode enable bits, [10:6] = TAP0-TAP4 */
+	return rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xf, tap_id + 6, tap_id + 6,
+				    enable ? 0x0 : 0x1);
+}
+
+static int rtpcs_931x_sds_rxeq_vth_set_value(struct rtpcs_serdes *sds, unsigned int vth_p,
+					     unsigned int vth_n)
+{
+	return rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x12, 11, 4,
+				    FIELD_PREP(GENMASK(3, 0), vth_p) |
+				    FIELD_PREP(GENMASK(7, 4), vth_n));
+}
+
+static int rtpcs_931x_sds_rxeq_vth_set_adapt(struct rtpcs_serdes *sds, bool enable)
+{
+	return rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xf, 12, 12, enable ? 0x0 : 0x1);
+}
+
+static int rtpcs_931x_sds_rxeq_vth_get(struct rtpcs_serdes *sds, unsigned int *vth_p,
+				       unsigned int *vth_n)
+{
+	int ret, val;
+
+	ret = rtpcs_931x_sds_set_debug(sds, 0x2);
+	if (ret < 0)
+		return ret;
+
+	ret = rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x14, 10, 5, 0x0c); /* COEF_SEL = VTH */
+	if (ret < 0)
+		return ret;
+	usleep_range(1000, 2000);
+
+	val = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 7, 0);
+	if (val < 0)
+		return val;
+
+	*vth_p = FIELD_GET(GENMASK(3, 0), val);
+	*vth_n = FIELD_GET(GENMASK(7, 4), val);
+
+	return 0;
 }
 
 /**
@@ -3269,6 +3385,64 @@ static void rtpcs_931x_sds_rxcal_leq_adapt(struct rtpcs_serdes *sds)
 	msleep(10);
 	rtpcs_931x_sds_rxeq_leq_set_adapt(sds, true);
 	msleep(100);
+}
+
+/*
+ * rtpcs_931x_sds_rxcal_fiber_adapt() - RX calibration for 10G fiber.
+ *
+ * Only used for 10GBase-R fiber; calibration not needed for fiber running
+ * on slower speeds.
+ *
+ * Deviates from the vendor SDK's retry shape which is considerably tighter
+ * (3 symbol error rechecks, 150ms delay, exact-0 target). symErr's field
+ * (8 bits wide) has been observed reading a saturated 0xff right after
+ * rx_reset(), which looks like "link hasn't relocked yet" rather than a
+ * genuine error count. Thus, recheck more times with more patience per
+ * check instead (no reset in between, so a settling link isn't interrupted),
+ * and tolerate a small nonzero symbol-error count rather than requiring
+ * exactly 0.
+ */
+static void rtpcs_931x_sds_rxcal_fiber_adapt(struct rtpcs_serdes *sds)
+{
+	struct device *dev = sds->ctrl->dev;
+	unsigned int vth_p = 0, vth_n = 0;
+	int i, symerr = -1;
+
+	/* per-port calibration offset in the SDK, kept 0 here */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xc, 14, 10, 0x0);
+
+	rtpcs_931x_sds_reset_leq_dfe(sds);
+
+	/* let VTH + TAP0 auto-adapt run and settle before sampling/forcing values */
+	rtpcs_931x_sds_rxeq_tap_set_adapt(sds, 0, true);
+	rtpcs_931x_sds_rxeq_vth_set_adapt(sds, true);
+	msleep(200);
+
+	/* VTH is sampled from auto-adapt and locked in; TAP0 is always forced to 31 */
+	if (rtpcs_931x_sds_rxeq_vth_get(sds, &vth_p, &vth_n) < 0)
+		dev_warn(dev, "SerDes %u failed to read auto-adapted VTH\n", sds->id);
+
+	rtpcs_931x_sds_rxeq_tap_set_value(sds, 0, 31, 0);
+	rtpcs_931x_sds_rxeq_tap_set_adapt(sds, 0, false);
+	rtpcs_931x_sds_rxeq_vth_set_value(sds, vth_p, vth_n);
+	rtpcs_931x_sds_rxeq_vth_set_adapt(sds, false);
+
+	rtpcs_931x_sds_rx_reset(sds);
+
+	/* let DFE TAP1-4 auto-adapt continuously */
+	for (i = 1; i <= 4; i++)
+		rtpcs_931x_sds_rxeq_tap_set_adapt(sds, i, true);
+
+	for (i = 0; i < 8; i++) {
+		rtpcs_931x_sds_clear_symerr(sds, RTPCS_SDS_MODE_10GBASER);
+		msleep(300);
+		symerr = rtpcs_931x_sds_fiber_get_symerr(sds, RTPCS_SDS_MODE_10GBASER);
+		if (symerr >= 0 && symerr <= 5)
+			return;
+	}
+
+	dev_warn(dev, "SerDes %u fiber RX calibration failed after %d symErr checks\n",
+		 sds->id, i);
 }
 
 static int rtpcs_931x_sds_get_pll_select(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type *pll)
@@ -3638,8 +3812,13 @@ static int rtpcs_931x_sds_post_config(struct rtpcs_serdes *sds, enum rtpcs_sds_m
 		rtpcs_931x_sds_rxcal_leq_adapt(sds);
 		break;
 
+	case RTPCS_SDS_ATTACH_FIBER:
+		if (hw_mode == RTPCS_SDS_MODE_10GBASER)
+			rtpcs_931x_sds_rxcal_fiber_adapt(sds);
+		break;
+
 	default:
-		/* TODO: fiber/DAC RX calibration */
+		/* TODO: DAC RX calibration */
 		break;
 	}
 

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3435,9 +3435,9 @@ static void rtpcs_931x_sds_rxcal_leq_adapt(struct rtpcs_serdes *sds)
  */
 static void rtpcs_931x_sds_rxcal_fiber_adapt(struct rtpcs_serdes *sds)
 {
+	unsigned int vth_p = 0, vth_n = 0, sum_p = 0, sum_n = 0;
 	struct device *dev = sds->ctrl->dev;
-	unsigned int vth_p = 0, vth_n = 0;
-	int i, symerr = -1;
+	int i, samples = 0, symerr = -1;
 
 	dev_dbg(dev, "SerDes %u fiber RX calibration...\n", sds->id);
 	/* per-port calibration offset in the SDK, kept 0 here */
@@ -3450,9 +3450,26 @@ static void rtpcs_931x_sds_rxcal_fiber_adapt(struct rtpcs_serdes *sds)
 	rtpcs_931x_sds_rxeq_vth_set_adapt(sds, true);
 	msleep(200);
 
-	/* VTH is sampled from auto-adapt and locked in; TAP0 is always forced to 31 */
-	if (rtpcs_931x_sds_rxeq_vth_get(sds, &vth_p, &vth_n) < 0)
+	/* average several samples instead of trusting one possibly-noisy read */
+	for (i = 0; i < 10; i++) {
+		unsigned int p, n;
+
+		if (rtpcs_931x_sds_rxeq_vth_get(sds, &p, &n) == 0) {
+			sum_p += p;
+			sum_n += n;
+			samples++;
+		}
+		usleep_range(10000, 11000);
+	}
+
+	if (samples > 0) {
+		vth_p = DIV_ROUND_CLOSEST(sum_p, samples);
+		vth_n = DIV_ROUND_CLOSEST(sum_n, samples);
+	} else {
+		/* fallback baseline */
+		vth_p = vth_n = 0xa;
 		dev_warn(dev, "SerDes %u failed to read auto-adapted VTH\n", sds->id);
+	}
 
 	dev_dbg(dev, "SerDes %u VTH = %#x/%#x\n", sds->id, vth_p, vth_n);
 

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -2075,8 +2075,8 @@ static int rtpcs_930x_sds_set_debug(struct rtpcs_serdes *sds, unsigned int debug
 	return rtpcs_sds_write_bits(sds, PAGE_ANA_COM, 0x06, 11, 6, debug_sel); /* RX_DEBUG_SEL */
 }
 
-static int rtpcs_930x_sds_rxcal_dcvs_set_adapt(struct rtpcs_serdes *sds, unsigned int dcvs_id,
-					       bool enable)
+static int rtpcs_930x_sds_rxeq_dcvs_set_adapt(struct rtpcs_serdes *sds, unsigned int dcvs_id,
+					      bool enable)
 {
 	u8 reg[6] = { 0x1e, 0x1e, 0x1e, 0x1e, 0x01, 0x02 };
 	u8 bit[6] = { 14, 13, 12, 11, 15, 11 };
@@ -2088,8 +2088,8 @@ static int rtpcs_930x_sds_rxcal_dcvs_set_adapt(struct rtpcs_serdes *sds, unsigne
 				    bit[dcvs_id], enable ? 0x0 : 0x1);
 }
 
-static int rtpcs_930x_sds_rxcal_dcvs_set_coef(struct rtpcs_serdes *sds, unsigned int dcvs_id,
-					      int dcvs_coef)
+static int rtpcs_930x_sds_rxeq_dcvs_set_coef(struct rtpcs_serdes *sds, unsigned int dcvs_id,
+					     int dcvs_coef)
 {
 	u8 reg[6] = { 0x1c, 0x1d, 0x1d, 0x1d, 0x02, 0x11 };
 	u8 lbit[6] = { 0, 11, 6, 1, 6, 0 };
@@ -2101,8 +2101,8 @@ static int rtpcs_930x_sds_rxcal_dcvs_set_coef(struct rtpcs_serdes *sds, unsigned
 }
 
 __maybe_unused
-static int rtpcs_930x_sds_rxcal_dcvs_get_coef(struct rtpcs_serdes *sds,
-					      unsigned int dcvs_id, int *dcvs_coef)
+static int rtpcs_930x_sds_rxeq_dcvs_get_coef(struct rtpcs_serdes *sds, unsigned int dcvs_id,
+					     int *dcvs_coef)
 {
 	u8 manual_reg[6] = { 0x1e, 0x1e, 0x1e, 0x1e, 0x01, 0x02 };
 	u8 coeff_sel[6] = { 0x22, 0x23, 0x24, 0x25, 0x2c, 0x2d };
@@ -2138,7 +2138,7 @@ static int rtpcs_930x_sds_rxcal_dcvs_get_coef(struct rtpcs_serdes *sds,
 	return 0;
 }
 
-static int rtpcs_930x_sds_rxcal_leq_set_adapt(struct rtpcs_serdes *sds, bool enable)
+static int rtpcs_930x_sds_rxeq_leq_set_adapt(struct rtpcs_serdes *sds, bool enable)
 {
 	int ret;
 
@@ -2149,8 +2149,8 @@ static int rtpcs_930x_sds_rxcal_leq_set_adapt(struct rtpcs_serdes *sds, bool ena
 	return ret;
 }
 
-static int rtpcs_930x_sds_rxcal_leq_set_coef(struct rtpcs_serdes *sds, unsigned int leq_gray,
-					     unsigned int offset)
+static int rtpcs_930x_sds_rxeq_leq_set_coef(struct rtpcs_serdes *sds, unsigned int leq_gray,
+					    unsigned int offset)
 {
 	int ret;
 
@@ -2161,7 +2161,7 @@ static int rtpcs_930x_sds_rxcal_leq_set_coef(struct rtpcs_serdes *sds, unsigned 
 	return rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x16, 14, 10, leq_gray);
 }
 
-static int rtpcs_930x_sds_rxcal_leq_get_coef(struct rtpcs_serdes *sds)
+static int rtpcs_930x_sds_rxeq_leq_get_coef(struct rtpcs_serdes *sds)
 {
 	int bin, gray, manual, ret;
 
@@ -2186,13 +2186,13 @@ static int rtpcs_930x_sds_rxcal_leq_get_coef(struct rtpcs_serdes *sds)
 	return bin;
 }
 
-static int rtpcs_930x_sds_rxcal_vth_set_adapt(struct rtpcs_serdes *sds, bool enable)
+static int rtpcs_930x_sds_rxeq_vth_set_adapt(struct rtpcs_serdes *sds, bool enable)
 {
 	return rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0f, 13, 13, enable ? 0 : 1);
 }
 
-static int rtpcs_930x_sds_rxcal_vth_set_value(struct rtpcs_serdes *sds, unsigned int vth_p,
-					      unsigned int vth_n)
+static int rtpcs_930x_sds_rxeq_vth_set_value(struct rtpcs_serdes *sds, unsigned int vth_p,
+					     unsigned int vth_n)
 {
 	int ret;
 
@@ -2207,8 +2207,8 @@ static int rtpcs_930x_sds_rxcal_vth_set_value(struct rtpcs_serdes *sds, unsigned
 	return 0;
 }
 
-static int rtpcs_930x_sds_rxcal_vth_get(struct rtpcs_serdes *sds, unsigned int *vth_p,
-					unsigned int *vth_n)
+static int rtpcs_930x_sds_rxeq_vth_get(struct rtpcs_serdes *sds, unsigned int *vth_p,
+				       unsigned int *vth_n)
 {
 	int manual, ret, val;
 
@@ -2235,8 +2235,8 @@ static int rtpcs_930x_sds_rxcal_vth_get(struct rtpcs_serdes *sds, unsigned int *
 	return 0;
 }
 
-static int rtpcs_930x_sds_rxcal_tap_set_adapt(struct rtpcs_serdes *sds, unsigned int tap_id,
-					      bool enable)
+static int rtpcs_930x_sds_rxeq_tap_set_adapt(struct rtpcs_serdes *sds, unsigned int tap_id,
+					     bool enable)
 {
 	if (tap_id > 4)
 		return -EINVAL;
@@ -2246,8 +2246,8 @@ static int rtpcs_930x_sds_rxcal_tap_set_adapt(struct rtpcs_serdes *sds, unsigned
 				    enable ? 0x0 : 0x1);
 }
 
-static int rtpcs_930x_sds_rxcal_tap_set_value(struct rtpcs_serdes *sds, unsigned int tap_id,
-					      int tap_even, int tap_odd)
+static int rtpcs_930x_sds_rxeq_tap_set_value(struct rtpcs_serdes *sds, unsigned int tap_id,
+					     int tap_even, int tap_odd)
 {
 	int ret = 0;
 
@@ -2297,8 +2297,8 @@ static int rtpcs_930x_sds_rxcal_tap_set_value(struct rtpcs_serdes *sds, unsigned
 	return ret;
 }
 
-static int rtpcs_930x_sds_rxcal_tap_get(struct rtpcs_serdes *sds, unsigned int tap_id,
-					int *tap_even, int *tap_odd)
+static int rtpcs_930x_sds_rxeq_tap_get(struct rtpcs_serdes *sds, unsigned int tap_id,
+				       int *tap_even, int *tap_odd)
 {
 	struct device *dev = sds->ctrl->dev;
 	int ret, val;
@@ -2356,8 +2356,8 @@ static void rtpcs_930x_sds_rxcal_init(struct rtpcs_serdes *sds, enum rtpcs_sds_m
 
 	/* DCVS */
 	for (int i = 0; i <= 5; i++) {
-		rtpcs_930x_sds_rxcal_dcvs_set_coef(sds, i, 0);
-		rtpcs_930x_sds_rxcal_dcvs_set_adapt(sds, i, true);
+		rtpcs_930x_sds_rxeq_dcvs_set_coef(sds, i, 0);
+		rtpcs_930x_sds_rxeq_dcvs_set_adapt(sds, i, true);
 	}
 
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x00, 3, 0, 0x0f); /* z0_ok_X */
@@ -2367,14 +2367,14 @@ static void rtpcs_930x_sds_rxcal_init(struct rtpcs_serdes *sds, enum rtpcs_sds_m
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x16, 14, 8, 0x00); /* FILTER_OUT */
 
 	/* DFE (Decision Feedback Equalizer) TAPs */
-	rtpcs_930x_sds_rxcal_tap_set_value(sds, 0, tap0_init_val, 0);
-	rtpcs_930x_sds_rxcal_tap_set_value(sds, 1, 0, 0);
-	rtpcs_930x_sds_rxcal_tap_set_value(sds, 2, 0, 0);
-	rtpcs_930x_sds_rxcal_tap_set_value(sds, 3, 0, 0);
-	rtpcs_930x_sds_rxcal_tap_set_value(sds, 4, 0, 0);
+	rtpcs_930x_sds_rxeq_tap_set_value(sds, 0, tap0_init_val, 0);
+	rtpcs_930x_sds_rxeq_tap_set_value(sds, 1, 0, 0);
+	rtpcs_930x_sds_rxeq_tap_set_value(sds, 2, 0, 0);
+	rtpcs_930x_sds_rxeq_tap_set_value(sds, 3, 0, 0);
+	rtpcs_930x_sds_rxeq_tap_set_value(sds, 4, 0, 0);
 
 	/* VTH (Voltage Threshold) */
-	rtpcs_930x_sds_rxcal_vth_set_value(sds, 0x07, 0x07);
+	rtpcs_930x_sds_rxeq_vth_set_value(sds, 0x07, 0x07);
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0b, 5, 3, vth_min);
 
 	/* load DFE initial value */
@@ -2480,11 +2480,11 @@ static void rtpcs_930x_sds_rxcal_leq_adapt_lock(struct rtpcs_serdes *sds)
 	if (!direct_serdes)
 		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xc, 8, 8, 0x0);
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x17, 7, 7, 0x0);
-	rtpcs_930x_sds_rxcal_leq_set_adapt(sds, true);
+	rtpcs_930x_sds_rxeq_leq_set_adapt(sds, true);
 
 	/* 1.3.2: sample the auto-adapted LEQ value 10 times over ~100ms */
 	for (i = 0; i < 10; i++) {
-		val = rtpcs_930x_sds_rxcal_leq_get_coef(sds);
+		val = rtpcs_930x_sds_rxeq_leq_get_coef(sds);
 		if (val < 0)
 			return;
 
@@ -2520,12 +2520,12 @@ static void rtpcs_930x_sds_rxcal_leq_adapt_lock(struct rtpcs_serdes *sds)
 	/* lock LEQ at corrected value for direct SerDes; PHY-attached stays in auto-adapt */
 	if (direct_serdes) {
 		rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x17, 7, 7, 0x1);
-		rtpcs_930x_sds_rxcal_leq_set_adapt(sds, false);
-		rtpcs_930x_sds_rxcal_leq_set_coef(sds, avg10, 0);
+		rtpcs_930x_sds_rxeq_leq_set_adapt(sds, false);
+		rtpcs_930x_sds_rxeq_leq_set_coef(sds, avg10, 0);
 	}
 
 	dev_dbg(sds->ctrl->dev, "SerDes %u: LEQ = %u\n", sds->id,
-		rtpcs_930x_sds_rxcal_leq_get_coef(sds));
+		rtpcs_930x_sds_rxeq_leq_get_coef(sds));
 }
 
 static void rtpcs_930x_sds_rxcal_vth_tap0_adapt_lock(struct rtpcs_serdes *sds)
@@ -2534,43 +2534,43 @@ static void rtpcs_930x_sds_rxcal_vth_tap0_adapt_lock(struct rtpcs_serdes *sds)
 	int tap0;
 
 	/* run VTH/TAP auto-adapt */
-	rtpcs_930x_sds_rxcal_vth_set_adapt(sds, true);
-	rtpcs_930x_sds_rxcal_tap_set_adapt(sds, 0, true);
+	rtpcs_930x_sds_rxeq_vth_set_adapt(sds, true);
+	rtpcs_930x_sds_rxeq_tap_set_adapt(sds, 0, true);
 	msleep(200);
 
 	/* manually set learned VTH */
-	if (rtpcs_930x_sds_rxcal_vth_get(sds, &vth_p, &vth_n) < 0)
+	if (rtpcs_930x_sds_rxeq_vth_get(sds, &vth_p, &vth_n) < 0)
 		return;
-	rtpcs_930x_sds_rxcal_vth_set_value(sds, vth_p, vth_n);
-	rtpcs_930x_sds_rxcal_vth_set_adapt(sds, false);
+	rtpcs_930x_sds_rxeq_vth_set_value(sds, vth_p, vth_n);
+	rtpcs_930x_sds_rxeq_vth_set_adapt(sds, false);
 
 	msleep(100);
 
 	/* manually set learned TAP0 */
-	if (rtpcs_930x_sds_rxcal_tap_get(sds, 0, &tap0, NULL) < 0)
+	if (rtpcs_930x_sds_rxeq_tap_get(sds, 0, &tap0, NULL) < 0)
 		return;
-	rtpcs_930x_sds_rxcal_tap_set_value(sds, 0, tap0, 0);
-	rtpcs_930x_sds_rxcal_tap_set_adapt(sds, 0, false);
+	rtpcs_930x_sds_rxeq_tap_set_value(sds, 0, tap0, 0);
+	rtpcs_930x_sds_rxeq_tap_set_adapt(sds, 0, false);
 }
 
-static void rtpcs_930x_sds_rxcal_dfe_taps_adapt(struct rtpcs_serdes *sds)
+static void rtpcs_930x_sds_rxeq_dfe_taps_adapt(struct rtpcs_serdes *sds)
 {
 	/* dfeTap1_4Enable true */
-	rtpcs_930x_sds_rxcal_tap_set_adapt(sds, 1, true);
-	rtpcs_930x_sds_rxcal_tap_set_adapt(sds, 2, true);
-	rtpcs_930x_sds_rxcal_tap_set_adapt(sds, 3, true);
-	rtpcs_930x_sds_rxcal_tap_set_adapt(sds, 4, true);
+	rtpcs_930x_sds_rxeq_tap_set_adapt(sds, 1, true);
+	rtpcs_930x_sds_rxeq_tap_set_adapt(sds, 2, true);
+	rtpcs_930x_sds_rxeq_tap_set_adapt(sds, 3, true);
+	rtpcs_930x_sds_rxeq_tap_set_adapt(sds, 4, true);
 
 	msleep(30);
 }
 
-static void rtpcs_930x_sds_rxcal_dfe_disable(struct rtpcs_serdes *sds)
+static void rtpcs_930x_sds_rxeq_dfe_disable(struct rtpcs_serdes *sds)
 {
 	int tap_even = 0, tap_odd = 0;
 
 	for (int i = 1; i <= 4; i++) {
-		rtpcs_930x_sds_rxcal_tap_set_value(sds, i, tap_even, tap_odd);
-		rtpcs_930x_sds_rxcal_tap_set_adapt(sds, i, false);
+		rtpcs_930x_sds_rxeq_tap_set_value(sds, i, tap_even, tap_odd);
+		rtpcs_930x_sds_rxeq_tap_set_adapt(sds, i, false);
 	}
 
 	usleep_range(10000, 11000);
@@ -2587,16 +2587,16 @@ static void rtpcs_930x_sds_do_rx_calibration(struct rtpcs_serdes *sds,
 
 	/* Do this only for 10GR mode */
 	if (hw_mode == RTPCS_SDS_MODE_10GBASER) {
-		rtpcs_930x_sds_rxcal_dfe_taps_adapt(sds);
+		rtpcs_930x_sds_rxeq_dfe_taps_adapt(sds);
 		msleep(20);
 
 		latch_sts = rtpcs_sds_read_bits(sds, PAGE_TGR_STD_0, 1, 2, 2);
 		usleep_range(1000, 2000);
 		latch_sts = rtpcs_sds_read_bits(sds, PAGE_TGR_STD_0, 1, 2, 2);
 		if (latch_sts) {
-			rtpcs_930x_sds_rxcal_dfe_disable(sds);
+			rtpcs_930x_sds_rxeq_dfe_disable(sds);
 			rtpcs_930x_sds_rxcal_vth_tap0_adapt_lock(sds);
-			rtpcs_930x_sds_rxcal_dfe_taps_adapt(sds);
+			rtpcs_930x_sds_rxeq_dfe_taps_adapt(sds);
 		}
 	}
 }
@@ -3313,7 +3313,7 @@ static int rtpcs_931x_sds_reset_leq_dfe(struct rtpcs_serdes *sds)
  * calibrating this lane's 10G LEQ/DFE. Used by the vendor SDK's
  * PHY-attached and PCB-adapt calibration paths.
  */
-static int rtpcs_931x_sds_dfe_disable_5g(struct rtpcs_serdes *sds)
+static int rtpcs_931x_sds_rxeq_dfe_disable_5g(struct rtpcs_serdes *sds)
 {
 	return rtpcs_sds_write_bits(sds, PAGE_ANA_5G0, 0xf, 12, 6, 0x7f);
 }
@@ -3411,7 +3411,7 @@ static void rtpcs_931x_sds_rxcal_leq_adapt(struct rtpcs_serdes *sds)
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xd, 1, 0, 0x0);   /* undocumented */
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xd, 13, 13, 0x0); /* undocumented */
 
-	rtpcs_931x_sds_dfe_disable_5g(sds);
+	rtpcs_931x_sds_rxeq_dfe_disable_5g(sds);
 
 	rtpcs_931x_sds_rxeq_leq_set_adapt(sds, false);
 	rtpcs_931x_sds_rx_reset(sds);

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3277,19 +3277,23 @@ static int rtpcs_931x_sds_rxeq_vth_get(struct rtpcs_serdes *sds, unsigned int *v
  */
 static int rtpcs_931x_sds_reset_leq_dfe(struct rtpcs_serdes *sds)
 {
+	rtpcs_931x_sds_rxeq_leq_set_adapt(sds, false);
 	rtpcs_931x_sds_rxeq_leq_set_coef(sds, 0);
 	/* bits [1:0] are undocumented but part of the known-good reset value */
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xd, 1, 0, 0x0);
-	rtpcs_931x_sds_rxeq_leq_set_adapt(sds, false);
+
+	/*
+	 * Force manual mode before writing values - not after like the vendor
+	 * SDK does - to prevent the adapt engine from overwriting '0' in the
+	 * short timeframe.
+	 */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xf, 12, 6, 0x7f);
 
 	rtpcs_931x_sds_rxeq_tap_set_value(sds, 0, 0x1e, 0);
 	rtpcs_931x_sds_rxeq_tap_set_value(sds, 1, 0, 0);
 	rtpcs_931x_sds_rxeq_tap_set_value(sds, 2, 0, 0);
 	rtpcs_931x_sds_rxeq_tap_set_value(sds, 3, 0, 0);
 	rtpcs_931x_sds_rxeq_tap_set_value(sds, 4, 0, 0);
-
-	/* manual-mode enable mask for VTH + TAP0-4, bits [12:6] */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xf, 12, 6, 0x7f);
 
 	rtpcs_931x_sds_rxeq_vth_set_value(sds, 0xa, 0xa);
 	/* bits [15:12] and [3:0] are undocumented but part of the known-good reset value */

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -365,6 +365,17 @@ static unsigned int rtpcs_sign_mag_encode(int val, unsigned int sign_bit)
 	return (val < 0 ? BIT(sign_bit) : 0) | (abs(val) & GENMASK(sign_bit - 1, 0));
 }
 
+static u32 rtpcs_gray_to_binary(u32 gray_code)
+{
+	u32 binary = gray_code;
+
+	gray_code &= 0x1f; /* only lower 5 bits */
+	while (gray_code >>= 1)
+		binary ^= gray_code;
+
+	return binary;
+}
+
 /*
  * Basic helpers
  *
@@ -2150,17 +2161,6 @@ static int rtpcs_930x_sds_rxcal_leq_set_coef(struct rtpcs_serdes *sds, unsigned 
 	return rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x16, 14, 10, leq_gray);
 }
 
-static u32 rtpcs_930x_sds_rxcal_gray_to_binary(u32 gray_code)
-{
-	u32 binary = gray_code;
-
-	gray_code &= 0x1f; /* only lower 5 bits */
-	while (gray_code >>= 1)
-		binary ^= gray_code;
-
-	return binary;
-}
-
 static int rtpcs_930x_sds_rxcal_leq_get_coef(struct rtpcs_serdes *sds)
 {
 	int bin, gray, manual, ret;
@@ -2175,7 +2175,7 @@ static int rtpcs_930x_sds_rxcal_leq_get_coef(struct rtpcs_serdes *sds)
 	if (gray < 0)
 		return gray;
 
-	bin = rtpcs_930x_sds_rxcal_gray_to_binary(gray);
+	bin = rtpcs_gray_to_binary(gray);
 
 	manual = rtpcs_sds_read_bits(sds, PAGE_ANA_10G, 0x18, 15, 15);
 	if (manual < 0)
@@ -3156,6 +3156,21 @@ static int rtpcs_931x_sds_rxeq_leq_set_coef(struct rtpcs_serdes *sds, unsigned i
 	return rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xd, 6, 2, gain);
 }
 
+static int rtpcs_931x_sds_rxeq_leq_get_coef(struct rtpcs_serdes *sds)
+{
+	int ret, gray;
+
+	ret = rtpcs_931x_sds_set_debug(sds, 0x1);
+	if (ret < 0)
+		return ret;
+
+	gray = rtpcs_sds_read_bits(sds, PAGE_WDIG, 0x14, 7, 3);
+	if (gray < 0)
+		return gray;
+
+	return rtpcs_gray_to_binary(gray);
+}
+
 static int rtpcs_931x_sds_rxeq_tap_set_value(struct rtpcs_serdes *sds, unsigned int tap_id,
 					     int tap_even, int tap_odd)
 {
@@ -3381,6 +3396,8 @@ static void rtpcs_931x_sds_rx_reset(struct rtpcs_serdes *sds)
  */
 static void rtpcs_931x_sds_rxcal_leq_adapt(struct rtpcs_serdes *sds)
 {
+	dev_dbg(sds->ctrl->dev, "SerDes %u PHY-attached RX calibration...\n", sds->id);
+
 	rtpcs_931x_sds_rxeq_leq_set_coef(sds, 0);
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xd, 1, 0, 0x0);   /* undocumented */
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xd, 13, 13, 0x0); /* undocumented */
@@ -3392,6 +3409,9 @@ static void rtpcs_931x_sds_rxcal_leq_adapt(struct rtpcs_serdes *sds)
 	msleep(10);
 	rtpcs_931x_sds_rxeq_leq_set_adapt(sds, true);
 	msleep(100);
+
+	dev_dbg(sds->ctrl->dev, "SerDes %u LEQ = %#x\n", sds->id,
+		rtpcs_931x_sds_rxeq_leq_get_coef(sds));
 }
 
 /*
@@ -3415,6 +3435,7 @@ static void rtpcs_931x_sds_rxcal_fiber_adapt(struct rtpcs_serdes *sds)
 	unsigned int vth_p = 0, vth_n = 0;
 	int i, symerr = -1;
 
+	dev_dbg(dev, "SerDes %u fiber RX calibration...\n", sds->id);
 	/* per-port calibration offset in the SDK, kept 0 here */
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xc, 14, 10, 0x0);
 
@@ -3428,6 +3449,8 @@ static void rtpcs_931x_sds_rxcal_fiber_adapt(struct rtpcs_serdes *sds)
 	/* VTH is sampled from auto-adapt and locked in; TAP0 is always forced to 31 */
 	if (rtpcs_931x_sds_rxeq_vth_get(sds, &vth_p, &vth_n) < 0)
 		dev_warn(dev, "SerDes %u failed to read auto-adapted VTH\n", sds->id);
+
+	dev_dbg(dev, "SerDes %u VTH = %#x/%#x\n", sds->id, vth_p, vth_n);
 
 	rtpcs_931x_sds_rxeq_tap_set_value(sds, 0, 31, 0);
 	rtpcs_931x_sds_rxeq_tap_set_adapt(sds, 0, false);
@@ -3444,8 +3467,14 @@ static void rtpcs_931x_sds_rxcal_fiber_adapt(struct rtpcs_serdes *sds)
 		rtpcs_931x_sds_clear_symerr(sds, RTPCS_SDS_MODE_10GBASER);
 		msleep(300);
 		symerr = rtpcs_931x_sds_fiber_get_symerr(sds, RTPCS_SDS_MODE_10GBASER);
-		if (symerr >= 0 && symerr <= 5)
+
+		dev_dbg(dev, "SerDes %u symErr check %d: 0x%x\n", sds->id, i + 1, symerr);
+
+		if (symerr >= 0 && symerr <= 5) {
+			dev_dbg(dev, "SerDes %u fiber RX calibration OK (check %d)\n",
+				sds->id, i + 1);
 			return;
+		}
 	}
 
 	dev_warn(dev, "SerDes %u fiber RX calibration failed after %d symErr checks\n",

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3262,17 +3262,24 @@ static int rtpcs_931x_sds_rxeq_vth_get(struct rtpcs_serdes *sds, unsigned int *v
  */
 static int rtpcs_931x_sds_reset_leq_dfe(struct rtpcs_serdes *sds)
 {
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xd, 6, 0, 0x0);	/* [6:2] LEQ gain */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xd, 7, 7, 0x1);	/* LEQ manual 1=true,0=false */
+	rtpcs_931x_sds_rxeq_leq_set_coef(sds, 0);
+	/* bits [1:0] are undocumented but part of the known-good reset value */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xd, 1, 0, 0x0);
+	rtpcs_931x_sds_rxeq_leq_set_adapt(sds, false);
 
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1c, 5, 0, 0x1e); /* TAP0 */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1d, 11, 0, 0x0); /* TAP1 [11:6] ODD | [5:0] EVEN */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x1f, 11, 0, 0x0); /* TAP2 [11:6] ODD | [5:0] EVEN */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0, 11, 0, 0x0); /* TAP3 [11:6] ODD | [5:0] EVEN */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x1, 11, 0, 0x0); /* TAP4 [11:6] ODD | [5:0] EVEN */
+	rtpcs_931x_sds_rxeq_tap_set_value(sds, 0, 0x1e, 0);
+	rtpcs_931x_sds_rxeq_tap_set_value(sds, 1, 0, 0);
+	rtpcs_931x_sds_rxeq_tap_set_value(sds, 2, 0, 0);
+	rtpcs_931x_sds_rxeq_tap_set_value(sds, 3, 0, 0);
+	rtpcs_931x_sds_rxeq_tap_set_value(sds, 4, 0, 0);
 
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xf, 12, 6, 0x7f);	/* set manual mode */
-	rtpcs_sds_write(sds, PAGE_ANA_10G_EXT, 0x12, 0xaaa); /* [11:8] VTHN | [7:4] VTHP */
+	/* manual-mode enable mask for VTH + TAP0-4, bits [12:6] */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xf, 12, 6, 0x7f);
+
+	rtpcs_931x_sds_rxeq_vth_set_value(sds, 0xa, 0xa);
+	/* bits [15:12] and [3:0] are undocumented but part of the known-good reset value */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x12, 15, 12, 0x0);
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x12, 3, 0, 0xa);
 
 	return 0;
 }


### PR DESCRIPTION
This series adds some calibration functionality to the RTL931x PCS code, similar to what RTL930x already has. While there are no wonders to expect from this right now, it could make links with PHY and fiber attachment slightly more stable, and seems to improve DAC cable behavior slightly. In other words, the link comes up a bit more reliably and should suffer less from link flapping. At least this applies to DACs <= 2m, for longer ones there is still some work to do.

Tested on: Zyxel XS1930-12HP, Linksys LGS352C, Plasma Cloud PSX28