### PR TITLE
[25.12] mediatek: fix nmbm max-reserved-blocks for Keenetic/Netcraze devices

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-keenetic-kap-630.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kap-630.dtsi
@@ -138,7 +138,7 @@
 
 		mediatek,nmbm;
 		mediatek,bmt-max-ratio = <1>;
-		mediatek,bmt-max-reserved-blocks = <64>;
+		mediatek,bmt-max-reserved-blocks = <256>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3711.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3711.dts
@@ -211,7 +211,7 @@
 
 		mediatek,nmbm;
 		mediatek,bmt-max-ratio = <1>;
-		mediatek,bmt-max-reserved-blocks = <64>;
+		mediatek,bmt-max-reserved-blocks = <256>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3811.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3811.dts
@@ -227,7 +227,7 @@
 
 		mediatek,nmbm;
 		mediatek,bmt-max-ratio = <1>;
-		mediatek,bmt-max-reserved-blocks = <64>;
+		mediatek,bmt-max-reserved-blocks = <256>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3911.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3911.dts
@@ -174,7 +174,7 @@
 
 		mediatek,nmbm;
 		mediatek,bmt-max-ratio = <1>;
-		mediatek,bmt-max-reserved-blocks = <64>;
+		mediatek,bmt-max-reserved-blocks = <256>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dtsi
+++ b/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dtsi
@@ -170,7 +170,7 @@
 
 		mediatek,nmbm;
 		mediatek,bmt-max-ratio = <1>;
-		mediatek,bmt-max-reserved-blocks = <64>;
+		mediatek,bmt-max-reserved-blocks = <256>;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
The devicetree set mediatek,bmt-max-reserved-blocks to 64, but the factory firmware uses 256. With the lower value NMBM fails to locate its signature on some boards, and the device does not boot.

Restore the factory value of 256 to match stock firmware and fix boot on affected units.

Vendor nmbm max blocks value:
https://github.com/keenetic/kernel-49/blob/master/drivers/mtd/nmbm/nmbm-mtd.c#L31


Link: https://github.com/openwrt/openwrt/pull/24001

(cherry picked from commit 7085d165524f8f1623cd88327725073c25610bad)