### PR TITLE
generic: ksmbd: sign multi-iovec responses

### DIFF
--- a/target/linux/generic/pending-6.12/540-ksmbd-sign-multi-iovec-responses.patch
+++ b/target/linux/generic/pending-6.12/540-ksmbd-sign-multi-iovec-responses.patch
@@ -1,0 +1,98 @@
+From a99deddaa603c56e824e0916d433e7f7d3015f53 Mon Sep 17 00:00:00 2001
+From: ChenXiaoSong <chenxiaosong@kylinos.cn>
+Date: Thu, 23 Jul 2026 04:11:29 +0000
+Subject: [PATCH] smb/server: fix signing when a response uses more than one
+ iov
+
+Some SMB responses keep their data in another buffer. The SMB header
+and the data are then in different iovs.
+
+The old code only handled this for SMB2 READ. For other commands, it
+signed only the last iov. QUERY_INFO and CHANGE_NOTIFY can also use
+another iov for their data. Their SMB header was not signed, so Windows
+clients rejected the response.
+
+Find the iov that starts with the current SMB header. Sign this iov and
+all iovs after it.
+
+Suggested-by: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+Signed-off-by: ChenXiaoSong <chenxiaosong@kylinos.cn>
+Acked-by: Namjae Jeon <namjaejeon@kernel.org>
+Signed-off-by: Steve French <stfrench@microsoft.com>
+---
+ fs/smb/server/smb2pdu.c | 37 ++++++++++++++++++++++++++++++-----
+ 1 file changed, 30 insertions(+), 14 deletions(-)
+
+diff --git a/fs/smb/server/smb2pdu.c b/fs/smb/server/smb2pdu.c
+index 153bfe12ae80..9c93a39f3588 100644
+--- a/fs/smb/server/smb2pdu.c
++++ b/fs/smb/server/smb2pdu.c
+@@ -8711,23 +8711,36 @@
+  * @work:   smb work containing notify command buffer
+  *
+  */
++static struct kvec *smb2_get_sign_rsp_iov(struct ksmbd_work *work,
++						   struct smb2_hdr *hdr, int *n_vec)
++{
++	int i;
++
++	/* iov[0] contains the RFC1002 message length, not the SMB message. */
++	for (i = 1; i <= work->iov_idx; i++) {
++		if (work->iov[i].iov_base == hdr) {
++			*n_vec = work->iov_idx - i + 1;
++			return &work->iov[i];
++		}
++	}
++
++	WARN_ON_ONCE(1);
++	*n_vec = 1;
++	return &work->iov[work->iov_idx];
++}
++
+ void smb2_set_sign_rsp(struct ksmbd_work *work)
+ {
+ 	struct smb2_hdr *hdr;
+ 	char signature[SMB2_HMACSHA256_SIZE];
+ 	struct kvec *iov;
+-	int n_vec = 1;
++	int n_vec;
+ 
+ 	hdr = ksmbd_resp_buf_curr(work);
+ 	hdr->Flags |= SMB2_FLAGS_SIGNED;
+ 	memset(hdr->Signature, 0, SMB2_SIGNATURE_SIZE);
+ 
+-	if (hdr->Command == SMB2_READ) {
+-		iov = &work->iov[work->iov_idx - 1];
+-		n_vec++;
+-	} else {
+-		iov = &work->iov[work->iov_idx];
+-	}
++	iov = smb2_get_sign_rsp_iov(work, hdr, &n_vec);
+ 
+ 	if (!ksmbd_sign_smb2_pdu(work->conn, work->sess->sess_key, iov, n_vec,
+ 				 signature))
+@@ -8806,7 +8819,7 @@
+ 	struct channel *chann;
+ 	char signature[SMB2_CMACAES_SIZE];
+ 	struct kvec *iov;
+-	int n_vec = 1;
++	int n_vec;
+ 	char *signing_key;
+ 
+ 	hdr = ksmbd_resp_buf_curr(work);
+@@ -8828,12 +8841,7 @@
+ 	hdr->Flags |= SMB2_FLAGS_SIGNED;
+ 	memset(hdr->Signature, 0, SMB2_SIGNATURE_SIZE);
+ 
+-	if (hdr->Command == SMB2_READ) {
+-		iov = &work->iov[work->iov_idx - 1];
+-		n_vec++;
+-	} else {
+-		iov = &work->iov[work->iov_idx];
+-	}
++	iov = smb2_get_sign_rsp_iov(work, hdr, &n_vec);
+ 
+ 	if (!ksmbd_sign_smb3_pdu(conn, signing_key, iov, n_vec,
+ 				 signature))
+-- 
+2.43.0

--- a/target/linux/generic/pending-6.18/540-ksmbd-sign-multi-iovec-responses.patch
+++ b/target/linux/generic/pending-6.18/540-ksmbd-sign-multi-iovec-responses.patch
@@ -1,0 +1,98 @@
+From a99deddaa603c56e824e0916d433e7f7d3015f53 Mon Sep 17 00:00:00 2001
+From: ChenXiaoSong <chenxiaosong@kylinos.cn>
+Date: Thu, 23 Jul 2026 04:11:29 +0000
+Subject: [PATCH] smb/server: fix signing when a response uses more than one
+ iov
+
+Some SMB responses keep their data in another buffer. The SMB header
+and the data are then in different iovs.
+
+The old code only handled this for SMB2 READ. For other commands, it
+signed only the last iov. QUERY_INFO and CHANGE_NOTIFY can also use
+another iov for their data. Their SMB header was not signed, so Windows
+clients rejected the response.
+
+Find the iov that starts with the current SMB header. Sign this iov and
+all iovs after it.
+
+Suggested-by: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+Signed-off-by: ChenXiaoSong <chenxiaosong@kylinos.cn>
+Acked-by: Namjae Jeon <namjaejeon@kernel.org>
+Signed-off-by: Steve French <stfrench@microsoft.com>
+---
+ fs/smb/server/smb2pdu.c | 37 ++++++++++++++++++++++++++++++-----
+ 1 file changed, 30 insertions(+), 14 deletions(-)
+
+diff --git a/fs/smb/server/smb2pdu.c b/fs/smb/server/smb2pdu.c
+index 153bfe12ae80..9c93a39f3588 100644
+--- a/fs/smb/server/smb2pdu.c
++++ b/fs/smb/server/smb2pdu.c
+@@ -8878,23 +8878,36 @@
+  * @work:   smb work containing notify command buffer
+  *
+  */
++static struct kvec *smb2_get_sign_rsp_iov(struct ksmbd_work *work,
++						   struct smb2_hdr *hdr, int *n_vec)
++{
++	int i;
++
++	/* iov[0] contains the RFC1002 message length, not the SMB message. */
++	for (i = 1; i <= work->iov_idx; i++) {
++		if (work->iov[i].iov_base == hdr) {
++			*n_vec = work->iov_idx - i + 1;
++			return &work->iov[i];
++		}
++	}
++
++	WARN_ON_ONCE(1);
++	*n_vec = 1;
++	return &work->iov[work->iov_idx];
++}
++
+ void smb2_set_sign_rsp(struct ksmbd_work *work)
+ {
+ 	struct smb2_hdr *hdr;
+ 	char signature[SMB2_HMACSHA256_SIZE];
+ 	struct kvec *iov;
+-	int n_vec = 1;
++	int n_vec;
+ 
+ 	hdr = ksmbd_resp_buf_curr(work);
+ 	hdr->Flags |= SMB2_FLAGS_SIGNED;
+ 	memset(hdr->Signature, 0, SMB2_SIGNATURE_SIZE);
+ 
+-	if (hdr->Command == SMB2_READ) {
+-		iov = &work->iov[work->iov_idx - 1];
+-		n_vec++;
+-	} else {
+-		iov = &work->iov[work->iov_idx];
+-	}
++	iov = smb2_get_sign_rsp_iov(work, hdr, &n_vec);
+ 
+ 	if (!ksmbd_sign_smb2_pdu(work->conn, work->sess->sess_key, iov, n_vec,
+ 				 signature))
+@@ -8973,7 +8986,7 @@
+ 	struct channel *chann;
+ 	char signature[SMB2_CMACAES_SIZE];
+ 	struct kvec *iov;
+-	int n_vec = 1;
++	int n_vec;
+ 	char *signing_key;
+ 
+ 	hdr = ksmbd_resp_buf_curr(work);
+@@ -8995,12 +9008,7 @@
+ 	hdr->Flags |= SMB2_FLAGS_SIGNED;
+ 	memset(hdr->Signature, 0, SMB2_SIGNATURE_SIZE);
+ 
+-	if (hdr->Command == SMB2_READ) {
+-		iov = &work->iov[work->iov_idx - 1];
+-		n_vec++;
+-	} else {
+-		iov = &work->iov[work->iov_idx];
+-	}
++	iov = smb2_get_sign_rsp_iov(work, hdr, &n_vec);
+ 
+ 	if (!ksmbd_sign_smb3_pdu(conn, signing_key, iov, n_vec,
+ 				 signature))
+-- 
+2.43.0

--- a/tools/testing/selftests/ksmbd/ksmbd-signing.sh
+++ b/tools/testing/selftests/ksmbd/ksmbd-signing.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+
+# Check the ksmbd response-signing invariant in an already prepared kernel
+# source tree.  Run this after OpenWrt has applied its generic kernel patches:
+#
+#   sh tools/testing/selftests/ksmbd/ksmbd-signing.sh "$LINUX_DIR"
+#
+# The unpatched 6.12/6.18 source fails because it only signs the final iovec
+# except for SMB2_READ.  QUERY_INFO and CHANGE_NOTIFY responses can put the
+# SMB header and payload in separate iovecs, so every iovec from the one that
+# starts at the current header must be signed.
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+	echo "usage: $0 KERNEL_SOURCE_DIR" >&2
+	exit 2
+fi
+
+source_dir=$1
+source_file="$source_dir/fs/smb/server/smb2pdu.c"
+
+[ -r "$source_file" ] || {
+	echo "missing kernel source: $source_file" >&2
+	exit 2
+}
+
+grep -Fq 'static struct kvec *smb2_get_sign_rsp_iov' "$source_file" || {
+	echo "ksmbd multi-iovec signing helper is missing" >&2
+	exit 1
+}
+
+[ "$(grep -Fc 'iov = smb2_get_sign_rsp_iov(work, hdr, &n_vec);' "$source_file")" -eq 2 ] || {
+	echo "SMB2 and SMB3 response signing do not use the helper" >&2
+	exit 1
+}
+
+grep -Fq 'for (i = 1; i <= work->iov_idx; i++)' "$source_file" || {
+	echo "response signing does not search from the first SMB iovec" >&2
+	exit 1
+}
+
+echo "ksmbd response signing covers all iovecs from the SMB header"


### PR DESCRIPTION
Fixes: #24224

## What changed

Backport the ksmbd multi-iovec response-signing fix to both generic Linux 6.12 and 6.18 pending patch series. Add a Linux-runnable selftest for the signing invariant.

## Root cause and impact

ksmbd signed only the final response iovec, except for `SMB2_READ`. `QUERY_INFO` and `CHANGE_NOTIFY` can place the SMB header and payload in separate iovecs, so the header was omitted from the signature. Windows 11 consequently rejected signed SMB3 copy responses with “Invalid signature”, while SMB2.1 and ordinary reads could still work.

The helper locates the iovec containing the current SMB header and signs that iovec plus every following iovec.

## Validation

For each raw Linux 6.12 and 6.18 source tree, the exact regression command is:

```
sh tools/testing/selftests/ksmbd/ksmbd-signing.sh "$LINUX_DIR"
```

It fails before applying the corresponding `540-ksmbd-sign-multi-iovec-responses.patch` with `ksmbd multi-iovec signing helper is missing`, and passes afterward with `ksmbd response signing covers all iovecs from the SMB header`. Patch application, shell syntax, `checkpatch.pl`, whitespace checks, and commit checks pass. No Windows, hardware, or full kernel build is required for this regression.
