### PR TITLE
dropbear: enable ECDSA by default for backward compatibility

### DIFF
--- a/package/network/services/dropbear/Config.in
+++ b/package/network/services/dropbear/Config.in
@@ -900,6 +900,7 @@ menu "Encryption options"
 
 	config DROPBEAR_ECDSA
 		bool "ECDSA"
+		default y if !SMALL_FLASH
 		help
 			This enables the following public key algorithm:
 			 * ecdsa-sha2-nistp256 - 256-bit elliptic curve
@@ -911,7 +912,7 @@ menu "Encryption options"
 
 			ECDSA significantly faster than RSA or DSS, but slower than Ed25519.
 
-			Default: disabled.
+			Default: enabled, except devices with very small flash.
 
 	config DROPBEAR_ED25519
 		bool "Ed25519"

--- a/package/network/services/dropbear/Makefile
+++ b/package/network/services/dropbear/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dropbear
 PKG_VERSION:=2026.94
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:= \


### PR DESCRIPTION
dropbear: enable ECDSA by default for backward compatibility
Enable ECDSA by default to:
- Support login with existing ECDSA keys.
- Ensure compatibility with legacy YubiKey devices (e.g., firmware 5.4)
  and PIV-based SSH keys (RSA/ECDSA only).
- Maintain access until Ed25519 adoption is widespread.

Default 'y' for all builds except those with SMALL_FLASH.
This activates:
- DROPBEAR_ECC_256 (via DROPBEAR_ECDH || DROPBEAR_ECDSA), enabling
  NIST-curve code for non-SMALL_FLASH builds.
- DROPBEAR_SK_ECDSA (default y), offering
  sk-ecdsa-sha2-nistp256@openssh.com by default.

Note: Increases only binary size for non-SMALL_FLASH targets.
