### PR TITLE
realtek: dts: specify rtl9303 soc compatible on two Hasivo boards

### DIFF
--- a/target/linux/realtek/dts/rtl9303_hasivo_s1100w-8xgt-se.dts
+++ b/target/linux/realtek/dts/rtl9303_hasivo_s1100w-8xgt-se.dts
@@ -4,6 +4,6 @@
 #include "rtl9303_hasivo_s1100w-8xgt-se-common.dtsi"
 
 / {
-	compatible = "hasivo,s1100w-8xgt-se", "realtek,rtl930x-soc";
+	compatible = "hasivo,s1100w-8xgt-se", "realtek,rtl9303-soc";
 	model = "Hasivo S1100W-8XGT-SE";
 };

--- a/target/linux/realtek/dts/rtl9303_hasivo_s1100wp-8xgt-se.dts
+++ b/target/linux/realtek/dts/rtl9303_hasivo_s1100wp-8xgt-se.dts
@@ -4,7 +4,7 @@
 #include "rtl9303_hasivo_s1100w-8xgt-se-common.dtsi"
 
 / {
-	compatible = "hasivo,s1100wp-8xgt-se", "realtek,rtl930x-soc";
+	compatible = "hasivo,s1100wp-8xgt-se", "realtek,rtl9303-soc";
 	model = "Hasivo S1100WP-8XGT-SE";
 
 	aliases {


### PR DESCRIPTION
S1100W-8XGT-SE and S1100WP-8XGT-ST have realtek,rtl930x-soc in their compatibles. Specify realtek,rtl9303-soc to be explicit.