### PR TITLE
tools/cmake: update to 4.4.2

### DIFF
--- a/include/cmake.mk
+++ b/include/cmake.mk
@@ -93,7 +93,7 @@ define Build/Configure/Default
 		CXXFLAGS="$(TARGET_CXXFLAGS) $(EXTRA_CXXFLAGS) $(TARGET_CPPFLAGS) $(EXTRA_CPPFLAGS)" \
 		LDFLAGS="$(TARGET_LDFLAGS) $(EXTRA_LDFLAGS)" \
 		cmake \
-			--no-warn-unused-cli \
+			-Wno-unused-cli \
 			-DCMAKE_SYSTEM_NAME=Linux \
 			-DCMAKE_SYSTEM_VERSION=1 \
 			-DCMAKE_SYSTEM_PROCESSOR=$(ARCH) \
@@ -146,7 +146,7 @@ define Host/Configure/Default
 		CXXFLAGS="$(HOST_CFLAGS)" \
 		LDFLAGS="$(HOST_LDFLAGS)" \
 		cmake \
-			--no-warn-unused-cli \
+			-Wno-unused-cli \
 			-DCMAKE_BUILD_TYPE=Release \
 			-DCMAKE_C_COMPILER_LAUNCHER="$(CMAKE_C_COMPILER_LAUNCHER)" \
 			-DCMAKE_C_COMPILER="$(CMAKE_HOST_C_COMPILER)" \

--- a/tools/cmake/Makefile
+++ b/tools/cmake/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cmake
-PKG_VERSION:=4.4.0
+PKG_VERSION:=4.4.2
 PKG_VERSION_MAJOR:=$(word 1,$(subst ., ,$(PKG_VERSION))).$(word 2,$(subst ., ,$(PKG_VERSION)))
 PKG_RELEASE:=1
 PKG_CPE_ID:=cpe:/a:kitware:cmake
@@ -15,7 +15,7 @@ PKG_CPE_ID:=cpe:/a:kitware:cmake
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/Kitware/CMake/releases/download/v$(PKG_VERSION)/ \
 		https://cmake.org/files/v$(PKG_VERSION_MAJOR)/
-PKG_HASH:=65757f442fdd242e27f1728fc26dc0cba4164f7a0791a5c788631c00080369bc
+PKG_HASH:=1db9e61e60b6e0874c86386340b910382f3c5e75b9fbfb44d122063129a2789d
 
 HOST_BUILD_PARALLEL:=1
 HOST_CONFIGURE_PARALLEL:=1


### PR DESCRIPTION
Release notes:https://cmake.org/cmake/help/latest/release/4.4.html

No need refresh patches.

The --no-warn-unused-cli command-line option is deprecated. The new spelling is -Wno-unused-cli.

