### PR TITLE
toolchain: gcc: skip unsupported Ada compiler probe

### DIFF
--- a/tests/toolchain-gcc-ada.sh
+++ b/tests/toolchain-gcc-ada.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Verify that the GCC configure invocation disables the Ada compiler probe.
+#
+# The probe can recursively invoke the compiler when Ada support is absent,
+# exhausting the host process table during an otherwise serial toolchain
+# build.  Keep this test independent of a downloaded GCC source archive by
+# replacing configure with a small executable that checks its environment.
+
+set -eu
+
+TOPDIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT HUP INT TERM
+
+cat > "$TMPDIR/configure" <<'EOF'
+#!/bin/sh
+
+test "${acx_cv_cc_gcc_supports_ada-}" = no
+EOF
+chmod +x "$TMPDIR/configure"
+
+make -f - --no-print-directory \
+	TOPDIR="$TOPDIR" \
+	GCC_VARIANT=minimal \
+	HOST_BUILD_DIR="$TMPDIR" \
+	CONFIG_GCC_VERSION=15.3.0 \
+	REAL_GNU_TARGET_NAME=x86_64-openwrt-linux \
+	GNU_HOST_NAME=x86_64-pc-linux-gnu \
+	all <<'EOF'
+
+include $(TOPDIR)/toolchain/gcc/common.mk
+
+all:
+	@$(GCC_CONFIGURE)
+EOF

--- a/toolchain/gcc/common.mk
+++ b/toolchain/gcc/common.mk
@@ -86,6 +86,7 @@ else
 endif
 
 GCC_CONFIGURE:= \
+	acx_cv_cc_gcc_supports_ada=no \
 	SHELL="$(BASH)" \
 	$(HOST_SOURCE_DIR)/configure \
 		--with-bugurl=$(BUGURL) \


### PR DESCRIPTION
Issue: #23973  
Source commit: `d026989de5dd1671dc015e7db7baedfb39f4ec95`

Submission status: HOLD — the issue is open but currently labeled `invalid`, and its report mixes the confirmed Ada-probe workaround with unverified fork-storm analysis. Obtain maintainer confirmation before submitting.

## What changed

Set GCC’s `acx_cv_cc_gcc_supports_ada=no` cache result in the OpenWrt host GCC configure command.

## Root cause and impact

When Ada support is unavailable, the initial GCC configure probe can recursively invoke compiler tests during a clean toolchain bootstrap. On affected hosts this creates a process/fork storm and can exhaust memory before the build progresses. OpenWrt does not build an Ada-enabled host compiler here, so explicitly answering the probe skips the unsupported test and keeps the bootstrap bounded.

## Validation

```
sh tests/toolchain-gcc-ada.sh
```

The test substitutes a minimal configure executable and verifies that OpenWrt’s generated `GCC_CONFIGURE` command exports the cache result. It exits successfully with the fix, and the commit passes `git show --check`; no full toolchain build was run.
