### PR TITLE
netifd: recognise dynamic hostapd vlan interfaces

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless-device.uc
+++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless-device.uc
@@ -1,6 +1,7 @@
 'use strict';
 import * as ubus from "ubus";
 import * as uloop from "uloop";
+import * as nl80211 from "nl80211";
 import { is_equal } from "./utils.uc";
 import { access } from "fs";
 
@@ -559,12 +560,67 @@ function hotplug(name, add)
 	if (m)
 		name = m[1];
 
+	let suspect_more_ifaces = false;
+	let handled = false;
+	let known_phys = {};
 	for (let section, data in this.handler_data) {
+		if (data.type == "vif" && data?.config?.dynamic_vlan)
+			suspect_more_ifaces = true;
+		// remember all phy we see and assume this handler is responsible for those (and no others)
+		if (data.type == "device" && data.phy)
+			known_phys[data.phy] = section;
 		if (data.ifname != name ||
 		    data.type != "vif" && data.type != "vlan")
 			continue;
 
 		handle_link(dev, data, add);
+		handled = true;
+	}
+	// Return if the device was found, if it is not about to be added, and also if there is no indication for more devices
+	if (handled || !add || !suspect_more_ifaces)
+		return;
+
+	// We got a wireless device we don't know about yet: find it
+
+	// Get all radios on this device
+	phys = nl80211.request(nl80211.const.NL80211_CMD_GET_WIPHY, nl80211.const.NLM_F_DUMP, { split_wiphy_dump: true });
+	// Get all known interfaces on this device: this should contain the one about to be added
+	nl80211interfaces = nl80211.request(nl80211.const.NL80211_CMD_GET_INTERFACE, nl80211.const.NLM_F_DUMP);
+
+	// Loop through all radios found
+	for (let phy in phys) {
+		// skip if this radio is not part of this handlers'
+		if (!known_phys[phy.wiphy_name])
+			continue;
+		// loop through all interfaces found
+		for (let k, v in nl80211interfaces) {
+			// check if this interface has the requested name, skip otherwise
+			if (v.ifname != name)
+				continue;
+			// check if this interface is on one of this handler's radios, skip otherwise
+			if (v.wiphy != phy.wiphy)
+				continue;
+			// Only handle vlans here
+			if (v.iftype != nl80211.const.NL80211_IFTYPE_AP_VLAN)
+				continue;
+			// Add this interface to our known list
+			let radio = known_phys[phy.wiphy_name];
+			let ifdata = {
+				"check_vlan": false,
+				"config": {
+					"device": [ radio ],
+					"mode": "ap",
+					"vlan_bridge": dev,
+				},
+				"ifname": dev,
+				"name" : dev,
+				"type" : "vif",
+			};
+
+			handle_link(dev, ifdata, add);
+			this.handler_data[dev] = ifdata;
+			push(this.data.vif, ifdata);
+		}
 	}
 }
 


### PR DESCRIPTION
If using hostapd with dynamic vlans, it is the task of hostapd to create the relevant interfaces, may they be specified in a file or received from radius. netifd, so far, does not know about and ignores them. Among not being able to see and query statistics for those devices from command line, this especially leads to luci not knowing about those interfaces either, as luci mostly relies on netifd for that type of information. This by itself might not sound like such a big thing to miss, as luci will not be able to manage those interfaces directly, but it also leads to luci ignoring those interfaces when displaying associated wireless clients.
The effect in the end is, that up until before this patch, luci will not display any wireless client associated via such a dynamic vlan, often leading to a completely empty list.

See https://github.com/openwrt/netifd/issues/26 for a bug report about this issue.

hostapd does not report these vlan interfaces using the netlink kernel interface as I believe it should (see
https://lists.infradead.org/pipermail/hostap/2026-July/045328.html) for an unanswered question regarding this issue. netifd might (not checked since not implemented) pickup those interfaces otherwise, but it is also unlikely that this is changed any time soon, if at all.

While netifd does not receive notification about those interfaces through the netlink kernel interface, it still receives notifications through hotplug, so the patch essentially does this whenever a new device is reported through hotplug (simplified):

- see if this is a dynamic vlan interface to be added
- see if this interface belongs to the current wifi device (radio) by querying nl80211 for all known interfaces of the "current" radio

If so: add this device to the known devices and from then on (until it is removed regularly), provide reports about it, especially its existence and the related radio.

Note that this patch alone will not solve the issue with luci mentioned above, only the one on the command line. However, this patch can stand on its own and solves a problem regardless of the relevance to luci.

A second patch will be provided to luci in its repository that handles its recognision and display of associated clients to those interfaces.

hostapd could, and possibly should, directly report those interfaces to the kernel, which it currently does not do. If that would be the case, this patch might not be necessary and/or might look differently. However, it is unclear to me whether this would be a correct solution and a query towards this remained unanswered
(https://lists.infradead.org/pipermail/hostap/2026-July/045328.html).

A second possibility would be to implement this logic into luci (and I initially did). This, however, would be, IMHO, not the the right place to do this, and would not solve the same issue on the netifd command line.
