### PR TITLE
tools: gnulib: drop the gl_-prefixed macros an older install left behind

### DIFF
--- a/tools/gnulib/Makefile
+++ b/tools/gnulib/Makefile
@@ -22,6 +22,7 @@ define Host/Install
 endef
 
 define Host/Uninstall
+	rm -f $(STAGING_DIR_HOST)/share/aclocal/gl_*.m4
 	rm -rf $(STAGING_DIR_HOST)/bin/gnulib-tool $(STAGING_DIR_HOST)/share/gnulib
 endef
 


### PR DESCRIPTION
An up-to-date tree fails its next build in `tools/elfutils`:

```
../libgnu/ctype.h:58:7: error: operator '||' has no left operand
../libgnu/ctype.h:813:5: error: #if with no expression
make[7]: *** [Makefile:3159: libgnu_la-argp-ba.lo] Error 1
    ERROR: tools/elfutils failed to build.
```

`tools/elfutils` is in `tools-y`, so this fails the whole tree, and it does
not reproduce from scratch — only on a tree that was also built between
c820f097e0be and cda598a59528.

### What is actually there

`Host/Install` copies `m4/*.m4` into `$(STAGING_DIR_HOST)/share/aclocal`;
`Host/Uninstall` removes only `bin/gnulib-tool` and `share/gnulib`. Nothing
deletes the macros, so the `gl_`-prefixed copies from the reverted prefix
scheme are still there next to the current ones:

```
$ ls -l --time-style=+%F staging_dir/host/share/aclocal/*.m4 | awk '{print $6}' | sort | uniq -c
   1520 2026-06-10
    943 2026-08-05
$ ls staging_dir/host/share/aclocal/gl_*.m4 | wc -l
914
```

914 is exactly the macro count of `gnulib-2025.07.01~a3151d45`, and 943 is
exactly `gnulib-2026.07.04~b22f5a30`'s — the two sets are two whole gnulib
releases, one shadowing the other.

They are not interchangeable. `gl_ctype_h.m4` is `serial 9`; `ctype_h.m4` is
`serial 23` and is the one that initialises the module indicators the current
`ctype.in.h` reads:

```
$ grep -c GNULIB_ISUPPER_L staging_dir/host/share/aclocal/{ctype_h,gl_ctype_h}.m4
staging_dir/host/share/aclocal/ctype_h.m4:1
staging_dir/host/share/aclocal/gl_ctype_h.m4:0
```

With both installed, `configure` ends up with zero occurrences of
`GNULIB_ISUPPER_L`, `@GNULIB_ISUPPER_L@` is substituted with the empty string,
and the generated `libgnu/ctype.h` gets `#if` with nothing after it.

### Fix

Remove the prefixed copies in `Host/Uninstall`. `Host/Install` calls it first,
so `make tools/gnulib/{clean,compile}` repairs an affected tree — no manual
`staging_dir` surgery.

Verified here: `tools/elfutils` failed before and builds after, with
`libelf.a` and `libdw.a` installed.

### Worth a second opinion

This deletes the one leftover set that exists today. The general shape —
`Host/Uninstall` not undoing what `Host/Install` wrote — is still there, so a
future gnulib that drops or renames a macro file leaves the old one shadowing
in the same way. Removing the previous install's macros by name using the
`share/gnulib/m4` copy that `Host/Uninstall` is about to delete would cover
that too; I left it out as speculative, but say the word and I will add it.
