### PR TITLE
mediatek: cmcc rax3000m: add all-in-UBI layout

### DIFF
--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -305,6 +305,30 @@ define U-Boot/mt7981_cmcc_rax3000m-nand-ddr4
   DEPENDS:=+trusted-firmware-a-mt7981-spim-nand-ddr4
 endef
 
+define U-Boot/mt7981_cmcc_rax3000m-ubi-ddr3
+  NAME:=CMCC RAX3000M (DDR3, UBI)
+  BUILD_SUBTARGET:=filogic
+  BUILD_DEVICES:=cmcc_rax3000m
+  UBOOT_CONFIG:=mt7981_cmcc_rax3000m-ubi
+  UBOOT_IMAGE:=u-boot.fip
+  BL2_BOOTDEV:=spim-nand-ubi
+  BL2_SOC:=mt7981
+  BL2_DDRTYPE:=ddr3-1866
+  DEPENDS:=+trusted-firmware-a-mt7981-spim-nand-ubi-ddr3-1866
+endef
+
+define U-Boot/mt7981_cmcc_rax3000m-ubi-ddr4
+  NAME:=CMCC RAX3000M (DDR4, UBI)
+  BUILD_SUBTARGET:=filogic
+  BUILD_DEVICES:=cmcc_rax3000m
+  UBOOT_CONFIG:=mt7981_cmcc_rax3000m-ubi
+  UBOOT_IMAGE:=u-boot.fip
+  BL2_BOOTDEV:=spim-nand-ubi
+  BL2_SOC:=mt7981
+  BL2_DDRTYPE:=ddr4
+  DEPENDS:=+trusted-firmware-a-mt7981-spim-nand-ubi-ddr4
+endef
+
 define U-Boot/mt7981_comfast_cf-wr632ax
   NAME:=COMFAST CF-WR632AX
   BUILD_SUBTARGET:=filogic
@@ -1378,6 +1402,8 @@ UBOOT_TARGETS := \
 	mt7981_cmcc_rax3000m-emmc-ddr4 \
 	mt7981_cmcc_rax3000m-nand-ddr3 \
 	mt7981_cmcc_rax3000m-nand-ddr4 \
+	mt7981_cmcc_rax3000m-ubi-ddr3 \
+	mt7981_cmcc_rax3000m-ubi-ddr4 \
 	mt7981_comfast_cf-wr632ax \
 	mt7981_comfast_cf-wr632ax-ubi \
 	mt7981_creatlentem_clt-r30b1-ubi \

--- a/package/boot/uboot-mediatek/patches/437-add-cmcc_rax3000m.patch
+++ b/package/boot/uboot-mediatek/patches/437-add-cmcc_rax3000m.patch
@@ -261,8 +261,140 @@
 +CONFIG_ZSTD=y
 +CONFIG_HEXDUMP=y
 --- /dev/null
