### PR TITLE
kernel: load r8152 USB network driver during boot

### DIFF
--- a/package/kernel/linux/modules/usb.mk
+++ b/package/kernel/linux/modules/usb.mk
@@ -1512,7 +1512,7 @@ define KernelPackage/usb-net-rtl8152
   DEPENDS:=+r8152-firmware +kmod-crypto-sha256 +kmod-mii +kmod-libphy
   KCONFIG:=CONFIG_USB_RTL8152
   FILES:=$(LINUX_DIR)/drivers/$(USBNET_DIR)/r8152.ko
-  AUTOLOAD:=$(call AutoProbe,r8152)
+  AUTOLOAD:=$(call AutoProbe,r8152,1)
   $(call AddDepends/usb)
 endef
 

--- a/scripts/test-usb-net-rtl8152-boot.sh
+++ b/scripts/test-usb-net-rtl8152-boot.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2026 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+MODULES="$SCRIPT_DIR/../package/kernel/linux/modules/usb.mk"
+
+awk '
+/^define KernelPackage\/usb-net-rtl8152$/ {
+	in_block = 1
+	next
+}
+
+in_block && /^endef$/ {
+	if (!boot_autoload)
+		exit 1
+	exit 0
+}
+
+in_block && /AUTOLOAD:=\$\(call AutoProbe,r8152,1\)/ {
+	boot_autoload = 1
+}
+' "$MODULES"


### PR DESCRIPTION
Issue: #23834  
Source commit: `16999bb4b1d817d8f5aca2be8affac41af29d838`

Submission status: HOLD — the issue is open but currently labeled `invalid`, and its target/version metadata was rejected by the issue bot. Reconfirm the report with an OpenWrt maintainer before submitting.

## What changed

Load the RTL8152 USB network driver during the early boot module phase by changing its autoload priority to:

```
AUTOLOAD:=$(call AutoProbe,r8152,1)
```

## Root cause and impact

Clean sysupgrades generate the initial network configuration before the late-loaded UE300 driver is available. The USB NIC is therefore absent from the generated `wan` configuration, even though it appears later once `r8152` loads. Priority-1 autoload makes the adapter visible during early configuration and failsafe boot.

## Validation

```
sh scripts/test-usb-net-rtl8152-boot.sh
```

The static regression test exits successfully only when the `usb-net-rtl8152` package uses the priority-1 autoload declaration. The commit also passes `git show --check`; no hardware test was run.
