### PR TITLE
mediatek: filogic: add support for Zyxel WX3400-T0

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -179,13 +179,19 @@ xiaomi,redmi-router-ax6000-stock)
 zyxel,ex5601-t0)
 	ubootenv_add_mtd "u-boot-env" "0x0" "0x20000" "0x40000" "2"
 	;;
-zyxel,ex5601-t0-ubootmod|\
-zyxel,wx5600-t0-ubootmod)
+zyxel,ex5601-t0-ubootmod)
 	ubootenv_add_ubi_default
 	ubootenv_add_sys_mtd "u-boot-env" "0x0" "0x20000" "0x40000" "2"
 	;;
 zyxel,ex5700-telenor)
 	ubootenv_add_uci_config "/dev/ubootenv" "0x0" "0x4000" "0x4000" "1"
+	;;
+zyxel,wx3400-t0)
+	ubootenv_add_mtd "u-boot-env" "0x0" "0x20000" "0x20000" "1"
+	;;
+zyxel,wx5600-t0-ubootmod)
+	ubootenv_add_ubi_default
+	ubootenv_add_sys_mtd "u-boot-env" "0x0" "0x20000" "0x40000" "2"
 	;;
 esac
 

--- a/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
+++ b/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
@@ -38,6 +38,10 @@ set_preinit_iface() {
 		ip link set eth0 up
 		ifname=lan4
 		;;
+	zyxel,wx3400-t0)
+		ip link set eth0 up
+		ifname=lan
+		;;
 	zyxel,wx5600-t0-ubootmod)
 		ifname=lan1
 		;;
@@ -49,4 +53,3 @@ set_preinit_iface() {
 }
 
 boot_hook_add preinit_main set_preinit_iface
-

