### PR TITLE
mediatek: filogic: fix sysupgrade for Wavlink WL-WNT100X3

### DIFF
--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -280,7 +280,6 @@ platform_do_upgrade() {
 	kebidumei,ax3000-u22|\
 	totolink,x6000r|\
 	wavlink,wl-wn573hx3|\
-	wavlink,wl-wnt100x3|\
 	widelantech,wap430x|\
 	yuncore,ax835)
 		default_do_upgrade "$1"


### PR DESCRIPTION
The stock layout of the WL-WNT100X3 splits the SPI-NAND into `bl2/u-boot-env/factory/fip/ubi/hw` and the sysupgrade image is a `sysupgrade-tar` that has to be unpacked into the `ubi` partition.

I added the board to the `default_do_upgrade()` case in 829d432ecda3, copying the entry of the neighbouring WL-WN573HX3 — but that one is SPI-NOR and does have a `firmware` partition. `default_do_upgrade()` writes to `${PART_NAME:-image}`, i.e. to `firmware`, which does not exist here:

```
find_mtd_index firmware -> []
find_mtd_index ubi      -> [4]
mtd: Could not open mtd device: firmware
```

`mtd` fails, `do_stage2` exits before flashing anything, and the board reboots into the old firmware without any visible error — so every OpenWrt-to-OpenWrt sysupgrade looks like a silent no-op. Only the initial installation works, because that one is done by the sysupgrade of the vendor firmware.

Reported here: https://forum.openwrt.org/t/sysupgrade-failed-on-wavlink-wl-wnt100x3-rev-a/252637

This drops the entry so the board falls through to the generic `nand_do_upgrade()` case with `CI_UBIPART` defaulting to `ubi`, like the identically partitioned WL-WN586X3B, which is not listed in `platform_do_upgrade()` either.

The WL-WNT100X3 (OpenWrt U-Boot layout) variant uses `fit_do_upgrade()` and is not affected.

Users already running an affected build can fix it in place, without reflashing, since `/lib/upgrade/platform.sh` is copied from the running rootfs into the ramfs:

```
sed -i '/^[[:space:]]*wavlink,wl-wnt100x3|\\$/d' /lib/upgrade/platform.sh
sysupgrade -v <image>
```

A backport to openwrt-25.12 will be submitted once this is merged — the device was cherry-picked there in ac12ba266ec6 and has not been in a release yet.
