### PR TITLE
mediatek: filogic: comfast cf-wr632ax: fix nmbm configuration mismatch

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-comfast-cf-wr632ax.dts
+++ b/target/linux/mediatek/dts/mt7981b-comfast-cf-wr632ax.dts
@@ -11,6 +11,7 @@
 	mediatek,nmbm;
 	mediatek,bmt-max-ratio = <1>;
 	mediatek,bmt-max-reserved-blocks = <64>;
+	mediatek,bmt-mtd-overridden-oobsize = <64>;
 };
 
 &ubi {


### PR DESCRIPTION
Fix nmbm configuration mismatch error due to different SPI NAND OOB size in the U-Boot and Linux drivers by overriding it to 64 using the property introduced in commit e585ae70d4f2a563b3b0e430e15ee ("kernel: nmbm: add mediatek,bmt-mtd-overridden-oobsize property").

Fixes: https://github.com/openwrt/openwrt/issues/24546