--- a/target/linux/mediatek/dts/mt7986b-zyxel-wx3400-t0.dts
+++ b/target/linux/mediatek/dts/mt7986b-zyxel-wx3400-t0.dts
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+
+#include "mt7986b.dtsi"
+
+/ {
+	model = "Zyxel WX3400-T0";
+	compatible = "zyxel,wx3400-t0", "mediatek,mt7986b";
+
+	aliases {
+		serial0 = &uart0;
+		label-mac-device = &gmac0;
+		led-boot = &led_green_power;
+		led-failsafe = &led_red_power;
+		led-running = &led_green_power;
+		led-upgrade = &led_red_power;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@40000000 {
+		device_type = "memory";
+		reg = <0 0x40000000 0 0x20000000>;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		poll-interval = <20>;
+
+		reset-button {
+			label = "reset";
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps-button {
+			label = "wps";
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_green_power: green-power {
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+		};
+
+		led_red_power: red-power {
+			gpios = <&pio 15 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_POWER;
+			panic-indicator;
+		};
+
+		green-signal {
+			gpios = <&pio 26 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_INDICATOR;
+		};
+
+		red-signal {
+			gpios = <&pio 32 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_INDICATOR;
+		};
+
+		green-wlan {
+			gpios = <&pio 17 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+		};
+
+		red-wlan {
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_flash_pins>;
+	cs-gpios = <0>, <0>;
+	status = "okay";
+
+	spi_nand: spi-nand@1 {
+		compatible = "spi-nand";
+		reg = <1>;
+		spi-max-frequency = <20000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			factory: partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_factory_24: macaddr@24 {
+						compatible = "mac-base";
+						reg = <0x24 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_factory_2a: macaddr@2a {
+						compatible = "mac-base";
+						reg = <0x2a 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x1c0000>;
+				read-only;
+			};
+
+			partition@540000 {
+				label = "zloader";
+				reg = <0x540000 0x40000>;
+				read-only;
+			};
+
+			partition@580000 {
+				compatible = "linux,ubi";
+				label = "ubi";
+				reg = <0x580000 0x4000000>;
+			};
+
+			partition@4580000 {
+				label = "ubi2";
+				reg = <0x4580000 0x4000000>;
+			};
+
+			partition@8580000 {
+				label = "zyubi";
+				reg = <0x8580000 0x6a80000>;
+			};
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		label = "lan";
+		nvmem-cells = <&macaddr_factory_24 0>;
+		nvmem-cell-names = "mac-address";
+		phy-mode = "sgmii";
+		phy-handle = <&phy0>;
+		managed = "in-band-status";
+		pause;
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		label = "wan";
+		nvmem-cells = <&macaddr_factory_2a 0>;
+		nvmem-cell-names = "mac-address";
+		phy-mode = "sgmii";
+		phy-handle = <&phy1>;
+		managed = "in-band-status";
+		pause;
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		phy0: ethernet-phy@18 {
+			compatible = "ethernet-phy-id03a2.9471";
+			reg = <0x18>;
+			phy-mode = "sgmii";
+			reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+			reset-assert-us = <10000>;
+		};
+
+		phy1: ethernet-phy@1a {
+			compatible = "ethernet-phy-id03a2.9471";
+			reg = <0x1a>;
+			phy-mode = "sgmii";
+			reset-gpios = <&pio 16 GPIO_ACTIVE_LOW>;
+			reset-assert-us = <10000>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	status = "okay";
+	pinctrl-names = "default", "dbdc";
+	pinctrl-0 = <&wf_2g_5g_pins>;
+	pinctrl-1 = <&wf_dbdc_pins>;
+	nvmem-cells = <&eeprom_factory>;
+	nvmem-cell-names = "eeprom";
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_4 0>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_4 1>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&pio {
+	spi_flash_pins: spi-flash-pins-33-to-38 {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			mediatek,pull-up-adv = <0>;
+		};
+
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			mediatek,pull-down-adv = <0>;
+		};
+	};
+
+	wf_2g_5g_pins: wf-2g-5g-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_2g", "wf_5g";
+		};
+
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+				"WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+				"WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+				"WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+				"WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+				"WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+				"WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <MTK_DRIVE_4mA>;
+		};
+	};
+
+	wf_dbdc_pins: wf-dbdc-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_dbdc";
+		};
+
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+				"WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+				"WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+				"WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+				"WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+				"WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+				"WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <MTK_DRIVE_4mA>;
+		};
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -384,6 +384,10 @@ zyxel,ex5700-telenor)
 	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:amber:wan" "eth1" "link_10 link_100 tx rx"
 	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:green:wan" "eth1" "link tx rx"
 	;;
+zyxel,wx3400-t0)
+	ucidef_set_led_netdev "wlan2g" "WLAN2G" "green:wlan-2ghz" "phy0-ap0" "link tx rx"
+	ucidef_set_led_netdev "wlan5g" "WLAN5G" "red:wlan-5ghz" "phy1-ap0" "link tx rx"
+	;;
 zyxel,wx5600-t0-ubootmod)
 	ucidef_set_led_netdev "lan1" "LAN1" "mdio-bus:06:green:lan" "lan1" "link tx rx"
 	ucidef_set_led_netdev "lan2" "LAN2" "mdio-bus:05:green:lan" "lan2" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -240,6 +240,9 @@ mediatek_setup_interfaces()
 	xiaomi,redmi-router-ax6000-ubootmod)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4" wan
 		;;
+	zyxel,wx3400-t0)
+		ucidef_set_interfaces_lan_wan lan wan
+		;;
 	zyxel,wx5600-t0-ubootmod)
 		ucidef_set_interface_lan "lan1 lan2"
 		;;

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -130,6 +130,88 @@ update_oem_ubi_volume() {
 	ubiupdatevol "/dev/$ubidev" -s "$oem_volume_size" "$oem_volume_data"
 }
 
