### PR TITLE
Fix ag71xx legacy mdio loading problem on MikroTik RouterBOARD 962UiGS-5HacT2HnT

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -45,16 +45,27 @@ endef
 $(eval $(call KernelPackage,ag71xx))
 
 
+define KernelPackage/ag71xx-legacy-mdio
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Downstream Atheros AR7XXX/AR9XXX ethernet MDIO support
+  DEPENDS:=@TARGET_ath79 +kmod-libphy +kmod-mdio-devres
+  HIDDEN:=1
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/atheros/ag71xx/ag71xx_legacy_mdio.ko
+  AUTOLOAD:=$(call AutoLoad,49,ag71xx-legacy-mdio,1)
+endef
+
+$(eval $(call KernelPackage,ag71xx-legacy-mdio))
+
+
 define KernelPackage/ag71xx-legacy
   SUBMENU:=$(NETWORK_DEVICES_MENU)
   TITLE:=Downstream Atheros AR7XXX/AR9XXX ethernet mac support
-  DEPENDS:=@TARGET_ath79 +kmod-libphy +kmod-mdio-devres
+  DEPENDS:=@TARGET_ath79 +kmod-ag71xx-legacy-mdio
   KCONFIG:=CONFIG_AG71XX_LEGACY \
 	CONFIG_AG71XX_LEGACY_DEBUG=n \
 	CONFIG_AG71XX_LEGACY_DEBUG_FS=y
-  FILES:=$(LINUX_DIR)/drivers/net/ethernet/atheros/ag71xx/ag71xx_legacy.ko \
-	 $(LINUX_DIR)/drivers/net/ethernet/atheros/ag71xx/ag71xx_legacy_mdio.ko
-  AUTOLOAD:=$(call AutoLoad,50,ag71xx-legacy ag71xx-legacy-mdio,1)
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/atheros/ag71xx/ag71xx_legacy.ko
+  AUTOLOAD:=$(call AutoLoad,50,ag71xx-legacy,1)
 endef
 
 $(eval $(call KernelPackage,ag71xx-legacy))


### PR DESCRIPTION
I have tried the OpenWRT 25.12.5 on the MikroTik RouterBOARD 962UiGS-5HacT2HnT and the bug #23739 still exists on the board: ethernet network doesn't work.

```log
[    3.489270] ag71xx-legacy 19000000.eth: invalid MAC address, using random address
[    3.818334] ag71xx-legacy 19000000.eth: Could not connect to PHY device. Deferring probe.
[    3.826994] ag71xx-legacy 1a000000.eth: invalid MAC address, using random address
[    4.316799] ag71xx-legacy 1a000000.eth: connected to PHY at fixed-0:00 [uid=00000000, driver=Generic PHY]
[    4.335017] ag71xx-legacy 19000000.eth: invalid MAC address, using random address
[    4.713056] ag71xx-legacy 19000000.eth: connected to PHY at mdio.0:00 [uid=00000000, driver=Generic PHY]
[   16.935925] ag71xx: max retries for SGMII fixup exceeded
[   56.185119] ag71xx: max retries for SGMII fixup exceeded
[   56.215642] ag71xx-legacy 1a000000.eth eth0: entered allmulticast mode
[   56.226921] ag71xx-legacy 1a000000.eth eth0: entered promiscuous mode
```

I made a quick patch with chatgpt, built, upgrade and it just works.

The log after the fix:
```log
[    3.443870] ag71xx-legacy 19000000.eth: invalid MAC address, using random address
[    4.027924] switch0: Atheros AR8337 rev. 2 switch registered on mdio.0
[    4.623096] ag71xx-legacy 19000000.eth: connected to PHY at mdio.0:00 [uid=004dd036, driver=Atheros AR8216/AR8236/AR8316]
[    4.635242] eth0: Atheros AG71xx at 0xb9000000, irq 4, mode: rgmii
[    4.642074] ag71xx-legacy 1a000000.eth: invalid MAC address, using random address
[    5.109368] ag71xx-legacy 1a000000.eth: connected to PHY at fixed-0:00 [uid=00000000, driver=Generic PHY]
[    5.120172] eth1: Atheros AG71xx at 0xba000000, irq 5, mode: sgmii
```

Since I completely has no exp in openwrt/kernel development and the fix was made by ai, the code needs to be reviewed by someone who understand all the things how kernel works, etc.