### PR TITLE
mpc85xx: red-15w: use nvmem for wifi MAC

### DIFF
--- a/target/linux/mpc85xx/base-files/etc/hotplug.d/ieee80211/10-fix-wifi-mac
+++ b/target/linux/mpc85xx/base-files/etc/hotplug.d/ieee80211/10-fix-wifi-mac
@@ -23,7 +23,4 @@ extreme-networks,ws-ap3825i)
 ocedo,panda)
 	mtd_get_mac_ascii uboot-env0 wmac$(($PHYNBR + 1)) > /sys${DEVPATH}/macaddress
 	;;
-sophos,red-15w-rev1)
-	mtd_get_mac_ascii u-boot-env ethaddr > /sys${DEVPATH}/macaddress
-	;;
 esac

--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/red-15w-rev1.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/red-15w-rev1.dts
@@ -13,6 +13,7 @@
 		led-failsafe = &system_red;
 		led-running = &system_green;
 		led-upgrade = &system_red;
+		label-mac-device = &enet0;
 	};
 
 	memory {
@@ -157,6 +158,14 @@
 				partition@100000 {
 					reg = <0x100000 0x100000>;
 					label = "u-boot-env";
+
+					nvmem-layout {
+						compatible = "u-boot,env";
+						env-size = <0x4000>;
+
+						macaddr_uboot_ethaddr: ethaddr {
+						};
+					};
 				};
 
 				partition@200000 {
@@ -222,6 +231,13 @@
 				 <0x1000000 0x0 0x0
 				  0x1000000 0x0 0x0
 				  0x0 0x100000>;
+
+			wifi@0,0 {
+				compatible = "pci168c,0030";
+				reg = <0x0000 0 0 0 0>;
+				nvmem-cells = <&macaddr_uboot_ethaddr>;
+				nvmem-cell-names = "mac-address";
+			};
 		};
 	};
 };

--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/red-15w-rev1.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/red-15w-rev1.dts
@@ -157,6 +157,14 @@
 				partition@100000 {
 					reg = <0x100000 0x100000>;
 					label = "u-boot-env";
+
+					nvmem-layout {
+						compatible = "u-boot,env-redundant-bool";
+						env-size = <0x20000>;
+
+						macaddr_uboot_ethaddr: ethaddr {
+						};
+					};
 				};
 
 				partition@200000 {
@@ -222,6 +230,13 @@
 				 <0x1000000 0x0 0x0
 				  0x1000000 0x0 0x0
 				  0x0 0x100000>;
+
+			wifi@0,0 {
+				compatible = "pci168c,0030";
+				reg = <0x0000 0 0 0 0>;
+				nvmem-cells = <&macaddr_uboot_ethaddr>;
+				nvmem-cell-names = "mac-address";
+			};
 		};
 	};
 };


### PR DESCRIPTION
Userspace handling is deprecated.

ping @Shine- 

No idea what the proper configuration is for the uboot environment. Other devices using a size of 0x100000 for the environment tend to have a redundant one of size 0x20000.