### PR TITLE
ramips: add support for D-Link DWR-921 C3 with U-Boot

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/ramips
+++ b/package/boot/uboot-tools/uboot-envtools/files/ramips
@@ -48,6 +48,9 @@ dlink,dir-806a-b1)
 dlink,covr-x1860-a1)
 	ubootenv_add_uci_config "/dev/mtd1" "0x2000" "0x4000" "0x2000"
 	;;
+dlink,dwr-921-c3-uboot)
+	ubootenv_add_mtd "u-boot-env" "0x0" "0x1000" "0x10000"
+	;;
 asus,rt-ax53u|\
 asus,rt-ax54|\
 asus,4g-ax56|\

--- a/target/linux/ramips/base-files/etc/uci-defaults/04_led_migration
+++ b/target/linux/ramips/base-files/etc/uci-defaults/04_led_migration
@@ -1,6 +1,12 @@
 . /lib/functions.sh
 . /lib/functions/migrations.sh
 
+case "$(board_name)" in
+dlink,dwr-921-c1)
+	migrate_leds "green:wifi=green:wlan"
+	;;
+esac
+
 remove_devicename_leds "rt2800soc-phy0" "rt2800pci-phy0"
 
 migrations_apply system

--- a/target/linux/ramips/dts/mt7620n_dlink_dwr-921-c1.dts
+++ b/target/linux/ramips/dts/mt7620n_dlink_dwr-921-c1.dts
@@ -1,96 +1,12 @@
-#include "mt7620n.dtsi"
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/leds/common.h>
+#include "mt7620n_dlink_dwr-921.dtsi"
+
 #include <dt-bindings/mtd/partitions/uimage.h>
 
 / {
 	compatible = "dlink,dwr-921-c1", "ralink,mt7620n-soc";
 	model = "D-Link DWR-921 C1";
-
-	aliases {
-		led-boot = &led_sstrenghg;
-		led-failsafe = &led_sstrenghg;
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		wps {
-			label = "wps";
-			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_WPS_BUTTON>;
-		};
-
-		reset {
-			label = "reset";
-			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
-		};
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		sms {
-			label = "green:sms";
-			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
-		};
-
-		lan {
-			function = LED_FUNCTION_LAN;
-			color = <LED_COLOR_ID_GREEN>;
-			gpios = <&gpio1 15 GPIO_ACTIVE_HIGH>;
-		};
-
-		led_sstrenghg: sstrengthg {
-			label = "green:sigstrength";
-			gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
-		};
-
-		sstrengthr {
-			label = "red:sigstrength";
-			gpios = <&gpio2 1 GPIO_ACTIVE_LOW>;
-		};
-
-		4g {
-			label = "green:4g";
-			gpios = <&gpio2 2 GPIO_ACTIVE_LOW>;
-		};
-
-		3g {
-			label = "green:3g";
-			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
-		};
-
-		wifi {
-			label = "green:wifi";
-			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
-		};
-	};
-
-	gpio_export {
-		compatible = "gpio-export";
-
-		lte_modem_enable {
-			gpio-export,name = "lte_modem_enable";
-			gpio-export,output = <1>;
-			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
-		};
-	};
-};
-
-&gpio1 {
-	status = "okay";
-};
-
-&gpio2 {
-	status = "okay";
-};
-
-&gpio3 {
-	status = "okay";
 };
 
 &spi0 {
@@ -126,20 +42,5 @@
 				read-only;
 			};
 		};
-	};
-};
-
-&ehci {
-	status = "okay";
-};
-
-&ohci {
-	status = "okay";
-};
-
-&state_default {
-	default {
-		groups = "spi refclk", "i2c", "ephy", "wled";
-		function = "gpio";
 	};
 };

