### PR TITLE
airoha: an7583: fix ethernet breakage on Nokia XG-040G-MF

### DIFF
--- a/target/linux/airoha/dts/an7583-nokia_xg-040g-mf-common.dtsi
+++ b/target/linux/airoha/dts/an7583-nokia_xg-040g-mf-common.dtsi
@@ -207,15 +207,15 @@
 	pinctrl-0 = <&mdio0_pins>;
 };
 
-&gsw_port1 {
-	status = "disabled";
-};
+&gsw_port2 {
+	status = "okay";
 
-&gsw_phy1 {
-	status = "disabled";
+	label = "lan2";
 };
 
 &gsw_phy2 {
+	status = "okay";
+
 	interrupts = <2>;
 
 	pinctrl-names = "gbe-led";
@@ -229,7 +229,15 @@
 	active-low;
 };
 
+&gsw_port3 {
+	status = "okay";
+
+	label = "lan3";
+};
+
 &gsw_phy3 {
+	status = "okay";
+
 	interrupts = <3>;
 
 	pinctrl-names = "gbe-led";
@@ -243,7 +251,15 @@
 	active-low;
 };
 
+&gsw_port4 {
+	status = "okay";
+
+	label = "lan4";
+};
+
 &gsw_phy4 {
+	status = "okay";
+
 	interrupts = <4>;
 
 	pinctrl-names = "gbe-led";


### PR DESCRIPTION
Recent upstream cleanups moved switch port labels to the board level and disabled switch ports/PHYs by default on the AN7583 SoC dtsi. This broke ethernet on the Nokia XG-040G-MF since its board DTS was not updated to explicitly configure and enable them.

Fix this by explicitly enabling gsw_port2-4 along with their respective PHYs and restoring the "lan2", "lan3", and "lan4" port labels.

Fixes: ce55cdde26a9 ("airoha: an7583: move the switch port label from soc-level to board-level")
Fixes: d2698d325b68 ("airoha: an7583: disable all switch ports and PHYs by default")

Cc @danielschwierzeck 
Cc @robimarko please help fix regression
