### PR TITLE
ath79: tplink: extract ath10k board.bin for TP-Link Deco M4R v1

### DIFF
--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -11,11 +11,15 @@ case "$FIRMWARE" in
 	case $board in
 	dlink,dir-842-c1|\
 	dlink,dir-842-c2|\
-	dlink,dir-842-c3)
+	dlink,dir-842-c3|\
+	tplink,deco-m4r-v1|\
+	tplink,deco-m4r-v2)
 		caldata_extract "art" 0x5000 0x2f20
 		caldata_valid "202f" || caldata_extract "reserved" 0x15000 0x2f20
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
+		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
+			/lib/firmware/ath10k/QCA9888/hw2.0/board-2.bin
 		;;
 	esac
 	;;


### PR DESCRIPTION
Extract the device-specific board image from the ART/flash partition
and provide it as board.bin for ath10k.
    
With generic `board-2.bin`, the link speed fluctuates around 150-200 Mbps and
fails to reach the full 867 Mbps PHY rate even at close proximity, resulting
in real-world throughput capped at 60-80 Mbps.
    
Extracting `board.bin` directly from the device's ART partition
restores performance close to the vendor firmware, bringing throughput up
to 200-300 Mbps.
