### PR TITLE
mediatek: use "network" LED trigger for ASUS TUF-AX4200Q

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-asus-tuf-ax4200q.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-tuf-ax4200q.dts
@@ -54,7 +54,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_WHITE>;
 			gpios = <&pio 2 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "phy1tpt";
+			linux,default-trigger = "network";
 		};
 
 		led_system: system {

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -511,7 +511,7 @@ define Device/asus_tuf-ax4200q
   DEVICE_MODEL := TUF-AX4200Q
   DEVICE_DTS := mt7986a-asus-tuf-ax4200q
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware kmod-ledtrig-network
   IMAGES := sysupgrade.bin
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k


### PR DESCRIPTION
Replaces the temporary workaround used during initial support, where the LED was triggered only by activity on a single phy. The WLAN LED now correctly reflects activity on both `phy0` and `phy1`.