### PR TITLE
mediatek: filogic: mtd: spinand: add HeYangTek HYF4GQ4UAACBE support

### DIFF
--- a/target/linux/generic/pending-6.18/489-mtd-spinand-add-heyangtek-HYF4GQ4UAACBE.patch
+++ b/target/linux/generic/pending-6.18/489-mtd-spinand-add-heyangtek-HYF4GQ4UAACBE.patch
@@ -1,0 +1,151 @@
+From: Feihong Liang <glrouter@gl-inet.com>
+Subject: generic: mtd: spinand: add HeYangTek HYF4GQ4UAACBE support
+
+Add support for the HeYangTek HYF4GQ4UAACBE 4-Gbit SPI-NAND.
+The device has 4096-byte pages, 256-byte OOB areas and requires
+14-bit ECC per 512-byte step.
+
+Signed-off-by: Feihong Liang <glrouter@gl-inet.com>
+---
+ drivers/mtd/nand/spi/Makefile    |   1 +
+ drivers/mtd/nand/spi/core.c      |   1 +
+ drivers/mtd/nand/spi/heyangtek.c | 105 +++++++++++++++++++++++++++++++++++++++
+ include/linux/mtd/spinand.h      |   1 +
+ 4 files changed, 108 insertions(+)
+ create mode 100644 drivers/mtd/nand/spi/heyangtek.c
+
+--- a/drivers/mtd/nand/spi/Makefile
++++ b/drivers/mtd/nand/spi/Makefile
+@@ -3,3 +3,4 @@ spinand-objs := core.o otp.o
+ spinand-objs += alliancememory.o ato.o esmt.o etron.o fmsh.o foresee.o gigadevice.o
+ spinand-objs += macronix.o micron.o paragon.o skyhigh.o toshiba.o winbond.o xtx.o
+ obj-$(CONFIG_MTD_SPI_NAND) += spinand.o
++spinand-objs += heyangtek.o
+--- a/drivers/mtd/nand/spi/core.c
++++ b/drivers/mtd/nand/spi/core.c
+@@ -1239,6 +1239,7 @@ static const struct spinand_manufacturer
+ 	&toshiba_spinand_manufacturer,
+ 	&winbond_spinand_manufacturer,
+ 	&xtx_spinand_manufacturer,
++	&heyangtek_spinand_manufacturer,
+ };
+ 
+ static int spinand_manufacturer_match(struct spinand_device *spinand,
+--- /dev/null
++++ b/drivers/mtd/nand/spi/heyangtek.c
+@@ -0,0 +1,105 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * HeYangTek SPI-NAND driver
++ */
++
++#include <linux/device.h>
++#include <linux/kernel.h>
++#include <linux/mtd/spinand.h>
++
++#define SPINAND_MFR_HEYANGTEK		0xc9
++
++#define HEYANGTEK_STATUS_ECC_LIMIT	(3 << 4)
++
++static SPINAND_OP_VARIANTS(read_cache_variants,
++		SPINAND_PAGE_READ_FROM_CACHE_1S_4S_4S_OP(0, 1, NULL, 0, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_1S_1S_4S_OP(0, 1, NULL, 0, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_1S_2S_2S_OP(0, 1, NULL, 0, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_1S_1S_2S_OP(0, 1, NULL, 0, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_FAST_1S_1S_1S_OP(0, 1, NULL, 0, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_1S_1S_1S_OP(0, 1, NULL, 0, 0));
++
++static SPINAND_OP_VARIANTS(write_cache_variants,
++		SPINAND_PROG_LOAD_1S_1S_4S_OP(true, 0, NULL, 0),
++		SPINAND_PROG_LOAD_1S_1S_1S_OP(true, 0, NULL, 0));
++
++static SPINAND_OP_VARIANTS(update_cache_variants,
++		SPINAND_PROG_LOAD_1S_1S_4S_OP(false, 0, NULL, 0),
++		SPINAND_PROG_LOAD_1S_1S_1S_OP(false, 0, NULL, 0));
++
++static int hyf4gq4_ooblayout_ecc(struct mtd_info *mtd, int section,
++				 struct mtd_oob_region *region)
++{
++	if (section)
++		return -ERANGE;
++
++	region->offset = 128;
++	region->length = 128;
++
++	return 0;
++}
++
++static int hyf4gq4_ooblayout_free(struct mtd_info *mtd, int section,
++				  struct mtd_oob_region *region)
++{
++	if (section)
++		return -ERANGE;
++
++	region->offset = 1;
++	region->length = 127;
++
++	return 0;
++}
++
++static const struct mtd_ooblayout_ops hyf4gq4_ooblayout = {
++	.ecc = hyf4gq4_ooblayout_ecc,
++	.free = hyf4gq4_ooblayout_free,
++};
++
++static int hyf4gq4_ecc_get_status(struct spinand_device *spinand, u8 status)
++{
++	struct nand_device *nand = spinand_to_nand(spinand);
++	unsigned int strength = nanddev_get_ecc_conf(nand)->strength;
++
++	switch (status & STATUS_ECC_MASK) {
++	case STATUS_ECC_NO_BITFLIPS:
++		return 0;
++
++	case STATUS_ECC_UNCOR_ERROR:
++		return -EBADMSG;
++
++	case STATUS_ECC_HAS_BITFLIPS:
++		return strength >> 1;
++
++	case HEYANGTEK_STATUS_ECC_LIMIT:
++		return strength;
++
++	default:
++		return -EINVAL;
++	}
++}
++
++static const struct spinand_info heyangtek_spinand_table[] = {
++	SPINAND_INFO("HYF4GQ4UAACBE",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_ADDR, 0xd4),
++		     NAND_MEMORG(1, 4096, 256, 64, 2048, 40, 1, 1, 1),
++		     NAND_ECCREQ(14, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&hyf4gq4_ooblayout,
++				     hyf4gq4_ecc_get_status)),
++};
++
++static const struct spinand_manufacturer_ops heyangtek_spinand_manuf_ops = {
++};
++
++const struct spinand_manufacturer heyangtek_spinand_manufacturer = {
++	.id = SPINAND_MFR_HEYANGTEK,
++	.name = "HeYangTek",
++	.chips = heyangtek_spinand_table,
++	.nchips = ARRAY_SIZE(heyangtek_spinand_table),
++	.ops = &heyangtek_spinand_manuf_ops,
++};
++
+--- a/include/linux/mtd/spinand.h
++++ b/include/linux/mtd/spinand.h
+@@ -373,6 +373,7 @@ extern const struct spinand_manufacturer
+ extern const struct spinand_manufacturer toshiba_spinand_manufacturer;
+ extern const struct spinand_manufacturer winbond_spinand_manufacturer;
+ extern const struct spinand_manufacturer xtx_spinand_manufacturer;
++extern const struct spinand_manufacturer heyangtek_spinand_manufacturer;
+ 
+ /**
+  * struct spinand_op_variants - SPI NAND operation variants

--- a/target/linux/generic/pending-6.18/489-mtd-spinand-add-heyangtek-HYF4GQ4UAACBE.patch
+++ b/target/linux/generic/pending-6.18/489-mtd-spinand-add-heyangtek-HYF4GQ4UAACBE.patch
@@ -1,0 +1,105 @@
+From: Feihong Liang <glrouter@gl-inet.com>
+Subject: generic: mtd: spinand: add HeYangTek HYF4GQ4UAACBE support
+
+Add support for the HeYangTek HYF4GQ4UAACBE 4-Gbit SPI-NAND.
+The device has 4096-byte pages, 256-byte OOB areas and requires
+14-bit ECC per 512-byte step.
+
+Signed-off-by: Feihong Liang <glrouter@gl-inet.com>
+---
+ drivers/mtd/nand/spi/heyangtek.c | 63 ++++++++++++++++++++++++++++++++
+ 1 file changed, 63 insertions(+)
+
+--- a/drivers/mtd/nand/spi/heyangtek.c
++++ b/drivers/mtd/nand/spi/heyangtek.c
+@@ -15,6 +15,7 @@
+ #define SPINAND_MFR_HEYANGTEK			0xc9
+ 
+ #define HYF1GQ4_STATUS_ECC_LIMIT_BITFLIPS	(3 << 4)
++#define HYF4GQ4_STATUS_ECC_LIMIT_BITFLIPS	(3 << 4)
+ 
+ static SPINAND_OP_VARIANTS(read_cache_variants,
+ 		SPINAND_PAGE_READ_FROM_CACHE_1S_4S_4S_OP(0, 1, NULL, 0, 0),
+@@ -73,6 +74,35 @@
+ 	.free = hyf1gq4_ooblayout_free,
+ };
+ 
++static int hyf4gq4_ooblayout_ecc(struct mtd_info *mtd, int section,
++				 struct mtd_oob_region *region)
++{
++	if (section)
++		return -ERANGE;
++
++	region->offset = 128;
++	region->length = 128;
++
++	return 0;
++}
++
++static int hyf4gq4_ooblayout_free(struct mtd_info *mtd, int section,
++				  struct mtd_oob_region *region)
++{
++	if (section)
++		return -ERANGE;
++
++	region->offset = 1;
++	region->length = 127;
++
++	return 0;
++}
++
++static const struct mtd_ooblayout_ops hyf4gq4_ooblayout = {
++	.ecc = hyf4gq4_ooblayout_ecc,
++	.free = hyf4gq4_ooblayout_free,
++};
++
+ static int hyf1gq4_ecc_get_status(struct spinand_device *spinand, u8 status)
+ {
+ 	struct nand_device *nand = spinand_to_nand(spinand);
+@@ -107,6 +137,29 @@
+ 	return -EINVAL;
+ }
+ 
++static int hyf4gq4_ecc_get_status(struct spinand_device *spinand, u8 status)
++{
++	struct nand_device *nand = spinand_to_nand(spinand);
++	unsigned int strength = nanddev_get_ecc_conf(nand)->strength;
++
++	switch (status & STATUS_ECC_MASK) {
++	case STATUS_ECC_NO_BITFLIPS:
++		return 0;
++
++	case STATUS_ECC_UNCOR_ERROR:
++		return -EBADMSG;
++
++	case STATUS_ECC_HAS_BITFLIPS:
++		return strength >> 1;
++
++	case HYF4GQ4_STATUS_ECC_LIMIT_BITFLIPS:
++		return strength;
++
++	default:
++		return -EINVAL;
++	}
++}
++
+ static const struct spinand_info heyangtek_spinand_table[] = {
+ 	SPINAND_INFO("HYF1GQ4UDACAE",
+ 		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_ADDR, 0x21),
+@@ -118,6 +171,16 @@
+ 		     SPINAND_HAS_QE_BIT,
+ 		     SPINAND_ECCINFO(&hyf1gq4_ooblayout,
+ 				     hyf1gq4_ecc_get_status)),
++	SPINAND_INFO("HYF4GQ4UAACBE",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_ADDR, 0xd4),
++		     NAND_MEMORG(1, 4096, 256, 64, 2048, 40, 1, 1, 1),
++		     NAND_ECCREQ(14, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&hyf4gq4_ooblayout,
++				     hyf4gq4_ecc_get_status)),
+ };
+ 
+ static const struct spinand_manufacturer_ops heyangtek_spinand_manuf_ops = {


### PR DESCRIPTION
Add support for the HeYangTek HYF4GQ4UAACBE 4-Gbit SPI-NAND. The device has 4096-byte pages, 256-byte OOB areas and requires 14-bit ECC per 512-byte step.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
