### PR TITLE
kirkwood: dns325: configure Marvell PHY LEDs via reg-init

### DIFF
--- a/target/linux/kirkwood/patches-6.12/119-dns325-add-phy-led-reg-init.patch
+++ b/target/linux/kirkwood/patches-6.12/119-dns325-add-phy-led-reg-init.patch
@@ -1,0 +1,11 @@
+--- a/arch/arm/boot/dts/marvell/kirkwood-dns325.dts
++++ b/arch/arm/boot/dts/marvell/kirkwood-dns325.dts
+@@ -113,3 +113,8 @@
+ &fan0 {
+ 	#cooling-cells = <2>;
+ };
++
++&ethphy0 {
++	marvell,reg-init = <3 0x10 0xffff 0x1107>,
++	                   <3 0x11 0xffff 0x4411>;
++};


### PR DESCRIPTION
Configure the Marvell 88E1116R PHY LED control registers on the D-Link DNS-325 so they match the board LED wiring (left LED = 1 Gbps link, right LED = activity). The mainline Marvell PHY driver resets the PHY during config_init, restoring the default LED behaviour; the added marvell,reg-init property re-applies the registers after the soft reset.

Values were verified on a DNS-325 rev A2 (stock LED behaviour, 0x1107/0x4411).