### PR TITLE
ramips: add support for D-Link DIR-853 R3

### DIFF
--- a/target/linux/ramips/dts/mt7621_dlink_dir-853-r3.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-853-r3.dts
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "dlink,dir-853-r3", "mediatek,mt7621-soc";
+	model = "D-Link DIR-853 R3";
+
+	aliases {
+		label-mac-device = &gmac0;
+
+		led-boot = &led_wps;
+		led-failsafe = &led_wps;
+		led-running = &led_wps;
+		led-upgrade = &led_wps;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		usb {
+			function = LED_FUNCTION_USB;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&ehci_port2>;
+			linux,default-trigger = "usbport";
+		};
+
+		led_wps: wps {
+			function = LED_FUNCTION_WPS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "config";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x40000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					compatible = "mac-base";
+					reg = <0xe006 0x6>;
+					#nvmem-cell-cells = <1>;
+				};
+			};
+		};
+
+		partition@140000 {
+			label = "kernel";
+			reg = <0x140000 0x360000>;
+		};
+
+		/* Kept intact for recovery to the vendor firmware. */
+		partition@4a0000 {
+			label = "stock-rootfs";
+			reg = <0x4a0000 0xb60000>;
+			read-only;
+		};
+
+		partition@1000000 {
+			label = "ubi";
+			reg = <0x1000000 0x4a20000>;
+		};
+
+		/* Contains vendor JFFS2 data and must not be overwritten. */
+		partition@5a20000 {
+			label = "stock-tail";
+			reg = <0x5a20000 0x2560000>;
+			read-only;
+		};
+
+		/* The final 512 KiB is also unmapped by the vendor firmware. */
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4>;
+		nvmem-cell-names = "eeprom", "mac-address";
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e006 1>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_factory_e006 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethphy4 {
+	/delete-property/ interrupts;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart2", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1095,6 +1095,18 @@ define Device/dlink_dir-853-r1
 endef
 TARGET_DEVICES += dlink_dir-853-r1
 
+define Device/dlink_dir-853-r3
+  $(Device/nand)
+  IMAGE_SIZE := 75904k
+  KERNEL_SIZE := 3456k
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DIR-853
+  DEVICE_VARIANT := R3
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 \
+	kmod-usb-ledtrig-usbport -uboot-envtools
+endef
+TARGET_DEVICES += dlink_dir-853-r3
+
 define Device/dlink_dir-860l-b1
   $(Device/dsa-migration)
   $(Device/seama-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -124,6 +124,10 @@ dlink,dir-853-a3)
 dlink,dir-853-r1)
 	ucidef_set_led_netdev "internet" "internet" "blue:net" "wan"
 	;;
+dlink,dir-853-r3)
+	ucidef_set_led_wlan "wlan2g" "WiFi 2.4GHz" "mt76-phy0" "phy0tpt"
+	ucidef_set_led_wlan "wlan5g" "WiFi 5GHz" "mt76-phy1" "phy1tpt"
+	;;
 dlink,dir-1935-a1|\
 dlink,dir-860l-b1|\
 dlink,dir-867-a1|\

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -66,6 +66,13 @@ case "$board" in
 			macaddr_setbit_la "$base_mac" > /sys${DEVPATH}/macaddress
 		fi
 		;;
+	dlink,dir-853-r3)
+		if [ "$PHYNBR" = "0" ]; then
+			base_mac="$(mtd_get_mac_binary factory 0x4)"
+			macaddr_setbit_la "$(macaddr_setbit "$base_mac" 27)" \
+				> /sys${DEVPATH}/macaddress
+		fi
+		;;
 	edup,ep-rt2960s|\
 	haier,har-20s2u1|\
 	jcg,y2|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -95,6 +95,7 @@ platform_do_upgrade() {
 	dlink,dir-3040-a1|\
 	dlink,dir-3060-a1|\
 	dlink,dir-853-a3|\
+	dlink,dir-853-r3|\
 	dlink,dir-x1860-b1|\
 	edup,ep-rt2960s|\
 	edup,ep-rt2983|\


### PR DESCRIPTION
Add support for the D-Link DIR-853 hardware revision R3.

Specifications:
- SoC: MediaTek MT7621AT
- Flash: 128 MiB NAND
- RAM: 128 MiB
- Wireless: MT7615 2.4/5GHz Dual-Band
- Ports: 4x LAN, 1x WAN, 1x USB 2.0

Hardware validated on both identified 128 MiB NAND variants:
- ESMT F59L1G81MB-25T
- AMD/Spansion S34ML01G2