### PR TITLE
airoha: fix EN8811H PHY binding on Nokia XG-040G-MF and MD

### DIFF
--- a/target/linux/airoha/dts/an7581-nokia_xg-040g-md-common.dtsi
+++ b/target/linux/airoha/dts/an7581-nokia_xg-040g-md-common.dtsi
@@ -134,7 +134,7 @@
 &mdio {
 	/* Airoha EN8811 2.5Gbps phy */
 	en8811: ethernet-phy@f {
-		compatible = "ethernet-phy-ieee802.3-c45";
+		compatible = "ethernet-phy-id03a2.a411";
 		reg = <0xf>;
 
 		reset-gpios = <&en7581_pinctrl 31 GPIO_ACTIVE_LOW>;

--- a/target/linux/airoha/dts/an7583-nokia_xg-040g-mf-common.dtsi
+++ b/target/linux/airoha/dts/an7583-nokia_xg-040g-mf-common.dtsi
@@ -166,7 +166,7 @@
 &mdio_0 {
 	/* Airoha EN8811 2.5Gbps phy */
 	en8811: ethernet-phy@f {
-		compatible = "ethernet-phy-ieee802.3-c45";
+		compatible = "ethernet-phy-id03a2.a411";
 		reg = <0xf>;
 
 		reset-gpios = <&an7583_pinctrl 34 GPIO_ACTIVE_LOW>;


### PR DESCRIPTION
The 2.5G port (`lan1`) on Nokia XG-040G-MF never came up. The wrong driver bound to the PHY, and every attempt to bring the link up ended in a `-EINVAL` and a WARNING backtrace:

```
airoha_eth 1fb50000.ethernet lan1: PHY [...:0f] driver [Generic Clause 45 PHY]
airoha_eth 1fb50000.ethernet lan1: configuring for phy/2500base-x link mode
_phy_start_aneg+0x0/0xa0: returned: -22
WARNING: CPU: 0 PID: 592 at _phy_state_machine+0x100/0x3e0
```

### Cause

The PHY node is described as `ethernet-phy-ieee802.3-c45`. That makes `fwnode_mdiobus_register_phy()` take the `get_phy_device()` path, which reads the PHY ID off the bus while scanning it. The EN8811H does not answer that early, the ID reads back as zero, so `air_en8811h` never matches and the generic Clause 45 driver binds instead.

The generic driver builds `phydev->supported` without the `Autoneg` bit, so `phy_probe()` clears `phydev->autoneg`. `_phy_start_aneg()` then lands in `genphy_c45_config_aneg()`, which takes the forced path and bails out of `genphy_c45_pma_setup_forced()` with `-EINVAL`. The state machine turns that into a `WARN`, on every attempt to bring the link up.

### Fix

Describe the PHY by ID instead. `phy_device_create()` then takes the ID from the device tree, no bus read happens during the scan, and the right driver binds:

```
- compatible = "ethernet-phy-ieee802.3-c45";
+ compatible = "ethernet-phy-id03a2.a411";
```

Dropping the c45 compatible alone does not help: phylib would still read the ID from the hardware and get zero. No `air_en8811h` change is needed either, `en8811h_probe()` sets up the AN MMD itself once the PHY firmware is loaded.

### Test

Nokia XG-040G-MF, OpenWrt SNAPSHOT, kernel 6.18.41:

```
airoha_eth 1fb50000.ethernet lan1: PHY [...:0f] driver [Airoha EN8811H]
Airoha EN8811H ...:0f: MD32 firmware version: 25062302
airoha_eth 1fb50000.ethernet lan1: Link is Up - 2.5Gbps/Full - flow control rx/tx
```

`phy_id` reads back `0x03a2a411`, `ethtool` reports `Supports auto-negotiation: Yes`, and the WARNING is gone. A 45 minute iperf3 run over the port moved 561 GByte at 1.78 Gbit/s without a single link event.

### The MD commit

Nokia XG-040G-MD carries the same EN8811H behind the same binding, and there LAN1 does come up: the PHY sits behind the switch MDIO bus and answers the MMD device ID reads in time, so `air_en8811h` is still matched through `phydev->c45_ids` even though the Clause 22 ID reads back as zero. Nothing guarantees that ordering — the MF is what happens when it does not hold. Describing the PHY by ID there as well removes the dependency on timing.

Verified on hardware: the ID now comes from the device tree, the driver binds and the port links at 2.5 Gbit/s. Since no breakage is observed on the MD, that commit carries no `Fixes:` tag.