### PR TITLE
urngd: enable optimization for Jitter RNG 3.x

### DIFF
--- a/package/system/urngd/Makefile
+++ b/package/system/urngd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=urngd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/urngd.git

--- a/package/system/urngd/Makefile
+++ b/package/system/urngd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=urngd
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/urngd.git

--- a/package/system/urngd/files/urngd.init
+++ b/package/system/urngd/files/urngd.init
@@ -9,6 +9,7 @@ PROG=/sbin/urngd
 start_service() {
 	procd_open_instance
 	procd_set_param command "$PROG"
+	procd_set_param nice 19
 	procd_close_instance
 }
 

--- a/package/system/urngd/patches/100-jitterentropy-enable-optimization.patch
+++ b/package/system/urngd/patches/100-jitterentropy-enable-optimization.patch
@@ -1,0 +1,32 @@
+From f7f9185b1296c005efe58cd756d2646ca00acb8d Mon Sep 17 00:00:00 2001
+From: Gleb Pesin <dormancygrace@gmail.com>
+Date: Thu, 6 Aug 2026 19:46:43 +0000
+Subject: [PATCH] CMakeLists: enable optimization for Jitter RNG 3.x
+
+Jitter RNG 2.x prohibited compiler optimization. That restriction was
+removed in 3.x and the standalone Makefile builds the core with -O2.
+Bring the CMake build in line with it while retaining fortification.
+This depends on the pinned 3rdparty/jitterentropy-rngd submodule being 3.x.
+
+Upstream-Status: Submitted [https://github.com/openwrt/urngd/pull/1]
+
+Signed-off-by: Gleb Pesin <dormancygrace@gmail.com>
+---
+ CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -22,10 +22,10 @@ ADD_EXECUTABLE(urngd
+ )
+ TARGET_LINK_LIBRARIES(urngd ${ubox})
+ 
+-# jitter RNG must not be compiled with optimizations, _FORTIFY_SOURCE needs optimizations
++# Jitter RNG 3.x supports optimization; match its standalone Makefile.
+ SET_PROPERTY(
+   SOURCE ${JTEN_DIR}/jitterentropy-base.c
+-  APPEND PROPERTY COMPILE_OPTIONS -U_FORTIFY_SOURCE -O0
++  APPEND PROPERTY COMPILE_OPTIONS -O2
+ )
+ 
+ INSTALL(TARGETS urngd RUNTIME DESTINATION ${CMAKE_INSTALL_SBINDIR})


### PR DESCRIPTION
Jitter RNG 2.x required its core to be built without compiler optimization. This restriction was removed in Jitter RNG 3.x, and the pinned `3rdparty/jitterentropy-rngd` submodule's standalone Makefile uses `-O2`. The urngd CMake file nevertheless still forces `-O0` for `jitterentropy-base.c`.

The CPU-intensive entropy initialization can also monopolize a slow single-core CPU while the remaining init scripts are still starting. Run urngd at nice level 19 so network and management services can initialize first without disabling entropy generation.

Together these changes bring the CMake build in line with the standalone build, prevent urngd from blocking startup on CPU-constrained devices and bump the OpenWrt package release.

The CMake change has also been submitted upstream as openwrt/urngd#1. The local patch remains until that change is merged and OpenWrt updates the pinned urngd revision.

Fixes #21573.

Validation:

- OpenWrt `checkpatch.pl`: 0 errors, 0 warnings.
- The patch applies cleanly to urngd `f17e33d9942750edbd73124e6f03118a98abb402`.
- `make package/urngd/clean` and `make package/urngd/compile -j12 V=s` succeeded with GCC 14.3.0 for ramips/mt7620; generated build rules and the compiler invocation end in `-O2` for `jitterentropy-base.c`, while retaining OpenWrt's `_FORTIFY_SOURCE=1` toolchain flag.
- A complete WE826 image build with `make -j12 V=s` succeeded.
- On MIPS32 QEMU with the same compiler and source, initialization plus one 64-byte block improved from about 0.40 s to 0.13 s; four blocks improved from about 0.81 s to 0.26 s.
- The resulting binary was run on an MT7620 WE826; urngd stayed healthy and completed its entropy initialization successfully.
- On the WE826, lowering urngd's priority reduced cold boot time to SSH and HTTP from about 117 s to 81 s with the unoptimized entropy core, and to about 80 s together with `-O2`.
