### PR TITLE
hostapd: ucode: fix setup of a BSS added at run time

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hostapd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://w1.fi/hostap.git
 PKG_SOURCE_PROTO:=git

--- a/package/network/services/hostapd/src/src/ap/ucode.c
+++ b/package/network/services/hostapd/src/src/ap/ucode.c
@@ -470,7 +470,7 @@ uc_hostapd_iface_add_bss(uc_vm_t *vm, size_t nargs)
 
 	if (iface->state == HAPD_IFACE_ENABLED) {
 		hapd->conf->start_disabled = 0;
-		if (hostapd_setup_bss(hapd, -1, true))
+		if (hostapd_setup_bss(hapd, false, true))
 			goto deinit_ctrl;
 	}
 


### PR DESCRIPTION
The 2026-07-09 update changed the type of the first parameter of hostapd_setup_bss() from int to bool. Before the update, add_bss passed -1. The value -1 selected the setup path for a secondary BSS and told hostapd to adopt an existing netdev. Converted to bool, -1 becomes true. As a result, hostapd does not do the setup of a secondary BSS. The new BSS uses the driver state of the first BSS.

Pass false so the non-first block runs again. In this path, use_existing is true, and hostapd adopts a netdev that already exists.

Fixes: 345404476ac8 ("hostapd: update to 2026-07-09")