++++ b/configs/mt7981_cmcc_rax3000m-ubi_defconfig
+@@ -0,0 +1,129 @@
++CONFIG_ARM=y
++CONFIG_ARM_SMCCC=y
++CONFIG_SYS_HAS_NONCACHED_MEMORY=y
++CONFIG_POSITION_INDEPENDENT=y
++CONFIG_ARCH_MEDIATEK=y
++CONFIG_TEXT_BASE=0x41e00000
++CONFIG_SYS_MALLOC_F_LEN=0x4000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEFAULT_DEVICE_TREE="mt7981-cmcc-rax3000m-ubi"
++CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_TARGET_MT7981=y
++CONFIG_SYS_LOAD_ADDR=0x46000000
++CONFIG_PRE_CON_BUF_ADDR=0x4007EF00
++CONFIG_DEBUG_UART_BASE=0x11002000
++CONFIG_DEBUG_UART_CLOCK=40000000
++CONFIG_PCI=y
++CONFIG_DEBUG_UART=y
++CONFIG_AHCI=y
++CONFIG_FIT=y
++CONFIG_BOOTDELAY=30
++CONFIG_AUTOBOOT_KEYED=y
++CONFIG_AUTOBOOT_MENU_SHOW=y
++CONFIG_USE_PREBOOT=y
++CONFIG_DEFAULT_FDT_FILE="mt7981-cmcc-rax3000m-ubi"
++CONFIG_LOGLEVEL=7
++CONFIG_PRE_CONSOLE_BUFFER=y
++CONFIG_LOG=y
++# CONFIG_BOARD_INIT is not set
++CONFIG_BOARD_LATE_INIT=y
++CONFIG_HUSH_PARSER=y
++CONFIG_SYS_PROMPT="MT7981> "
++CONFIG_CMD_CPU=y
++CONFIG_CMD_LICENSE=y
++# CONFIG_CMD_BOOTEFI_BOOTMGR is not set
++CONFIG_CMD_BOOTMENU=y
++CONFIG_CMD_ASKENV=y
++CONFIG_CMD_ERASEENV=y
++CONFIG_CMD_ENV_FLAGS=y
++CONFIG_CMD_RNG=y
++CONFIG_CMD_STRINGS=y
++CONFIG_CMD_DM=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_PWM=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_MTD=y
++CONFIG_CMD_PART=y
++CONFIG_CMD_PCI=y
++CONFIG_CMD_TFTPSRV=y
++CONFIG_CMD_RARP=y
++CONFIG_CMD_CDP=y
++CONFIG_CMD_SNTP=y
++CONFIG_CMD_LINK_LOCAL=y
++CONFIG_CMD_DHCP=y
++CONFIG_CMD_DNS=y
++CONFIG_CMD_PING=y
++CONFIG_CMD_PXE=y
++CONFIG_CMD_CACHE=y
++CONFIG_CMD_PSTORE=y
++CONFIG_CMD_PSTORE_MEM_ADDR=0x42ff0000
++CONFIG_CMD_UUID=y
++CONFIG_CMD_HASH=y
++CONFIG_CMD_SMC=y
++CONFIG_CMD_EXT4=y
++CONFIG_CMD_FAT=y
++CONFIG_CMD_FS_GENERIC=y
++CONFIG_CMD_FS_UUID=y
++CONFIG_CMD_UBI=y
++CONFIG_CMD_UBI_RENAME=y
++CONFIG_OF_EMBED=y
++CONFIG_ENV_OVERWRITE=y
++CONFIG_ENV_IS_IN_UBI=y
++CONFIG_ENV_REDUNDANT=y
++CONFIG_ENV_UBI_PART="ubi"
++CONFIG_ENV_UBI_VOLUME="ubootenv"
++CONFIG_ENV_UBI_VOLUME_REDUND="ubootenv2"
++CONFIG_ENV_RELOC_GD_ENV_ADDR=y
++CONFIG_ENV_USE_DEFAULT_ENV_TEXT_FILE=y
++CONFIG_ENV_DEFAULT_ENV_TEXT_FILE="defenvs/cmcc_rax3000m-ubi_env"
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_VERSION_VARIABLE=y
++CONFIG_NETCONSOLE=y
++CONFIG_USE_IPADDR=y
++CONFIG_IPADDR="192.168.1.1"
++CONFIG_USE_SERVERIP=y
++CONFIG_SERVERIP="192.168.1.254"
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_SCSI_AHCI=y
++CONFIG_AHCI_PCI=y
++CONFIG_MTK_AHCI=y
++CONFIG_BUTTON=y
++CONFIG_BUTTON_GPIO=y
++CONFIG_CLK=y
++CONFIG_GPIO_HOG=y
++CONFIG_LED=y
++CONFIG_LED_BLINK=y
++CONFIG_LED_GPIO=y
++# CONFIG_MMC is not set
++CONFIG_MTD=y
++CONFIG_DM_MTD=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_MTD_UBI_FASTMAP=y
++CONFIG_PHY_FIXED=y
++CONFIG_MEDIATEK_ETH=y
++CONFIG_PCIE_MEDIATEK=y
++CONFIG_PHY=y
++CONFIG_PHY_MTK_TPHY=y
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++CONFIG_PINCTRL_MT7622=y
++CONFIG_PINCTRL_MT7981=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MTK_POWER_DOMAIN=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_DM_PWM=y
++CONFIG_PWM_MTK=y
++CONFIG_RAM=y
++CONFIG_DM_RNG=y
++CONFIG_RNG_MTK_V2=y
++CONFIG_SCSI=y
++CONFIG_DM_SERIAL=y
++CONFIG_SERIAL_RX_BUFFER=y
++CONFIG_MTK_SERIAL=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_MTK_SPIM=y
++CONFIG_ZSTD=y
++CONFIG_HEXDUMP=y
+--- /dev/null
 +++ b/arch/arm/dts/mt7981-cmcc-rax3000m.dtsi
-@@ -0,0 +1,85 @@
+@@ -0,0 +1,138 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
 + * Copyright (c) 2022 MediaTek Inc.
@@ -340,78 +472,6 @@
 +	};
 +};
 +
