### PR TITLE
ath79: remove swconfig from DSA users

### DIFF
--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -58,7 +58,7 @@ TARGET_DEVICES += ubnt_edgeswitch-5xp
 define Device/ubnt_edgeswitch-8xp
   $(Device/ubnt-sw)
   DEVICE_MODEL := EdgeSwitch 8XP
-  DEVICE_PACKAGES += kmod-dsa-b53-mdio
+  DEVICE_PACKAGES += kmod-dsa-b53-mdio -swconfig
   DEVICE_COMPAT_VERSION := 1.1
   DEVICE_COMPAT_MESSAGE := Config cannot be migrated from swconfig to DSA
 endef

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -534,7 +534,7 @@ define Device/tplink_tl-wr941-v2
   $(Device/tplink-4m)
   SOC := ar9132
   DEVICE_MODEL := TL-WR941ND
-  DEVICE_PACKAGES := kmod-dsa-mv88e6060
+  DEVICE_PACKAGES := kmod-dsa-mv88e6060 -swconfig
   DEVICE_VARIANT := v2/v3
   DEVICE_ALT0_VENDOR := TP-Link
   DEVICE_ALT0_MODEL := TL-WR941N


### PR DESCRIPTION
There is no need to have the swconfig binary when DSA is in use.

Both of these devices have a single switch.