### PR TITLE
mbedtls: select the prerequisites of the EC-JPAKE key exchange

### DIFF
--- a/package/libs/mbedtls/Config.in
+++ b/package/libs/mbedtls/Config.in
@@ -86,6 +86,9 @@ config MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED
 
 config MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
 	bool "MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED"
+	select MBEDTLS_AES_C
+	select MBEDTLS_CCM_C
+	select MBEDTLS_ECP_DP_SECP256R1_ENABLED
 	default n
 
 comment "Curves - unselect old or less-used curves to reduce binary size"


### PR DESCRIPTION
`MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED` was added in 97dc9f8dbfde so that software needing that
cipher suite (e.g. OpenThread Border Router) could be built against the shared library rather than a
separate copy. Enabling it does not currently achieve that — it adds no cipher suite at all.

mbedTLS defines exactly one EC-JPAKE cipher suite, `TLS-ECJPAKE-WITH-AES-128-CCM-8`, and its table
entry is guarded by `MBEDTLS_SSL_HAVE_AES` and `MBEDTLS_SSL_HAVE_CCM` as well:
https://github.com/Mbed-TLS/mbedtls/blob/v3.6.6/library/ssl_ciphersuites.c#L1321

Those two are derived from `MBEDTLS_AES_C` and `MBEDTLS_CCM_C` while `MBEDTLS_USE_PSA_CRYPTO` is
off, which is the case here. So with `MBEDTLS_CCM_C` left at its default the suite is compiled out,
and the option only enables handshake code that nothing can negotiate.

The option now selects the three symbols it needs, the way `MBEDTLS_SSL_PROTO_TLS1_3` already does
in the same file:

- `MBEDTLS_CCM_C` — `default n`, and the reason the suite is missing today.
- `MBEDTLS_AES_C` — `default y`, so it only guards against a configuration that turns it off.
- `MBEDTLS_ECP_DP_SECP256R1_ENABLED` — `default y` as well, but turning that one off is worse than
  a missing suite: mbedTLS' EC-JPAKE is fixed to secp256r1, so `check_config.h` fails the build
  outright ("MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED defined, but not all prerequisites"). It is
  user-toggleable in this same file, so that is reachable today.

### Testing

Built mbedTLS 3.6.6 three times for `arm_cortex-a9_vfpv3-d16` from OpenWrt's generated
`mbedtls_config.h`, varying the EC-JPAKE option and `MBEDTLS_CCM_C`. `MBEDTLS_AES_C` and
`MBEDTLS_ECP_DP_SECP256R1_ENABLED` are `default y`, so they are on in all three.

| | EC-JPAKE | CCM | cipher suites offered | `TLS-ECJPAKE-WITH-AES-128-CCM-8` |
|---|---|---|---|---|
| stock | off | off | 26 | absent |
| today | **on** | off | **26, an identical list** | **absent** |
| patched | on | on | 35 | present |

The middle row is the problem: enabling the option changes the offered suite list not at all.

The default build is unchanged, since `MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED` remains `default n` and
none of the selects fire. For someone who has enabled EC-JPAKE, `libmbedcrypto.so` grows by 4096
bytes (352395 -> 356491, stripped as packaged) — all of it `MBEDTLS_CCM_C`, since the other two are
already on in a default build — and `libmbedtls.so` / `libmbedx509.so` are unchanged in size.

### Backport

`openwrt-25.12` and `openwrt-24.10` carry the same option (the latter via 2cffcdc7ae) and are
affected identically, so both would want a cherry-pick.
