### PR TITLE
qualcommax: fix SoC hang after the CMN PLL probe on IPQ5018

### DIFF
--- a/target/linux/qualcommax/patches-6.18/0191-clk-qcom-ipq-cmn-pll-keep-the-CMN-block-bus-clocks-enabled.patch
+++ b/target/linux/qualcommax/patches-6.18/0191-clk-qcom-ipq-cmn-pll-keep-the-CMN-block-bus-clocks-enabled.patch
@@ -1,0 +1,67 @@
+From bd6a3f8a0ee98d465d83863b4e80efcae0b1d24c Mon Sep 17 00:00:00 2001
+From: Stanislaw Pal <kuncy7@gmail.com>
+Date: Thu, 13 Aug 2026 11:38:12 +0200
+Subject: [PATCH] clk: qcom: ipq-cmn-pll: keep the CMN block bus clocks enabled
+
+The probe function takes a runtime PM reference to enable the GCC AHB &
+SYS clocks of the CMN PLL block, registers the clocks, and then drops
+the reference, letting pm_clk gate both clocks asynchronously a few
+milliseconds after probe has returned.
+
+On IPQ5018 that gate races with early-boot activity on the bus and can
+hang the SoC: boards die silently right after the CMN PLL probe, before
+the next initcall gets to run, and the watchdog resets them. Whether a
+given kernel binary survives depends on micro-timing, ranging from an
+occasional hang to a 100% reproducible boot loop. The failure has been
+reported independently on three boards from three vendors (TP-Link
+Archer AX55 v1, GL.iNet GL-B3000, Cudy P5).
+
+Isolation on the Cudy P5 (by Georg Seema) shows the failure is a
+matter of timing against boot activity, not a steady-state clock
+dependency: the probe completes in ~628 us and the board dies before
+the next initcall starts; stretching the end of probe by ~15 ms makes
+the same kernel boot reliably; an enabled UNIPHY0 node is what arms
+the failure there. The armed configuration differs per board (on the
+GL-B3000 the failure persists with UNIPHY0 disabled), and so does the
+window: the same 15 ms stretch - or a 2 s one - still dies 8 of 8
+boots on the GL-B3000, so a delay is a diagnostic, not a workaround.
+Gating the same clocks on an idle, fully booted system is harmless.
+The window between the CMN PLL probe and the first reference taken by
+any consumer is exactly where the gate lands, so no consumer-side
+scheme can cover it.
+
+Take a devres-managed runtime PM reference in probe, so the bus clocks
+stay enabled for as long as the driver is bound and the reference is
+released again on unbind.
+
+Upstream submission (v4):
+https://lore.kernel.org/linux-clk/20260813093351.178419-1-kuncy7@gmail.com/
+
+Fixes: f81715a4c87c ("clk: qcom: Add CMN PLL clock controller driver for IPQ SoC")
+Signed-off-by: Stanislaw Pal <kuncy7@gmail.com>
+Tested-by: Georg Seema <georgseema@gmail.com>
+---
+ drivers/clk/qcom/ipq-cmn-pll.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+--- a/drivers/clk/qcom/ipq-cmn-pll.c
++++ b/drivers/clk/qcom/ipq-cmn-pll.c
+@@ -433,6 +433,18 @@ static int ipq_cmn_pll_clk_probe(struct
+ 	if (ret)
+ 		return dev_err_probe(dev, ret, "Failed to add SYS clock\n");
+ 
++	/*
++	 * Gating the CMN block AHB & SYS clocks is only safe on an idle
++	 * system: without this reference the gate lands asynchronously a
++	 * few milliseconds after probe, in the middle of the early-boot
++	 * probe activity, and on IPQ5018 that races with other bus
++	 * traffic and hangs the SoC. Hold the reference for as long as
++	 * the driver is bound so that the bus clocks stay enabled.
++	 */
++	ret = devm_pm_runtime_get_noresume(dev);
++	if (ret)
++		return ret;
++
+ 	ret = pm_runtime_resume_and_get(dev);
+ 	if (ret)
+ 		return ret;


### PR DESCRIPTION
The `ipq-cmn-pll` driver enables the GCC AHB & SYS clocks of the CMN block
through a runtime PM reference taken in probe, registers its clocks and then
drops that reference, so `pm_clk` gates both clocks a few milliseconds after
probe returns.

IPQ5018 does not survive that gate. Boards die silently within milliseconds of
the CMN PLL probe - before userspace exists, and with no consumer of the PLL
outputs active. Depending on the binary layout (micro-timing) this ranges from
an occasional hang to a fully reproducible boot loop.

**This currently affects released images:** the snapshot image for the GL.iNet
GL-B3000 boot loops on my unit. Booting the very same image with
`initcall_blacklist=ipq_cmn_pll_clk_driver_init` brings the board up, and so
does this patch - that is how it was isolated.

### Isolation on a GL-B3000 (UART, all four on the same unit)

| what was booted | result |
|---|---|
| official snapshot image (6.18) | boot loop, dies ~0.39 s, last line `bsg` |
| same image + `initcall_blacklist=ipq_cmn_pll_clk_driver_init` | boots fully |
| own build, no patch | same boot loop |
| own build **with this patch** | boots fully, `clk_summary` shows the CMN block bus clocks held by `9b000.clock-controller` |

### On the mechanism

This is *not* about the driver's own register accesses: the common clock
framework already wraps the provider ops in `clk_pm_runtime_get()/put()`, so
accesses through CCF are safe with or without this change. The failure has
since been isolated as a race between the asynchronous `pm_clk` gate and
early-boot bus activity, on three boards from three vendors:

- Cudy P5 (isolation by @MayorBug): the probe completes in ~628 us and the
  board dies before the next initcall starts; stretching the end of probe by
  ~15 ms makes the same kernel boot reliably; an enabled UNIPHY0 node is what
  arms the failure there (MDIO0/1, GMAC0/1, QCA8337 do not trigger it).
- GL-B3000: neither a 15 ms nor a 2 s stretch helps (8 of 8 boots die with
  either delay), while gating the same clocks on an idle, fully booted system
  is harmless. A delay is a diagnostic, not a workaround: the gate lands in
  the window between the CMN PLL probe and the first consumer reference, and
  no consumer-side scheme can cover that window.

The patch is submitted upstream - v4 carries the isolation above:
https://lore.kernel.org/linux-clk/20260813093351.178419-1-kuncy7@gmail.com/

I am opening this PR separately from the upstream discussion because the
boards are unbootable without it today. Once the fix (or an equivalent) lands
upstream and reaches a 6.18 stable release, the patch can be dropped.

### Testing

- GL.iNet GL-B3000 (IPQ5018): boot loop before, boots reliably after; NAND,
  both radios and ethernet working.
- TP-Link Archer AX55 v1 (IPQ5018): in daily use with this patch.
- Cudy P5 (IPQ5018): hangs during boot without the patch, boots reliably
  with it (Tested-by: Georg Seema, carried in the patch header).
- No effect on other qualcommax subtargets - the gate only ever hurt IPQ5018
  and the change merely keeps a clock enabled while the driver is bound.

