### PR TITLE
kernel: backport quirk for Horaco SFP+ Copper module

### DIFF
--- a/target/linux/generic/backport-6.12/755-v7.3-net-sfp-add-quirk-for-HORACO-copper-SFP-module.patch
+++ b/target/linux/generic/backport-6.12/755-v7.3-net-sfp-add-quirk-for-HORACO-copper-SFP-module.patch
@@ -1,0 +1,28 @@
+From 1bb028baab541900d3603d4f93c1c0fb5aba5401 Mon Sep 17 00:00:00 2001
+From: Aleksander Jan Bajkowski <olek2@wp.pl>
+Date: Sun, 19 Jul 2026 12:01:55 +0200
+Subject: [PATCH] net: sfp: add quirk for HORACO copper SFP+ module
+
+Add quirk for a copper SFP+ module that identifies itself as "OEM"
+"HC-10GE-113C". It uses RollBall protocol to talk to the PHY.
+
+Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Link: https://patch.msgid.link/20260719100158.874882-1-olek2@wp.pl
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/phy/sfp.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -569,6 +569,9 @@ static const struct sfp_quirk sfp_quirks
+ 
+ 	SFP_QUIRK_F("YV", "SFP+ONU-XGSPON", sfp_fixup_potron),
+ 
++	// HORACO HC-10GE-113C uses Rollball protocol to talk to the PHY.
++	SFP_QUIRK_F("OEM", "HC-10GE-113C", sfp_fixup_rollball),
++
+ 	// OEM SFP-GE-T is a 1000Base-T module with broken TX_FAULT indicator
+ 	SFP_QUIRK_F("OEM", "SFP-GE-T", sfp_fixup_ignore_tx_fault),
+ 

--- a/target/linux/generic/backport-6.18/755-v7.3-net-sfp-add-quirk-for-HORACO-copper-SFP-module.patch
+++ b/target/linux/generic/backport-6.18/755-v7.3-net-sfp-add-quirk-for-HORACO-copper-SFP-module.patch
@@ -1,0 +1,28 @@
+From 1bb028baab541900d3603d4f93c1c0fb5aba5401 Mon Sep 17 00:00:00 2001
+From: Aleksander Jan Bajkowski <olek2@wp.pl>
+Date: Sun, 19 Jul 2026 12:01:55 +0200
+Subject: [PATCH] net: sfp: add quirk for HORACO copper SFP+ module
+
+Add quirk for a copper SFP+ module that identifies itself as "OEM"
+"HC-10GE-113C". It uses RollBall protocol to talk to the PHY.
+
+Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Link: https://patch.msgid.link/20260719100158.874882-1-olek2@wp.pl
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/phy/sfp.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -593,6 +593,9 @@ static const struct sfp_quirk sfp_quirks
+ 
+ 	SFP_QUIRK_F("YV", "SFP+ONU-XGSPON", sfp_fixup_potron),
+ 
++	// HORACO HC-10GE-113C uses Rollball protocol to talk to the PHY.
++	SFP_QUIRK_F("OEM", "HC-10GE-113C", sfp_fixup_rollball),
++
+ 	// OEM SFP-GE-T is a 1000Base-T module with broken TX_FAULT indicator
+ 	SFP_QUIRK_F("OEM", "SFP-GE-T", sfp_fixup_ignore_tx_fault),
+ 

--- a/target/linux/generic/pending-6.12/750-net-sfp-add-quirk-for-QINIYEK-BJ-SFP-10G-T-copper-SF.patch
+++ b/target/linux/generic/pending-6.12/750-net-sfp-add-quirk-for-QINIYEK-BJ-SFP-10G-T-copper-SF.patch
@@ -16,7 +16,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -578,6 +578,7 @@ static const struct sfp_quirk sfp_quirks
+@@ -581,6 +581,7 @@ static const struct sfp_quirk sfp_quirks
  	SFP_QUIRK_S("OEM", "SFP-2.5G-BX10-U", sfp_quirk_2500basex),
  	SFP_QUIRK_F("OEM", "RTSFP-10", sfp_fixup_rollball_cc),
  	SFP_QUIRK_F("OEM", "RTSFP-10G", sfp_fixup_rollball_cc),

--- a/target/linux/generic/pending-6.18/750-net-sfp-add-quirk-for-QINIYEK-BJ-SFP-10G-T-copper-SF.patch
+++ b/target/linux/generic/pending-6.18/750-net-sfp-add-quirk-for-QINIYEK-BJ-SFP-10G-T-copper-SF.patch
@@ -16,7 +16,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -602,6 +602,7 @@ static const struct sfp_quirk sfp_quirks
+@@ -605,6 +605,7 @@ static const struct sfp_quirk sfp_quirks
  	SFP_QUIRK_S("OEM", "SFP-2.5G-BX10-U", sfp_quirk_2500basex),
  	SFP_QUIRK_F("OEM", "RTSFP-10", sfp_fixup_rollball_cc),
  	SFP_QUIRK_F("OEM", "RTSFP-10G", sfp_fixup_rollball_cc),

