### PR TITLE
arm-trusted-firmware-airoha: sync an7581-bl31 BUILD_DEVICES with bl2

### DIFF
--- a/package/boot/arm-trusted-firmware-airoha/Makefile
+++ b/package/boot/arm-trusted-firmware-airoha/Makefile
@@ -50,7 +50,7 @@ define Trusted-Firmware-A/an7581-bl31
   $(call Trusted-Firmware-A/bl31/Default)
   BUILD_SUBTARGET:=an7581
   SOC:=EN7581
-  BUILD_DEVICES:=airoha_an7581-evb airoha_an7581-evb-emmc
+  BUILD_DEVICES:=airoha_an7581-evb airoha_an7581-evb-emmc-eagle airoha_an7581-evb-emmc-kite nokia_valyrian nokia_xg-040g-md-ubi
 endef
 
 define Trusted-Firmware-A/an7583-bl31


### PR DESCRIPTION
arm-trusted-firmware-airoha: sync an7581-bl31 BUILD_DEVICES with bl2

an7581-bl31 BUILD_DEVICES list was incomplete and missed:
 - airoha_an7581-evb-emmc-eagle
 - airoha_an7581-evb-emmc-kite
 - nokia_valyrian
 - nokia_xg-040g-md-ubi

These devices are present in an7581-bl2 but missing for bl31.
When building these targets, an7581‑bl31 package is never built,
causes FIP failure "fopen ...an7581‑bl31.lzma: No such file or directory".

Sync an7581‑bl31 BUILD_DEVICES to exactly match an7581‑bl2.

Fixes: https://github.com/openwrt/openwrt/commit/467c5b90ba1140dcdabc2e2e203c1d91fca9963e
