### PR TITLE
ramips: add support for ipTIME A3004NS-M

### DIFF
--- a/package/kernel/mt76/Makefile
+++ b/package/kernel/mt76/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mt76
-PKG_RELEASE=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=BSD-3-Clause-Clear
 PKG_LICENSE_FILES:=

--- a/package/kernel/mt76/patches/100-mt7615-allow-forcing-DBDC-from-device-tree.patch
+++ b/package/kernel/mt76/patches/100-mt7615-allow-forcing-DBDC-from-device-tree.patch
@@ -1,0 +1,84 @@
+From e538f79812380b9a191942e0a6c072677b288f3d Mon Sep 17 00:00:00 2001
+From: Hyunwoo Kim <hwkim3330@gmail.com>
+Date: Wed, 12 Aug 2026 18:40:08 +0900
+Subject: [PATCH] wifi: mt76: mt7615: allow forcing DBDC from the device tree
+
+mt7615_eeprom_parse_hw_band_cap() derives the band configuration
+entirely from MT_EE_WIFI_CONF (EEPROM offset 0x3e, bits 5:4). Some
+boards are wired for DBDC yet report MT_EE_DUAL_BAND there, because
+their vendor driver enables DBDC unconditionally and never consults the
+EEPROM, so the mismatch is invisible in stock firmware. Under mt76 such
+a board registers a single dual-band phy and only one band is usable at
+a time.
+
+Add a "mediatek,dbdc" boolean so the device tree can correct the EEPROM.
+The override is applied before the switch, so everything downstream
+takes the ordinary DBDC path: dbdc_support is set at probe time,
+mt7615_mcu_init() applies the DBDC calibration cache, and
+mt7615_register_ext_phy() registers band 1 with mphy->chainmask =
+dev->chainmask & ~dev->mphy.chainmask. Devices that do not set the
+property are bit-for-bit unaffected.
+
+Alternatives considered:
+
+- Rewriting the EEPROM bytes on the way to the driver. There is no
+  mechanism to modify an nvmem cell in flight, and editing the factory
+  partition on the device would be destructive.
+- Enabling DBDC from userspace through the existing debugfs knob. That
+  works and is what affected boards do today, but the device still comes
+  up wrong on every boot and hardware description ends up in a startup
+  script.
+- A new compatible string. The chip is not different; only the board's
+  EEPROM contents are, which is what device tree properties describe.
+
+The affected device is the ipTIME A3004NS-M (MT7615D). In
+openwrt/openwrt#4915 ptpt52 identified the encoding of this field, and
+mans0n then dumped it on the hardware:
+
+  root@OpenWrt:~# hexdump -e '1/1 "%02x" "\n"' -s $((0x3e)) -n 1 /dev/mtd2
+  0a
+
+0x0a is band_sel 0, MT_EE_DUAL_BAND, on a board whose second phy works
+once DBDC is forced through debugfs. That pull request added this device
+and was then closed by its author, in his words, because "there is no
+way to override it in dts" and he considered shipping the debugfs
+workaround "a major flaw".
+
+If this is accepted, "mediatek,dbdc" should also be documented in
+Documentation/devicetree/bindings/net/wireless/mediatek,mt76.yaml in the
+kernel tree, which this repository does not carry.
+
+Signed-off-by: Hyunwoo Kim <hwkim3330@gmail.com>
+---
+ mt7615/eeprom.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+Carried here on purpose rather than waiting: the same change is proposed
+against openwrt/mt76 in openwrt/mt76#1119, and this patch should be dropped
+at whichever "mt76: update to Git HEAD" bump includes it.
+
+diff --git a/mt7615/eeprom.c b/mt7615/eeprom.c
+index d6828e1..622cf21 100644
+--- a/mt7615/eeprom.c
++++ b/mt7615/eeprom.c
+@@ -124,6 +124,20 @@ mt7615_eeprom_parse_hw_band_cap(struct mt7615_dev *dev)
+ 
+ 	val = FIELD_GET(MT_EE_NIC_WIFI_CONF_BAND_SEL,
+ 			eeprom[MT_EE_WIFI_CONF]);
++
++	/*
++	 * Some boards wire the chip up for DBDC but ship an EEPROM that still
++	 * describes it as a single dual-band phy. The vendor driver enables
++	 * DBDC unconditionally, so the mismatch goes unnoticed there; here it
++	 * means only one band is usable at a time. Let the device tree correct
++	 * it.
++	 *
++	 * Affected: ipTIME A3004NS-M (MT7615D), which reads 0x0a here, i.e.
++	 * MT_EE_DUAL_BAND. See openwrt/openwrt#4915.
++	 */
++	if (of_property_read_bool(dev_of_node(dev->mt76.dev), "mediatek,dbdc"))
++		val = MT_EE_DBDC;
++
+ 	switch (val) {
+ 	case MT_EE_5GHZ:
+ 		dev->mphy.cap.has_5ghz = true;

--- a/target/linux/ramips/dts/mt7621_iptime_a3004ns-m.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_a3004ns-m.dts
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "iptime,a3004ns-m", "mediatek,mt7621-soc";
+	model = "ipTIME A3004NS-M";
+
+	aliases {
+		led-boot = &led_cpu;
+		led-failsafe = &led_cpu;
+		led-running = &led_cpu;
+		led-upgrade = &led_cpu;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_cpu: led-0 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_CPU;
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WLAN;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc20: macaddr@1fc20 {
+						compatible = "mac-base";
+						reg = <0x1fc20 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_uboot_1fc40: macaddr@1fc40 {
+						reg = <0x1fc40 0x6>;
+					};
+				};
+			};
+
+			partition@20000 {
+				label = "config";
+				reg = <0x20000 0x10000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "factory";
+				reg = <0x30000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x4da8>;
+					};
+				};
+			};
+
+			partition@40000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x40000 0xfc0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_uboot_1fc20 3>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_uboot_1fc40>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+
+		/*
+		 * The MT7615D is wired for DBDC, but the factory EEPROM
+		 * describes it as a single dual-band phy (MT_EE_WIFI_CONF
+		 * band_sel == MT_EE_DUAL_BAND), so the driver cannot detect
+		 * DBDC on its own.  Force it here, otherwise only one band
+		 * comes up at a time.
+		 */
+		mediatek,dbdc;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1897,6 +1897,15 @@ define Device/iptime_a3004ns-dual
 endef
 TARGET_DEVICES += iptime_a3004ns-dual
 
