### PR TITLE
airoha: an7581: reserve NPU Wi-Fi memory only where it is used, fix NPU firmware loading

### DIFF
--- a/target/linux/airoha/dts/an7581-evb.dts
+++ b/target/linux/airoha/dts/an7581-evb.dts
@@ -8,6 +8,7 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 #include "an7581.dtsi"
+#include "an7581-npu-wlan.dtsi"
 
 / {
 	model = "Airoha AN7581 Evaluation Board";

--- a/target/linux/airoha/dts/an7581-npu-mt7992.dtsi
+++ b/target/linux/airoha/dts/an7581-npu-mt7992.dtsi
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 
+#include "an7581-npu-wlan.dtsi"
+
 &npu {
 	firmware-name = "airoha/en7581_npu_rv32.bin",
                         "airoha/en7581_npu_data.bin";

--- a/target/linux/airoha/dts/an7581-npu-mt7996.dtsi
+++ b/target/linux/airoha/dts/an7581-npu-mt7996.dtsi
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 
+#include "an7581-npu-wlan.dtsi"
+
 &npu {
 	firmware-name = "airoha/en7581_MT7996_npu_rv32.bin",
                         "airoha/en7581_MT7996_npu_data.bin";

--- a/target/linux/airoha/dts/an7581-npu-wlan.dtsi
+++ b/target/linux/airoha/dts/an7581-npu-wlan.dtsi
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+
+/*
+ * Memory regions used by the NPU Wi-Fi packet offloading only. Boards that
+ * do not run an Airoha-offloaded Wi-Fi chip must not reserve them: the NPU
+ * needs the binary region alone to run its firmware and to offload flows.
+ */
+
+/ {
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		npu_pkt: npu-pkt@8a000000 {
+			no-map;
+			reg = <0x0 0x8a000000 0x0 0x2c00000>;
+		};
+
+		npu_txpkt: npu-txpkt@8cc00000 {
+			no-map;
+			reg = <0x0 0x8cc00000 0x0 0x4000000>;
+		};
+
+		npu_txbufid: npu-txbufid@90c00000 {
+			no-map;
+			reg = <0x0 0x90c00000 0x0 0x6800>;
+		};
+
+		npu_ba: npu-ba@90c06800 {
+			no-map;
+			reg = <0x0 0x90c06800 0x0 0x200000>;
+		};
+	};
+};
+
+&npu {
+	memory-region = <&npu_binary>, <&npu_pkt>, <&npu_txpkt>,
+			<&npu_txbufid>, <&npu_ba>;
+	memory-region-names = "binary", "pkt", "tx-pkt",
+			      "tx-bufid", "ba";
+};

--- a/target/linux/airoha/dts/an7581.dtsi
+++ b/target/linux/airoha/dts/an7581.dtsi
@@ -39,26 +39,6 @@
 			no-map;
 			reg = <0x0 0x89000000 0x0 0x1000000>;
 		};
-
-		npu_pkt: npu-pkt@8a000000 {
-			no-map;
-			reg = <0x0 0x8a000000 0x0 0x2c00000>;
-		};
-
-		npu_txpkt: npu-txpkt@8cc00000 {
-			no-map;
-			reg = <0x0 0x8cc00000 0x0 0x4000000>;
-		};
-
-		npu_txbufid: npu-txbufid@90c00000 {
-			no-map;
-			reg = <0x0 0x90c00000 0x0 0x6800>;
-		};
-
-		npu_ba: npu-ba@90c06800 {
-			no-map;
-			reg = <0x0 0x90c06800 0x0 0x200000>;
-		};
 	};
 
 	psci {
@@ -904,10 +884,9 @@
 				     <GIC_SPI 121 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 122 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 123 IRQ_TYPE_LEVEL_HIGH>;
-			memory-region = <&npu_binary>, <&npu_pkt>, <&npu_txpkt>,
-					<&npu_txbufid>, <&npu_ba>;
-			memory-region-names = "binary", "pkt", "tx-pkt",
-					      "tx-bufid", "ba";
+			memory-region = <&npu_binary>;
+			memory-region-names = "binary";
+
 			status = "disabled";
 		};
 

