### PR TITLE
dnsmasq: fix where startup would fail in the absence of DHCP

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=dnsmasq
 PKG_UPSTREAM_VERSION:=2.93
 PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=https://thekelleys.org.uk/dnsmasq/

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1194,7 +1194,7 @@ dnsmasq_start()
 	echo >> "$CONFIGFILE_TMP"
 
 	config_get_bool dhcpbogushostname "$cfg" dhcpbogushostname 1
-	[ "$dhcpbogushostname" -gt 0 ] && {
+	[ "$dhcpbogushostname" -gt 0 ] && ! dnsmasq_ignore_opt dhcp-name-match && {
 		xappend "--dhcp-ignore-names=tag:dhcp_bogus_hostname"
 		[ -r "$DHCPBOGUSHOSTNAMEFILE" ] && xappend "--conf-file=$DHCPBOGUSHOSTNAMEFILE"
 	}


### PR DESCRIPTION
The `dhcp-name-match` option in the `dhcpbogushostname.conf` configuration file prevents the software from starting if DHCP support is missing.