### PR TITLE
mediatek: use nmbm for ipTIME AX7800M-6E

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-iptime-ax7800m-6e.dts
+++ b/target/linux/mediatek/dts/mt7986a-iptime-ax7800m-6e.dts
@@ -184,6 +184,10 @@
 		spi-tx-buswidth = <4>;
 		spi-rx-buswidth = <4>;
 
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;

--- a/target/linux/mediatek/dts/mt7986a-iptime-ax7800m-6e.dts
+++ b/target/linux/mediatek/dts/mt7986a-iptime-ax7800m-6e.dts
@@ -184,6 +184,10 @@
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;


### PR DESCRIPTION
The nmbm was accidentally excluded from initial support for ipTIME AX7800M-6E.
