### PR TITLE
network: run pppd and odhcpd unprivileged in ujail

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=dnsmasq
 PKG_UPSTREAM_VERSION:=2.93
 PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=https://thekelleys.org.uk/dnsmasq/
@@ -169,7 +169,7 @@ define Package/dnsmasq/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/dnsmasq $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/config
-	$(INSTALL_CONF) ./files/dhcp.conf $(1)/etc/config/dhcp
+	$(INSTALL_DATA) ./files/dhcp.conf $(1)/etc/config/dhcp
 	$(INSTALL_CONF) ./files/dnsmasq.conf $(1)/etc/dnsmasq.conf
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/dnsmasq.init $(1)/etc/init.d/dnsmasq
@@ -188,6 +188,7 @@ define Package/dnsmasq/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/50-dnsmasq-migrate-resolv-conf-auto.sh $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/50-dnsmasq-migrate-ipset.sh $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/50-dnsmasq-relax-dhcp-config-mode.sh $(1)/etc/uci-defaults
 endef
 
 Package/dnsmasq-dhcpv6/install = $(Package/dnsmasq/install)

--- a/package/network/services/dnsmasq/files/50-dnsmasq-relax-dhcp-config-mode.sh
+++ b/package/network/services/dnsmasq/files/50-dnsmasq-relax-dhcp-config-mode.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# odhcpd uci_load()s /etc/config/dhcp directly and runs unprivileged;
+# INSTALL_CONF shipped it 0600, which locked it out.
+chmod 0644 /etc/config/dhcp
+
+exit 0

--- a/package/network/services/odhcpd/Makefile
+++ b/package/network/services/odhcpd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=odhcpd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/odhcpd.git
@@ -28,6 +28,7 @@ define Package/odhcpd/default
   SECTION:=net
   CATEGORY:=Network
   DEPENDS:=+libjson-c +libubox +libuci +libubus +libnl-tiny
+  USERID:=odhcpd=455:odhcpd=455
 endef
 
 define Package/odhcpd/default/description
@@ -77,6 +78,10 @@ define Package/odhcpd/install
 	$(INSTALL_BIN) ./files/odhcpd-update $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/odhcpd.init $(1)/etc/init.d/odhcpd
+	$(INSTALL_DIR) $(1)/etc/capabilities
+	$(INSTALL_DATA) ./files/odhcpd.capabilities $(1)/etc/capabilities/odhcpd.json
+	$(INSTALL_DIR) $(1)/usr/share/acl.d
+	$(INSTALL_DATA) ./files/odhcpd_acl.json $(1)/usr/share/acl.d/odhcpd.json
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/odhcpd.defaults $(1)/etc/uci-defaults/15_odhcpd
 endef

--- a/package/network/services/odhcpd/files/odhcpd.capabilities
+++ b/package/network/services/odhcpd/files/odhcpd.capabilities
@@ -1,0 +1,27 @@
+{
+	"bounding": [
+		"CAP_NET_ADMIN",
+		"CAP_NET_RAW",
+		"CAP_NET_BIND_SERVICE"
+	],
+	"effective": [
+		"CAP_NET_ADMIN",
+		"CAP_NET_RAW",
+		"CAP_NET_BIND_SERVICE"
+	],
+	"ambient": [
+		"CAP_NET_ADMIN",
+		"CAP_NET_RAW",
+		"CAP_NET_BIND_SERVICE"
+	],
+	"permitted": [
+		"CAP_NET_ADMIN",
+		"CAP_NET_RAW",
+		"CAP_NET_BIND_SERVICE"
+	],
+	"inheritable": [
+		"CAP_NET_ADMIN",
+		"CAP_NET_RAW",
+		"CAP_NET_BIND_SERVICE"
+	]
+}

--- a/package/network/services/odhcpd/files/odhcpd.init
+++ b/package/network/services/odhcpd/files/odhcpd.init
@@ -4,14 +4,78 @@ START=35
 STOP=85
 USE_PROCD=1
 
