### PR TITLE
ramips: allow Youku L1 series images to flash on either model

### DIFF
--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -1465,7 +1465,7 @@ define Device/youku_yk-l1
   DEVICE_MODEL := YK-L1
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-mmc-mtk \
 	kmod-usb-ledtrig-usbport
-  SUPPORTED_DEVICES += youku-yk1 youku,yk1
+  SUPPORTED_DEVICES += youku-yk1 youku,yk1 youku,yk-l1c
   UIMAGE_MAGIC := 0x12291000
   UIMAGE_NAME := 400000000000000000000000
 endef
@@ -1478,6 +1478,7 @@ define Device/youku_yk-l1c
   DEVICE_MODEL := YK-L1c
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-mmc-mtk \
 	kmod-usb-ledtrig-usbport
+  SUPPORTED_DEVICES += youku-yk1 youku,yk1 youku,yk-l1
   UIMAGE_MAGIC := 0x12291000
   UIMAGE_NAME := 400000000000000000000000
 endef


### PR DESCRIPTION
These boards are shown to be identical hardware, but ever since commit 4a9f389ed2dce they have been treated as separate devices due to differing flash size.

Some of these boards are actually a L1 when released with an enclosure with the L1c label, leading people to flash the wrong factory.bin file and have the 4-byte flash mode reboot issue.

To help mitigate the problem, allow the board to accept both images instead of give a warning so users can go between the two DTS easily.

relevant to #22952 
better fix than #24545 