### PR TITLE
gettext-full: update to 1.0

### DIFF
--- a/package/libs/gettext-full/Makefile
+++ b/package/libs/gettext-full/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gettext-full
-PKG_VERSION:=0.24.2
+PKG_VERSION:=1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=gettext-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/gettext
-PKG_HASH:=fcc0187f597aef6bc5bc95c629db1126315beb196b20570eaec6a4941850f7c5
+PKG_HASH:=71132a3fb71e68245b8f2ac4e9e97137d3e5c02f415636eb508ae607bc01add7
 PKG_BUILD_DIR:=$(BUILD_DIR)/gettext-$(PKG_VERSION)
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/gettext-$(PKG_VERSION)
 
@@ -43,11 +43,12 @@ PKG_SUBDIRS:= \
 		libgrep \
 		libtextstyle \
 		m4 \
-		misc \
 		po \
 		projects \
 		src \
 		styles \
+		autotools \
+		wizard \
 		gettext-runtime \
 		gettext-tools \
 	,$$$$(wildcard $$$$(dir)) )
@@ -87,7 +88,7 @@ CONFIGURE_ARGS += \
 	--disable-java \
 	--disable-openmp \
 	--disable-curses \
-	--with-included-gettext \
+	--with-included-libintl \
 	--without-libintl-prefix \
 	--without-libexpat-prefix \
 	--with-libunistring-prefix=$(STAGING_DIR)/usr \
@@ -114,6 +115,9 @@ HOST_CFLAGS += $(HOST_FPIC)
 define Host/Bootstrap
 	( \
 		cd $(HOST_BUILD_DIR); \
+		for dir in $$$$(find . -maxdepth 3 \( -name configure.ac -o -name configure.in \) -exec dirname {} \;); do \
+			(cd $$$$dir && $(AM_TOOL_PATHS) $(STAGING_DIR_HOST)/bin/libtoolize --copy --force) || exit 1; \
+		done && \
 		$(AM_TOOL_PATHS) \
 		./autogen.sh \
 	)
@@ -137,6 +141,9 @@ endef
 define Build/Bootstrap
 	( \
 		cd $(PKG_BUILD_DIR); \
+		for dir in $$$$(find . -maxdepth 3 \( -name configure.ac -o -name configure.in \) -exec dirname {} \;); do \
+			(cd $$$$dir && $(AM_TOOL_PATHS) $(STAGING_DIR_HOST)/bin/libtoolize --copy --force) || exit 1; \
+		done && \
 		$(AM_TOOL_PATHS) \
 		./autogen.sh \
 	)

--- a/package/libs/gettext-full/patches/000-relocatable.patch
+++ b/package/libs/gettext-full/patches/000-relocatable.patch
@@ -1,6 +1,6 @@
---- a/gettext-tools/misc/autopoint.in
-+++ b/gettext-tools/misc/autopoint.in
-@@ -27,7 +27,11 @@ archive_version=@ARCHIVE_VERSION@
+--- a/gettext-tools/autotools/autopoint.in
++++ b/gettext-tools/autotools/autopoint.in
+@@ -28,7 +28,11 @@ archive_version=@ARCHIVE_VERSION@
  
  # Set variables
  # - gettext_datadir     directory where the data files are stored.
@@ -13,9 +13,9 @@
  datarootdir="@datarootdir@"
  : ${gettext_datadir="@datadir@/gettext"}
  : ${AUTOM4TE=autom4te}
---- a/gettext-tools/misc/gettextize.in
-+++ b/gettext-tools/misc/gettextize.in
-@@ -27,7 +27,11 @@ archive_version=@ARCHIVE_VERSION@
+--- a/gettext-tools/wizard/gettextize.in
++++ b/gettext-tools/wizard/gettextize.in
+@@ -28,7 +28,11 @@ archive_version=@ARCHIVE_VERSION@
  
  # Set variables
  # - gettext_datadir     directory where the data files are stored.

--- a/package/libs/gettext-full/patches/001-autotools.patch
+++ b/package/libs/gettext-full/patches/001-autotools.patch
@@ -1,6 +1,6 @@
 --- a/gettext-runtime/man/Makefile.am
 +++ b/gettext-runtime/man/Makefile.am
-@@ -176,8 +176,7 @@ textdomain.3.html: textdomain.3.in
+@@ -183,8 +183,7 @@ textdomain.3.html: textdomain.3.in
  bindtextdomain.3.html: bindtextdomain.3.in
  bind_textdomain_codeset.3.html: bind_textdomain_codeset.3.in
  
@@ -12,9 +12,9 @@
  	  $(INSTALL_DATA) $$dir/$$file $(DESTDIR)$(htmldir)/$$file; \
 --- a/gettext-tools/man/Makefile.am
 +++ b/gettext-tools/man/Makefile.am
-@@ -158,8 +158,7 @@ recode-sr-latin.1.html: recode-sr-latin.
- gettextize.1.html: gettextize.1
+@@ -184,8 +184,7 @@ gettextize.1.html: gettextize.1
  autopoint.1.html: autopoint.1
+ po-fetch.1.html: po-fetch.1
  
 -install-html-local:
 -	$(MKDIR_P) $(DESTDIR)$(htmldir)

--- a/package/libs/gettext-full/patches/200-libunistring-missing-link.patch
+++ b/package/libs/gettext-full/patches/200-libunistring-missing-link.patch
@@ -1,21 +1,21 @@
 --- a/autogen.sh
 +++ b/autogen.sh
-@@ -104,6 +104,7 @@ if ! $skip_gnulib; then
-     getopt-gnu
+@@ -108,6 +108,7 @@ if ! $skip_gnulib; then
+     fzprintf-posix
      gettext-h
      havelib
 +    libunistring-optional
+     mbrtoc32
+     mbszero
      memmove
-     noreturn
-     progname
 --- a/gettext-runtime/src/Makefile.am
 +++ b/gettext-runtime/src/Makefile.am
-@@ -43,7 +43,7 @@ envsubst_SOURCES = envsubst.c
+@@ -51,7 +51,7 @@ libgrtsrc_a_SOURCES = \
  
  # Link dependencies.
  # Need @LTLIBICONV@ because striconv.c uses iconv().
--LDADD = ../gnulib-lib/libgrt.a @LTLIBINTL@ @LTLIBICONV@ $(WOE32_LDADD)
-+LDADD = ../gnulib-lib/libgrt.a $(LTLIBUNISTRING) @LTLIBINTL@ @LTLIBICONV@ $(WOE32_LDADD)
+-LDADD = libgrtsrc.a ../gnulib-lib/libgrt.a @LTLIBINTL@ @LTLIBICONV@ $(WOE32_LDADD)
++LDADD = libgrtsrc.a ../gnulib-lib/libgrt.a $(LTLIBUNISTRING) @LTLIBINTL@ @LTLIBICONV@ $(WOE32_LDADD)
  
  # Specify installation directory, for --enable-relocatable.
  gettext_CFLAGS = -DINSTALLDIR=$(bindir_c_make)


### PR DESCRIPTION
0.24.2 was several releases and over a year out of date and required patching to circumvent a build failure.

Makefile needed to be modifed since autogen.sh never runs libtoolize, so aclocal.m4 picks up the newer LT_INIT macros from the shared host libtool package while ltmain.sh while stays at the version bundled in the release tarball, causing a libtool version-mismatch abort at build time.

Patches were manually rebeased.

Changes between these releases can be found here:
https://github.com/autotools-mirror/gettext/blob/master/NEWS#L9-L178