### PR TITLE
dnsmasq: support MAC-only host entries

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=dnsmasq
 PKG_UPSTREAM_VERSION:=2.93
 PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=https://thekelleys.org.uk/dnsmasq/

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -359,16 +359,17 @@ dhcp_host_add() {
 	config_get name "$cfg" name
 	config_get ip "$cfg" ip
 	config_get hostid "$cfg" hostid
+	config_get mac "$cfg" mac
+	config_get duid "$cfg" duid
 
-	[ -z "$ip" ] && [ -z "$name" ] && [ -z "$hostid" ] && return 0
+	[ -z "$ip" ] && [ -z "$name" ] && [ -z "$hostid" ] &&
+		[ -z "$mac" ] && [ -z "$duid" ] && return 0
 
 	config_get_bool dns "$cfg" dns 0
 	[ "$dns" = "1" ] && [ -n "$ip" ] && [ -n "$name" ] && {
 		echo "$ip $name${DOMAIN:+.$DOMAIN}" >> "$HOSTFILE_TMP"
 	}
 
-	config_get mac "$cfg" mac
-	config_get duid "$cfg" duid
 	config_get tag "$cfg" tag
 
 	add_tag() {


### PR DESCRIPTION
dnsmasq accepts dhcp-host entries without requiring a static IP
address. These entries can identify known clients or assign tags while
addresses continue to be allocated dynamically.

`dhcp_host_add()` currently discards an entry unless it contains a
name, IPv4 address, or IPv6 host ID. The check happens before the MAC
value is read, causing valid MAC-only entries to be ignored.

Read the client identifiers before the check and include them when
deciding whether the section is empty. This allows MAC-only entries to
reach dnsmasq configuration generation.

## Testing

Tested on OpenWrt 25.12.4 with the following MAC-only host entry:

```uci
config host
	option mac '11:22:33:44:55:66'
	option tag 'mytag'
```

Before the change, no `dhcp-host` section appeared in
the generated dnsmasq config.

After the change, the generated config contains:

```text
dhcp-host=11:22:33:44:55:66,set:mytag
```

Existing host entries containing a name and static IPv4 address
continue to be generated correctly.

Fixes #22051
