### PR TITLE
kernel: video: split videobuf2-vmalloc into its own package

### DIFF
--- a/package/kernel/linux/modules/video.mk
+++ b/package/kernel/linux/modules/video.mk
@@ -847,14 +847,12 @@ define KernelPackage/video-videobuf2
   KCONFIG:= \
 	CONFIG_VIDEOBUF2_CORE \
 	CONFIG_VIDEOBUF2_MEMOPS \
-	CONFIG_VIDEOBUF2_V4L2 \
-	CONFIG_VIDEOBUF2_VMALLOC
+	CONFIG_VIDEOBUF2_V4L2
   FILES:= \
 	$(LINUX_DIR)/drivers/media/common/videobuf2/videobuf2-common.ko \
 	$(LINUX_DIR)/drivers/media/common/videobuf2/videobuf2-v4l2.ko \
-	$(LINUX_DIR)/drivers/media/common/videobuf2/videobuf2-memops.ko \
-	$(LINUX_DIR)/drivers/media/common/videobuf2/videobuf2-vmalloc.ko
-  AUTOLOAD:=$(call AutoLoad,65,videobuf2-core videobuf-v4l2 videobuf2-memops videobuf2-vmalloc)
+	$(LINUX_DIR)/drivers/media/common/videobuf2/videobuf2-memops.ko
+  AUTOLOAD:=$(call AutoLoad,65,videobuf2-common videobuf2-v4l2 videobuf2-memops)
   $(call AddDepends/video)
 endef
 
@@ -863,6 +861,23 @@ define KernelPackage/video-videobuf2/description
 endef
 
 $(eval $(call KernelPackage,video-videobuf2))
+
+define KernelPackage/video-vmalloc
+  SUBMENU:=$(VIDEO_MENU)
+  TITLE:=Video vmalloc support
+  HIDDEN:=1
+  DEPENDS:=+kmod-video-videobuf2 +kmod-dma-buf
+  KCONFIG:=CONFIG_VIDEOBUF2_VMALLOC
+  FILES:=$(LINUX_DIR)/drivers/media/common/videobuf2/videobuf2-vmalloc.ko
+  AUTOLOAD:=$(call AutoLoad,66,videobuf2-vmalloc)
+  $(call AddDepends/video)
+endef
+
+define KernelPackage/video-vmalloc/description
+  Video vmalloc support
+endef
+
+$(eval $(call KernelPackage,video-vmalloc))
 
 define KernelPackage/video-async
   TITLE:=V4L2 ASYNC support
@@ -889,7 +904,7 @@ $(eval $(call KernelPackage,video-fwnode))
 
 define KernelPackage/video-pwc
   TITLE:=Philips USB webcam support
-  DEPENDS:=@USB_SUPPORT +kmod-usb-core +kmod-video-videobuf2
+  DEPENDS:=@USB_SUPPORT +kmod-usb-core +kmod-video-videobuf2 +kmod-video-vmalloc
   KCONFIG:= \
 	CONFIG_USB_PWC \
 	CONFIG_USB_PWC_DEBUG=n
@@ -907,7 +922,7 @@ $(eval $(call KernelPackage,video-pwc))
 
 define KernelPackage/video-uvc
   TITLE:=USB Video Class (UVC) support
-  DEPENDS:=@USB_SUPPORT +kmod-usb-core +kmod-video-videobuf2 +kmod-input-core
+  DEPENDS:=@USB_SUPPORT +kmod-usb-core +kmod-video-videobuf2 +kmod-video-vmalloc +kmod-input-core
   KCONFIG:= CONFIG_USB_VIDEO_CLASS CONFIG_UVC_COMMON
   FILES:=$(LINUX_DIR)/drivers/media/usb/uvc/uvcvideo.ko \
 	$(LINUX_DIR)/drivers/media/common/uvc.ko
@@ -925,7 +940,7 @@ $(eval $(call KernelPackage,video-uvc))
 define KernelPackage/video-gspca-core
   MENU:=1
   TITLE:=GSPCA webcam core support framework
-  DEPENDS:=@USB_SUPPORT +kmod-usb-core +kmod-input-core +kmod-video-videobuf2
+  DEPENDS:=@USB_SUPPORT +kmod-usb-core +kmod-input-core +kmod-video-videobuf2 +kmod-video-vmalloc
   KCONFIG:=CONFIG_USB_GSPCA
   FILES:=$(LINUX_DIR)/drivers/media/usb/gspca/gspca_main.ko
   AUTOLOAD:=$(call AutoProbe,gspca_main)
@@ -1569,7 +1584,7 @@ $(eval $(call KernelPackage,video-dma-sg))
 
 define KernelPackage/video-coda
   TITLE:=i.MX VPU support
-  DEPENDS:=@(TARGET_imx&&TARGET_imx_cortexa9) +kmod-video-mem2mem +kmod-video-dma-contig
+  DEPENDS:=@(TARGET_imx&&TARGET_imx_cortexa9) +kmod-video-mem2mem +kmod-video-dma-contig +kmod-video-vmalloc
   KCONFIG:= \
   	CONFIG_VIDEO_CODA \
   	CONFIG_VIDEO_IMX_VDOA
@@ -1691,7 +1706,7 @@ $(eval $(call KernelPackage,video-ov5645))
 
 define KernelPackage/video-tw686x
   TITLE:=TW686x support
-  DEPENDS:=@PCIE_SUPPORT +kmod-video-dma-contig +kmod-video-dma-sg +kmod-sound-core
+  DEPENDS:=@PCIE_SUPPORT +kmod-video-dma-contig +kmod-video-dma-sg +kmod-sound-core +kmod-video-vmalloc
   KCONFIG:= CONFIG_VIDEO_TW686X
   FILES:= $(LINUX_DIR)/drivers/media/pci/tw686x/tw686x.ko
   AUTOLOAD:=$(call AutoProbe,tw686x)

--- a/target/linux/bcm27xx/modules/video.mk
+++ b/target/linux/bcm27xx/modules/video.mk
@@ -8,8 +8,8 @@ define KernelPackage/camera-bcm2835
     CONFIG_VIDEO_BCM2835
   FILES:= \
     $(LINUX_DIR)/drivers/staging/vc04_services/bcm2835-camera/bcm2835-v4l2.ko
-  AUTOLOAD:=$(call AutoLoad,66,bcm2835-v4l2)
-  $(call AddDepends/video,@TARGET_bcm27xx +kmod-vchiq-mmal-bcm2835 +kmod-video-videobuf2)
+  AUTOLOAD:=$(call AutoLoad,67,bcm2835-v4l2)
+  $(call AddDepends/video,@TARGET_bcm27xx +kmod-vchiq-mmal-bcm2835 +kmod-video-videobuf2 +kmod-video-vmalloc)
 endef
 
 define KernelPackage/camera-bcm2835/description


### PR DESCRIPTION
`CONFIG_VIDEOBUF2_VMALLOC` has no prompt in Kconfig — it's select-only, pulled in only by drivers like pwc/uvc/gspca that need it. Since it was listed unconditionally in video-videobuf2's FILES, any build without one of those drivers enabled (with `CONFIG_ALL_KMODS=y`) failed hard with `ERROR: module '.../videobuf2-vmalloc.ko' is missing.`

This splits it into its own `kmod-video-vmalloc` package (matching `video-dma-contig`/`video-dma-sg`) and adds it into the drivers that actually need it.