### PR TITLE
realtek: dts: add missing soc compatible to two Hasivo boards (s1100wp, s600wp)

### DIFF
--- a/target/linux/realtek/dts/rtl9303_hasivo_s1100wp-8gt-se.dts
+++ b/target/linux/realtek/dts/rtl9303_hasivo_s1100wp-8gt-se.dts
@@ -8,7 +8,7 @@
 #include <dt-bindings/leds/common.h>
 
 / {
-	compatible = "hasivo,s1100wp-8gt-se";
+	compatible = "hasivo,s1100wp-8gt-se", "realtek,rtl9303-soc";
 	model = "Hasivo S1100WP-8GT-SE";
 
 	memory@0 {

--- a/target/linux/realtek/dts/rtl9303_hasivo_s600wp-5gt-2sx-se.dts
+++ b/target/linux/realtek/dts/rtl9303_hasivo_s600wp-5gt-2sx-se.dts
@@ -8,7 +8,7 @@
 #include <dt-bindings/leds/common.h>
 
 / {
-	compatible = "hasivo,s600wp-5gt-2sx-se";
+	compatible = "hasivo,s600wp-5gt-2sx-se", "realtek,rtl9303-soc";
 	model = "Hasivo S600WP-5GT-2SX-SE";
 
 	memory@0 {


### PR DESCRIPTION
Both boards do not boot on current main. They hang early with:

`Failed to get CPU clock: -2`

They set only the board string in the root node, which replaces the value from rtl930x.dtsi instead of extending it, so the SoC compatible is missing from the DTB. Since 7cc31af7bd ("realtek: convert to generic machine initialization") that string is what MIPS_MACHINE(realtek) matches on, so prom init never runs and no clockevent is registered.

These were the only two board DTS in the realtek target without a SoC fallback in the root compatible.

Tested on S1100WP-8GT-SE.

pinging @plappermaul & @jonasjelonek  :-) 