### PR TITLE
iwinfo: pull in ucode wifi scripts

### DIFF
--- a/package/network/utils/iwinfo/Makefile
+++ b/package/network/utils/iwinfo/Makefile
@@ -63,7 +63,7 @@ define Package/iwinfo
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=Generalized Wireless Information utility
-  DEPENDS:=+@!WIFI_SCRIPTS_UCODE:libiwinfo
+  DEPENDS:=+@!WIFI_SCRIPTS_UCODE:libiwinfo +WIFI_SCRIPTS_UCODE:wifi-scripts
 endef
 
 define Package/iwinfo/description

--- a/tests/imagebuilder-iwinfo-deps.sh
+++ b/tests/imagebuilder-iwinfo-deps.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+
+set -eu
+
+TOPDIR=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+IWINFO_MAKEFILE="$TOPDIR/package/network/utils/iwinfo/Makefile"
+WIFI_SCRIPTS_MAKEFILE="$TOPDIR/package/network/config/wifi-scripts/Makefile"
+
+iwinfo_package=$(sed -n '/^define Package\/iwinfo$/,/^endef$/p' "$IWINFO_MAKEFILE")
+wifi_scripts_package=$(sed -n \
+	'/^define Package\/wifi-scripts$/,/^endef$/p' "$WIFI_SCRIPTS_MAKEFILE")
+
+case "$iwinfo_package" in
+	*'+WIFI_SCRIPTS_UCODE:wifi-scripts'*)
+		;;
+	*)
+		echo "iwinfo does not pull wifi-scripts for ucode builds" >&2
+		exit 1
+		;;
+esac
+
+case "$wifi_scripts_package" in
+	*'PKGARCH:=all'*)
+		;;
+	*)
+		echo "wifi-scripts is not an ImageBuilder-installable package" >&2
+		exit 1
+		;;
+esac
+
+test -f "$TOPDIR/package/network/config/wifi-scripts/files-ucode/usr/bin/iwinfo"
+
+echo "iwinfo -> wifi-scripts -> /usr/bin/iwinfo closure is present"


### PR DESCRIPTION
When ucode-based wireless scripts are enabled, selecting `iwinfo` in an
ImageBuilder profile can omit the package that provides its replacement
`/usr/bin/iwinfo` helper. Wireless initialization then reports `iwinfo: not
found` and cannot resolve PHY names.

Add the conditional `iwinfo` dependency on `wifi-scripts` for
`WIFI_SCRIPTS_UCODE` builds. This keeps the ImageBuilder package closure
complete while retaining the existing `libiwinfo` dependency for other
builds.

Validation:

    tests/imagebuilder-iwinfo-deps.sh
    iwinfo -> wifi-scripts -> /usr/bin/iwinfo closure is present

Fixes: #20234