-+&uart0 {
-+	mediatek,force-highspeed;
-+	status = "okay";
-+};
-+
-+&watchdog {
-+	status = "disabled";
-+};
---- /dev/null
-+++ b/arch/arm/dts/mt7981-cmcc-rax3000m-emmc.dts
-@@ -0,0 +1,53 @@
-+// SPDX-License-Identifier: GPL-2.0-only
-+
-+/dts-v1/;
-+#include "mt7981-cmcc-rax3000m.dtsi"
-+
-+/ {
-+	reg_3p3v: regulator-3p3v {
-+		compatible = "regulator-fixed";
-+		regulator-name = "fixed-3.3V";
-+		regulator-min-microvolt = <3300000>;
-+		regulator-max-microvolt = <3300000>;
-+		regulator-boot-on;
-+		regulator-always-on;
-+	};
-+};
-+
-+&mmc0 {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&mmc0_pins_default>;
-+	max-frequency = <26000000>;
-+	bus-width = <8>;
-+	cap-mmc-hw-reset;
-+	vmmc-supply = <&reg_3p3v>;
-+	non-removable;
-+	status = "okay";
-+};
-+
-+&pio {
-+	mmc0_pins_default: mmc0default {
-+		mux {
-+			function = "flash";
-+			groups =  "emmc_45";
-+		};
-+		conf-cmd-dat {
-+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO",
-+				"SPI0_CS",  "SPI0_HOLD", "SPI0_WP",
-+				"SPI1_CLK", "SPI1_MOSI", "SPI1_MISO";
-+			input-enable;
-+			drive-strength = <MTK_DRIVE_4mA>;
-+			bias-pull-up = <MTK_PUPD_SET_R1R0_01>;
-+		};
-+		conf-clk {
-+			pins = "SPI1_CS";
-+			drive-strength = <MTK_DRIVE_6mA>;
-+			bias-pull-down = <MTK_PUPD_SET_R1R0_10>;
-+		};
-+		conf-rst {
-+			pins = "PWM0";
-+			drive-strength = <MTK_DRIVE_4mA>;
-+			bias-pull-up = <MTK_PUPD_SET_R1R0_01>;
-+		};
-+	};
-+};
---- /dev/null
-+++ b/arch/arm/dts/mt7981-cmcc-rax3000m-nand.dts
-@@ -0,0 +1,77 @@
-+// SPDX-License-Identifier: GPL-2.0-only
-+
-+/dts-v1/;
-+#include "mt7981-cmcc-rax3000m.dtsi"
-+
 +&pio {
 +	spi_flash_pins: spi0-pins-func-1 {
 +		mux {
@@ -452,7 +512,7 @@
 +		reg = <0>;
 +		spi-max-frequency = <52000000>;
 +
-+		partitions {
++		partitions: partitions {
 +			compatible = "fixed-partitions";
 +			#address-cells = <1>;
 +			#size-cells = <1>;
@@ -461,27 +521,115 @@
 +				label = "bl2";
 +				reg = <0x0 0x100000>;
 +			};
-+
-+			partition@100000 {
-+				label = "orig-env";
-+				reg = <0x100000 0x80000>;
-+			};
-+
-+			partition@160000 {
-+				label = "factory";
-+				reg = <0x180000 0x200000>;
-+			};
-+
-+			partition@380000 {
-+				label = "fip";
-+				reg = <0x380000 0x200000>;
-+			};
-+
-+			partition@580000 {
-+				label = "ubi";
-+				reg = <0x580000 0x7200000>;
-+			};
 +		};
++	};
++};
++
++&uart0 {
++	mediatek,force-highspeed;
++	status = "okay";
++};
++
++&watchdog {
++	status = "disabled";
++};
+--- /dev/null
++++ b/arch/arm/dts/mt7981-cmcc-rax3000m-emmc.dts
+@@ -0,0 +1,55 @@
++// SPDX-License-Identifier: GPL-2.0-only
++
++#include "mt7981-cmcc-rax3000m.dtsi"
++
++/ {
++	reg_3p3v: regulator-3p3v {
++		compatible = "regulator-fixed";
++		regulator-name = "fixed-3.3V";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-boot-on;
++		regulator-always-on;
++	};
++};
++
++&mmc0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc0_pins_default>;
++	max-frequency = <26000000>;
++	bus-width = <8>;
++	cap-mmc-hw-reset;
++	vmmc-supply = <&reg_3p3v>;
++	non-removable;
++	status = "okay";
++};
++
++/delete-node/ &spi0;
++/delete-node/ &spi_flash_pins;
++
++&pio {
++	mmc0_pins_default: mmc0default {
++		mux {
++			function = "flash";
++			groups =  "emmc_45";
++		};
++		conf-cmd-dat {
++			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO",
++				"SPI0_CS",  "SPI0_HOLD", "SPI0_WP",
++				"SPI1_CLK", "SPI1_MOSI", "SPI1_MISO";
++			input-enable;
++			drive-strength = <MTK_DRIVE_4mA>;
++			bias-pull-up = <MTK_PUPD_SET_R1R0_01>;
++		};
++		conf-clk {
++			pins = "SPI1_CS";
++			drive-strength = <MTK_DRIVE_6mA>;
++			bias-pull-down = <MTK_PUPD_SET_R1R0_10>;
++		};
++		conf-rst {
++			pins = "PWM0";
++			drive-strength = <MTK_DRIVE_4mA>;
++			bias-pull-up = <MTK_PUPD_SET_R1R0_01>;
++		};
++	};
++};
+--- /dev/null
++++ b/arch/arm/dts/mt7981-cmcc-rax3000m-nand.dts
+@@ -0,0 +1,25 @@
++// SPDX-License-Identifier: GPL-2.0-only
++
++#include "mt7981-cmcc-rax3000m.dtsi"
++
++&partitions {
++	partition@100000 {
++		label = "orig-env";
++		reg = <0x100000 0x80000>;
++	};
++
++	partition@180000 {
++		label = "factory";
++		reg = <0x180000 0x200000>;
++	};
++
++	partition@380000 {
++		label = "fip";
++		reg = <0x380000 0x200000>;
++	};
++
++	partition@580000 {
++		label = "ubi";
++		reg = <0x580000 0x7200000>;
++	};
++};
+--- /dev/null
++++ b/arch/arm/dts/mt7981-cmcc-rax3000m-ubi.dts
+@@ -0,0 +1,10 @@
++// SPDX-License-Identifier: GPL-2.0-only
++
++#include "mt7981-cmcc-rax3000m.dtsi"
++
++&partitions {
++	partition@100000 {
++		label = "ubi";
++		reg = <0x100000 0x7f00000>;
 +	};
 +};
 --- /dev/null
