### PR TITLE
airoha: configure network activity LEDs for Nokia XG-040G-MD

### DIFF
--- a/target/linux/airoha/an7581/base-files/etc/board.d/01_leds
+++ b/target/linux/airoha/an7581/base-files/etc/board.d/01_leds
@@ -19,6 +19,12 @@ gemtek,w1700k-ubi)
 	ucidef_set_led_netdev "lan4-yellow" "lan4" "yellow:lan-4" "lan4" "link_10 link_100"
 	ucidef_set_led_netdev "lan4-green" "lan4" "green:lan-4" "lan4" "link_1000 tx rx"
 	;;
+nokia,xg-040g-md|\
+nokia,xg-040g-md-ubi)
+	ucidef_set_led_netdev "lan2" "lan2" "mt7530-0:0a:green:lan-2" "lan2" "link tx rx"
+	ucidef_set_led_netdev "lan3" "lan3" "mt7530-0:0b:green:lan-3" "lan3" "link tx rx"
+	ucidef_set_led_netdev "lan4" "lan4" "mt7530-0:0c:green:lan-4" "lan4" "link tx rx"
+	;;
 esac
 
 board_config_flush


### PR DESCRIPTION
Set up network device LEDs for lan2, lan3, and lan4 interfaces on the Nokia XG-040G-MD board to display network TX and RX activity.

