### PR TITLE
ramips: mt7621: add TL-R605 v1 as alternative name for TP-Link ER605 v1

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -3129,6 +3129,9 @@ define Device/tplink_er605-v1
   DEVICE_VENDOR := TP-Link
   DEVICE_MODEL := ER605
   DEVICE_VARIANT := v1
+  DEVICE_ALT0_VENDOR := TP-Link
+  DEVICE_ALT0_MODEL := TL-R605
+  DEVICE_ALT0_VARIANT := v1
   DEVICE_PACKAGES := -wpad-basic-mbedtls -uboot-envtools
   IMAGE_SIZE := 13760k
 endef


### PR DESCRIPTION
This was the original name for the TP-Link ER605 v1 before rebranding.
Hardware is identical. Adds DEVICE_ALT0 entries for the original branding.