--- a/target/linux/ramips/dts/mt7620n_dlink_dwr-921-c3-uboot.dts
+++ b/target/linux/ramips/dts/mt7620n_dlink_dwr-921-c3-uboot.dts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620n_dlink_dwr-921.dtsi"
+
+/ {
+	compatible = "dlink,dwr-921-c3-uboot", "ralink,mt7620n-soc";
+	model = "D-Link DWR-921 C3 (U-Boot)";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x200>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_4 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wmac {
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4 1>;
+	nvmem-cell-names = "eeprom", "mac-address";
+};

--- a/target/linux/ramips/dts/mt7620n_dlink_dwr-921.dtsi
+++ b/target/linux/ramips/dts/mt7620n_dlink_dwr-921.dtsi
@@ -32,7 +32,8 @@
 		compatible = "gpio-leds";
 
 		sms {
-			label = "green:sms";
+			function = "sms";
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
 		};
 
@@ -43,27 +44,32 @@
 		};
 
 		led_sstrenghg: sstrengthg {
-			label = "green:sigstrength";
+			function = "sigstrength";
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
 		};
 
 		sstrengthr {
-			label = "red:sigstrength";
+			function = "sigstrength";
+			color = <LED_COLOR_ID_RED>;
 			gpios = <&gpio2 1 GPIO_ACTIVE_LOW>;
 		};
 
 		4g {
-			label = "green:4g";
+			function = "4g";
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio2 2 GPIO_ACTIVE_LOW>;
 		};
 
 		3g {
-			label = "green:3g";
+			function = "3g";
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
 		};
 
 		wifi {
-			label = "green:wifi";
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ramips/dts/mt7620n_dlink_dwr-921.dtsi
+++ b/target/linux/ramips/dts/mt7620n_dlink_dwr-921.dtsi
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620n.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	aliases {
+		led-boot = &led_sstrenghg;
+		led-failsafe = &led_sstrenghg;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		sms {
+			label = "green:sms";
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio1 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_sstrenghg: sstrengthg {
+			label = "green:sigstrength";
+			gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
+		};
+
+		sstrengthr {
+			label = "red:sigstrength";
+			gpios = <&gpio2 1 GPIO_ACTIVE_LOW>;
+		};
+
+		4g {
+			label = "green:4g";
+			gpios = <&gpio2 2 GPIO_ACTIVE_LOW>;
+		};
+
+		3g {
+			label = "green:3g";
+			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			label = "green:wifi";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+
+		lte_modem_enable {
+			gpio-export,name = "lte_modem_enable";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&state_default {
+	default {
+		groups = "spi refclk", "i2c", "ephy", "wled";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -333,6 +333,20 @@ define Device/dlink_dwr-921-c3
 endef
 TARGET_DEVICES += dlink_dwr-921-c3
 
+define Device/dlink_dwr-921-c3-uboot
+  SOC := mt7620n
+  IMAGE_SIZE := 16064k
+  UIMAGE_NAME := DWR_921
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DWR-921
+  DEVICE_VARIANT := C3 (U-Boot)
+  DEVICE_PACKAGES += kmod-usb2 kmod-usb-net-qmi-wwan \
+	kmod-usb-serial-option uboot-envtools uqmi zram-swap
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size
+endef
+TARGET_DEVICES += dlink_dwr-921-c3-uboot
+
 define Device/dlink_dwr-922-e2
   $(Device/amit_jboot)
   SOC := mt7620n

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -80,6 +80,7 @@ dlink,dwr-118-a2)
 	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan2g" "wlan1"
 	;;
 dlink,dwr-921-c1|\
+dlink,dwr-921-c3-uboot|\
 dlink,dwr-922-e2)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x0f"
 	ucidef_set_led_netdev "signalstrength" "signalstrength" "green:sigstrength" "wwan0" "link"

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -80,7 +80,12 @@ dlink,dwr-118-a2)
 	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan2g" "wlan1"
 	;;
 dlink,dwr-921-c1|\
-dlink,dwr-921-c3-uboot|\
+dlink,dwr-921-c3-uboot)
+	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x0f"
+	ucidef_set_led_netdev "signalstrength" "signalstrength" "green:sigstrength" "wwan0" "link"
+	ucidef_set_led_netdev "4g" "4g" "green:4g" "wwan0" "tx rx"
+	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan" "wlan0"
+	;;
 dlink,dwr-922-e2)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x0f"
 	ucidef_set_led_netdev "signalstrength" "signalstrength" "green:sigstrength" "wwan0" "link"

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -13,6 +13,7 @@ ramips_setup_interfaces()
 	asus,rt-n12p|\
 	dlink,dwr-116-a1|\
 	dlink,dwr-921-c1|\
+	dlink,dwr-921-c3-uboot|\
 	dlink,dwr-922-e2|\
 	dovado,tiny-ac|\
 	hongdian,h8922-v30|\
@@ -357,6 +358,11 @@ ramips_setup_macs()
 	dlink,dwr-961-a1|\
 	lava,lr-25g001)
 		wan_mac=$(jboot_config_read -m -i $(find_mtd_part "config") -o 0xE000)
+		lan_mac=$(macaddr_add "$wan_mac" 1)
+		label_mac=$wan_mac
+		;;
+	dlink,dwr-921-c3-uboot)
+		wan_mac=$(mtd_get_mac_binary factory 0x4)
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		label_mac=$wan_mac
 		;;