+wx3400_write_le16() {
+	local output="$1"
+	local offset="$2"
+	local value="$3"
+	local low high
+
+	low="$(printf '%03o' $((value & 255)))"
+	high="$(printf '%03o' $((value >> 8)))"
+	printf '%b' "\\0$low\\0$high" | \
+		dd of="$output" bs=1 seek="$offset" conv=notrunc 2>/dev/null
+}
+
+wx3400_prepare_zyfwinfo() {
+	local output="$1"
+	local bank mtdnum ubidev volume model stored calculated sequence checksum
+
+	bank="$(cmdline_get_var rootubi)"
+	case "$bank" in
+	ubi|ubi2) ;;
+	*)
+		echo "invalid or missing rootubi kernel parameter: $bank"
+		return 1
+		;;
+	esac
+
+	mtdnum="$(find_mtd_index "$bank")"
+	[ -n "$mtdnum" ] || return 1
+	ubidev="$(nand_find_ubi "$bank")"
+	if [ -z "$ubidev" ]; then
+		ubiattach -m "$mtdnum" >/dev/null 2>&1 || return 1
+		ubidev="$(nand_find_ubi "$bank")"
+	fi
+	volume="$(nand_find_volume "$ubidev" zyfwinfo)"
+	[ -n "$volume" ] || return 1
+	dd if="/dev/$volume" of="$output" bs=256 count=1 2>/dev/null || return 1
+
+	[ "$(wc -c < "$output")" -eq 256 ] || return 1
+	[ "$(dd if="$output" bs=4 count=1 2>/dev/null)" = "EXYZ" ] || return 1
+	model="$(hexdump -v -s 116 -n 4 -e '1/1 "%02x"' "$output")"
+	[ "$model" = "040a000d" ] || return 1
+	stored="$(hexdump -v -s 254 -n 2 -e '1/2 "%u"' "$output")"
+	calculated="$(hexdump -v -n 254 -e '1/1 "%u\n"' "$output" | awk '
+		{ sum += $1 }
+		END { sum += int(sum / 65536); print sum % 65536 }
+	')"
+	[ "$stored" = "$calculated" ] || return 1
+
+	sequence="$(hexdump -v -s 6 -n 2 -e '1/2 "%u"' "$output")"
+	echo "WX3400-T0: booted from $bank with zyfwinfo sequence $sequence"
+	[ "$sequence" -lt 65535 ] || {
+		echo "WX3400-T0 zyfwinfo sequence overflow"
+		return 1
+	}
+
+	sequence=$((sequence + 1))
+	wx3400_write_le16 "$output" 6 "$sequence"
+	dd if=/dev/zero of="$output" bs=1 seek=254 count=2 conv=notrunc 2>/dev/null
+	checksum="$(hexdump -v -n 254 -e '1/1 "%u\n"' "$output" | awk '
+		{ sum += $1 }
+		END {
+			sum += int(sum / 65536)
+			print sum % 65536
+		}
+	')"
+	wx3400_write_le16 "$output" 254 "$checksum"
+
+	echo "WX3400-T0: new ubi zyfwinfo sequence $sequence"
+}
+
+wx3400_ensure_zyfwinfo_volume() {
+	local ubidev="$1"
+	local volume
+
+	volume="$(nand_find_volume "$ubidev" zyfwinfo)"
+	[ -n "$volume" ] && return 0
+
+	# Make room before rootfs_data is recreated with all remaining LEBs.
+	volume="$(nand_find_volume "$ubidev" rootfs_data)"
+	[ -z "$volume" ] || ubirmvol "/dev/$ubidev" -N rootfs_data
+	ubimkvol "/dev/$ubidev" -N zyfwinfo -s 256 -t dynamic
+}
+
 platform_do_upgrade() {
 	local board=$(board_name)
 
@@ -349,6 +431,32 @@ platform_do_upgrade() {
 		CI_KERNPART="kernel0"
 		EMMC_ROOT_DEV="$(cmdline_get_var root)"
 		emmc_do_upgrade "$1"
+		;;
+	zyxel,wx3400-t0)
+		local header="/tmp/wx3400-zyfwinfo.bin"
+		local ubidev volume
+
+		wx3400_prepare_zyfwinfo "$header" || nand_do_upgrade_failed
+
+		CI_UBIPART="ubi"
+		CI_KERN_UBIPART="ubi"
+		CI_ROOT_UBIPART="ubi"
+		CI_DATA_UBIPART="ubi"
+
+		ubidev="$(nand_attach_ubi ubi)"
+		[ -n "$ubidev" ] || nand_do_upgrade_failed
+		wx3400_ensure_zyfwinfo_volume "$ubidev" || nand_do_upgrade_failed
+
+		echo "WX3400-T0: installing OpenWrt to fixed bank ubi"
+		if nand_do_flash_file "$1"; then
+			ubidev="$(nand_find_ubi ubi)"
+			volume="$(nand_find_volume "$ubidev" zyfwinfo)"
+			[ -n "$volume" ] || nand_do_upgrade_failed
+			ubiupdatevol "/dev/$volume" -s 256 "$header" || nand_do_upgrade_failed
+			nand_do_upgrade_success
+		fi
+
+		nand_do_upgrade_failed
 		;;
 	unielec,u7981-01*)
 		local rootdev="$(cmdline_get_var root)"

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -124,6 +124,58 @@ define Build/zyxel-nwa-fit-filogic
 	@mv $@.new $@
 endef
 