+define Device/iptime_a3004ns-m
+  IMAGE_SIZE := 16128k
+  UIMAGE_NAME := a3004nm
+  DEVICE_VENDOR := ipTIME
+  DEVICE_MODEL := A3004NS-M
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 -uboot-envtools
+endef
+TARGET_DEVICES += iptime_a3004ns-m
+
 define Device/iptime_a3004t
   $(Device/nand)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -95,6 +95,7 @@ case "$board" in
 			macaddr_unsetbit "$(cat /sys${DEVPATH}/macaddress)" 6 > /sys${DEVPATH}/macaddress
 		;;
 	iptime,a3002mesh|\
+	iptime,a3004ns-m|\
 	iptime,a3004t)
 		hw_mac_addr="$(mtd_get_mac_binary factory 0x4)"
 		[ "$PHYNBR" = "0" ] && \


### PR DESCRIPTION
This revives [#4915](https://github.com/openwrt/openwrt/pull/4915), which added
this device in 2021 and was closed unmerged by its author. The reason it was
closed is fixed here, so the port is proposed again rather than left in a fork.

@mans0n wrote the device support and the commit is still his, with his
`Signed-off-by` intact; the bracketed note in it records what the rebase changed.
He closed the original because the MT7615D on this board is wired for DBDC while
its factory EEPROM reports `MT_EE_DUAL_BAND` at 0x3e, so mt76 registered a single
dual-band phy and only 2.4 GHz worked. In his words there was *"no way to
override it in dts"*, and he would not merge it with the debugfs workaround — "a
major flaw".

The first commit is that override, carried as
`package/kernel/mt76/patches/100-mt7615-allow-forcing-DBDC-from-device-tree.patch`.
The same change is proposed against openwrt/mt76 in
[openwrt/mt76#1119](https://github.com/openwrt/mt76/pull/1119); this
patch should be dropped at whichever `mt76: update to Git HEAD` bump includes it,
and the patch header says so. Carrying it rather than waiting keeps the two
reviews independent — without it the port still builds and still works on
2.4 GHz, which is the state that got the original closed.

### Rebased onto current conventions

- `nvmem-layout` with `fixed-layout` rather than a bare `nvmem-cells` partition
- a `mac-base` cell instead of `mac-address-increment`
- LED nodes without the deprecated `label` property
- no `dsa-migration`: this device never shipped a swconfig release, so there is no
  configuration to migrate from and adding it would only force `-F` on users
- the WLAN LED gained `linux,default-trigger = "phy0radio"`; without a trigger it
  never lit. a3002mesh and a3004t are the same chip driving the same GPIO 17 for
  the same purpose and both use it

`label-mac-device` is deliberately absent. The stock firmware used the un-offset
u-boot value for its LAN address, which under OpenWrt belongs to the 5 GHz phy
while LAN is that value + 3 — so it is likely no netdev carries the label MAC.
Nobody has read the sticker on the underside to confirm it, so rather than guess
the property is left out; happy to add it if a maintainer would prefer a
specific interface named.

### Tested on hardware

ipTIME A3004NS-M, kernel 6.18.41. Flashed through the stock web interface, then
sysupgraded to the persistent image; everything below survived a power-cycle
reboot with the overlay on flash (`/dev/mtdblock6`, jffs2).

| | result |
|---|---|
| Wi-Fi | `phy0` 2412 MHz and `phy1` 5180 MHz, both Master **at the same time** — ch1 HT20 and ch36 VHT80 |
| a 5 GHz client | 866.7 Mbit/s, VHT-MCS 9, 80 MHz, VHT-NSS 2, took a DHCP lease |
| antenna split | `0x34` = `0x44` → phy0 `0x3`, phy1 `0xc`, i.e. 2x2 + 2x2 |
| EEPROM 0x3e | `0x0a`, matching what was dumped on this model in 2021 |
| Ethernet | lan1 links at 1000 Mbps; lan2-4 and wan correctly down when unplugged |
| USB 3.0 | a UVC camera enumerates at 5000 Mbps |
| LEDs, buttons | CPU LED on boot, WLAN LED follows phy0, reset and WPS both report |
| flash layout | partitions tile 0→16 MiB exactly; `IMAGE_SIZE` 16128k == the firmware partition |
| driver log | no mt76 or MCU errors |

MAC assignment, matching the table in the commit message:

| | measured | rule |
|---|---|---|
| LAN | `70:5d:cc:77:4c:03` | u-boot 0x1fc20 **+3** |
| WAN | `70:5d:cc:77:4c:01` | u-boot 0x1fc40 |
| WLAN 5 GHz | `70:5d:cc:77:4c:00` | factory 0x4 |
| WLAN 2.4 GHz | `72:5d:cc:77:4c:03` | LAN with the local bit set |

### Installation

Flash the **initramfs** image through the stock web interface, boot it, then
`sysupgrade` with the squashfs image. Reverting is a `sysupgrade` with an official
ipTIME image (`a3004nm_kr_*.bin`), which carries the same `a3004nm` uImage name
the stock updater checks.

### Release notes

> ramips: add support for the ipTIME A3004NS-M (MT7621A, 256 MiB RAM, 16 MiB
> SPI NOR, 5x 1GbE, MT7615D DBDC Wi-Fi 5, 1x USB 3.0). Requires the accompanying
> mt7615 change to bring up both bands; without it only 2.4 GHz is available.