### PR DESCRIPTION
Newer D-Link DWR-921 C3 units shipped with factory firmware 3.0.x use U-Boot and a different flash layout, so the existing JBoot C3 images cannot be installed or booted on them.

This adds a separate `dlink_dwr-921-c3-uboot` profile with:

- the factory U-Boot/environment/Factory/Linux partition map;
- Wi-Fi EEPROM and MAC data read from the Factory partition;
- a raw legacy-uImage factory image named `DWR_921`, matching the OEM updater;
- writable access to the OEM 4 KiB environment in its 64 KiB erase sector through `uboot-envtools`;
- USB2, QMI and serial-option support for the internal LTE modem;
- `zram-swap` with its standard OpenWrt defaults;
- the existing swconfig switch, LEDs, buttons, Wi-Fi and serial wiring.

The shared hardware description was factored out of the existing C1 DTS. Its DTB is byte-identical before and after that refactor. A separate follow-up commit modernizes the shared LED definitions while keeping the existing generated names except for the standard `green:wlan` Wi-Fi LED. Existing C1 and C3 U-Boot configurations migrate that one LED name; DWR-922 E2 remains unchanged.

The SPI clock is deliberately kept at the OEM-proven 25 MHz without fast-read. Disassembly of the stock U-Boot shows clock divisor 8, while the official D-Link GPL kernel independently selects the same divisor, leaves its fast-read mode disabled and issues normal `0x03` reads.

This profile deliberately retains the current MT7620 Ethernet and swconfig path. The separate, still-unmerged DSA, generic MediaTek Ethernet and PPE series are not prerequisites for this device support.

Validation:

- clean `ramips/mt7620` target configuration for this device;
- complete `make -j12` build;
- rootfs checked for `uboot-envtools`, USB2, QMI, zram-swap and swconfig;
- generated environment setup checked for a 4 KiB environment in a 64 KiB erase sector on `u-boot-env`;
- generated DTB checked for the 25 MHz SPI setting, partition map, NVMEM cells and generated LED names;
- factory/sysupgrade uImage headers, partition bounds, rootfs and image metadata inspected;
- official D-Link 3.0.2 updater, transition image, stock U-Boot and GPL kernel inspected;
- both stages of the official transition reproduced against a copy of a complete 16 MiB flash dump, preserving the legacy configuration sector;
- `git diff --check` and strict checkpatch pass with no findings.

There is no surviving factory-U-Boot unit in the current lab, so runtime testing on that bootloader is still needed. The available DWR-921 C3 has already been converted to JBoot and was not flashed for this target-only change.

Fixes #21848
