### PR TITLE
build: avoid recursive host tool aliases

### DIFF
--- a/scripts/bundle-libraries.sh
+++ b/scripts/bundle-libraries.sh
@@ -199,6 +199,15 @@ for BIN in "$@"; do
 
 		_mv "$BIN" "$RUNDIR/.${BIN##*/}.bin"
 
+		# Keep aliases from invoking the wrapper through another wrapper.
+		# This is relevant for host tools installed as g-prefixed binaries,
+		# such as readlink -> greadlink.
+		for LINK in "$RUNDIR"/*; do
+			[ -L "$LINK" ] || continue
+			[ "$(readlink "$LINK")" = "${BIN##*/}" ] || continue
+			_ln ".${BIN##*/}.bin" "$LINK"
+		done
+
 		cat <<-EOF > "$BIN"
 			#!/usr/bin/env bash
 			dir="\$(dirname "\$0")"

--- a/scripts/tests/bundle-libraries.sh
+++ b/scripts/tests/bundle-libraries.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-only
+
+set -euo pipefail
+
+TOPDIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+TESTDIR="$(mktemp -d)"
+trap 'rm -rf "$TESTDIR"' EXIT
+
+mkdir -p "$TESTDIR/bin"
+cp "$(command -v readlink)" "$TESTDIR/bin/greadlink"
+ln -s greadlink "$TESTDIR/bin/readlink"
+
+PATH="/usr/bin:/bin" "$TOPDIR/scripts/bundle-libraries.sh" \
+	"$TESTDIR" "$TESTDIR/bin/greadlink" >/dev/null
+
+test "$(readlink "$TESTDIR/bin/readlink")" = .greadlink.bin
+timeout 2 "$TESTDIR/bin/readlink" /proc/self/exe >/dev/null


### PR DESCRIPTION
build: avoid recursive host tool aliases

Fixes: #23589

The host-library bundler generated wrappers in `staging_dir/host/bin` while
leaving aliases such as `readlink -> greadlink` pointing at another wrapper.
The wrapper's PATH lookup therefore resolved back to itself and recursively
spawned processes during ImageBuilder use.

After moving the real binary aside, repoint aliases targeting that binary to
the hidden real executable.  Add a deterministic regression test that builds
a `greadlink` alias, verifies the resulting link, and confirms invocation
completes instead of recursing.

Validation:

    ./scripts/tests/bundle-libraries.sh
    git diff 467c5b90ba1140dcdabc2e2e203c1d91fca9963e..HEAD --check