@@ -595,6 +743,63 @@
 +ubi_read_production=ubi read $loadaddr fit && iminfo $loadaddr && run ubi_prepare_rootfs
 +ubi_read_recovery=ubi check recovery && ubi read $loadaddr recovery
 +ubi_remove_rootfs=ubi check rootfs_data && ubi remove rootfs_data
++ubi_write_production=ubi check fit && ubi remove fit ; run ubi_remove_rootfs ; ubi create fit $filesize dynamic && ubi write $loadaddr fit $filesize
++ubi_write_recovery=ubi check recovery && ubi remove recovery ; run ubi_remove_rootfs ; ubi create recovery $filesize dynamic && ubi write $loadaddr recovery $filesize
++_init_env=setenv _init_env ; run ubi_create_env ; saveenv ; saveenv
++_firstboot=setenv _firstboot ; run _switch_to_menu ; run _init_env ; run boot_first
++_switch_to_menu=setenv _switch_to_menu ; setenv bootdelay 3 ; setenv bootmenu_delay 3 ; setenv bootmenu_0 $bootmenu_0d ; setenv bootmenu_0d ; run _bootmenu_update_title
++_bootmenu_update_title=setenv _bootmenu_update_title ; setenv bootmenu_title "$bootmenu_title       [33m$ver[0m"
+--- /dev/null
++++ b/defenvs/cmcc_rax3000m-ubi_env
+@@ -0,0 +1,54 @@
++ipaddr=192.168.1.1
++serverip=192.168.1.254
++loadaddr=0x46000000
++console=earlycon=uart8250,mmio32,0x11002000 console=ttyS0
++bootcmd=if pstore check ; then run boot_recovery ; else run boot_ubi ; fi
++bootconf=config-1#mt7981b-cmcc-rax3000m-ubi
++bootdelay=0
++bootfile=openwrt-mediatek-filogic-cmcc_rax3000m-initramfs-recovery.itb
++bootfile_bl2=openwrt-mediatek-filogic-cmcc_rax3000m-ubi-preloader.bin
++bootfile_fip=openwrt-mediatek-filogic-cmcc_rax3000m-ubi-bl31-uboot.fip
++bootfile_upg=openwrt-mediatek-filogic-cmcc_rax3000m-squashfs-sysupgrade.itb
++bootled_pwr=red:status
++bootled_rec=blue:status
++bootmenu_confirm_return=askenv - Press ENTER to return to menu ; bootmenu 60
++bootmenu_default=0
++bootmenu_delay=0
++bootmenu_title=      [0;34m( ( ( [1;39mOpenWrt[0;34m ) ) )  [0;36m[UBI][0m
++bootmenu_0=Initialize environment.=run _firstboot
++bootmenu_0d=Run default boot command.=run boot_default
++bootmenu_1=Boot system via TFTP.=run boot_tftp ; run bootmenu_confirm_return
++bootmenu_2=Boot production system from NAND.=run boot_production ; run bootmenu_confirm_return
++bootmenu_3=Boot recovery system from NAND.=run boot_recovery ; run bootmenu_confirm_return
++bootmenu_4=Load production system via TFTP then write to NAND.=setenv noboot 1 ; setenv replacevol 1 ; run boot_tftp_production ; setenv noboot ; setenv replacevol ; run bootmenu_confirm_return
++bootmenu_5=Load recovery system via TFTP then write to NAND.=setenv noboot 1 ; setenv replacevol 1 ; run boot_tftp_recovery ; setenv noboot ; setenv replacevol ; run bootmenu_confirm_return
++bootmenu_6=[31mLoad BL31+U-Boot FIP via TFTP then write to NAND.[0m=run boot_tftp_write_fip ; run bootmenu_confirm_return
++bootmenu_7=[31mLoad BL2 preloader via TFTP then write to NAND.[0m=run boot_tftp_write_bl2 ; run bootmenu_confirm_return
++bootmenu_8=Reboot.=reset
++bootmenu_9=Reset all settings to factory defaults.=run reset_factory ; reset
++boot_first=if button reset ; then led $bootled_pwr off ; run boot_tftp_recovery ; setenv flag_recover 1 ; run boot_default ; fi ; bootmenu
++boot_default=if env exists flag_recover ; then else run bootcmd ; fi ; run boot_recovery ; setenv replacevol 1 ; run boot_tftp_forever
++boot_production=led $bootled_rec off ; run ubi_read_production && bootm $loadaddr#$bootconf ; led $bootled_pwr off
++boot_recovery=led $bootled_pwr off ; run ubi_read_recovery && bootm $loadaddr#$bootconf ; led $bootled_rec off
++boot_ubi=run boot_production ; run boot_recovery ; run boot_tftp_forever
++boot_tftp_forever=led $bootled_pwr off ; while true ; do run boot_tftp_recovery ; sleep 1 ; done
++boot_tftp_production=tftpboot $loadaddr $bootfile_upg && env exists replacevol && iminfo $loadaddr && run ubi_write_production ; if env exists noboot ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp_recovery=tftpboot $loadaddr $bootfile && env exists replacevol && iminfo $loadaddr && run ubi_write_recovery ; if env exists noboot ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp=tftpboot $loadaddr $bootfile && bootm $loadaddr#$bootconf
++boot_tftp_write_fip=tftpboot $loadaddr $bootfile_fip && run ubi_write_fip && run reset_factory
++boot_tftp_write_bl2=tftpboot $loadaddr $bootfile_bl2 && run mtd_write_bl2
++preboot=led $bootled_pwr on ; led $bootled_rec on
++reset_factory=mw $loadaddr 0xff 0x1f000 ; ubi write $loadaddr ubootenv 0x1f000 ; ubi write $loadaddr ubootenv2 0x1f000 ; ubi remove rootfs_data
++mtd_write_bl2=mtd erase bl2 && mtd write bl2 $loadaddr
++ubi_create_env=ubi check ubootenv || ubi create ubootenv 0x1f000 dynamic ; ubi check ubootenv2 || ubi create ubootenv2 0x1f000 dynamic
++ubi_prepare_rootfs=if ubi check rootfs_data ; then else if env exists rootfs_data_max ; then ubi create rootfs_data $rootfs_data_max dynamic || ubi create rootfs_data - dynamic ; else ubi create rootfs_data - dynamic ; fi ; fi
++ubi_read_production=ubi read $loadaddr fit && iminfo $loadaddr && run ubi_prepare_rootfs
++ubi_read_recovery=ubi check recovery && ubi read $loadaddr recovery
++ubi_remove_rootfs=ubi check rootfs_data && ubi remove rootfs_data
++ubi_write_fip=run ubi_remove_rootfs ; ubi check fip && ubi remove fip ; ubi create fip 0x200000 static ; ubi write $loadaddr fip 0x200000
 +ubi_write_production=ubi check fit && ubi remove fit ; run ubi_remove_rootfs ; ubi create fit $filesize dynamic && ubi write $loadaddr fit $filesize
 +ubi_write_recovery=ubi check recovery && ubi remove recovery ; run ubi_remove_rootfs ; ubi create recovery $filesize dynamic && ubi write $loadaddr recovery $filesize
 +_init_env=setenv _init_env ; run ubi_create_env ; saveenv ; saveenv

--- a/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m-emmc.dtso
+++ b/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m-emmc.dtso
@@ -65,6 +65,18 @@
 									reg = <0x0 0x1000>;
 								};
 
+								macaddr_factory_4: macaddr@4 {
+									reg = <0x4 0x6>;
+									compatible = "mac-base";
+									#nvmem-cell-cells = <1>;
+								};
+
+								macaddr_factory_a: macaddr@a {
+									reg = <0xa 0x6>;
+									compatible = "mac-base";
+									#nvmem-cell-cells = <1>;
+								};
+
 								macaddr_factory_24: macaddr@24 {
 									compatible = "mac-base";
 									reg = <0x24 0x6>;
@@ -112,6 +124,18 @@
 		__overlay__ {
 			nvmem-cells = <&eeprom_factory_0>;
 			nvmem-cell-names = "eeprom";
+
+			band@0 {
+				reg = <0>;
+				nvmem-cells = <&macaddr_factory_4 0>;
+				nvmem-cell-names = "mac-address";
+			};
+
+			band@1 {
+				reg = <1>;
+				nvmem-cells = <&macaddr_factory_a 0>;
+				nvmem-cell-names = "mac-address";
+			};
 		};
 	};
 };

--- a/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m-nand.dtso
+++ b/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m-nand.dtso
@@ -102,6 +102,18 @@
 								reg = <0x0 0x1000>;
 							};
 
+							macaddr_factory_4: macaddr@4 {
+								reg = <0x4 0x6>;
+								compatible = "mac-base";
+								#nvmem-cell-cells = <1>;
+							};
+
+							macaddr_factory_a: macaddr@a {
+								reg = <0xa 0x6>;
+								compatible = "mac-base";
+								#nvmem-cell-cells = <1>;
+							};
+
 							macaddr_factory_24: macaddr@24 {
 								compatible = "mac-base";
 								reg = <0x24 0x6>;
@@ -143,6 +155,18 @@
 		__overlay__ {
 			nvmem-cells = <&eeprom_factory_0>;
 			nvmem-cell-names = "eeprom";
+
+			band@0 {
+				reg = <0>;
+				nvmem-cells = <&macaddr_factory_4 0>;
+				nvmem-cell-names = "mac-address";
+			};
+
+			band@1 {
+				reg = <1>;
+				nvmem-cells = <&macaddr_factory_a 0>;
+				nvmem-cell-names = "mac-address";
+			};
 		};
 	};
 };

--- a/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m-ubi.dtso
+++ b/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m-ubi.dtso
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/pinctrl/mt65xx.h>
+
+/ {
+	compatible = "cmcc,rax3000m", "mediatek,mt7981";
+
+	fragment@0 {
+		target = <&chosen>;
+		__overlay__ {
+			rootdisk = <&ubi_rootdisk>;
+		};
+	};
+
+	fragment@1 {
+		target = <&gmac0>;
+		__overlay__ {
+			nvmem-cells = <&macaddr_factory_2a 0>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+
+	fragment@2 {
+		target = <&gmac1>;
+		__overlay__ {
+			nvmem-cells = <&macaddr_factory_24 0>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+
+	fragment@3 {
+		target = <&pio>;
+		__overlay__ {
+			spi0_flash_pins: spi0-pins {
+				mux {
+					function = "spi";
+					groups = "spi0", "spi0_wp_hold";
+				};
+
+				conf-pu {
+					pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+					drive-strength = <MTK_DRIVE_8mA>;
+					bias-disable; /* bias-disable */
+				};
+
+				conf-pd {
+					pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+					drive-strength = <MTK_DRIVE_8mA>;
+					bias-disable; /* bias-disable */
+				};
+			};
+		};
+	};
+
+	fragment@4 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			pinctrl-names = "default";
+			pinctrl-0 = <&spi0_flash_pins>;
+			status = "okay";
+
+			spi_nand@0 {
+				compatible = "spi-nand";
+				reg = <0>;
+
+				spi-max-frequency = <52000000>;
+				spi-tx-bus-width = <4>;
+				spi-rx-bus-width = <4>;
+
+				partitions {
+					compatible = "fixed-partitions";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					partition@0 {
+						label = "bl2";
+						reg = <0x00000 0x0100000>;
+						read-only;
+					};
+
+					partition@100000 {
+						label = "ubi";
+						reg = <0x100000 0x7f00000>;
+						compatible = "linux,ubi";
+
+						volumes {
+							ubi_factory: ubi-volume-factory {
+								volname = "factory";
+							};
+
+							ubi_rootdisk: ubi-volume-fit {
+								volname = "fit";
+							};
+
+							ubi-volume-ubootenv {
+								volname = "ubootenv";
+								nvmem-layout {
+									compatible = "u-boot,env-redundant-bool";
+								};
+							};
+
+							ubi-volume-ubootenv2 {
+								volname = "ubootenv2";
+								nvmem-layout {
+									compatible = "u-boot,env-redundant-bool";
+								};
+							};
+						};
+					};
+				};
+			};
+		};
+	};
+
+	fragment@5 {
+		target = <&ubi_factory>;
+		__overlay__ {
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x1000>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+					compatible = "mac-base";
+					#nvmem-cell-cells = <1>;
+				};
+
+				macaddr_factory_a: macaddr@a {
+					reg = <0xa 0x6>;
+					compatible = "mac-base";
+					#nvmem-cell-cells = <1>;
+				};
+
+				macaddr_factory_24: macaddr@24 {
+					compatible = "mac-base";
+					reg = <0x24 0x6>;
+					#nvmem-cell-cells = <1>;
+				};
+
+				macaddr_factory_2a: macaddr@2a {
+					compatible = "mac-base";
+					reg = <0x2a 0x6>;
+					#nvmem-cell-cells = <1>;
+				};
+			};
+		};
+	};
+
+	fragment@6 {
+		target = <&wifi>;
+		__overlay__ {
+			nvmem-cells = <&eeprom_factory_0>;
+			nvmem-cell-names = "eeprom";
+
+			band@0 {
+				reg = <0>;
+				nvmem-cells = <&macaddr_factory_4 0>;
+				nvmem-cell-names = "mac-address";
+			};
+
+			band@1 {
+				reg = <1>;
+				nvmem-cells = <&macaddr_factory_a 0>;
+				nvmem-cell-names = "mac-address";
+			};
+		};
+	};
+};

--- a/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m.dts
+++ b/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m.dts
@@ -302,6 +302,9 @@
 
 &wifi {
 	status = "okay";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
 };
 
 &xhci {

--- a/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m.dts
+++ b/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m.dts
@@ -90,6 +90,7 @@
 	gmac1: mac@1 {
 		compatible = "mediatek,eth-mac";
 		reg = <1>;
+		openwrt,netdev-name = "wan";
 		phy-mode = "gmii";
 		phy-handle = <&int_gbe_phy>;
 	};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -10,7 +10,6 @@ mediatek_setup_interfaces()
 	case $board in
 	abt,asr3000|\
 	buffalo,wsr-6000ax8|\
-	cmcc,rax3000m|\
 	h3c,magic-nx30-pro|\
 	imou,hx21|\
 	konka,komi-a31|\
@@ -56,6 +55,7 @@ mediatek_setup_interfaces()
 	cetron,ct3003|\
 	cmcc,a10-stock|\
 	cmcc,a10-ubootmod|\
+	cmcc,rax3000m|\
 	confiabits,mt7981|\
 	creatlentem,clt-r30b1|\
 	creatlentem,clt-r30b1-112m|\

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/05_compat-version
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/05_compat-version
@@ -11,6 +11,7 @@ case "$(board_name)" in
 	bananapi,bpi-r4|\
 	bananapi,bpi-r4-2g5|\
 	bananapi,bpi-r4-poe|\
+	cmcc,rax3000m|\
 	mercusys,mr85x|\
 	routerich,ax3000|\
 	zbtlink,zbt-z8102ax-v2)

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -80,10 +80,6 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_add $addr 2) > /sys${DEVPATH}/macaddress
 		;;
-	cmcc,rax3000m)
-		addr=$(cat /sys/class/net/eth0/address)
-		[ "$PHYNBR" = "1" ] && macaddr_add $addr -1 > /sys${DEVPATH}/macaddress
-		;;
 	comfast,cf-e393ax)
 		addr=$(mtd_get_mac_binary "Factory" 0x8000)
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1032,6 +1032,9 @@ define Device/cmcc_rax3000m
   DEVICE_DTS_LOADADDR := 0x43f00000
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3 \
 	e2fsprogs f2fsck mkf2fs
+  DEVICE_COMPAT_VERSION := 1.1
+  DEVICE_COMPAT_MESSAGE := WAN port renamed from eth1 to wan to match its physical \
+	label, check wan interface configuration after upgrade.
   KERNEL_LOADADDR := 0x44000000
   KERNEL := kernel-bin | gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1026,7 +1026,7 @@ define Device/cmcc_rax3000m
   DEVICE_ALT0_VENDOR := CMCC
   DEVICE_ALT0_MODEL := RAX3000Me
   DEVICE_DTS := mt7981b-cmcc-rax3000m
-  DEVICE_DTS_OVERLAY := mt7981b-cmcc-rax3000m-emmc mt7981b-cmcc-rax3000m-nand
+  DEVICE_DTS_OVERLAY := mt7981b-cmcc-rax3000m-emmc mt7981b-cmcc-rax3000m-nand mt7981b-cmcc-rax3000m-ubi
   DEVICE_DTS_DIR := ../dts
   DEVICE_DTC_FLAGS := --pad 4096
   DEVICE_DTS_LOADADDR := 0x43f00000
@@ -1048,7 +1048,9 @@ define Device/cmcc_rax3000m
 	emmc-ddr3-bl31-uboot.fip emmc-ddr3-preloader.bin \
 	emmc-ddr4-bl31-uboot.fip emmc-ddr4-preloader.bin \
 	nand-ddr3-bl31-uboot.fip nand-ddr3-preloader.bin \
-	nand-ddr4-bl31-uboot.fip nand-ddr4-preloader.bin
+	nand-ddr4-bl31-uboot.fip nand-ddr4-preloader.bin \
+	ubi-ddr3-bl31-uboot.fip ubi-ddr3-preloader.bin \
+	ubi-ddr4-bl31-uboot.fip ubi-ddr4-preloader.bin
   ARTIFACT/emmc-gpt.bin := mt798x-gpt emmc
   ARTIFACT/emmc-ddr3-bl31-uboot.fip := mt7981-bl31-uboot cmcc_rax3000m-emmc-ddr3
   ARTIFACT/emmc-ddr3-preloader.bin  := mt7981-bl2 emmc-ddr3-1866
@@ -1058,6 +1060,10 @@ define Device/cmcc_rax3000m
   ARTIFACT/nand-ddr3-preloader.bin  := mt7981-bl2 spim-nand-ddr3-1866
   ARTIFACT/nand-ddr4-bl31-uboot.fip := mt7981-bl31-uboot cmcc_rax3000m-nand-ddr4
   ARTIFACT/nand-ddr4-preloader.bin  := mt7981-bl2 spim-nand-ddr4
+  ARTIFACT/ubi-ddr3-bl31-uboot.fip := mt7981-bl31-uboot cmcc_rax3000m-ubi-ddr3
+  ARTIFACT/ubi-ddr3-preloader.bin  := mt7981-bl2 spim-nand-ubi-ddr3-1866
+  ARTIFACT/ubi-ddr4-bl31-uboot.fip := mt7981-bl31-uboot cmcc_rax3000m-ubi-ddr4
+  ARTIFACT/ubi-ddr4-preloader.bin  := mt7981-bl2 spim-nand-ubi-ddr4
 endef
 TARGET_DEVICES += cmcc_rax3000m
 


### PR DESCRIPTION
```
This commit introduces OpenWrt U-Boot all-in-UBI layout support
for the CMCC RAX3000M / RAX3000Me, enabling:
- Prolonged device lifetime by allocating most of the flash
  to UBI (which takes care of wear-leveling)
- Maximum available storage space for OpenWrt

OpenWrt U-Boot UBI flash instructions
-------------------------------------
A device running stock firmware should be upgraded to the
latest OpenWrt firmware
(https://firmware-selector.openwrt.org/?target=mediatek%2Ffilogic&id=cmcc_rax3000m).

Back up critical data
---------------------
LuCI Web-UI:
"System" -> "Backup / Flash Firmware" -> "Save mtdblock contents"
Save mtdblock:
   factory

Make sure the file were successfully downloaded to your downloads directory.

Using the installer image
-------------------------
To simplify the installation process, this method uses a fork
of Daniel Golle's (@dangowrt) UBI Installer
https://github.com/dangowrt/owrt-ubi-installer

1. Ensure your router is running the latest OpenWrt firmware.
   Upgrade it if necessary.
2. Obtain the installer image:
   Build the installer from source according to your device variant
   https://github.com/andros-ua/owrt-ubi-installer/tree/rax3000m-ddr3
   or
   https://github.com/andros-ua/owrt-ubi-installer/tree/rax3000m-ddr4
   or download a prebuilt image from the
   https://github.com/andros-ua/owrt-ubi-installer/releases
3. Flash the openwrt*-initramfs-recovery-installer.itb
   image using sysupgrade.
4. Wait for installation:
   the green status LED will blink rapidly,
   indicating that the all-in-UBI installer is running.
   Once the installation finishes,
   the status LED will turn solid amber for 5 seconds.
5. After the device reboots, perform a final sysupgrade using the
   openwrt*-squashfs-sysupgrade.itb image.

BL2 and FIP Recovery
--------------------
Use mtk_uartboot to recover corrupted BL2 or FIP via UART:
https://github.com/981213/mtk_uartboot

OpenWrt U-Boot layout
----------------------------------------
| dev:    size   erasesize  name       |
| mtd4: 00100000 00020000 "bl2"        |
| mtd3: 00080000 00020000 "u-boot-env" |
| mtd2: 00200000 00020000 "factory"    |
| mtd1: 00200000 00020000 "fip"        |
| mtd0: 07200000 00020000 "ubi"        |
----------------------------------------

OpenWrt U-Boot UBI layout
----------------------------------
| dev:    size   erasesize  name |
| mtd1: 00100000 00020000 "bl2"  |
| mtd0: 07f00000 00020000 "ubi"  |
----------------------------------

Update MAC table after inspecting the factory partition:
----------------------------------------------------------------
| Interface    | MAC               | Source        |           |
|--------------|-------------------|---------------|-----------|
| WAN (label)  | 54:4d:d4:xx:xx:xx | factory, 0x24 | label     |
| LAN          | 54:4d:d4:xx:xx:xx | factory, 0x2a | label + 3 |
| WLAN 2.4 GHz | 54:4d:d4:xx:xx:xx | factory, 0x4  | label + 1 |
| WLAN 5 GHz   | 54:4d:d4:xx:xx:xx | factory, 0xa  | label + 2 |
----------------------------------------------------------------

```