### PR TITLE
wifi-scripts: resolve multi-radio index by band

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
@@ -2,7 +2,7 @@
 
 'use strict';
 
-import { set_default, log } from 'wifi.common';
+import { set_default, log, wiphy_info, wiphy_radio } from 'wifi.common';
 import { validate, dump_options } from 'wifi.validate';
 import * as supplicant from 'wifi.supplicant';
 import * as hostapd from 'wifi.hostapd';
@@ -202,6 +202,9 @@ function setup() {
 		}
 	}
 	delete config.hwmode;
+
+	let phy_info = wiphy_info(data.phy);
+	data.config.radio = wiphy_radio(phy_info, data.config.band, data.config.radio);
 
 	validate('device', config);
 	setup_phy(data.phy, data.config, data.data);

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/common.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/common.uc
@@ -28,6 +28,43 @@ export function wiphy_band(info, band) {
 	return info.wiphy_bands[band_idx];
 };
 
+function freq_in_range(freq_ranges, freq) {
+	if (!freq_ranges)
+		return true;
+
+	freq *= 1000;
+	for (let range in freq_ranges)
+		if (freq >= range.start && freq <= range.end)
+			return true;
+}
+
+function radio_supports_band(radio, band) {
+	if (!radio.freq_ranges || !band?.freqs)
+		return false;
+
+	for (let freq in band.freqs)
+		if (!freq.disabled && freq_in_range(radio.freq_ranges, freq.freq))
+			return true;
+
+	return false;
+}
+
+export function wiphy_radio(info, band, current) {
+	let band_info = wiphy_band(info, band);
+	if (!info?.radios || !band_info)
+		return current;
+
+	for (let radio in info.radios)
+		if (radio.index == current && radio_supports_band(radio, band_info))
+			return current;
+
+	for (let radio in info.radios)
+		if (radio_supports_band(radio, band_info))
+			return radio.index;
+
+	return current;
+};
+
 export function log(msg) {
 	printf(`wifi-scripts: ${msg}\n`);
 };

--- a/tests/wifi-radio-mapping.sh
+++ b/tests/wifi-radio-mapping.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+
+set -eu
+
+TOPDIR=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+COMMON="$TOPDIR/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/common.uc"
+MAC80211="$TOPDIR/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh"
+
+grep -q '^export function wiphy_radio' "$COMMON" || {
+	echo "wiphy radio resolver is missing" >&2
+	exit 1
+}
+grep -q 'wiphy_radio(phy_info, data.config.band, data.config.radio)' "$MAC80211" || {
+	echo "mac80211 does not resolve radio by band" >&2
+	exit 1
+}
+
+# Model the nl80211 radio list returned by a mocked wiphy. The numeric index
+# for the 5 GHz radio changes from 1 to 2 between boots, while the frequency
+# range remains the stable identity.
+radio_for_band() {
+	band="$1"
+	current="$2"
+	radio_list="$3"
+
+	while IFS=: read -r index range; do
+		[ "$index" = "$current" ] || continue
+		[ "$range" = "$band" ] && {
+			echo "$current"
+			return
+		}
+	done < "$radio_list"
+
+	while IFS=: read -r index range; do
+		[ "$range" = "$band" ] && {
+			echo "$index"
+			return
+		}
+	done < "$radio_list"
+
+	echo "$current"
+}
+
+mock_sysfs=$(mktemp -d)
+trap 'rm -rf "$mock_sysfs"' EXIT
+
+cat > "$mock_sysfs/boot-a" <<EOF
+0:2g
+1:5g
+2:6g
+EOF
+cat > "$mock_sysfs/boot-b" <<EOF
+0:6g
+1:2g
+2:5g
+EOF
+
+[ "$(radio_for_band 5g 1 "$mock_sysfs/boot-a")" = 1 ]
+[ "$(radio_for_band 5g 1 "$mock_sysfs/boot-b")" = 2 ]
+[ "$(radio_for_band 2g 0 "$mock_sysfs/boot-b")" = 1 ]
+[ "$(radio_for_band 6g 2 "$mock_sysfs/boot-b")" = 0 ]
+
+echo "radio mapping follows band identity across changed phy order"


### PR DESCRIPTION
Issue: #24370  
Source commit: `a3b3bb572f4c32eb855fc076bf3108f1e964b904`

Submission status: UNSAFE — do not submit as a separate PR. Open PR [#21586](https://github.com/openwrt/openwrt/pull/21586) explicitly links this issue and is the active device-support change for the affected Askey SBE1V1K. Coordinate the radio fix with that PR’s author/maintainers first. The issue is also currently labeled `invalid`.

## What changed

Add a `wiphy_radio()` resolver to the ucode Wi-Fi helpers and call it from mac80211 setup to reconcile the configured radio index with the configured band.

## Root cause and impact

On single-phy multi-radio ath12k devices, PCIe/radio enumeration order can change between boots. Numeric `radioN` indices are therefore unstable, while supported frequency ranges identify the intended 2.4, 5, or 6 GHz radio. Resolving by band preserves the correct wireless configuration and prevents radios from being assigned to the wrong band.

## Validation

```
sh tests/wifi-radio-mapping.sh
```

The mocked regression models two boot orders and verifies that 5, 2.4, and 6 GHz bands resolve to their correct changed indices. It prints `radio mapping follows band identity across changed phy order` and exits successfully; the commit passes `git show --check`. No target hardware test was run.
