### PR TITLE
wifi-scripts: Add 60G band to mac80211.uc to support 802.11ad

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -32,8 +32,10 @@ function set_device_defaults(config) {
 	/* validate band */
 	if (config.band == '2g')
 		config.hw_mode = 'g';
-	else if (config.band in [ '5g', '6g', '60g' ])
+	else if (config.band in [ '5g', '6g' ])
 		config.hw_mode = 'a';
+	else if (config.band == '60g')
+		config.hw_mode = 'ad';
 	else
 		switch (config.hw_mode) {
 		case 'a':

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
@@ -118,7 +118,7 @@ export function parse_encryption(config, dev_config, phy_features) {
 
 	if (!config.wpa)
 		config.wpa_pairwise ??= null;
-	else if (config.hw_mode == 'ad')
+	else if (dev_config.band == '60g')
 		config.wpa_pairwise ??= 'GCMP';
 	else if (config.gcmp256 && phy_features?.cipher_gcmp256)
 		config.wpa_pairwise ??= 'GCMP-256 CCMP';

--- a/package/network/config/wifi-scripts/files/lib/wifi/mac80211.uc
+++ b/package/network/config/wifi-scripts/files/lib/wifi/mac80211.uc
@@ -2,7 +2,7 @@
 import { readfile } from "fs";
 import * as uci from 'uci';
 
-const bands_order = [ "6G", "5G", "2G" ];
+const bands_order = [ "60G", "6G", "5G", "2G" ];
 const htmode_order = [ "EHT", "HE", "VHT", "HT" ];
 
 let board = json(readfile("/etc/board.json"));


### PR DESCRIPTION
This PR supersedes #20341.

/etc/config/wireless is missing 60G band for routers supporting it. This support was enabled in OpenWrt v23 but somehow disappeared in v24.

Run-tested-on: TP-Link Talon AD7200 v2

[Originally authored by Konstantin Glukhov, replaced SoB, because of lack of real email]
Backports to 25.12 and 24.10 will be needed as well, but this should cherry-pick cleanly.