### PR TITLE
mediatek: add support for Cudy TR3600 v1

### DIFF
--- a/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
+++ b/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
@@ -6,6 +6,7 @@ set_preinit_iface() {
 	cudy,tr3000-256mb-v1|\
 	cudy,tr3000-v1|\
 	cudy,tr3000-v1-ubootmod|\
+	cudy,tr3600-v1|\
 	glinet,gl-mt2500|\
 	glinet,gl-mt2500-airoha|\
 	glinet,gl-mt3000|\

--- a/target/linux/mediatek/dts/mt7987b-cudy-tr3600-v1.dts
+++ b/target/linux/mediatek/dts/mt7987b-cudy-tr3600-v1.dts
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+#include "mt7987b.dtsi"
+
+/ {
+	model = "Cudy TR3600 v1";
+	compatible = "cudy,tr3600-v1", "mediatek,mt7987b", "mediatek,mt7987";
+
+	aliases {
+		label-mac-device = &gmac1;
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_blue;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_blue;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n1 earlycon=uart8250,mmio32,0x11000000 pci=pcie_bus_perf";
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@40000000 {
+		device_type = "memory";
+		reg = <0 0x40000000 0 0x20000000>;
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: led-0 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 48 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: led-1 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 46 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-mode {
+			label = "mode";
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+			debounce-interval = <10>;
+		};
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <10>;
+		};
+	};
+
+	fan_3p3v: regulator-fan-3p3v {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		gpios = <&pio 6 GPIO_ACTIVE_HIGH>;
+		regulator-name = "fan";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+	};
+};
+
+&eth {
+	status = "okay";
+};
+
+&fan {
+	fan-supply = <&fan_3p3v>;
+	pwms = <&pwm 0 50000 0>;
+	status = "okay";
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_bdinfo_de00 1>;
+	nvmem-cell-names = "mac-address";
+	phy-handle = <&phy1>;
+	phy-mode = "2500base-x";
+	status = "okay";
+};
+
+&gmac1 {
+	nvmem-cells = <&macaddr_bdinfo_de00 0>;
+	nvmem-cell-names = "mac-address";
+	phy-handle = <&phy15>;
+	phy-mode = "internal";
+	status = "okay";
+};
+
+&mdio {
+	phy1: phy@1 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <1>;
+		reset-gpios = <&pio 42 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <100000>;
+		reset-deassert-us = <120000>;
+	};
+
+	phy15: phy@f {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <15>;
+	};
+};
+
+&pcie0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_pins>;
+	reset-gpios = <&pio 38 GPIO_ACTIVE_HIGH>;
+	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		device_type = "pci";
+
+		wifi@0,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+			ieee80211-freq-limit = <2400000 2500000>,
+					       <5170000 5835000>;
+
+			nvmem-cells = <&eeprom_factory_0>;
+			nvmem-cell-names = "eeprom";
+
+			band@0 {
+				reg = <0>;
+				nvmem-cells = <&macaddr_bdinfo_de00 3>;
+				nvmem-cell-names = "mac-address";
+			};
+
+			band@1 {
+				reg = <1>;
+				nvmem-cells = <&macaddr_bdinfo_de00 2>;
+				nvmem-cell-names = "mac-address";
+			};
+		};
+	};
+};
+
+&pwm {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm_pins>;
+	status = "okay";
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4e 0x41 0x4e 0x44>;
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "backup";
+				reg = <0x100000 0x80000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x400000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1e00>;
+					};
+				};
+			};
+
+			partition@580000 {
+				label = "bdinfo";
+				reg = <0x580000 0x40000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_bdinfo_de00: macaddr@de00 {
+						compatible = "mac-base";
+						reg = <0xde00 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@5c0000 {
+				label = "FIP";
+				reg = <0x5c0000 0x200000>;
+				read-only;
+			};
+
+			partition@7c0000 {
+				label = "ubi";
+				reg = <0x7c0000 0xe840000>;
+				compatible = "linux,ubi";
+			};
+		};
+	};
+};
+
+&ssusb {
+	status = "okay";
+};
+
+&tphyu3port0 {
+	status = "okay";
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_pins>;
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -165,6 +165,7 @@ mediatek_setup_interfaces()
 	cudy,tr3000-256mb-v1|\
 	cudy,tr3000-v1|\
 	cudy,tr3000-v1-ubootmod|\
+	cudy,tr3600-v1|\
 	glinet,gl-mt2500|\
 	glinet,gl-mt2500-airoha|\
 	glinet,gl-mt3000|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1405,6 +1405,25 @@ define Device/cudy_tr3000-v1-ubootmod
 endef
 TARGET_DEVICES += cudy_tr3000-v1-ubootmod
 
+define Device/cudy_tr3600-v1
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := TR3600
+  DEVICE_VARIANT := v1
+  DEVICE_DTS := mt7987b-cudy-tr3600-v1
+  DEVICE_DTS_DIR := ../dts
+  SUPPORTED_DEVICES += R126
+  DEVICE_PACKAGES := mt7987-2p5g-phy-firmware kmod-mt7990-firmware \
+	kmod-hwmon-pwmfan kmod-usb3
+  KERNEL_IN_UBI := 1
+  KERNEL_LOADADDR := 0x40000000
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 237824k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += cudy_tr3600-v1
+
 define Device/cudy_wr3000-v1
   DEVICE_VENDOR := Cudy
   DEVICE_MODEL := WR3000


### PR DESCRIPTION
## Hardware specifications

The Cudy TR3600 v1 is based on the MediaTek MT7987B SoC with 512 MiB DDR4 and an ESMT F50L2G41XA 2 Gbit (256 MiB) SPI-NAND.

- MediaTek MT7990AN dual-band radio: 2x2 on 2.4 GHz and 3x3 on 5 GHz
- Two 2.5GbE ports using the MT7987 integrated GMACs and a Realtek RTL8221B external PHY
- USB-A 3.0
- Red status LED on GPIO46 and blue status LED on GPIO48
- Mode button on GPIO0 and reset button on GPIO1
- PWM fan: GPIO6 fan supply enable and PWM0 output
- USB-C USB-PD input: 5 V/3 A, 9 V/2.2 A, or 12 V/1.6 A; 15 W maximum consumption
- Serial console: serial0, 115200 8N1. The vendor development files do not document the physical UART header location or pad pinout; UART is not required for installation.

## Flash instructions

1. From the stock Cudy web interface, upload cudy_tr3600-v1-sysupgrade_260715.bin from the official development files.
2. After the intermediate firmware boots, upload openwrt-mediatek-filogic-cudy_tr3600-v1-squashfs-sysupgrade.bin from the OpenWrt upgrade page.
3. This installation path does not require UART. Keep a stock firmware backup; the vendor recovery/dual-image revert procedure has not been validated by this change.

The intermediate firmware and the official device documentation are available from the [Cudy TR3600 download center](https://www.cudy.com/zh-cn/pages/download-center/tr3600-1-0).

The SPI-NAND layout follows the official Cudy R126 DTS and DTB: BL2, writable backup, Factory, bdinfo, FIP, and ubi. The vendor-defined backup label at 0x100000 is retained.

## MAC address layout

The base MAC is stored in bdinfo at offset 0xde00.

- LAN (eth1/gmac1): xx:xx:xx:xx:xx:xx, base + 0
- WAN (eth0/gmac0): xx:xx:xx:xx:xx:xx, base + 1
- 2.4 GHz (band@0): xx:xx:xx:xx:xx:xx, base + 3
- 5 GHz (band@1): xx:xx:xx:xx:xx:xx, base + 2

The 2.4 GHz offset is intentionally distinct from LAN to avoid duplicate MAC addresses.

The DTS follows the official Cudy intermediate firmware for the v1 identity, MT7990 calibration data, PWM0 fan output, red/blue status LEDs, and R126 NAND layout. The generic wifi@0,0 node follows the OpenWrt DT binding convention; the image recipe uses kmod-mt7990-firmware.

This update is pushed to the original PR branch so that the existing review context remains attached to this pull request.

