### PR TITLE
build: avoid recursive virtual package dependencies

### DIFF
--- a/scripts/package-metadata-test.sh
+++ b/scripts/package-metadata-test.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Regression test for virtual package dependencies in package-metadata.pl.
+#
+# Copyright (C) 2026 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+set -eu
+
+SCRIPTDIR=$(dirname "$0")
+BASEDIR=$(cd "$SCRIPTDIR/.." && pwd)
+TMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/package-metadata.XXXXXX")
+trap 'rm -rf "$TMPDIR"' EXIT HUP INT TERM
+
+cat > "$TMPDIR/packageinfo" <<'EOF'
+Source-Makefile: package/test/provider/Makefile
+
+Package: foo-default
+Depends:
+Provides: foo
+Default-Variant: 1
+Category: Test
+Title: Default foo provider
+Description: default
+@@
+
+Package: foo-self
+Depends: +foo
+Provides: foo
+Category: Test
+Title: Self-dependent foo provider
+Description: self
+@@
+
+Package: foo-other
+Depends:
+Provides: foo
+Category: Test
+Title: Other foo provider
+Description: other
+@@
+EOF
+
+"$BASEDIR/scripts/package-metadata.pl" config "$TMPDIR/packageinfo" > "$TMPDIR/config.in"
+
+if grep -Fq 'PACKAGE_foo-self<PACKAGE_foo-self' "$TMPDIR/config.in"; then
+	echo "package-metadata.pl emitted a recursive self-dependency" >&2
+	exit 1
+fi
+
+grep -Fq 'select PACKAGE_foo-default' "$TMPDIR/config.in"
+grep -Fq 'select PACKAGE_foo-default if PACKAGE_foo-other<PACKAGE_foo-self' "$TMPDIR/config.in"
+
+echo "package-metadata.pl virtual package dependency test: ok"

--- a/scripts/package-metadata.pl
+++ b/scripts/package-metadata.pl
@@ -194,6 +194,7 @@ sub mconf_depends {
 
 				$depend = shift @vdeps;
 
+				@vdeps = grep { $_ ne $pkgname } @vdeps;
 				if (@vdeps > 1) {
 					$condition = ($condition ? "$condition && " : '') . join("&&", map { "PACKAGE_$_<PACKAGE_$pkgname" } @vdeps);
 				} elsif (@vdeps > 0) {


### PR DESCRIPTION
Issue: #24341  
Source commit: `2112c1b294d9bfd669214301dca622112c2e9b7c`

Submission status: HOLD — the issue is open but currently labeled `invalid`. Reconfirm the report and proposed Kconfig behavior with a maintainer before submitting.

## What changed

Remove the consuming package itself from the virtual-provider dependency list before emitting Kconfig `select` conditions.

## Root cause and impact

When a package provides a virtual name and also depends on that virtual name, `package-metadata.pl` included the package itself in `@vdeps`. The generated expression then contained a recursive dependency such as `PACKAGE_foo-self<PACKAGE_foo-self`, causing Kconfig to reject package metadata generation. Filtering the consumer preserves valid provider constraints while removing only the self-edge.

## Validation

```
sh scripts/package-metadata-test.sh
```

The test creates a minimal provider/consumer metadata set, verifies that no recursive self-dependency is emitted, and checks that the remaining provider condition is preserved. It prints `package-metadata.pl virtual package dependency test: ok` and exits successfully; the commit passes `git show --check`.
