### PR TITLE
[25.12] wireguard-tools: bump to 20260223

### DIFF
--- a/package/network/utils/wireguard-tools/Makefile
+++ b/package/network/utils/wireguard-tools/Makefile
@@ -10,12 +10,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wireguard-tools
 
-PKG_VERSION:=1.0.20250521
+PKG_VERSION:=1.0.20260223
 PKG_RELEASE:=1
 
 PKG_SOURCE:=wireguard-tools-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://git.zx2c4.com/wireguard-tools/snapshot/
-PKG_HASH:=b6f2628b85b1b23cc06517ec9c74f82d52c4cdbd020f3dd2f00c972a1782950e
+PKG_HASH:=af459827b80bfd31b83b08077f4b5843acb7d18ad9a33a2ef532d3090f291fbf
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
```
% git shortlog v1.0.20250521..v1.0.20260223

Doug Freed (1):
      wg-quick@.service: add deps on wg-quick.target

Jason A. Donenfeld (8):
      wg-quick: linux: use smallest mtu, not largest
      syncconf: account for psks removed from config file
      wg-quick: linux: deal with resolvconf migration more gracefully
      wg-quick: use addconf instead of setconf
      wg-quick: linux: do not unnecessarily set sysctl
      config: preserve const correctness
      syncconf: account for persistent keepalive removed from config file
      version: bump

Robyn Kosching (1):
      wg-quick: pass on # comments to {Pre,Post}{Up,Down}
```

Build system: x86-64
Build-tested: generic

Link: https://github.com/openwrt/openwrt/pull/22190

(cherry picked from commit eda2630ceb7d98293fcc3cf9df1c27e1d8ed803a)

