### PR TITLE
hostapd: ubus: initialise MBO fields in bss_transition_request

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hostapd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://w1.fi/hostap.git
 PKG_SOURCE_PROTO:=git

--- a/package/network/services/hostapd/README.md
+++ b/package/network/services/hostapd/README.md
@@ -29,9 +29,9 @@ Initiate an 802.11v transition request.
 | neighbors | array | no | BSS Transition Candidate List |
 | abridged | bool | no | prefer APs in the BSS Transition Candidate List |
 | dialog_token | int32 | no | identifier for the request/report transaction |
-| mbo_reason | int32 | no | MBO Transition Reason Code Attribute |
-| cell_pref | int32 | no | MBO Cellular Data Connection Preference Attribute |
-| reassoc_delay | int32 | no | MBO Re-association retry delay |
+| mbo_reason | int32 | no | MBO Transition Reason Code Attribute; must be specified together with cell_pref and reassoc_delay or not at all |
+| cell_pref | int32 | no | MBO Cellular Data Connection Preference Attribute; must be specified together with mbo_reason and reassoc_delay or not at all |
+| reassoc_delay | int32 | no | MBO Re-association retry delay; must be specified together with mbo_reason and cell_pref or not at all |
 
 ### example
 `ubus call hostapd.wl5-fb bss_transition_request '{ "addr": "68:2F:67:8B:98:ED", "disassociation_imminent": false, "disassociation_timer": 0, "validity_period": 30, "neighbors": ["b6a7b9cbeebabf5900008064090603026a00"], "abridged": 1 }'`

