### PR TITLE
wifi-scripts: fix wdev fallback to use sprintf instead of printf

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
@@ -294,15 +294,7 @@ function setup() {
 		wdev_data[v.config.ifname] = config;
 	}
 
-	for (let ifname in active_ifnames) {
-		if (!wdev_data[ifname])
-			continue;
-
-		let if_config = {
-			[ifname]: wdev_data[ifname]
-		};
-		system(`ucode /usr/share/hostap/wdev.uc ${data.phy}${data.phy_suffix} set_config '${if_config}'`);
-	}
+	system([ "ucode", "/usr/share/hostap/wdev.uc", data.phy + data.phy_suffix, "set_config", sprintf("%J", wdev_data), ...active_ifnames ]);
 
 	if (fs.access('/usr/sbin/wpa_supplicant', 'x'))
 		supplicant.setup(supplicant_data, data);

--- a/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
@@ -224,7 +224,7 @@ function setup() {
 		if (v.config.encryption == 'owe' && v.config.owe_transition) {
 			mode_idx = idx[mode]++;
 			v.config.owe_transition_ifname = data.ifname_prefix + mode + mode_idx;
-			push(active_ifnames, v.config.ifname);
+			push(active_ifnames, v.config.owe_transition_ifname);
 		}
 
 		switch (mode) {


### PR DESCRIPTION
Previously, when printf was used, it didn't work because printf
returns the number of bytes written instead of the real content.
There was an attempt to fix that issue by using a loop, which
introduced several new bugs. It prevented orphan interfaces from
being correctly cleaned up since ubus wouldn't be called. Another
bug was that if we had several interfaces on the same radio, only
the last one would be applied because the loop called them
sequentially.

Update the command to use sprintf so it provides the correct
dictionary.

Signed-off-by: Alexander Astrovsky <astrouski@google.com>