### PR TITLE
scripts: account for built-in module dependencies

### DIFF
--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -276,6 +276,7 @@ ifneq ($(PKG_NAME),toolchain)
 			export \
 				READELF=$(TARGET_CROSS)readelf \
 				OBJCOPY=$(TARGET_CROSS)objcopy \
+				KERNEL_MODULES_BUILTIN="$(LINUX_DIR)/modules.builtin" \
 				XARGS="$(XARGS)"; \
 			$(SCRIPT_DIR)/gen-dependencies.sh "$$(IDIR_$(1))"; \
 		) | while read FILE; do \

--- a/scripts/gen-dependencies.sh
+++ b/scripts/gen-dependencies.sh
@@ -11,6 +11,7 @@ READELF="${READELF:-readelf}"
 OBJCOPY="${OBJCOPY:-objcopy}"
 TARGETS=$*
 XARGS="${XARGS:-xargs -r}"
+BUILTIN_MODULES="${KERNEL_MODULES_BUILTIN:-}"
 
 [ -z "$TARGETS" ] && {
   echo "$SELF: no directories / files specified"
@@ -25,9 +26,18 @@ find $TARGETS -type f -a -exec file {} \; | \
   sort -u
 
 tmp=$(mktemp $TMP_DIR/dep.XXXXXXXX)
+if [ -n "$BUILTIN_MODULES" ] && [ -f "$BUILTIN_MODULES" ]; then
+	builtin=$(mktemp $TMP_DIR/builtin.XXXXXXXX)
+	sed -e 's,.*/,,' "$BUILTIN_MODULES" > "$builtin"
+else
+	builtin=
+fi
 for kmod in $(find $TARGETS -type f -name \*.ko); do
 	$OBJCOPY -O binary -j .modinfo $kmod $tmp
 	sed -e 's,\x00,\n,g' $tmp | \
 		sed -ne '/^depends=.\+/ { s/^depends=//; s/,/.ko\n/g; s/$/.ko/p; q }'
-done | sort -u
-rm -f $tmp
+done | sort -u | while read dep; do
+	[ -n "$builtin" ] && grep -qxF "$dep" "$builtin" && continue
+	echo "$dep"
+done
+rm -f $tmp $builtin

--- a/scripts/test-gen-dependencies.sh
+++ b/scripts/test-gen-dependencies.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2026 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/gen-dependencies.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+
+printf '\0' > "$tmp/input"
+printf 'depends=xxhash\0' > "$tmp/modinfo"
+objcopy -I binary -O elf64-x86-64 -B i386 "$tmp/input" "$tmp/xxhash_generic.ko"
+objcopy --add-section .modinfo="$tmp/modinfo" \
+	--set-section-flags .modinfo=alloc,load,readonly,data \
+	"$tmp/xxhash_generic.ko"
+
+TMP_DIR="$tmp" "$SCRIPT_DIR/gen-dependencies.sh" "$tmp" > "$tmp/base"
+grep -qxF xxhash.ko "$tmp/base"
+
+printf 'kernel/lib/xxhash.ko\n' > "$tmp/modules.builtin"
+TMP_DIR="$tmp" KERNEL_MODULES_BUILTIN="$tmp/modules.builtin" \
+	"$SCRIPT_DIR/gen-dependencies.sh" "$tmp" > "$tmp/fixed"
+! grep -q . "$tmp/fixed"


### PR DESCRIPTION
scripts: account for built-in module dependencies

Fixes: #23094

Package dependency generation reported every module named by a kernel
module's `depends` metadata, even when that dependency was built into the
kernel and therefore had no corresponding kmod package.  This made SDK
package builds fail with a missing dependency for `xxhash.ko` on lan969x.

Pass `modules.builtin` to dependency generation and filter dependencies that
match built-in modules after normalizing their paths.  Add a deterministic
regression test proving that a module dependency is emitted normally and
suppressed when listed in `modules.builtin`.

Validation:

    ./scripts/test-gen-dependencies.sh
    git diff 467c5b90ba1140dcdabc2e2e203c1d91fca9963e..HEAD --check