+define Build/zyxel-wx3400-factory
+	rm -rf $@.tmp
+	mkdir -p $@.tmp/empty
+	$(TAR) -xf $@ -C $@.tmp
+	mv $@.tmp/sysupgrade-zyxel_wx3400-t0 \
+		$@.tmp/sysupgrade-wx3400-t0
+	printf 'BOARD=wx3400-t0\n' > \
+		$@.tmp/sysupgrade-wx3400-t0/CONTROL
+	env -u SOURCE_DATE_EPOCH $(STAGING_DIR_HOST)/bin/mksquashfs4 \
+		$@.tmp/empty $@.tmp/sysupgrade-wx3400-t0/zydefault \
+		-comp xz -b 131072 -nopad -noappend -root-owned \
+		-no-xattrs -no-exports \
+		$(if $(SOURCE_DATE_EPOCH),-repro-time $(SOURCE_DATE_EPOCH))
+	dd if=/dev/zero of=$@.tmp/sysupgrade-wx3400-t0/zyfwinfo \
+		bs=256 count=1 2>/dev/null
+	printf 'EXYZ\002\000\000\000\000\001\001\000\000\007\031\040\044\027\011\126' | \
+		dd of=$@.tmp/sysupgrade-wx3400-t0/zyfwinfo \
+		conv=notrunc 2>/dev/null
+	printf 'WX3400-T0' | dd of=$@.tmp/sysupgrade-wx3400-t0/zyfwinfo \
+		bs=1 seek=20 conv=notrunc 2>/dev/null
+	printf 'V5.70(ACHQ.0)b9' | dd of=$@.tmp/sysupgrade-wx3400-t0/zyfwinfo \
+		bs=1 seek=52 conv=notrunc 2>/dev/null
+	printf 'WX3400-T0-OPENWRT' | dd of=$@.tmp/sysupgrade-wx3400-t0/zyfwinfo \
+		bs=1 seek=82 conv=notrunc 2>/dev/null
+	printf '\004\012\000\015' | dd of=$@.tmp/sysupgrade-wx3400-t0/zyfwinfo \
+		bs=1 seek=116 conv=notrunc 2>/dev/null
+	od -An -tu1 -N254 $@.tmp/sysupgrade-wx3400-t0/zyfwinfo | \
+		awk '{ for (i = 1; i <= NF; i++) sum += $$i } END { \
+			sum += int(sum / 65536); \
+			printf "%c%c", sum % 256, int(sum / 256) \
+		}' | dd of=$@.tmp/sysupgrade-wx3400-t0/zyfwinfo \
+		bs=1 seek=254 conv=notrunc 2>/dev/null
+	test "$$(od -An -tu2 -j254 -N2 \
+		$@.tmp/sysupgrade-wx3400-t0/zyfwinfo | tr -d ' ')" = \
+		"$$(od -An -tu1 -N254 \
+		$@.tmp/sysupgrade-wx3400-t0/zyfwinfo | \
+		awk '{ for (i = 1; i <= NF; i++) sum += $$i } END { \
+			sum += int(sum / 65536); print sum % 65536 \
+		}')"
+	$(TAR) -cp --numeric-owner --owner=0 --group=0 --mode=a-s --sort=name \
+		$(if $(SOURCE_DATE_EPOCH),--mtime="@$(SOURCE_DATE_EPOCH)") \
+		-C $@.tmp sysupgrade-wx3400-t0 > $@.tar
+	$(STAGING_DIR_HOST)/bin/openssl enc -md md5 -aes-256-cbc -salt \
+		-in $@.tar -out $@ \
+		-pass pass:'4A0D_@5pWdazR1TqL7vHx'
+	$(STAGING_DIR_HOST)/bin/openssl enc -md md5 -aes-256-cbc -d \
+		-in $@ -pass pass:'4A0D_@5pWdazR1TqL7vHx' | \
+		$(TAR) -tf - >/dev/null
+	rm -f $@.tar
+	rm -rf $@.tmp
+endef
+
 define Build/cetron-header
 	$(eval magic=$(word 1,$(1)))
 	$(eval model=$(word 2,$(1)))
