### PR TITLE
mediatek: filogic: add NMBM properties for netis NX30 V2

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-netis-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-netis-common.dtsi
@@ -110,6 +110,10 @@
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;


### PR DESCRIPTION
Add MediaTek NMBM (NAND Flash Bad Block Management) properties to ensure proper flash storage handling, matching the vendor firmware configuration.

Kernel Log
> [    0.997117] spi-nand spi0.0: ESMT SPI NAND was found.
[    1.002208] spi-nand spi0.0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
[    1.011169] Signature found at block 1023 [0x07fe0000]
[    1.016303] NMBM management region starts at block 960 [0x07800000]
[    1.023658] First info table with writecount 0 found in block 960
[    1.032623] Second info table with writecount 0 found in block 963
[    1.038797] NMBM has been successfully attached
[    1.044282] 5 fixed-partitions partitions found on MTD device spi0.0

This change has been tested and verified on NX30 V2 in this PR. 
Please note that Netcore N30 Pro / netis NX35U (proposed by @bfdeh in #24316) is also expected to use this shared `.dtsi`, and runtime testing for that device will be required.