+ODHCPD_CAPS=/etc/capabilities/odhcpd.json
+
+odhcpd_jailed() {
+	[ -x /sbin/ujail ] && [ -e "$ODHCPD_CAPS" ]
+}
+
+odhcpd_ndp_relay() {
+	local ndp
+
+	config_get ndp "$1" ndp
+	[ "$ndp" = "relay" ] && relay=1
+}
+
+# Hand the unprivileged daemon what it cannot take itself: the state
+# directories it writes through a temporary file, and the global proxy_ndp
+# knob the kernel ORs with the per-interface one it can no longer write.
+odhcpd_prepare() {
+	local leasefile hostsdir piodir relay dir
+
+	config_load dhcp
+	config_get leasefile odhcpd leasefile
+	config_get hostsdir odhcpd hostsdir
+	config_get piodir odhcpd piodir
+	config_foreach odhcpd_ndp_relay dhcp
+
+	for dir in "${leasefile%/*}" "$hostsdir" "$piodir"; do
+		[ -n "$dir" ] || continue
+		mkdir -p "$dir" || continue
+		case "$(ls -ld "$dir" 2>/dev/null)" in
+		# world-writable: shared with everything else, not ours to take
+		????????w*) ;;
+		d*) chown odhcpd:odhcpd "$dir" ;;
+		esac
+	done
+
+	# an upgrade restarts the daemon inside the boot, leaving the leasefile
+	# owned by the root-run instance and the sticky bit stopping uid 455
+	# from renaming its replacement over it. Only where the directory is
+	# world-writable, which already grants everyone that much
+	case "$(ls -ld "${leasefile%/*}" 2>/dev/null)" in
+	????????w*) [ -f "$leasefile" ] && chown -h odhcpd:odhcpd "$leasefile" ;;
+	esac
+
+	# the kernel ORs this global with the per-interface knob uid 455 can no
+	# longer write; it is shared, so raise it and leave it to its owner
+	[ -n "$relay" ] && [ -e /proc/sys/net/ipv6/conf/all/proxy_ndp ] &&
+		echo 1 > /proc/sys/net/ipv6/conf/all/proxy_ndp
+
+	return 0
+}
+
 start_service() {
+	odhcpd_jailed && odhcpd_prepare
+
 	procd_open_instance
 	procd_set_param command /usr/sbin/odhcpd
 	procd_set_param respawn
+
+	odhcpd_jailed && {
+		procd_add_jail odhcpd
+		procd_set_param capabilities "$ODHCPD_CAPS"
+		procd_set_param no_new_privs 1
+		procd_set_param user odhcpd
+		procd_set_param group odhcpd
+	}
+
 	procd_close_instance
 }
 
 reload_service() {
+	odhcpd_jailed && odhcpd_prepare
+
 	procd_send_signal odhcpd
 }
 

--- a/package/network/services/odhcpd/files/odhcpd_acl.json
+++ b/package/network/services/odhcpd/files/odhcpd_acl.json
@@ -1,0 +1,24 @@
+{
+	"user": "odhcpd",
+	"publish": [
+		"dhcp"
+	],
+	"subscribe": [
+		"network.interface"
+	],
+	"listen": [
+		"ubus.object.add"
+	],
+	"access": {
+		"network.interface": {
+			"methods": [
+				"dump"
+			]
+		},
+		"service": {
+			"methods": [
+				"signal"
+			]
+		}
+	}
+}

--- a/package/network/services/ppp/Makefile
+++ b/package/network/services/ppp/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ppp
 PKG_VERSION:=2.5.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.samba.org/pub/ppp
@@ -55,6 +55,7 @@ define Package/ppp
 $(call Package/ppp/Default)
   DEPENDS:= +USE_GLIBC:libcrypt-compat +kmod-ppp
   TITLE:=PPP daemon
+  USERID:=ppp=454:ppp=454
   VARIANT:=default
 endef
 
@@ -62,6 +63,7 @@ define Package/ppp-multilink
 $(call Package/ppp/Default)
   DEPENDS:= +USE_GLIBC:libcrypt-compat +kmod-ppp
   TITLE:=PPP daemon (with multilink support)
+  USERID:=ppp=454:ppp=454
   VARIANT:=multilink
 endef
 
@@ -211,11 +213,17 @@ define Package/ppp/install
 	$(INSTALL_DATA) ./files/etc/ppp/filter $(1)/etc/ppp/
 	$(INSTALL_DATA) ./files/etc/ppp/options $(1)/etc/ppp/
 	$(LN) /tmp/resolv.conf.ppp $(1)/etc/ppp/resolv.conf
+	$(INSTALL_DIR) $(1)/etc/capabilities
+	$(INSTALL_DATA) ./files/pppd.capabilities $(1)/etc/capabilities/pppd.json
+	$(INSTALL_DIR) $(1)/usr/share/acl.d
+	$(INSTALL_DATA) ./files/pppd_acl.json $(1)/usr/share/acl.d/pppd.json
 	$(INSTALL_DIR) $(1)/lib/netifd/proto
 	$(INSTALL_BIN) ./files/ppp.sh $(1)/lib/netifd/proto/
 	$(INSTALL_BIN) ./files/lib/netifd/ppp-up $(1)/lib/netifd/
 	$(INSTALL_BIN) ./files/lib/netifd/ppp6-up $(1)/lib/netifd/
 	$(INSTALL_BIN) ./files/lib/netifd/ppp-down $(1)/lib/netifd/
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/50-ppp-secrets-mode.sh $(1)/etc/uci-defaults
 endef
 Package/ppp-multilink/install=$(Package/ppp/install)
 
@@ -242,6 +250,8 @@ define Package/ppp-mod-radius/install
 		$(1)/etc/ppp/radius/
 	$(INSTALL_CONF) ./files/etc/ppp/radius/servers \
 		$(1)/etc/ppp/radius/
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/50-ppp-radius-servers-mode.sh $(1)/etc/uci-defaults
 endef
 
 define Package/ppp-mod-pppol2tp/install

--- a/package/network/services/ppp/files/50-ppp-radius-servers-mode.sh
+++ b/package/network/services/ppp/files/50-ppp-radius-servers-mode.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# The RADIUS secret is read by uid ppp; INSTALL_CONF ships it 0600 root:root.
+[ -f /etc/ppp/radius/servers ] || exit 0
+chgrp ppp /etc/ppp/radius/servers
+chmod 0640 /etc/ppp/radius/servers
+
+exit 0

--- a/package/network/services/ppp/files/50-ppp-secrets-mode.sh
+++ b/package/network/services/ppp/files/50-ppp-secrets-mode.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# pppd reads these as uid ppp, and INSTALL_CONF ships them 0600 root:root -
+# as does a file preserved across sysupgrade from an install predating the uid.
+for secret in /etc/ppp/chap-secrets /etc/ppp/pap-secrets; do
+	[ -f "$secret" ] || continue
+	chgrp ppp "$secret"
+	chmod 0640 "$secret"
+done
+
+exit 0

--- a/package/network/services/ppp/files/ppp.sh
+++ b/package/network/services/ppp/files/ppp.sh
@@ -146,7 +146,21 @@ ppp_generic_setup() {
 	[ "$delegate" != "0" ] && delegate=""
 	[ "$norelease" = "1" ] || norelease=""
 
-	proto_run_command "$config" /usr/sbin/pppd \
+	local jail caps=/etc/capabilities/pppd.json
+	[ -x /sbin/ujail ] && [ -f "$caps" ] && {
+		jail="/sbin/ujail -t 5 -n pppd -U ppp -G ppp -C $caps -c --"
+		chown ppp /dev/ppp
+		mkdir -p /var/run/pppd
+		chown ppp /var/run/pppd
+		# A serial link is handed its TTY as a pppd argument - first by
+		# proto_ppp_setup, last by comgt's proto_3g_setup - and a TTY is
+		# root:dialout 0660, which no capability overrides.
+		for arg in "$@"; do
+			[ -c "$arg" ] && chown ppp "$arg"
+		done
+	}
+
+	proto_run_command "$config" $jail /usr/sbin/pppd \
 		nodetach ipparam "$config" \
 		ifname "$pppname" \
 		${localip:+$localip:} \

--- a/package/network/services/ppp/files/pppd.capabilities
+++ b/package/network/services/ppp/files/pppd.capabilities
@@ -1,0 +1,22 @@
+{
+	"bounding": [
+		"CAP_NET_ADMIN",
+		"CAP_NET_RAW"
+	],
+	"effective": [
+		"CAP_NET_ADMIN",
+		"CAP_NET_RAW"
+	],
+	"ambient": [
+		"CAP_NET_ADMIN",
+		"CAP_NET_RAW"
+	],
+	"permitted": [
+		"CAP_NET_ADMIN",
+		"CAP_NET_RAW"
+	],
+	"inheritable": [
+		"CAP_NET_ADMIN",
+		"CAP_NET_RAW"
+	]
+}

--- a/package/network/services/ppp/files/pppd_acl.json
+++ b/package/network/services/ppp/files/pppd_acl.json
@@ -1,0 +1,15 @@
+{
+	"user": "ppp",
+	"access": {
+		"network.interface": {
+			"methods": [
+				"notify_proto"
+			]
+		},
+		"network": {
+			"methods": [
+				"add_dynamic"
+			]
+		}
+	}
+}

--- a/package/network/services/ppp/patches/502-allow-nonroot-with-capnetadmin.patch
+++ b/package/network/services/ppp/patches/502-allow-nonroot-with-capnetadmin.patch
@@ -1,0 +1,195 @@
+From 0f0fd254c566bccee52eb814ebf671272f186838 Mon Sep 17 00:00:00 2001
+From: Julius Bairaktaris <julius@bairaktaris.de>
+Date: Thu, 6 Aug 2026 15:34:20 +0200
+Subject: [PATCH] pppd: allow running without root when CAP_NET_ADMIN is
+ present
+
+The euid != 0 gate dates from the setuid-root era: it refuses to run
+when the caller is not root and the binary is not setuid-root. On
+Linux that requirement is a capability, not a uid: the kernel's
+ppp_open() checks ns_capable(CAP_NET_ADMIN), and the interface ioctls
+require the same. A sandbox that grants the capability (procd/ujail,
+systemd) can therefore run pppd unprivileged, but the gate stops it
+before it can even try.
+
+Replace the check with ppp_privileged(): euid 0, or CAP_NET_ADMIN in
+the effective set (checked via capget on Linux, so no setuid bit and
+no libcap dependency). Solaris keeps the euid check.
+
+Passing the gate is not enough on its own. parse_args() grants OPT_PRIV
+options only when the privileged flag is set, and that flag was tied to
+getuid() == 0, so an unprivileged pppd holding the capability still
+died on its first privileged option: "ifname" for any caller that names
+the interface, "plugin" for pppoe. Grant the flag on the capability
+too, but only where the capability is the caller's own authority and
+not something the exec itself handed over. ppp_secure_exec() reads the
+kernel's own verdict on that from AT_SECURE, which covers a setuid or
+setgid bit and file capabilities alike; without it an unprivileged
+invoker of such a pppd would reach the OPT_PRIV "plugin" option and
+dlopen an attacker-chosen object with those privileges.
+
+run_program() re-roots the ip-up/ip-down child with setuid(0) before
+exec. Without CAP_SETUID that fails with EPERM and is fatal, so the
+link-up scripts never run under a capability sandbox. Only re-root when
+already euid 0 (the setuid-installed case); otherwise the child keeps
+its uid and any ambient capabilities reach the scripts unchanged.
+
+Validated on an ipq807x router: pppd runs as an unprivileged user
+(uid 454) with CAP_NET_ADMIN and proceeds past the gate; without the
+capability it exits EXIT_NOT_ROOT with the new message.
+
+Assisted-by: Claude:claude-opus-5
+Signed-off-by: Julius Bairaktaris <julius@bairaktaris.de>
+---
+ pppd/main.c        | 21 ++++++++++++++-------
+ pppd/pppd.h        | 13 +++++++++++++
+ pppd/sys-linux.c   | 34 +++++++++++++++++++++++++++++++++++
+ pppd/sys-solaris.c | 20 ++++++++++++++++++++
+ 4 files changed, 81 insertions(+), 7 deletions(-)
+
+--- a/pppd/main.c
++++ b/pppd/main.c
+@@ -401,7 +401,11 @@ main(int argc, char *argv[])
+     umask(umask(0777) | 022);
+ 
+     uid = getuid();
+-    privileged = uid == 0;
++    /* Privileged options come from the invoking user's own authority, so a
++     * pppd that gained privileges from the exec itself must not hand them
++     * to whoever ran it. */
++    privileged = uid == 0 || (uid == geteuid() && !ppp_secure_exec() &&
++                              ppp_privileged());
+     slprintf(numbuf, sizeof(numbuf), "%d", uid);
+     ppp_script_setenv("ORIG_UID", numbuf, 0);
+ 
+@@ -452,10 +456,11 @@ main(int argc, char *argv[])
+     }
+ 
+     /*
+-     * Check that we are running as root.
++     * Check that we have the privileges needed to open the ppp device
++     * and configure interfaces.
+      */
+-    if (geteuid() != 0) {
+-	ppp_option_error("must be root to run %s, since it is not setuid-root",
++    if (!ppp_privileged()) {
++	ppp_option_error("%s must be run as root or with CAP_NET_ADMIN",
+ 		     argv[0]);
+ 	exit(EXIT_NOT_ROOT);
+     }
+@@ -2004,9 +2009,11 @@ run_program(char *prog, char * const *ar
+     if (ret != 0) {
+         fatal("Failed to change directory to '/', %m");
+     }
+-    ret = setuid(0);		/* set real UID = root */
+-    if (ret != 0) {
+-        fatal("Failed to set uid, %m");
++    if (geteuid() == 0) {
++	ret = setuid(0);	/* set real UID = root */
++	if (ret != 0) {
++	    fatal("Failed to set uid, %m");
++	}
+     }
+     ret = setgid(getegid());
+     if (ret != 0) {
+--- a/pppd/pppd.h
++++ b/pppd/pppd.h
+@@ -444,6 +444,19 @@ void ppp_script_unsetenv(char *);
+ int ppp_check_kernel_support(void);
+ 
+ /*
++ * Test whether we have the privileges needed to open the ppp device
++ * and configure interfaces.
++ */
++int ppp_privileged(void);
++
++/*
++ * Test whether this exec raised our privileges - a setuid or setgid bit
++ * on the binary, or file capabilities - which the kernel grants to
++ * whoever runs it, and not to us on their behalf.
++ */
++int ppp_secure_exec(void);
++
++/*
+  * Restore device setting
+  */
+ void ppp_generic_disestablish(int dev_fd);
+--- a/pppd/sys-linux.c
++++ b/pppd/sys-linux.c
+@@ -107,6 +107,9 @@
+ 
+ #if !defined(__GLIBC__) || __GLIBC__ >= 2
+ #include <asm/types.h>		/* glibc 2 conflicts with linux/types.h */
++#include <sys/syscall.h>
++#include <sys/auxv.h>
++#include <linux/capability.h>
+ #include <net/if.h>
+ #include <net/if_arp.h>
+ #include <net/route.h>
+@@ -2863,6 +2866,37 @@ ppp_registered(void)
+     return ret;
+ }
+ 
++/*
++ * Check whether we have the privileges needed to open the ppp device
++ * and configure interfaces.  The kernel requires CAP_NET_ADMIN to open
++ * /dev/ppp (ppp_open in drivers/net/ppp/ppp_generic.c).
++ */
++int ppp_privileged(void)
++{
++    struct __user_cap_header_struct hdr;
++    struct __user_cap_data_struct data[2];
++
++    if (geteuid() == 0)
++	return 1;
++
++    hdr.version = _LINUX_CAPABILITY_VERSION_3;
++    hdr.pid = 0;
++    if (syscall(SYS_capget, &hdr, data) < 0)
++	return 0;
++
++    return !!(data[CAP_TO_INDEX(CAP_NET_ADMIN)].effective & CAP_TO_MASK(CAP_NET_ADMIN));
++}
++
++/*
++ * Test whether this exec raised our privileges.  The kernel sets AT_SECURE
++ * when a setuid or setgid bit or file capabilities did so, granting them
++ * to whoever runs the binary rather than to us on their behalf.
++ */
++int ppp_secure_exec(void)
++{
++    return getauxval(AT_SECURE) != 0;
++}
++
+ /********************************************************************
+  *
+  * ppp_check_kernel_support - check whether the system has any ppp interfaces
+--- a/pppd/sys-solaris.c
++++ b/pppd/sys-solaris.c
+@@ -636,6 +636,26 @@ sys_check_options(void)
+ }
+ 
+ /*
++ * ppp_privileged - check whether we have the privileges needed to open
++ * the ppp device and configure interfaces.
++ */
++int
++ppp_privileged(void)
++{
++    return geteuid() == 0;
++}
++
++/*
++ * ppp_secure_exec - Solaris has no AT_SECURE; the euid check in main.c
++ * covers setuid.
++ */
++int
++ppp_secure_exec(void)
++{
++    return 0;
++}
++
++/*
+  * ppp_check_kernel_support - check whether the system has any ppp interfaces
+  */
+ int


### PR DESCRIPTION
Implements #24553. pppd and odhcpd run as root today. This runs each in ujail as its own uid with only the capabilities its sockets need: pppd as uid 454 with `CAP_NET_ADMIN` and `CAP_NET_RAW`, odhcpd as uid 455 with those plus `CAP_NET_BIND_SERVICE` for 67/547. Both get `no_new_privs`, neither gets a mount namespace. uhttpd is #24740.

Each jail is opt-in. It applies only when `/sbin/ujail`, the capability file and the user are all present. Without any of them the daemon starts as it does now.

    package/network/services/ppp/files/ppp.sh, ppp_generic_setup():

        [ -x /sbin/ujail ] && [ -f "$caps" ] && id -u ppp >/dev/null 2>&1 && {
                jail="/sbin/ujail -t 5 -n pppd -U ppp -G ppp -C $caps -c --"

    package/network/services/odhcpd/files/odhcpd.init, odhcpd_jailed():

        [ -x /sbin/ujail ] && [ -e "$ODHCPD_CAPS" ] && id -u odhcpd >/dev/null 2>&1

The user check matters after a sysupgrade that preserved an `/etc/passwd` from before the uid existed. procd drops `user` and `group` without an error when the name does not resolve, so odhcpd would have kept running as uid 0 inside the jail.

ubusd denies every non-root uid by default, so each uid gets an `acl.d` file. pppd gets `network.interface notify_proto` and `network add_dynamic` for the ip-up scripts. odhcpd gets the `dhcp` object, `network.interface` subscribe and dump, `ubus.object.add` and `service signal`.

The dnsmasq commit comes first. `/etc/config/dhcp` ships 0600 root:root and odhcpd reads it directly, so a jailed odhcpd on a fresh image would serve nothing. It ships 0644 now, and a uci-defaults script relaxes existing installs. uci commit keeps the file's mode: on my router the file stayed 0600 across two commits.

The wrapper also hands pppd what uid 454 cannot take itself: `/dev/ppp`, `/var/run/pppd`, a serial TTY passed as an argument, and the peer DNS file behind `/etc/ppp/resolv.conf`. That last one is `/tmp/resolv.conf.ppp`, which pppd rewrites at every connect with `usepeerdns`. A copy left by a root-run pppd across an in-place package upgrade refuses uid 454 with `Permission denied`, so the wrapper removes it first. Nothing in OpenWrt reads that file; netifd takes the servers from the `DNS1`/`DNS2` environment.

The ppp commit goes the other way for the files that hold credentials. chap-secrets and the ppp-mod-radius server list go from 0600 root:root to 0640 root:ppp, from uci-defaults, because a postinst runs on the build host and `chgrp ppp` resolves against the host's `/etc/group` there.

Dependencies:

- openwrt/odhcpd#412 removes the `getuid() != 0` gate in `main()`. The odhcpd commit waits for it and for the `PKG_SOURCE_VERSION` bump.
- openwrt/rpcd#38. `rpc_file_access()` treats a call with no session id as authorised. That is only safe while uid 0 is the only uid that can reach ubus, and this series adds two more.
- openwrt/procd#40 is merged as procd 2c1834a but OpenWrt still pins 60fdbf0. Until the bump, a jailed pppd killed by `SIGSEGV` reaches netifd as exit 11, which pppd's table reads as `PEER_AUTH_FAILED`.
- ppp-project/ppp#608 for pppd's `euid != 0` gate. Carried here as `502-allow-nonroot-with-capnetadmin.patch`.

Tested on an ipq807x router with a PPPoE uplink, with the odhcpd#412 commit applied. At this head: pppd runs as uid 454 with `CapEff = CapAmb = 0x3000` and `NoNewPrivs: 1`, `wan` comes up with its v4 address and DNS and `wan_6` with its delegated prefix, and `ifdown wan` leaves no pppd behind. odhcpd runs as uid 455 with `0x3400`, writes its lease and hosts files as that uid and answers `ubus call dhcp ipv6leases`. The odhcpd user check was measured both ways: without the user the instance has no `user`, `group` or `jail` keys and odhcpd runs at uid 0; with the user present the instance carries all three and the capability file. `/etc/init.d/network restart` coming back with one pppd instance was measured on an earlier revision of this branch, not re-run at this head.

Not tested: pppoa, pptp, serial and 3G, since I have no hardware for them, and odhcpd's NDP relay mode under uid 455.