### PR TITLE
x86: add kmod-igen6-edac for IBECC reporting

### DIFF
--- a/target/linux/x86/modules.mk
+++ b/target/linux/x86/modules.mk
@@ -100,6 +100,49 @@ endef
 $(eval $(call KernelPackage,ib700-wdt))
 
 
+define KernelPackage/igen6-edac
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=Intel client SoC In-Band ECC (IBECC)
+  DEPENDS:=@TARGET_x86_64 @PCI_SUPPORT
+  KCONFIG:= \
+	CONFIG_EDAC=m \
+	CONFIG_EDAC_IGEN6=m \
+	CONFIG_EDAC_LEGACY_SYSFS=y \
+	CONFIG_EDAC_DEBUG=n \
+	CONFIG_EDAC_DECODE_MCE=n \
+	CONFIG_EDAC_SCRUB=n \
+	CONFIG_EDAC_ECS=n \
+	CONFIG_EDAC_MEM_REPAIR=n \
+	CONFIG_EDAC_E752X=n \
+	CONFIG_EDAC_I82975X=n \
+	CONFIG_EDAC_I3000=n \
+	CONFIG_EDAC_I3200=n \
+	CONFIG_EDAC_IE31200=n \
+	CONFIG_EDAC_X38=n \
+	CONFIG_EDAC_I5400=n \
+	CONFIG_EDAC_I7CORE=n \
+	CONFIG_EDAC_I5100=n \
+	CONFIG_EDAC_I7300=n \
+	CONFIG_EDAC_SBRIDGE=n \
+	CONFIG_EDAC_SKX=n \
+	CONFIG_EDAC_I10NM=n \
+	CONFIG_EDAC_PND2=n \
+	CONFIG_RAS=y
+  FILES:= \
+	$(LINUX_DIR)/drivers/edac/edac_core.ko \
+	$(LINUX_DIR)/drivers/edac/igen6_edac.ko
+  AUTOLOAD:=$(call AutoProbe,edac_core igen6_edac)
+endef
+
+define KernelPackage/igen6-edac/description
+  Kernel module for the Intel client SoC Integrated Memory Controller
+  In-Band ECC (IBECC), as found on Elkhart Lake, Tiger Lake, Alder Lake-N
+  and later. Reports corrected and uncorrected memory errors through EDAC.
+endef
+
+$(eval $(call KernelPackage,igen6-edac))
+
+
 define KernelPackage/intel-lpss
   SUBMENU:=$(OTHER_MENU)
   TITLE:=Intel LPSS common


### PR DESCRIPTION
OpenWrt builds the EDAC subsystem out entirely (CONFIG_EDAC is unset in target/linux/generic/config-6.18) and ships no EDAC module package, so memory errors cannot be reported on x86. Intel N-series SoCs such as the one on the ODROID H5 expose In-Band ECC, which corrects errors in the memory controller. Without EDAC those corrections are silent and a degrading DIMM goes unnoticed.

Add kmod-igen6-edac, packaging edac_core.ko and igen6_edac.ko. CONFIG_EDAC is tristate, so the core is built as a module alongside the driver rather than being enabled for every target.

Enabling EDAC makes a family of sibling symbols visible, which would otherwise stall a non-interactive build, so they are pinned off in KCONFIG. Derived against 6.18, the list is every symbol under "if EDAC" reachable on x86_64 with this target's configuration; the rest stay hidden by their own dependencies: EDAC_GHES needs ACPI_APEI_GHES, EDAC_AMD64 needs EDAC_DECODE_MCE, EDAC_I5000 and EDAC_I82443BXGX are BROKEN, and the remainder are X86_32 or another architecture. Anyone needing one of the sibling drivers should add it as a separate package.

EDAC_SCRUB, EDAC_ECS and EDAC_MEM_REPAIR are worth calling out: they carry no "depends on" at all, so they surface on every architecture as soon as EDAC is set. They are pinned off because they only add scrub.o, ecs.o and mem_repair.o to edac_core, providing sysfs control for drivers that register scrub, error check scrub or memory repair features, and igen6_edac registers none of them. Being version sensitive, the list wants rechecking whenever x86 moves to a new KERNEL_PATCHVER.

No kernel config change is needed. EDAC_IGEN6 requires X86_64, so the package is limited to the x86/64 subtarget, where its dependencies are already met: CONFIG_RAS=y and CONFIG_PCI_MMCONFIG=y in target/linux/x86/64/config-6.18, plus CONFIG_X86_MCE_INTEL=y and CONFIG_EDAC_SUPPORT=y in target/linux/x86/config-6.18.

The driver covers Elkhart Lake, Ice Lake, Tiger Lake, Alder Lake, Alder Lake-N, Raptor Lake-P and Meteor Lake.

Tested on an ODROID H5 (Alder Lake-N SKU12, device id 0x4632): both modules load and the memory controller registers with EDAC.