--- a/target/linux/airoha/patches-6.18/921-net-airoha-npu-load-firmware-without-the-sysfs-fallb.patch
+++ b/target/linux/airoha/patches-6.18/921-net-airoha-npu-load-firmware-without-the-sysfs-fallb.patch
@@ -1,0 +1,59 @@
+From 0509cfb2607a5a084617701f969b4bad0fd0f157 Mon Sep 17 00:00:00 2001
+From: Vitaliy Sochnev <sochnev.v.74@gmail.com>
+Date: Fri, 7 Aug 2026 03:37:00 +0100
+Subject: [PATCH] net: airoha: npu: load the firmware without the sysfs
+ fallback
+
+airoha_npu_load_firmware() maps a missing firmware file to -EPROBE_DEFER
+so that the NPU can be brought up once the rootfs carrying /lib/firmware
+has been mounted. That mapping holds only as long as request_firmware()
+reports -ENOENT.
+
+It does not when the sysfs fallback is in play. With
+CONFIG_FW_LOADER_USER_HELPER_FALLBACK set, or with the fallback armed at
+runtime through /proc/sys/kernel/firmware_config/force_sysfs_fallback,
+request_firmware() hands the request to a userspace helper, waits out the
+full loading_timeout and returns -ETIMEDOUT. The -ENOENT test no longer
+matches, dev_err_probe() turns the result into a hard failure, and the
+NPU is left unbound after stalling the boot for 60 seconds:
+
+  airoha-npu 1e900000.npu: Direct firmware load for airoha/en7581_npu_rv32.bin failed with error -2
+  airoha-npu 1e900000.npu: Falling back to sysfs fallback for: airoha/en7581_npu_rv32.bin
+  airoha-npu 1e900000.npu: error -ETIMEDOUT: failed to run npu firmware
+  airoha-npu 1e900000.npu: probe with driver airoha-npu failed with error -110
+
+Clearing FW_LOADER_USER_HELPER in the configuration is not a dependable
+guard against this, because unrelated drivers select it. On the affected
+build the symbol was turned back on by LEDS_LP55XX_COMMON, even though
+the platform had explicitly disabled it.
+
+request_firmware_direct() sets FW_OPT_NOFALLBACK_SYSFS, so a missing file
+is reported as -ENOENT whatever the firmware loader is configured to do,
+and the deferred probe path works as it was meant to.
+
+Measured on a Nokia XG-040G-MD with FW_LOADER_USER_HELPER=y and
+FW_LOADER_USER_HELPER_FALLBACK=y, on two images from the same tree
+differing only by this patch: without it the probe fails with
+-ETIMEDOUT after 64.5s and the NPU stays unbound, with it the NPU
+reports its firmware version at 3.7s. The fallback is compiled in and
+forced in both cases; the patch does not disable it, it only keeps the
+driver from falling into it.
+
+Fixes: 23290c7bc190 ("net: airoha: Introduce Airoha NPU support")
+Cc: stable@vger.kernel.org
+Signed-off-by: Vitaliy Sochnev <sochnev.v.74@gmail.com>
+---
+ drivers/net/ethernet/airoha/airoha_npu.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/ethernet/airoha/airoha_npu.c
++++ b/drivers/net/ethernet/airoha/airoha_npu.c
+@@ -202,7 +202,7 @@ static int airoha_npu_load_firmware(stru
+ 	const struct firmware *fw;
+ 	int ret;
+ 
+-	ret = request_firmware(&fw, fw_name, dev);
++	ret = request_firmware_direct(&fw, fw_name, dev);
+ 	if (ret)
+ 		return ret == -ENOENT ? -EPROBE_DEFER : ret;
+ 


### PR DESCRIPTION
Two independent NPU changes for AN7581, both tested on a Nokia XG-040G-MD.

### 1/2 airoha: an7581: reserve NPU Wi-Fi regions only on Wi-Fi boards

`an7581.dtsi` reserves five `no-map` regions for the NPU and hands all of them
to the `npu` node. Four of them — `pkt`, `tx-pkt`, `tx-bufid` and `ba`,
110 MiB plus 26 KiB — are consumed only by `airoha_npu_wlan_init_memory()`,
which the mt76 NPU layer calls when it attaches an Airoha-offloaded Wi-Fi chip.
To run its firmware and to offload flows the NPU needs the binary region alone,
and the driver looks that one up by index.

Boards that bind no Wi-Fi chip to the NPU lose 110 MiB of DRAM for nothing,
whether or not the NPU probes at all, because the memory is carved out by the
`reserved-memory` node itself. `an7583.dtsi` already reserves `npu_binary` only,
so this follows a pattern already in the tree.

The four regions move into a new `an7581-npu-wlan.dtsi`, included from the two
NPU overlays the Wi-Fi boards already pull in.

`an7581-evb` includes the new overlay directly instead. It declares two
`mediatek,mt76` nodes with `airoha,npu` and enables the NPU, but pins no
particular chip because the card goes into a PCIe slot, so it is the one board
using the offload that pulls in neither NPU overlay. Its DTB is unchanged.

Device trees built before and after, compared by sha256:

| board | before | after | |
|---|---|---|---|
| an7581-evb | 20778 | 20778 | identical |
| an7581-evb-emmc-eagle | 21457 | 21457 | identical |
| an7581-evb-emmc-kite | 21203 | 21203 | identical |
| an7581-nokia-valyrian | 24375 | 24375 | identical |
| an7581-w1700k-ubi | 22663 | 22663 | identical |
| an7581-nokia_xg-040g-md | 23584 | 23208 | −376 B, four regions gone |
| an7581-nokia_xg-040g-md-ubi | 22549 | 22173 | −376 B, four regions gone |

So every board that binds Wi-Fi to the NPU keeps a byte-identical DTB, and the
memory comes back on the two that do not. On the XG-040G-MD:

```
reserved   197296K -> 84400K
MemTotal   325900 kB -> 438736 kB
```

and the NPU still comes up on the binary region alone, reporting
`NPU fw version: 1456.62`, so the board keeps its hardware flow offloading.

The `ba` region stays with all four Wi-Fi boards even though it is described as
MT7996-only. It is already optional in the driver, but narrowing it down to
MT7996 would change behaviour on Kite, so that is left for a separate change.

### 2/2 airoha: npu: load the firmware without the sysfs fallback

The NPU driver maps a missing firmware file to `-EPROBE_DEFER` so that it can be
retried once the rootfs carrying `/lib/firmware` is mounted. That mapping holds
only while `request_firmware()` reports `-ENOENT`, and it does not when the sysfs
fallback is in play: the request goes to a userspace helper, blocks for the full
60 second `loading_timeout` and comes back as `-ETIMEDOUT`, which
`dev_err_probe()` turns into a hard failure. The board boots a minute slower and
ends up with no NPU at all, so no hardware flow offloading either.

Disabling `FW_LOADER_USER_HELPER` for the target is not a dependable guard:
`LEDS_LP55XX_COMMON` selects it, so any build pulling in
`kmod-leds-lp55xx-common` — every image built with `ALL_KMODS`, snapshots
included — gets it back, and generic's `FW_LOADER_USER_HELPER_FALLBACK=y` then
arms the fallback. That is exactly what the affected board was running.

Measured on the XG-040G-MD with `FW_LOADER_USER_HELPER=y` and
`FW_LOADER_USER_HELPER_FALLBACK=y` forced on, two images from the same tree
differing only by this patch:

| | without the patch | with the patch |
|---|---|---|
| sysfs fallback | 2.477s | never |
| `-ETIMEDOUT` | 64.555s | never |
| NPU | probe failed −110, unbound | fw version 1456.62 at 3.665s |
| `init: - preinit -` | 69.6s | 7.6s |

The fallback stays compiled in and forced in both cases; the patch does not
disable it, it only keeps the driver from falling into it.

The same failure was analysed independently in #22697 (Ziyang Huang, March
2026), against the code before the two `request_firmware()` call sites were
folded into `airoha_npu_load_firmware()`; that report was never submitted
upstream.

Submitted upstream:
https://lore.kernel.org/netdev/20260807024125.434055-1-sochnev.v.74@gmail.com/
It carries `Fixes: 23290c7bc190 ("net: airoha: Introduce Airoha NPU support")`
and `Cc: stable@vger.kernel.org`, so the local patch can be dropped once it
lands.

### Testing

Both commits were built and flashed on a Nokia XG-040G-MD. Not tested on any
board with Airoha Wi-Fi offloading — for those, 1/2 rests on the DTBs being
byte-identical, which shows there is no regression in the tree but cannot show
one in the driver.

### Not part of this PR

`target/linux/generic/config-6.18` sets `CONFIG_FW_LOADER_USER_HELPER_FALLBACK=y`,
which is what arms the fallback in the first place. Upstream's Kconfig says to
say N if unsure, and bcm53xx, gemini and layerscape already disable it locally.
Whether it should stay on by default is a question for the generic config and it
affects every target, so it is left alone here.

#24571 takes that route for the airoha targets specifically. It does not overlap
with 2/2: that one keeps the fallback from being armed, this one keeps the
driver from falling into it whatever the configuration says.