### PR TITLE
odhcp6c: allow disabling RA address assignment

### DIFF
--- a/package/network/ipv6/odhcp6c/files/dhcpv6.script
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.script
@@ -64,16 +64,18 @@ setup_interface () {
 		proto_add_ipv6_prefix "$prefix"
 	done
 
-	# Merge addresses
-	for entry in $RA_ADDRESSES; do
-		local duplicate=0
-		local addr="${entry%%/*}"
-		for dentry in $ADDRESSES; do
-			local daddr="${dentry%%/*}"
-			[ "$addr" = "$daddr" ] && duplicate=1
+	# Merge addresses unless RA-derived addresses are disabled
+	if [ "$NORAADDR" != "1" ]; then
+		for entry in $RA_ADDRESSES; do
+			local duplicate=0
+			local addr="${entry%%/*}"
+			for dentry in $ADDRESSES; do
+				local daddr="${dentry%%/*}"
+				[ "$addr" = "$daddr" ] && duplicate=1
+			done
+			[ "$duplicate" = "0" ] && ADDRESSES="$ADDRESSES $entry"
 		done
-		[ "$duplicate" = "0" ] && ADDRESSES="$ADDRESSES $entry"
-	done
+	fi
 
 	for entry in $ADDRESSES; do
 		local addr="${entry%%/*}"

--- a/package/network/ipv6/odhcp6c/files/dhcpv6.sh
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.sh
@@ -11,6 +11,7 @@ proto_dhcpv6_init_config() {
 
 	proto_config_add_string 'reqaddress:or("try","force","none")'
 	proto_config_add_string reqprefix
+	proto_config_add_boolean noraaddr
 	proto_config_add_string clientid
 	proto_config_add_string 'sendclientid:or("auto","global","hardware")'
 	proto_config_add_string 'reqopts:list(uinteger)'
@@ -73,7 +74,7 @@ proto_dhcpv6_setup() {
 	local config="$1"
 	local iface="$2"
 
-	local reqaddress reqprefix clientid sendclientid reqopts defaultreqopts
+	local reqaddress reqprefix noraaddr clientid sendclientid reqopts defaultreqopts
 	local noslaaconly forceprefix extendprefix norelease strict_rfc7550
 	local noserverunicast noclientfqdn noacceptreconfig iface_dslite
 	local iface_map iface_464xlat ip6ifaceid userclass vendorclass
@@ -83,7 +84,7 @@ proto_dhcpv6_setup() {
 
 	local ip6prefix ip6prefixes
 
-	json_get_vars reqaddress reqprefix clientid sendclientid reqopts defaultreqopts
+	json_get_vars reqaddress reqprefix noraaddr clientid sendclientid reqopts defaultreqopts
 	json_get_vars noslaaconly forceprefix extendprefix norelease strict_rfc7550
 	json_get_vars noserverunicast noclientfqdn noacceptreconfig iface_dslite
 	json_get_vars iface_map iface_464xlat ip6ifaceid userclass vendorclass
@@ -206,6 +207,7 @@ proto_dhcpv6_setup() {
 	[ "$fakeroutes" != "0" ] && proto_export "FAKE_ROUTES=1"
 	[ "$sourcefilter" = "0" ] && proto_export "NOSOURCEFILTER=1"
 	[ "$extendprefix" = "1" ] && proto_export "EXTENDPREFIX=1"
+	[ "$noraaddr" = "1" ] && proto_export "NORAADDR=1"
 
 	if [ "$dynamic" = 0 ]; then
 		proto_export "DYNAMIC=0"

--- a/package/network/ipv6/odhcp6c/tests/test-noraaddr.sh
+++ b/package/network/ipv6/odhcp6c/tests/test-noraaddr.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -eu
+
+script=${1:-"$(dirname "$0")/../files/dhcpv6.script"}
+
+merge=$(awk '
+/^[[:space:]]*# Merge addresses/ { in_block = 1; next }
+/^[[:space:]]*for entry in \$ADDRESSES; do$/ { exit }
+in_block { print }
+' "$script")
+
+run_merge()
+{
+	eval "$merge"
+}
+
+original='2001:db8:1::1/64,3600,7200'
+ra_address='2001:db8:ffff::1/64,3600,7200'
+
+ADDRESSES="$original"
+RA_ADDRESSES="$ra_address"
+NORAADDR=1
+run_merge
+[ "$ADDRESSES" = "$original" ] || {
+	echo "noraaddr failed to suppress an RA-derived address" >&2
+	exit 1
+}
+
+ADDRESSES="$original"
+RA_ADDRESSES="$ra_address"
+NORAADDR=0
+run_merge
+case " $ADDRESSES " in
+	*" $ra_address "*) ;;
+	*) echo "RA-derived address was not merged by default" >&2; exit 1 ;;
+esac
+
+echo "noraaddr regression passed"


### PR DESCRIPTION
Some WAN Router Advertisements advertise SLAAC prefixes that are not routable
back to the CPE. `odhcp6c` currently merges those RA-derived addresses into
the interface unconditionally, allowing the kernel to select an unusable
source address and breaking router-originated IPv6 traffic.

Add the `noraaddr` DHCPv6 option. When enabled, `dhcpv6.script` skips merging
RA-derived addresses while retaining RA routes, DNS, and delegated prefixes;
the default behavior remains unchanged. The option is propagated from UCI
through the DHCPv6 protocol handler.

Validation:

    package/network/ipv6/odhcp6c/tests/test-noraaddr.sh
    noraaddr regression passed

Fixes: #22469
