### PR TITLE
dropbear: Add additional fixes from 2026.91

### DIFF
--- a/package/network/services/dropbear/Makefile
+++ b/package/network/services/dropbear/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dropbear
 PKG_VERSION:=2024.86
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:= \

--- a/package/network/services/dropbear/patches/017-scp-don-t-use-reallocarray.patch
+++ b/package/network/services/dropbear/patches/017-scp-don-t-use-reallocarray.patch
@@ -1,0 +1,29 @@
+From 47d14bbfb7ff0e909e673357a64c3264a2a7fbaf Mon Sep 17 00:00:00 2001
+From: Matt Johnston <matt@ucc.asn.au>
+Date: Mon, 4 May 2026 21:35:57 +0800
+Subject: [PATCH 7/8] scp: don't use reallocarray
+
+reallocarray() isn't portable. An overflow check can be used instead.
+
+Fixes: 143291baca6e ("scp: more CVE-2019-6111 fix")
+(cherry picked from commit 0c5629a5d543ef5e4eff43345b1eedf2afef84ca)
+---
+ src/scp.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+--- a/src/scp.c
++++ b/src/scp.c
+@@ -614,7 +614,12 @@ append(char *cp, char ***ap, size_t *np)
+ {
+ 	char **tmp;
+ 
+-	if ((tmp = reallocarray(*ap, *np + 1, sizeof(*tmp))) == NULL)
++	if (*np + 1 > (SIZE_MAX / sizeof(*tmp))) {
++		/* overflow */
++		return -1;
++	}
++
++	if ((tmp = realloc(*ap, (*np + 1) * sizeof(*tmp))) == NULL)
+ 		return -1;
+ 	tmp[(*np)] = cp;
+ 	(*np)++;

--- a/package/network/services/dropbear/patches/018-scp-fix-recursive-overwrite-check.patch
+++ b/package/network/services/dropbear/patches/018-scp-fix-recursive-overwrite-check.patch
@@ -1,0 +1,38 @@
+From 984d412b4f8238e41b114c8ee70dbb91fd39d805 Mon Sep 17 00:00:00 2001
+From: Matt Johnston <matt@ucc.asn.au>
+Date: Mon, 4 May 2026 21:36:41 +0800
+Subject: [PATCH 8/8] scp: fix recursive overwrite check
+
+Non-recursive transfers were incorrectly disallowed to an existing
+destination.
+
+In addition, the destination check logic was wrong.
+
+Fixes: 61bd0e3e6573 ("scp: Disallow -r to an existing directory")
+(cherry picked from commit 16ce059ed8e914e210af67e199041943ec747034)
+---
+ src/scp.c | 13 ++++++++-----
+ 1 file changed, 8 insertions(+), 5 deletions(-)
+
+--- a/src/scp.c
++++ b/src/scp.c
+@@ -585,11 +585,14 @@ tolocal(int argc, char **argv)
+ 		}
+ 
+ 		char *dest = *(argv + argc - 1);
+-		if (!(access(dest, F_OK) == 0 && errno == ENOENT)) {
+-			/* paths sent from the server in recursive mode aren't adequately
+-			 * checked that they match the requested files, so disallow this */
+-			fprintf(stderr, "-r destination \"%s\" must not already exist\n", dest);
+-			exit(1);
++		if (iamrecursive) {
++			/* Destination must not exist */
++			if (!(access(dest, F_OK) == -1 && errno == ENOENT)) {
++				/* paths sent from the server in recursive mode aren't adequately
++				 * checked that they match the requested files, so disallow this */
++				fprintf(stderr, "-r destination \"%s\" must not already exist\n", dest);
++				exit(1);
++			}
+ 		}
+ 
+ 		host = cleanhostname(host);


### PR DESCRIPTION
This fixes some bugs introduced with the recent security fixes.

Fixes: 262c09368fda ("dropbear: backport some security fixes from 2026.90")

Patches are copied and renamed from patch 6dead2869209 that Hauke Mehrtens <hauke@hauke-m.de> added to 25.12. It seems they where forgotten for 24.10, causing scp in 24.10.8 to fail.

@hauke