@@ -3948,6 +4000,32 @@ define Device/zyxel_nwa50ax-pro
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += zyxel_nwa50ax-pro
+
+define Device/zyxel_wx3400-t0
+  DEVICE_VENDOR := Zyxel
+  DEVICE_MODEL := WX3400-T0
+  DEVICE_DTS := mt7986b-zyxel-wx3400-t0
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware uboot-envtools
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 65536k
+  KERNEL_IN_UBI := 1
+  KERNEL := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | pad-to 64k
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  KERNEL_INITRAMFS_SUFFIX := .itb
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+ifeq ($(IB),)
+ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
+  IMAGES += initramfs-factory.bin
+  IMAGE/initramfs-factory.bin := append-image-stage initramfs.itb | \
+	sysupgrade-tar kernel=$$$$@ | zyxel-wx3400-factory
+endif
+endif
+endef
+TARGET_DEVICES += zyxel_wx3400-t0
 
 define Device/zyxel_wx5600-t0-ubootmod
   DEVICE_VENDOR := Zyxel


### PR DESCRIPTION
The Zyxel WX3400-T0 is a dual-band Wi-Fi 6 mesh extender based on the MediaTek MT7986B.

### Hardware:
- MediaTek MT7986B quad-core Cortex-A53 SoC
- 512 MB DDR3 RAM
- 256 MB Winbond SPI-NAND flash
- 2.4 GHz 4x4 and 5 GHz 4x4 802.11ax wireless
- 2x Gigabit Ethernet ports using Airoha EN8801SN PHYs
- Reset and WPS buttons
- 6 GPIO-controlled LED channels
- UART header on rear side of PCB, pin order `3.3V TX RX _ GND`,
  115200 8N1
- 12 V, 2 A DC input using a 5.5 x 2.1 mm barrel jack

### MAC addresses
- LAN: 48:ed:e6:xx:xx:xx (Factory 0x24, label-mac-device)
- WAN: 48:ed:e6:xx:xx:xx (Factory 0x2a)
- Wi-Fi 2.4 GHz: 48:ed:e6:xx:xx:xx (Factory 0x4 + 0)
- Wi-Fi 5 GHz: 48:ed:e6:xx:xx:xx (Factory 0x4 + 1)

### Official firmware

The stock WebUI accepts a vendor tar archive encrypted with AES-256-CBC
and the legacy OpenSSL MD5 key derivation. The factory image reproduces
this format and contains an initramfs FIT, a minimal zydefault volume
and a generated zyfwinfo header.

The stock bootloader uses two UBI firmware banks. The sysupgrade code reads
rootubi from the kernel command line, validates and increments the active
zyfwinfo sequence number, and installs the persistent kernel and root
filesystem into ubi (mtd5). The stock bootloader remains unchanged.

### Installation
1. Open the stock "Firmware Upgrade" page at
   http://192.168.0.1/FirmwareUpgrade
2. Select initramfs-factory.bin and click "Upgrade", then wait for reboot.
3. Open LuCI at http://192.168.1.1/
4. Open "System -> Backup / Flash Firmware" and flash sysupgrade.bin without
   preserving settings.

### Reverting to stock

A complete stock backup made before installation is required. The stock WebUI
may write the initramfs image to either ubi (mtd5) or ubi2 (mtd6), while
sysupgrade always writes persistent OpenWrt to ubi (mtd5). If the WebUI
selected ubi2, both stock banks are overwritten after sysupgrade. The active
bank cannot be determined reliably before upload, so booting ubi2 is not a
supported revert method. Restore the saved stock backup through a suitable
bootloader or recovery procedure.