--- a/package/network/services/hostapd/src/src/ap/ubus.c
+++ b/package/network/services/hostapd/src/src/ap/ubus.c
@@ -1360,7 +1360,7 @@ static int
 hostapd_bss_tr_send(struct hostapd_data *hapd, u8 *addr, bool disassoc_imminent, bool abridged,
 		    u16 disassoc_timer, u8 validity_period, u8 dialog_token,
 		    struct blob_attr *neighbors, bool include_mbo, u8 mbo_reason,
-		    u8 cell_pref, u8 reassoc_delay)
+		    u8 cell_pref, unsigned int reassoc_delay)
 {
 	struct blob_attr *cur;
 	struct sta_info *sta;
@@ -1506,7 +1506,7 @@ hostapd_bss_transition_request(struct ubus_context *ctx, struct ubus_object *obj
 	bool include_mbo = false;
 	u8 mbo_reason = 0;
 	u8 cell_pref = 0;
-	u8 reassoc_delay = 0;
+	unsigned int reassoc_delay = 0;
 
 	blobmsg_parse(bss_tr_policy, __BSS_TR_DISASSOC_MAX, tb, blob_data(msg), blob_len(msg));
 

--- a/package/network/services/hostapd/src/src/ap/ubus.c
+++ b/package/network/services/hostapd/src/src/ap/ubus.c
@@ -1359,7 +1359,8 @@ void hostapd_ubus_handle_link_measurement(struct hostapd_data *hapd, const u8 *d
 static int
 hostapd_bss_tr_send(struct hostapd_data *hapd, u8 *addr, bool disassoc_imminent, bool abridged,
 		    u16 disassoc_timer, u8 validity_period, u8 dialog_token,
-		    struct blob_attr *neighbors, u8 mbo_reason, u8 cell_pref, u8 reassoc_delay)
+		    struct blob_attr *neighbors, bool include_mbo, u8 mbo_reason,
+		    u8 cell_pref, u8 reassoc_delay)
 {
 	struct blob_attr *cur;
 	struct sta_info *sta;
@@ -1446,7 +1447,8 @@ hostapd_bss_tr_send(struct hostapd_data *hapd, u8 *addr, bool disassoc_imminent,
 		mbo_pos += 2;
 	}
 
-	mbo_len = mbo_pos - mbo;
+	if (include_mbo)
+		mbo_len = mbo_pos - mbo;
 #endif
 
 	if (wnm_send_bss_tm_req(hapd, sta, req_mode, disassoc_timer, validity_period, NULL,
@@ -1501,9 +1503,10 @@ hostapd_bss_transition_request(struct ubus_context *ctx, struct ubus_object *obj
 	u32 dialog_token = 1;
 	bool abridged;
 	bool da_imminent;
-	u8 mbo_reason;
-	u8 cell_pref;
-	u8 reassoc_delay;
+	bool include_mbo = false;
+	u8 mbo_reason = 0;
+	u8 cell_pref = 0;
+	u8 reassoc_delay = 0;
 
 	blobmsg_parse(bss_tr_policy, __BSS_TR_DISASSOC_MAX, tb, blob_data(msg), blob_len(msg));
 
@@ -1526,6 +1529,12 @@ hostapd_bss_transition_request(struct ubus_context *ctx, struct ubus_object *obj
 	abridged = !!(tb[BSS_TR_ABRIDGED] && blobmsg_get_bool(tb[BSS_TR_ABRIDGED]));
 
 #ifdef CONFIG_MBO
+	include_mbo = tb[BSS_TR_MBO_REASON] && tb[BSS_TR_CELL_PREF] && tb[BSS_TR_REASSOC_DELAY];
+
+	if (!include_mbo &&
+	    (tb[BSS_TR_MBO_REASON] || tb[BSS_TR_CELL_PREF] || tb[BSS_TR_REASSOC_DELAY]))
+		return UBUS_STATUS_INVALID_ARGUMENT;
+
 	if (tb[BSS_TR_MBO_REASON])
 		mbo_reason = blobmsg_get_u32(tb[BSS_TR_MBO_REASON]);
 
@@ -1537,7 +1546,8 @@ hostapd_bss_transition_request(struct ubus_context *ctx, struct ubus_object *obj
 #endif
 
 	return hostapd_bss_tr_send(hapd, addr, da_imminent, abridged, da_timer, valid_period,
-				   dialog_token, tb[BSS_TR_NEIGHBORS], mbo_reason, cell_pref, reassoc_delay);
+				   dialog_token, tb[BSS_TR_NEIGHBORS], include_mbo,
+				   mbo_reason, cell_pref, reassoc_delay);
 }
 #endif
 


### PR DESCRIPTION
The `CONFIG_MBO` block in `hostapd_bss_tr_send()` writes `MBO_ATTR_ID_TRANSITION_REASON` and `MBO_ATTR_ID_CELL_DATA_PREF` unconditionally, and `mbo_reason`, `cell_pref` and `reassoc_delay` in `hostapd_bss_transition_request()` were declared uninitialised, assigned only when the caller supplied the matching ubus attributes. When they were omitted the validation failed non-deterministically on stack garbage, dropping the BTM request with `UBUS_STATUS_INVALID_ARGUMENT` even though all three are documented as optional.

Simply zero-initialising the three variables is not correct: `cell_pref = 0` on the wire is `MBO_CELL_PREF_EXCLUDED` ("the AP does not want the STA to use its cellular data connection"), a real directive to the STA, not a no-preference sentinel. Upstream hostapd accepts MBO fields all-or-nothing (`mbo=<reason>:<delay>:<pref>`, all three required together) and never invents defaults.

**Commit 1** initialises the three variables to zero (for defined values), passes an `include_mbo` flag to `hostapd_bss_tr_send()` that is true only when all three MBO ubus attributes are present, and returns `UBUS_STATUS_INVALID_ARGUMENT` when some but not all are supplied. When `include_mbo` is false, `mbo_len` is left at zero and no MBO IE is attached. README updated to note that the three fields must all be supplied together or not at all. Observed with DAWN, which sends none of the three today and was affected non-deterministically.

**Commit 2** widens `reassoc_delay` from `u8` to `unsigned int`, matching upstream hostapd. With `u8` the `reassoc_delay > 65535` guard was dead code and values above 255 were silently truncated (e.g. 256 → 0, which drops `MBO_ATTR_ID_ASSOC_RETRY_DELAY` altogether).