### PR TITLE
ramips: mt7621: include uboot-envtools for EdgeRouter X

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -3255,7 +3255,7 @@ define Device/ubnt_edgerouter_common
   FILESYSTEMS := squashfs
   KERNEL_SIZE := 6144k
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES += -wpad-basic-mbedtls -uboot-envtools
+  DEVICE_PACKAGES += -wpad-basic-mbedtls
   DEVICE_COMPAT_VERSION := 2.0
   DEVICE_COMPAT_MESSAGE :=  Partition table has been changed due to kernel size restrictions. \
     Refer to the wiki page for instructions to migrate to the new layout: \

--- a/tests/owut-installed-package.sh
+++ b/tests/owut-installed-package.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Ensure the EdgeRouter X image manifest retains uboot-envtools, which is a
+# target default and may already be installed when owut selects packages.
+
+set -eu
+
+TOPDIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+device_file=$TOPDIR/target/linux/ramips/image/mt7621.mk
+target_file=$TOPDIR/target/linux/ramips/mt7621/target.mk
+
+device=$(sed -n '/^define Device\/ubnt_edgerouter_common$/,/^endef$/p' "$device_file")
+defaults=$(sed -n 's/^DEFAULT_PACKAGES += //p' "$target_file")
+
+# The device must not subtract a package supplied by the target defaults.
+test -n "$device"
+if printf '%s\n' "$device" | grep -q -- '-uboot-envtools'; then
+	exit 1
+fi
+printf '%s\n' "$defaults" | grep -qw uboot-envtools
+
+# Model owut's installed-package selection against the generated manifest.
+manifest="$defaults $(printf '%s\n' "$device" | sed -n 's/.*DEVICE_PACKAGES[^=]*=[[:space:]]*//p')"
+printf '%s\n' "$manifest" | grep -qw uboot-envtools


### PR DESCRIPTION
The EdgeRouter X removes `uboot-envtools` from its device package list even
though it is supplied by the mt7621 target defaults. An installed
`uboot-envtools` package can therefore be absent from the generated manifest,
causing owut's installed-package selection to fail.

Stop subtracting `uboot-envtools` from the EdgeRouter X device packages and
add a deterministic manifest-selection regression. The target default remains
the single source of the package while the device manifest now includes it.

Validation:

    tests/owut-installed-package.sh
    (exited successfully)

Fixes: #22527
