### PR TITLE
mediatek: filogic: fix sysupgrade for Wavlink WL-WNT100X3

### DIFF
--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -204,7 +204,6 @@ platform_do_upgrade() {
 	kebidumei,ax3000-u22|\
 	totolink,x6000r|\
 	wavlink,wl-wn573hx3|\
-	wavlink,wl-wnt100x3|\
 	widelantech,wap430x|\
 	yuncore,ax835)
 		default_do_upgrade "$1"


### PR DESCRIPTION
Backport of 17d131669fa0 ("mediatek: filogic: fix sysupgrade for Wavlink WL-WNT100X3") from main, PR #24684.

The WL-WNT100X3 was added to the default_do_upgrade() case, which writes the image to the "firmware" MTD partition — that partition does not exist on this device, so every OpenWrt-to-OpenWrt sysupgrade fails silently and the board reboots into the old firmware. Only the initial installation works, because that one is done by the sysupgrade of the vendor firmware.

Reported here: https://forum.openwrt.org/t/sysupgrade-failed-on-wavlink-wl-wnt100x3-rev-a/252637

The device support was cherry-picked into openwrt-25.12 in ac12ba266ec6 and has not been in a release yet, so this fixes it before 25.12.6 ships a broken sysupgrade path.

Cherry-picked cleanly, no changes needed.
