### PR TITLE
unetmsg: fix TCP_USER_TIMEOUT socket option level

### DIFF
--- a/package/network/services/unetmsg/Makefile
+++ b/package/network/services/unetmsg/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unetmsg
-PKG_RELEASE:=14
+PKG_RELEASE:=15
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>

--- a/package/network/services/unetmsg/files/usr/share/ucode/unetmsg/unetmsgd-remote.uc
+++ b/package/network/services/unetmsg/files/usr/share/ucode/unetmsg/unetmsgd-remote.uc
@@ -301,7 +301,8 @@ function network_open_channel(net, name, peer)
 		return;
 
 	core.dbg(`Try to connect to ${name}\n`);
-	sock.setopt(socket.SOL_TCP, socket.TCP_USER_TIMEOUT, TCP_TIMEOUT);
+	if (!sock.setopt(socket.IPPROTO_TCP, socket.TCP_USER_TIMEOUT, TCP_TIMEOUT))
+		warn(`Failed to set TCP user timeout on channel socket: ${socket.error()}\n`);
 	sock.connect(addr);
 	let auth_data_cb = (msg) => {
 		if (!network_auth_valid(sock_data.name, sock_data.id, msg.token))
@@ -425,7 +426,8 @@ function network_open(name, info)
 	net.rx_channels = {};
 	net.tx_channels = {};
 
-	net.socket.setopt(socket.SOL_TCP, socket.TCP_USER_TIMEOUT, TCP_TIMEOUT);
+	if (!net.socket.setopt(socket.IPPROTO_TCP, socket.TCP_USER_TIMEOUT, TCP_TIMEOUT))
+		warn(`Failed to set TCP user timeout on listen socket: ${socket.error()}\n`);
 
 	let cb = () => {
 		let addr = {};


### PR DESCRIPTION
The ucode socket module exports no SOL_TCP so setopt() was called with level 0 and silently failed. This left inter-node connections without the 5 second user timeout. A peer that stopped reading could then stall a blocking channel write forever, deadlocking every unetmsgd in the mesh along with their local clients.

Use IPPROTO_TCP and warn when setopt fails.