### PR TITLE
kernel: 6.12-6.18: ksmbd: backport multi-iov signing fix

### DIFF
--- a/target/linux/generic/pending-6.12/501-smb-server-fix-signing-multi-iov-response.patch
+++ b/target/linux/generic/pending-6.12/501-smb-server-fix-signing-multi-iov-response.patch
@@ -1,0 +1,111 @@
+From a99deddaa603c56e824e0916d433e7f7d3015f53 Mon Sep 17 00:00:00 2001
+From: ChenXiaoSong <chenxiaosong@kylinos.cn>
+Date: Thu, 23 Jul 2026 04:11:29 +0000
+Subject: [PATCH] smb/server: fix signing when a response uses more than one
+ iov
+
+Some SMB responses keep their data in another buffer. The SMB header
+and the data are then in different iovs.
+
+The old code only handled this for SMB2 READ. For other commands, it
+signed only the last iov. QUERY_INFO and CHANGE_NOTIFY can also use
+another iov for their data. Their SMB header was not signed, so Windows
+will client rejected the response.
+
+Find the iov that starts with the current SMB header. Sign this iov and
+all iovs after it.
+
+Suggested-by: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+Signed-off-by: ChenXiaoSong <chenxiaosong@kylinos.cn>
+Acked-by: Namjae Jeon <linkinjeon@kernel.org>
+Signed-off-by: Steve French <stfrench@microsoft.com>
+---
+ fs/smb/server/smb2pdu.c | 51 ++++++++++++++++++++++++++++++-----------
+ 1 file changed, 37 insertions(+), 14 deletions(-)
+
+--- a/fs/smb/server/smb2pdu.c
++++ b/fs/smb/server/smb2pdu.c
+@@ -9014,6 +9014,39 @@ int smb2_check_sign_req(struct ksmbd_wor
+ }
+ 
+ /**
++ * smb2_get_sign_rsp_iov() - get the iovecs used to sign a response
++ * @work: work that has the response iovecs
++ * @hdr: SMB2 header of the response
++ * @n_vec: set to the number of iovecs to sign
++ *
++ * Response data may be in another buffer. In this case, the response uses
++ * more than one iovec. Find the iovec that starts with @hdr. Sign this
++ * iovec and all iovecs after it.
++ *
++ * Return: The first iovec to sign.
++ */
++static struct kvec *smb2_get_sign_rsp_iov(struct ksmbd_work *work,
++					  struct smb2_hdr *hdr, int *n_vec)
++{
++	int i;
++
++	/*
++	 * iov[0] has the RFC1002 message length. It is not part of the SMB2
++	 * message, so do not sign it.
++	 */
++	for (i = 1; i <= work->iov_idx; i++) {
++		if (work->iov[i].iov_base == hdr) {
++			*n_vec = work->iov_idx - i + 1;
++			return &work->iov[i];
++		}
++	}
++
++	WARN_ON_ONCE(1);
++	*n_vec = 1;
++	return &work->iov[work->iov_idx];
++}
++
++/**
+  * smb2_set_sign_rsp() - handler for rsp packet sign processing
+  * @work:   smb work containing notify command buffer
+  *
+@@ -9023,18 +9056,13 @@ void smb2_set_sign_rsp(struct ksmbd_work
+ 	struct smb2_hdr *hdr;
+ 	char signature[SMB2_HMACSHA256_SIZE];
+ 	struct kvec *iov;
+-	int n_vec = 1;
++	int n_vec;
+ 
+ 	hdr = ksmbd_resp_buf_curr(work);
+ 	hdr->Flags |= SMB2_FLAGS_SIGNED;
+ 	memset(hdr->Signature, 0, SMB2_SIGNATURE_SIZE);
+ 
+-	if (hdr->Command == SMB2_READ) {
+-		iov = &work->iov[work->iov_idx - 1];
+-		n_vec++;
+-	} else {
+-		iov = &work->iov[work->iov_idx];
+-	}
++	iov = smb2_get_sign_rsp_iov(work, hdr, &n_vec);
+ 
+ 	if (!ksmbd_sign_smb2_pdu(work->conn, work->sess->sess_key, iov, n_vec,
+ 				 signature))
+@@ -9113,7 +9141,7 @@ void smb3_set_sign_rsp(struct ksmbd_work
+ 	struct channel *chann;
+ 	char signature[SMB2_CMACAES_SIZE];
+ 	struct kvec *iov;
+-	int n_vec = 1;
++	int n_vec;
+ 	char *signing_key;
+ 
+ 	hdr = ksmbd_resp_buf_curr(work);
+@@ -9135,12 +9163,7 @@ void smb3_set_sign_rsp(struct ksmbd_work
+ 	hdr->Flags |= SMB2_FLAGS_SIGNED;
+ 	memset(hdr->Signature, 0, SMB2_SIGNATURE_SIZE);
+ 
+-	if (hdr->Command == SMB2_READ) {
+-		iov = &work->iov[work->iov_idx - 1];
+-		n_vec++;
+-	} else {
+-		iov = &work->iov[work->iov_idx];
+-	}
++	iov = smb2_get_sign_rsp_iov(work, hdr, &n_vec);
+ 
+ 	if (!ksmbd_sign_smb3_pdu(conn, signing_key, iov, n_vec,
+ 				 signature))

--- a/target/linux/generic/pending-6.18/501-smb-server-fix-signing-multi-iov-response.patch
+++ b/target/linux/generic/pending-6.18/501-smb-server-fix-signing-multi-iov-response.patch
@@ -1,0 +1,111 @@
+From a99deddaa603c56e824e0916d433e7f7d3015f53 Mon Sep 17 00:00:00 2001
+From: ChenXiaoSong <chenxiaosong@kylinos.cn>
+Date: Thu, 23 Jul 2026 04:11:29 +0000
+Subject: [PATCH] smb/server: fix signing when a response uses more than one
+ iov
+
+Some SMB responses keep their data in another buffer. The SMB header
+and the data are then in different iovs.
+
+The old code only handled this for SMB2 READ. For other commands, it
+signed only the last iov. QUERY_INFO and CHANGE_NOTIFY can also use
+another iov for their data. Their SMB header was not signed, so Windows
+will client rejected the response.
+
+Find the iov that starts with the current SMB header. Sign this iov and
+all iovs after it.
+
+Suggested-by: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+Signed-off-by: ChenXiaoSong <chenxiaosong@kylinos.cn>
+Acked-by: Namjae Jeon <linkinjeon@kernel.org>
+Signed-off-by: Steve French <stfrench@microsoft.com>
+---
+ fs/smb/server/smb2pdu.c | 51 ++++++++++++++++++++++++++++++-----------
+ 1 file changed, 37 insertions(+), 14 deletions(-)
+
+--- a/fs/smb/server/smb2pdu.c
++++ b/fs/smb/server/smb2pdu.c
+@@ -9072,6 +9072,39 @@ int smb2_check_sign_req(struct ksmbd_wor
+ }
+ 
+ /**
++ * smb2_get_sign_rsp_iov() - get the iovecs used to sign a response
++ * @work: work that has the response iovecs
++ * @hdr: SMB2 header of the response
++ * @n_vec: set to the number of iovecs to sign
++ *
++ * Response data may be in another buffer. In this case, the response uses
++ * more than one iovec. Find the iovec that starts with @hdr. Sign this
++ * iovec and all iovecs after it.
++ *
++ * Return: The first iovec to sign.
++ */
++static struct kvec *smb2_get_sign_rsp_iov(struct ksmbd_work *work,
++					  struct smb2_hdr *hdr, int *n_vec)
++{
++	int i;
++
++	/*
++	 * iov[0] has the RFC1002 message length. It is not part of the SMB2
++	 * message, so do not sign it.
++	 */
++	for (i = 1; i <= work->iov_idx; i++) {
++		if (work->iov[i].iov_base == hdr) {
++			*n_vec = work->iov_idx - i + 1;
++			return &work->iov[i];
++		}
++	}
++
++	WARN_ON_ONCE(1);
++	*n_vec = 1;
++	return &work->iov[work->iov_idx];
++}
++
++/**
+  * smb2_set_sign_rsp() - handler for rsp packet sign processing
+  * @work:   smb work containing notify command buffer
+  *
+@@ -9081,18 +9114,13 @@ void smb2_set_sign_rsp(struct ksmbd_work
+ 	struct smb2_hdr *hdr;
+ 	char signature[SMB2_HMACSHA256_SIZE];
+ 	struct kvec *iov;
+-	int n_vec = 1;
++	int n_vec;
+ 
+ 	hdr = ksmbd_resp_buf_curr(work);
+ 	hdr->Flags |= SMB2_FLAGS_SIGNED;
+ 	memset(hdr->Signature, 0, SMB2_SIGNATURE_SIZE);
+ 
+-	if (hdr->Command == SMB2_READ) {
+-		iov = &work->iov[work->iov_idx - 1];
+-		n_vec++;
+-	} else {
+-		iov = &work->iov[work->iov_idx];
+-	}
++	iov = smb2_get_sign_rsp_iov(work, hdr, &n_vec);
+ 
+ 	ksmbd_sign_smb2_pdu(work->conn, work->sess->sess_key, iov, n_vec,
+ 			    signature);
+@@ -9171,7 +9199,7 @@ void smb3_set_sign_rsp(struct ksmbd_work
+ 	struct channel *chann;
+ 	char signature[SMB2_CMACAES_SIZE];
+ 	struct kvec *iov;
+-	int n_vec = 1;
++	int n_vec;
+ 	char *signing_key;
+ 
+ 	hdr = ksmbd_resp_buf_curr(work);
+@@ -9193,12 +9221,7 @@ void smb3_set_sign_rsp(struct ksmbd_work
+ 	hdr->Flags |= SMB2_FLAGS_SIGNED;
+ 	memset(hdr->Signature, 0, SMB2_SIGNATURE_SIZE);
+ 
+-	if (hdr->Command == SMB2_READ) {
+-		iov = &work->iov[work->iov_idx - 1];
+-		n_vec++;
+-	} else {
+-		iov = &work->iov[work->iov_idx];
+-	}
++	iov = smb2_get_sign_rsp_iov(work, hdr, &n_vec);
+ 
+ 	if (!ksmbd_sign_smb3_pdu(conn, signing_key, iov, n_vec,
+ 				 signature))


### PR DESCRIPTION
Backport the ksmbd fix for signing responses whose SMB header and payload are stored in separate iovecs. The existing code only handles SMB2 READ specially, causing QUERY_INFO and CHANGE_NOTIFY responses to omit the header from the signature and be rejected by Windows clients.

The change is queued in the KSMBD maintainer code-review tree. Refresh the patch against 6.12 and 6.18