--- a/target/linux/generic/pending-6.18/751-net-sfp-add-quirk-for-TP-LINK-SM410U.patch
+++ b/target/linux/generic/pending-6.18/751-net-sfp-add-quirk-for-TP-LINK-SM410U.patch
@@ -14,7 +14,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -608,6 +608,7 @@ static const struct sfp_quirk sfp_quirks
+@@ -611,6 +611,7 @@ static const struct sfp_quirk sfp_quirks
  	SFP_QUIRK_F("Turris", "RTSFP-10G", sfp_fixup_rollball),
  
  	SFP_QUIRK_S("ZOERAX", "SFP-2.5G-T", sfp_quirk_oem_2_5g),

--- a/target/linux/generic/pending-6.18/896-03-net-phy-own-phydev-psec-via-PSE-notifier-and-remove-.patch
+++ b/target/linux/generic/pending-6.18/896-03-net-phy-own-phydev-psec-via-PSE-notifier-and-remove-.patch
@@ -369,7 +369,7 @@ Tested-by: Jonas Jelonek <jelonek.jonas@gmail.com>
  	rtnl_lock();
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -1992,7 +1992,7 @@ static int sfp_sm_probe_phy(struct sfp *
+@@ -1995,7 +1995,7 @@ static int sfp_sm_probe_phy(struct sfp *
  	/* Mark this PHY as being on a SFP module */
  	phy->is_on_sfp_module = true;
  

--- a/target/linux/realtek/patches-6.18/705-v7.1-net-sfp-initialize-i2c_block_size-at-adapter-configu.patch
+++ b/target/linux/realtek/patches-6.18/705-v7.1-net-sfp-initialize-i2c_block_size-at-adapter-configu.patch
@@ -31,7 +31,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -1816,6 +1816,7 @@ static int sfp_hwmon_insert(struct sfp *
+@@ -1819,6 +1819,7 @@ static int sfp_hwmon_insert(struct sfp *
  		sfp->hwmon_tries = R_PROBE_RETRY_SLOW;
  	}
  

--- a/target/linux/realtek/patches-6.18/706-01-v7.2-net-sfp-apply-I2C-adapter-quirks-to-limit-block-size.patch
+++ b/target/linux/realtek/patches-6.18/706-01-v7.2-net-sfp-apply-I2C-adapter-quirks-to-limit-block-size.patch
@@ -24,7 +24,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -826,21 +826,29 @@ static int sfp_smbus_byte_write(struct s
+@@ -829,21 +829,29 @@ static int sfp_smbus_byte_write(struct s
  
  static int sfp_i2c_configure(struct sfp *sfp, struct i2c_adapter *i2c)
  {

--- a/target/linux/realtek/patches-6.18/706-02-v7.2-net-sfp-extend-SMBus-support.patch
+++ b/target/linux/realtek/patches-6.18/706-02-v7.2-net-sfp-extend-SMBus-support.patch
@@ -75,7 +75,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  #include <linux/workqueue.h>
  
  #include "sfp.h"
-@@ -775,50 +776,113 @@ static int sfp_i2c_write(struct sfp *sfp
+@@ -778,50 +779,113 @@ static int sfp_i2c_write(struct sfp *sfp
  	return ret == ARRAY_SIZE(msgs) ? len : 0;
  }
  
@@ -213,7 +213,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  	}
  
  	return data - (u8 *)buf;
-@@ -834,10 +898,29 @@ static int sfp_i2c_configure(struct sfp
+@@ -837,10 +901,29 @@ static int sfp_i2c_configure(struct sfp
  		sfp->read = sfp_i2c_read;
  		sfp->write = sfp_i2c_write;
  		max_block_size = SFP_EEPROM_BLOCK_SIZE;

--- a/target/linux/realtek/patches-6.18/714-net-phy-sfp-add-support-for-SMBus.patch
+++ b/target/linux/realtek/patches-6.18/714-net-phy-sfp-add-support-for-SMBus.patch
@@ -10,7 +10,7 @@ Signed-off-by: Antoine Tenart <antoine.tenart@bootlin.com>
 
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -959,6 +959,29 @@ static int sfp_i2c_mdiobus_create(struct
+@@ -962,6 +962,29 @@ static int sfp_i2c_mdiobus_create(struct
  	return 0;
  }
  
@@ -40,7 +40,7 @@ Signed-off-by: Antoine Tenart <antoine.tenart@bootlin.com>
  static void sfp_i2c_mdiobus_destroy(struct sfp *sfp)
  {
  	mdiobus_unregister(sfp->i2c_mii);
-@@ -2174,9 +2197,15 @@ static void sfp_sm_fault(struct sfp *sfp
+@@ -2177,9 +2200,15 @@ static void sfp_sm_fault(struct sfp *sfp
  
  static int sfp_sm_add_mdio_bus(struct sfp *sfp)
  {


### PR DESCRIPTION
Backport quirks for Horaco SFP+ Copper modules. This module support RollBall protocol.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>