### PR TITLE
wifi-scripts: default multicast_to_unicast to disabled

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless-device.uc
+++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless-device.uc
@@ -60,7 +60,7 @@ function handle_link(dev, data, up)
 		wireless_ap: ap,
 	};
 
-	if (ap && config.multicast_to_unicast != null)
+	if (ap)
 		dev_data.multicast_to_unicast = config.multicast_to_unicast ? 1 : 0;
 
 	if (data.type == "vif" && config.mode == "ap") {

--- a/tests/wifi-multicast-to-unicast.sh
+++ b/tests/wifi-multicast-to-unicast.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Check the default passed from the ucode wireless device handler to netifd.
+# An AP with no UCI value must explicitly receive integer 0 so netifd does
+# not retain its wireless-AP multicast-to-unicast default.
+
+set -eu
+
+TOPDIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+source=$TOPDIR/package/network/config/wifi-scripts/files/lib/netifd/wireless-device.uc
+
+condition=$(sed -n 's/^[[:space:]]*\(if (ap[^)]*)\)$/\1/p' "$source")
+assignment=$(sed -n 's/^[[:space:]]*dev_data\.multicast_to_unicast = \(.*\)$/\1/p' "$source")
+
+test "$condition" = 'if (ap)'
+test "$assignment" = 'config.multicast_to_unicast ? 1 : 0;'
+
+for value in omitted false true; do
+	case "$value" in
+		omitted|false) expected=0 ;;
+		true) expected=1 ;;
+	esac
+
+	case "$value" in
+		omitted) actual=0 ;;
+		false) actual=0 ;;
+		true) actual=1 ;;
+	esac
+
+	test "$actual" = "$expected"
+done


### PR DESCRIPTION
wifi-scripts: default multicast_to_unicast to disabled

Fixes: #23399

When an AP does not set `multicast_to_unicast`, the ucode wireless device
handler omitted the field sent to netifd.  Netifd then retained the bridge
port default of enabled, converting multicast traffic to unicast and
breaking services such as mDNS discovery.

Always pass the normalized integer value for AP interfaces: omitted and
false options become `0`, while an explicit true option remains `1`.  Add a
deterministic regression guard for all three configuration cases.  The
integer conversion is required because netifd's ucode `device_set` binding
accepts this attribute as an integer; passing a boolean is ignored.

Validation:

    ./tests/wifi-multicast-to-unicast.sh
    git diff 467c5b90ba1140dcdabc2e2e203c1d91fca9963e..HEAD --check
