### PR TITLE
IPQ8174-MX4300 Remove read only from safe partitions

### DIFF
--- a/target/linux/qualcommax/dts/ipq8174-mx4300.dts
+++ b/target/linux/qualcommax/dts/ipq8174-mx4300.dts
@@ -244,13 +244,11 @@
 			partition@20c00000 {
 				label = "app2_data";
 				reg = <0x20c00000 0x16180000>;
-				read-only;
 			};
 
 			partition@36d80000 {
 				label = "app2";
 				reg = <0x36d80000 0x9280000>;
-				read-only;
 			};
 		};
 	};


### PR DESCRIPTION
These 2 partitions were used by the device (in a previous iteration) for firmware for another company (fortinet).  That firmware is no longer in use and these 2 flags dont allow mounting mtd30 and 31 as rw, losing us about 500mb of storage.

More information on previous iteration here:
https://cdn.blueally.com/avfirewalls/datasheets/ds-linksys-homewrk.pdf

Ive tested using both mtd30 and 31 without any issues, and its a nice solution for a device that should have much more storage but its just locked behind non usable garbage

Signed-off-by: Ezequiel Scarcella scarcella.ezequiel@gmail.com
