### PR TITLE
ramips: add broken-flash-reset for youku yk-l1c

### DIFF
--- a/target/linux/ramips/dts/mt7620a_youku_yk-l1c.dts
+++ b/target/linux/ramips/dts/mt7620a_youku_yk-l1c.dts
@@ -7,6 +7,10 @@
 	model = "Youku YK-L1c";
 };
 
+&flash0 {
+	broken-flash-reset;
+};
+
 &firmware {
 	reg = <0x50000 0xfb0000>;
 };


### PR DESCRIPTION
The Winbond W25Q256 on the YK-L1c does not handle the SPI NOR software reset
command correctly, causing the system to hang on reboot until power-cycled.

The sibling YK-L1 already has this property set.

### Without `broken-flash-reset`

After sysupgrade, the system hangs after `reboot: Restarting system` and
never reaches the bootloader. A physical power cycle is required.

```
Mon Jun 29 13:34:46 UTC 2026 upgrade: Upgrade completed
Mon Jun 29 13:34:47 UTC 2026 upgrade: Rebooting system...
umount: can't unmount /dev: Resource busy
[  921.672571] reboot: Restarting system
<-- hangs here, requires power cycle -->
```

### With `broken-flash-reset`

The system reboots normally and the bootloader loads the firmware from flash:

```
Mon Jun 29 20:43:24 UTC 2026 upgrade: Upgrade completed
Mon Jun 29 20:43:25 UTC 2026 upgrade: Rebooting system...
umount: can't unmount /dev: Resource busy
[ 7655.514929] reboot: Restarting system

Boot and Recovery Environment for Embedded Devices
...
Flash: Winbond W25Q256 (32MB) on rt2880-spi
...
Starting kernel at 0x80000000...
```

### Tested on

- **Device**: Youku YK-L1c
- **SoC**: MediaTek MT7620A ver 2, eco 6
- **Flash**: Winbond W25Q256 (32MB)
- **Kernel**: 6.12.94
- **OpenWrt**: v25.12.5
