### PR TITLE
qualcommax: fix the RT-AX89X coming up with no ethernet ports

### DIFF
--- a/target/linux/qualcommax/dts/ipq8074-rt-ax89x.dts
+++ b/target/linux/qualcommax/dts/ipq8074-rt-ax89x.dts
@@ -17,6 +17,12 @@
 	aliases {
 		serial0 = &blsp1_uart5;
 		mdio-gpio0 = &mdio1;
+		ethernet0 = &port_switch;
+		ethernet1 = &port_lan2;
+		ethernet2 = &port_lan1;
+		ethernet3 = &port_wan;
+		ethernet4 = &port_10g_sfp;
+		ethernet5 = &port_10g_copper;
 		led-boot = &led_pwr;
 		led-failsafe = &led_pwr;
 		led-running = &led_pwr;
@@ -684,7 +690,7 @@
 			nvmem-cell-names = "mac-address";
 		};
 
-		port@2 {
+		port_lan2: port@2 {
 			reg = <2>;
 			label = "lan2";
 			phy-handle = <&qca8075_9>;
@@ -694,7 +700,7 @@
 			nvmem-cell-names = "mac-address";
 		};
 
-		port@3 {
+		port_lan1: port@3 {
 			reg = <3>;
 			label = "lan1";
 			phy-handle = <&qca8075_a>;
@@ -704,7 +710,7 @@
 			nvmem-cell-names = "mac-address";
 		};
 
-		port@4 {
+		port_wan: port@4 {
 			reg = <4>;
 			label = "wan";
 			phy-handle = <&qca8075_b>;
@@ -714,7 +720,7 @@
 			nvmem-cell-names = "mac-address";
 		};
 
-		port@5 {
+		port_10g_sfp: port@5 {
 			reg = <5>;
 			label = "10g-sfp";
 			sfp = <&sfp>;
@@ -725,7 +731,7 @@
 			nvmem-cell-names = "mac-address";
 		};
 
-		port@6 {
+		port_10g_copper: port@6 {
 			reg = <6>;
 			label = "10g-copper";
 			phy-handle = <&aqr113c>;

--- a/target/linux/qualcommax/dts/ipq8074-rt-ax89x.dts
+++ b/target/linux/qualcommax/dts/ipq8074-rt-ax89x.dts
@@ -17,6 +17,12 @@
 	aliases {
 		serial0 = &blsp1_uart5;
 		mdio-gpio0 = &mdio1;
+		ethernet0 = &port_switch;
+		ethernet1 = &port_lan2;
+		ethernet2 = &port_lan1;
+		ethernet3 = &port_wan;
+		ethernet4 = &port_10g_sfp;
+		ethernet5 = &port_10g_copper;
 		led-boot = &led_pwr;
 		led-failsafe = &led_pwr;
 		led-running = &led_pwr;
@@ -451,12 +457,6 @@
 			partition@3e0000 {
 				label = "0:appsblenv";
 				reg = <0x003e0000 0x20000>;
-
-				nvmem-layout {
-					compatible = "u-boot,env";
-
-					macaddr_ubootenv_ethaddr: ethaddr {};
-				};
 			};
 
 			partition@400000 {
@@ -572,40 +572,30 @@
 				reg = <1>;
 				label = "lan7";
 				phy-handle = <&qca8337_0>;
-				nvmem-cells = <&macaddr_ubootenv_ethaddr>;
-				nvmem-cell-names = "mac-address";
 			};
 
 			port@2 {
 				reg = <2>;
 				label = "lan6";
 				phy-handle = <&qca8337_1>;
-				nvmem-cells = <&macaddr_ubootenv_ethaddr>;
-				nvmem-cell-names = "mac-address";
 			};
 
 			port@3 {
 				reg = <3>;
 				label = "lan5";
 				phy-handle = <&qca8337_2>;
-				nvmem-cells = <&macaddr_ubootenv_ethaddr>;
-				nvmem-cell-names = "mac-address";
 			};
 
 			port@4 {
 				reg = <4>;
 				label = "lan4";
 				phy-handle = <&qca8337_3>;
-				nvmem-cells = <&macaddr_ubootenv_ethaddr>;
-				nvmem-cell-names = "mac-address";
 			};
 
 			port@5 {
 				reg = <5>;
 				label = "lan3";
 				phy-handle = <&qca8337_4>;
-				nvmem-cells = <&macaddr_ubootenv_ethaddr>;
-				nvmem-cell-names = "mac-address";
 			};
 
 			port@6 {
@@ -615,8 +605,6 @@
 				phy-handle = <&qca8033>;
 				managed = "in-band-status";
 				qca,sgmii-enable-pll;
-				nvmem-cells = <&macaddr_ubootenv_ethaddr>;
-				nvmem-cell-names = "mac-address";
 			};
 		};
 	};
@@ -680,60 +668,48 @@
 			phy-handle = <&qca8075_8>;
 			phy-mode = "qsgmii";
 			pcs-handle = <&uniphy0 0>;
-			nvmem-cells = <&macaddr_ubootenv_ethaddr>;
-			nvmem-cell-names = "mac-address";
 		};
 
-		port@2 {
+		port_lan2: port@2 {
 			reg = <2>;
 			label = "lan2";
 			phy-handle = <&qca8075_9>;
 			phy-mode = "qsgmii";
 			pcs-handle = <&uniphy0 1>;
-			nvmem-cells = <&macaddr_ubootenv_ethaddr>;
-			nvmem-cell-names = "mac-address";
 		};
 
-		port@3 {
+		port_lan1: port@3 {
 			reg = <3>;
 			label = "lan1";
 			phy-handle = <&qca8075_a>;
 			phy-mode = "qsgmii";
 			pcs-handle = <&uniphy0 2>;
-			nvmem-cells = <&macaddr_ubootenv_ethaddr>;
-			nvmem-cell-names = "mac-address";
 		};
 
-		port@4 {
+		port_wan: port@4 {
 			reg = <4>;
 			label = "wan";
 			phy-handle = <&qca8075_b>;
 			phy-mode = "qsgmii";
 			pcs-handle = <&uniphy0 3>;
-			nvmem-cells = <&macaddr_ubootenv_ethaddr>;
-			nvmem-cell-names = "mac-address";
 		};
 
-		port@5 {
+		port_10g_sfp: port@5 {
 			reg = <5>;
 			label = "10g-sfp";
 			sfp = <&sfp>;
 			phy-mode = "10gbase-r";
 			managed = "in-band-status";
 			pcs-handle = <&uniphy1 0>;
-			nvmem-cells = <&macaddr_ubootenv_ethaddr>;
-			nvmem-cell-names = "mac-address";
 		};
 
-		port@6 {
+		port_10g_copper: port@6 {
 			reg = <6>;
 			label = "10g-copper";
 			phy-handle = <&aqr113c>;
 			phy-mode = "usxgmii";
 			managed = "in-band-status";
 			pcs-handle = <&uniphy2 0>;
-			nvmem-cells = <&macaddr_ubootenv_ethaddr>;
-			nvmem-cell-names = "mac-address";
 		};
 	};
 };

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
@@ -1123,16 +1123,18 @@ static const struct regmap_config edma_regmap_cfg = {
  * whose ports carry the board's addresses either from DT or patched in by
  * the bootloader. DSA user ports without one of their own inherit whatever
  * ends up here.
+ *
+ * A port address is optional here, so no lookup error is fatal: a cell whose
+ * layout driver never binds defers forever, and dsa_port_setup() reads these
+ * same addresses without acting on the error either.
  */
 static int edma_get_mac_address(struct net_device *netdev,
 				struct device_node *np)
 {
 	struct device_node *cpu_port;
-	int ret;
 
-	ret = of_get_ethdev_address(np, netdev);
-	if (!ret || ret == -EPROBE_DEFER)
-		return ret;
+	if (!of_get_ethdev_address(np, netdev))
+		return 0;
 
 	for_each_node_with_property(cpu_port, "ethernet") {
 		struct device_node *conduit __free(device_node) =
@@ -1142,10 +1144,9 @@ static int edma_get_mac_address(struct net_device *netdev,
 			continue;
 
 		for_each_available_child_of_node_scoped(cpu_port->parent, port) {
-			ret = of_get_ethdev_address(port, netdev);
-			if (!ret || ret == -EPROBE_DEFER) {
+			if (!of_get_ethdev_address(port, netdev)) {
 				of_node_put(cpu_port);
-				return ret;
+				return 0;
 			}
 		}
 	}
@@ -1195,11 +1196,10 @@ static int edma_probe(struct platform_device *pdev)
 	priv->pdev = pdev;
 	priv->soc = device_get_match_data(dev);
 
-	ret = edma_get_mac_address(netdev, dev->of_node);
-	if (ret == -EPROBE_DEFER)
-		return dev_err_probe(dev, ret, "failed to get MAC address\n");
-	if (ret)
+	if (edma_get_mac_address(netdev, dev->of_node)) {
+		dev_warn(dev, "failed to get MAC address from DT, using a random one\n");
 		eth_hw_addr_random(netdev);
+	}
 
 	ret = edma_page_pool_create(priv);
 	if (ret)

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
@@ -1227,16 +1227,17 @@ static const struct regmap_config edma_regmap_cfg = {
  * whose ports carry the board's addresses either from DT or patched in by
  * the bootloader. DSA user ports without one of their own inherit whatever
  * ends up here.
+ *
+ * No lookup error is fatal here: a cell whose layout driver never binds
+ * defers forever, and the conduit carries every tree behind it.
  */
 static int edma_get_mac_address(struct net_device *netdev,
 				struct device_node *np)
 {
 	struct device_node *cpu_port;
-	int ret;
 
-	ret = of_get_ethdev_address(np, netdev);
-	if (!ret || ret == -EPROBE_DEFER)
-		return ret;
+	if (!of_get_ethdev_address(np, netdev))
+		return 0;
 
 	for_each_node_with_property(cpu_port, "ethernet") {
 		struct device_node *conduit __free(device_node) =
@@ -1246,10 +1247,9 @@ static int edma_get_mac_address(struct net_device *netdev,
 			continue;
 
 		for_each_available_child_of_node_scoped(cpu_port->parent, port) {
-			ret = of_get_ethdev_address(port, netdev);
-			if (!ret || ret == -EPROBE_DEFER) {
+			if (!of_get_ethdev_address(port, netdev)) {
 				of_node_put(cpu_port);
-				return ret;
+				return 0;
 			}
 		}
 	}
@@ -1299,11 +1299,10 @@ static int edma_probe(struct platform_device *pdev)
 	priv->pdev = pdev;
 	priv->soc = device_get_match_data(dev);
 
-	ret = edma_get_mac_address(netdev, dev->of_node);
-	if (ret == -EPROBE_DEFER)
-		return dev_err_probe(dev, ret, "failed to get MAC address\n");
-	if (ret)
+	if (edma_get_mac_address(netdev, dev->of_node)) {
+		dev_warn(dev, "failed to get MAC address from DT, using a random one\n");
 		eth_hw_addr_random(netdev);
+	}
 
 	priv->rx_page_order = edma_rx_page_order(netdev->mtu);
 	priv->rx_buffer_size = edma_rx_buffer_size(priv->rx_page_order);


### PR DESCRIPTION
`edma_probe()` propagates `-EPROBE_DEFER` out of the conduit's MAC address
lookup, but a DSA port address is optional, so the whole datapath ends up
waiting on a supplier that may never arrive. Once an nvmem provider is
registered whose layout driver never bound, that lookup defers for good:

    drivers/nvmem/core.c, nvmem_layout_module_get_optional():

        if (!nvmem->layout->dev.driver ||
            !try_module_get(nvmem->layout->dev.driver->owner))
                return -EPROBE_DEFER;

On the RT-AX89X every port points at one `u-boot,env` cell in `0:appsblenv`,
and the `fw_printenv` output @Razerwire posted here reports a bad CRC over
that whole partition, which is the span the layout driver reads. My
understanding is the layout probe fails on that CRC and adds no cells, so the
conduit never probes: no `eth0`, no DSA, no ports.

Patch 1 treats every lookup error the same and falls back to a random address,
with a warning that names the failed lookup. A conduit is not a port: losing
it loses `eth0` and every tree behind it. That gives up the transient case, a
provider not yet registered, since the two states look the same at this API.

Patch 2 restores the `ethernet0..5` aliases
[f50435627d](https://github.com/openwrt/openwrt/commit/f50435627d370a1bb07d455d7081207b7b6a744e)
dropped, now pointing at the ports that replaced the dp nodes, so the
bootloader can patch each address in. The `nvmem-cells` pairs and the
`u-boot,env` layout node go with them, because the six qca8337 ports have no
alias and nothing else to read, and since 679b73b1884a a deferring port takes
its whole tree down:

    target/linux/generic/pending-6.18/
    704-net-dsa-support-EPROBE_DEFER-when-reading-the-port-M.patch:

        err = dsa_port_setup(dp);
        if (err == -EPROBE_DEFER)
                goto teardown;

Patch 1 ran on my AX3600 (ipq8071): `eth0` comes up with the `0:art` address
the WAN port uses, ports and WAN unaffected. Patch 2 has not run on any board
and I have no RT-AX89X. Which `ethNaddr` variables the environment holds is
unknown: on a bad CRC `fw_printenv` prints U-Boot's sandbox default
environment, so that dump cannot say.

Fixes https://github.com/openwrt/openwrt/issues/24604

I used AI to help me write this change. @Razerwire, could you test a build with
these two patches on your RT-AX89X and post the boot dmesg?
