### PR TITLE
lantiq: xrx200: fix fiber port support on AVM 5490/5491

### DIFF
--- a/target/linux/lantiq/dts/vr9_avm_fritz5490.dtsi
+++ b/target/linux/lantiq/dts/vr9_avm_fritz5490.dtsi
@@ -107,7 +107,7 @@
 	port@0 {
 		reg = <0>;
 		label = "wan";
-		phy-mode = "rgmii";
+		phy-mode = "rgmii-rxid";
 		phy-handle = <&phy6>;
 	};
 

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
@@ -74,6 +74,10 @@ lantiq_setup_dsl()
 	avm,fritz7490-micron)
 		annex="b"
 		;;
+	avm,fritz5490|\
+	avm,fritz5490-micron)
+		return
+		;;
 	esac
 
 	lantiq_setup_dsl_helper "$annex"


### PR DESCRIPTION
The fiber port on the AVM 5490/5491 is only partially working. Frames are sent correctly. Most received frames are dropped due to an invalid FCS. It turns out that delays are needed between the MAC and the PHY. This commit enables RGMII delays on the PHY side. Traffic now flows in both directions.

Fiber port topology:
SWITCH<-----RGMII----->PHY<-----SGMII----->SFP/SFF cage

Tested on the AVM 5490. On the other end is a network card with a 1000Base-BX10 SFP module (HiKivision HK-SFP-1.25G-20-1550).

The fiber port on the AVM5491 should also work. The AVM 5490 and 5491 share the same PCB and are almost identical. The only difference is that the AVM5491 has a standard SFP cage with an external GPON module, while the 5490 has a soldered 1000Base-BX SFF module.

Fixes: 48b2df5a4164 ("lantiq: add support for AVM Fritzbox 5490/5491")
Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
