### PR TITLE
qualcommax: fix QCA8081 2.5G port egress corruption

### DIFF
--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -2,6 +2,7 @@
 
 #include <linux/delay.h>
 #include <linux/clk.h>
+#include <linux/clk-provider.h>
 #include <linux/module.h>
 #include <linux/of_device.h>
 #include <linux/of_net.h>
@@ -1015,6 +1016,7 @@ static void qca_ppe_mac_link_up(struct phylink_config *config,
 {
 	struct dsa_port *dp = dsa_phylink_to_port(config);
 	struct qca_ppe_priv *priv = ds_to_priv(dp->ds);
+	phy_interface_t cfg_interface;
 	int port = dp->index;
 	unsigned long rate;
 
@@ -1103,6 +1105,68 @@ static void qca_ppe_mac_link_up(struct phylink_config *config,
 		clk_set_rate(priv->port_rx_clk[port], rate);
 	if (priv->port_tx_clk[port])
 		clk_set_rate(priv->port_tx_clk[port], rate);
+
+	/* QCA8081 2500BASE-X (uniphy1) egress-corruption fix.
+	 *
+	 * The bootloader leaves nss_port5_tx_clk_src muxed to the uniphy1 RX
+	 * serdes clock. At mac_link_up() the requested rate already matches (the
+	 * uniphy1 RX and TX serdes run at the same rate), so clk_set_rate() bails
+	 * out early and never reprograms the mux -- the port keeps transmitting
+	 * off the recovered RX clock and egress frames get corrupted on the wire
+	 * (TX-only; tx_dropped/tx_errors stay zero). Point the RCG at the uniphy1
+	 * TX serdes clock explicitly.
+	 *
+	 * Gate on the configured device-tree serdes mode, not the runtime
+	 * phydev->interface: qca808x_read_status() rewrites the interface to
+	 * SGMII for every negotiated speed below 2.5G, so the runtime value reads
+	 * 2500BASE-X only while the link is actually at 2.5G -- but the same
+	 * uniphy1 TX-clock corruption hits at 1G too. of_get_phy_mode() reads the
+	 * fixed port mode, so the fix applies at all speeds on the 2500BASE-X
+	 * port. The uniphy1-TX-parent check below still keeps PSGMII port-5
+	 * (uniphy0) setups untouched.
+	 *
+	 * The parent is matched by name ("uniphy1_gcc_tx_clk"), not index,
+	 * because the uniphy provider indices are inverted relative to the
+	 * names: the binding defines UNIPHY_CLK_RX as 0 and UNIPHY_CLK_TX as 1,
+	 * while ipq6018-ess.dtsi (and ipq8074-ess.dtsi) list clock-output-names
+	 * TX-first, so <&uniphy1 0> is the RX index yet carries the TX name.
+	 * That also makes a device-tree-only alternative -- an
+	 * assigned-clock-parents on GCC_NSS_PORT5_TX_CLK_SRC pointing at the
+	 * uniphy1 TX output -- easy to get wrong, so the name match here is the
+	 * robust choice.
+	 */
+	if (!of_get_phy_mode(dp->dn, &cfg_interface) &&
+	    cfg_interface == PHY_INTERFACE_MODE_2500BASEX &&
+	    priv->port_tx_clk[port]) {
+		struct clk *div = clk_get_parent(priv->port_tx_clk[port]);
+		struct clk *rcg = div ? clk_get_parent(div) : NULL;
+
+		if (rcg) {
+			struct clk_hw *rhw = __clk_get_hw(rcg);
+			unsigned int i, n = clk_hw_get_num_parents(rhw);
+
+			for (i = 0; i < n; i++) {
+				struct clk_hw *ph = clk_hw_get_parent_by_index(rhw, i);
+				struct clk *pc;
+				int ret;
+
+				if (!ph || strcmp(clk_hw_get_name(ph), "uniphy1_gcc_tx_clk"))
+					continue;
+
+				pc = clk_hw_get_clk(ph, NULL);
+				if (IS_ERR_OR_NULL(pc))
+					break;
+
+				ret = clk_set_parent(rcg, pc);
+				if (ret)
+					dev_warn(dp->ds->dev,
+						 "port %d: failed to set TX clock parent: %d\n",
+						 port, ret);
+				clk_put(pc);
+				break;
+			}
+		}
+	}
 
 	switch (interface) {
 	case PHY_INTERFACE_MODE_SGMII:


### PR DESCRIPTION
The 2.5G port (QCA8081, PPE port 5) on IPQ6018 corrupts frames on **egress**
under load: TCP TX drops to ~900 Mbit/s with thousands of retransmits while RX
stays clean, on both 1G and 2.5G links.

**Root cause:** the bootloader leaves the port 5 TX clock RCG
(`nss_port5_tx_clk_src`) muxed to the uniphy1 **RX** serdes clock instead of
uniphy1 **TX**, and nothing reprograms it. At `mac_link_up()` the requested rate
already matches — the uniphy1 RX and TX serdes run at the same rate — so
`clk_set_rate()` bails out early ("nothing to do") and the freq-multi selector
never runs, leaving the bootloader's mux setting in place. Egress is then clocked
from the recovered RX clock, mangling transmitted frames on the wire
(tx_dropped/tx_errors stay 0 — the MAC transmits fine). The vendor SSDK avoids
this by explicitly setting the port 5 clock parents.

**Fix:** point the RCG at the uniphy1 TX serdes clock explicitly, matching the
parent by name (`uniphy1_gcc_tx_clk`) rather than by index. Gated on two things:

- the **configured device-tree serdes mode** (`of_get_phy_mode()`), not the
  runtime `phydev->interface` — `qca808x_read_status()` rewrites the interface to
  SGMII for every negotiated speed below 2.5G, so a runtime-mode gate would miss
  1G even though the same TX-clock corruption is present there;
- the RCG actually exposing a uniphy1 TX parent, so PSGMII port-5 (uniphy0)
  configurations are left untouched.

**Verified** on a MikroTik Chateau 5G R17 ax, iperf3 over the 2.5G port to a
bare-metal peer:

| direction | before | after |
|---|---|---|
| TX (egress), 2.5G link | ~900 Mbit/s, ~4400 retransmits | **~1.5 Gbit/s, 0 retransmits** |
| RX, 2.5G link | ~1.7 Gbit/s, clean | ~1.7 Gbit/s, clean |

Register ground truth (`nss_port5_tx_clk_src` CFG): `src=4` (uniphy1 RX) before,
`src=3` (uniphy1 TX) after.

The 1G case was reported and tested by @Jan64X on a MikroTik hAP ax3, which uses
the same QCA8081/uniphy1 path: 1G link, parent stuck at `uniphy1_gcc_rx_clk`,
715 Mbit/s with 3061 retransmits before — 940 Mbit/s with 11 retransmits after
the device-tree-mode gate.

The driver lives in `target/linux/qualcommax/files/`, so no per-kernel patch is
needed (qualcommax is on 6.18 since 55a7d7c45f7).

Affects any IPQ6018/IPQ8074 board whose port 5 is a 2500BASE-X uniphy1 port, e.g.
the MikroTik Chateau 5G R17 ax (#24335) and the MikroTik hAP ax3 (#24526). The
low-speed behaviour on the ipq807x boards with a 2500BASE-X port 5 (e.g.
`ipq8072-dl-wrx36`) is a no-op by analysis — both uniphy outputs recalc to the
same rate for a given serdes mode — but has not been measured on that hardware.
