### PR TITLE
realtek: pcs: several improvements

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3383,12 +3383,12 @@ static void rtpcs_931x_sds_rx_reset(struct rtpcs_serdes *sds)
 		return;
 
 	rtpcs_sds_write(sds, PAGE_ANA_10G, 0x12, 0x2740);
-	rtpcs_sds_write(sds, PAGE_ANA_10G_EXT, 0x0, 0x0);	/* [11:6] DFE_TAP3_ODD | [5:0] DFE_TAP3_EVEN */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0, 15, 12, 0x0);
 	rtpcs_sds_write(sds, PAGE_ANA_10G_EXT, 0x2, 0x2010);
 	rtpcs_sds_write(sds, PAGE_ANA_MISC, 0x0, 0xc10);
 
 	rtpcs_sds_write(sds, PAGE_ANA_10G, 0x12, 0x27c0);
-	rtpcs_sds_write(sds, PAGE_ANA_10G_EXT, 0x0, 0xc000); /* [11:6] DFE_TAP3_ODD | [5:0] DFE_TAP3_EVEN */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0, 15, 12, 0xc);
 	rtpcs_sds_write(sds, PAGE_ANA_10G_EXT, 0x2, 0x6010);
 	rtpcs_sds_write(sds, PAGE_ANA_MISC, 0x0, 0xc30);
 
@@ -3793,7 +3793,7 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 	 *   while rx_reset doesn't do this.
 	 */
 	rtpcs_sds_write(sds, PAGE_ANA_10G, 0x12, 0x2740);
-	rtpcs_sds_write(sds, PAGE_ANA_10G_EXT, 0x0, 0x0);	/* [11:6] DFE_TAP3_ODD | [5:0] DFE_TAP3_EVEN */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0, 15, 12, 0x0);
 	rtpcs_sds_write(sds, PAGE_ANA_10G_EXT, 0x2, 0x2010);
 	rtpcs_sds_write(sds, PAGE_ANA_MISC, 0x0, 0xcd1); /* from 930x: [7:6] POWER_DOWN OF ?? */
 
@@ -3846,7 +3846,7 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 
 	if (is_10g) {
 		rtpcs_sds_write(sds, PAGE_ANA_10G, 0x12, 0x27c0);
-		rtpcs_sds_write(sds, PAGE_ANA_10G_EXT, 0x0, 0xc000); /* [11:6] DFE_TAP3_ODD | [5:0] DFE_TAP3_EVEN */
+		rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0, 15, 12, 0xc);
 		rtpcs_sds_write(sds, PAGE_ANA_10G_EXT, 0x2, 0x6010);
 	}
 

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3824,42 +3824,12 @@ static int rtpcs_931x_sds_config_tx_amps(struct rtpcs_serdes *sds, u8 pre_amp, u
 	return rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0x0, 1, 0, en_val);
 }
 
-/**
- * rtpcs_931x_sds_config_tx - Configure static TX path parameters
- */
-static int rtpcs_931x_sds_config_tx(struct rtpcs_serdes *sds,
-				    enum rtpcs_sds_attachment attachment)
-{
-	const struct rtpcs_sds_tx_config *tx_cfg;
-
-	switch (attachment) {
-	case RTPCS_SDS_ATTACH_DAC_SHORT:
-		tx_cfg = &rtpcs_931x_sds_tx_cfg_sdac;
-		break;
-
-	case RTPCS_SDS_ATTACH_DAC_LONG:
-		tx_cfg = &rtpcs_931x_sds_tx_cfg_ldac;
-		break;
-
-	default:
-		if (sds->ctrl->chip_version == RTPCS_CHIP_V2)
-			/* consider 9311 vs. 9313 here too, see SDK */
-			tx_cfg = &rtpcs_931x_sds_tx_cfg_v2[sds->id - 2];
-		else
-			tx_cfg = &rtpcs_931x_sds_tx_cfg_v1[sds->id - 2];
-
-		break;
-	}
-
-	return rtpcs_931x_sds_config_tx_amps(sds, tx_cfg->pre_amp, tx_cfg->main_amp,
-					     tx_cfg->post_amp);
-}
-
 static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 					    enum rtpcs_sds_attachment attachment,
 					    enum rtpcs_sds_mode hw_mode)
 {
 	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
+	const struct rtpcs_sds_tx_config *tx_cfg;
 	bool is_dac, is_10g;
 	int ret;
 
@@ -3884,11 +3854,6 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 	if (attachment == RTPCS_SDS_ATTACH_NONE)
 		return 0;
 
-	/* config SerDes TX path (amps, impedance, etc.) */
-	ret = rtpcs_931x_sds_config_tx(sds, attachment);
-	if (ret < 0)
-		return ret;
-
 	is_dac = (attachment == RTPCS_SDS_ATTACH_DAC_SHORT ||
 		  attachment == RTPCS_SDS_ATTACH_DAC_LONG);
 	is_10g = (hw_mode == RTPCS_SDS_MODE_10GBASER ||
@@ -3904,6 +3869,9 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 	switch (attachment) {
 	case RTPCS_SDS_ATTACH_DAC_SHORT:
 	case RTPCS_SDS_ATTACH_DAC_LONG:
+		tx_cfg = (attachment == RTPCS_SDS_ATTACH_DAC_SHORT) ? &rtpcs_931x_sds_tx_cfg_sdac :
+								      &rtpcs_931x_sds_tx_cfg_ldac;
+
 		rtpcs_sds_write(sds, PAGE_ANA_COM, 0x19, 0xf0a5);
 		rtpcs_sds_write(even_sds, PAGE_ANA_10G, 0x8, 0x02a0); /* [10:7] TX impedance */
 		break;
@@ -3914,10 +3882,20 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 
 		fallthrough;
 	default:
+		if (sds->ctrl->chip_version == RTPCS_CHIP_V2)
+			tx_cfg = &rtpcs_931x_sds_tx_cfg_v2[sds->id - 2];
+		else
+			tx_cfg = &rtpcs_931x_sds_tx_cfg_v1[sds->id - 2];
+
 		rtpcs_sds_write(sds, PAGE_ANA_COM, 0x19, 0xf0f0);
 		rtpcs_sds_write(even_sds, PAGE_ANA_10G, 0x8, 0x0294); /* [10:7] TX impedance */
 		break;
 	}
+
+	ret = rtpcs_931x_sds_config_tx_amps(sds, tx_cfg->pre_amp, tx_cfg->main_amp,
+					    tx_cfg->post_amp);
+	if (ret)
+		return ret;
 
 	rtpcs_sds_write_mask(sds, PAGE_TGR_PRO_0, 0xd, RTL93XX_LINKDW_SEL,
 			     is_dac ? RTL93XX_LINKDW_SEL_DAC : RTL93XX_LINKDW_SEL_NON_DAC);

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3832,9 +3832,6 @@ static int rtpcs_931x_sds_config_tx(struct rtpcs_serdes *sds,
 {
 	const struct rtpcs_sds_tx_config *tx_cfg;
 
-	if (sds->type != RTPCS_SDS_TYPE_10G)
-		return 0;
-
 	switch (attachment) {
 	case RTPCS_SDS_ATTACH_DAC_SHORT:
 		tx_cfg = &rtpcs_931x_sds_tx_cfg_sdac;
@@ -3865,6 +3862,9 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
 	bool is_dac, is_10g;
 	int ret;
+
+	if (sds->type != RTPCS_SDS_TYPE_10G)
+		return 0;
 
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xe, 13, 11, 0x0);
 	if (hw_mode != RTPCS_SDS_MODE_XSGMII)

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3480,10 +3480,12 @@ static void rtpcs_931x_sds_rx_reset(struct rtpcs_serdes *sds)
 		return;
 
 	rtpcs_931x_sds_10g_ana_pre(sds);
-	rtpcs_sds_write(sds, PAGE_ANA_MISC, 0x0, 0xc10);
+	rtpcs_sds_write_mask(sds, PAGE_ANA_MISC, 0x0, RTL93XX_FRC_RX_EN_MASK,
+			     RTL93XX_FRC_RX_EN_OFF);
 
 	rtpcs_931x_sds_10g_ana_post(sds);
-	rtpcs_sds_write(sds, PAGE_ANA_MISC, 0x0, 0xc30);
+	rtpcs_sds_write_mask(sds, PAGE_ANA_MISC, 0x0, RTL93XX_FRC_RX_EN_MASK,
+			     RTL93XX_FRC_RX_EN_ON);
 	msleep(50);
 }
 

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -168,6 +168,10 @@ enum rtpcs_page {
 #define DIGI_1(page)	((page) + 0x40)
 #define DIGI_2(page)	((page) + 0x80)
 
+#define RTL93XX_FRC_CMU_EN_MASK		GENMASK(11, 10)
+#define RTL93XX_FRC_CMU_EN_UNFORCED	FIELD_PREP(RTL93XX_FRC_CMU_EN_MASK, 0x0)
+#define RTL93XX_FRC_CMU_EN_FORCE_OFF	FIELD_PREP(RTL93XX_FRC_CMU_EN_MASK, 0x1)
+#define RTL93XX_FRC_CMU_EN_FORCE_ON	FIELD_PREP(RTL93XX_FRC_CMU_EN_MASK, 0x3)
 #define RTL93XX_FRC_PDOWN_MASK		GENMASK(7, 6)
 #define RTL93XX_FRC_PDOWN_DOWN		FIELD_PREP(RTL93XX_FRC_PDOWN_MASK, 0x3)
 #define RTL93XX_FRC_PDOWN_UNFORCED	FIELD_PREP(RTL93XX_FRC_PDOWN_MASK, 0x0)
@@ -3868,7 +3872,8 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 	/* SDK: media none behavior - baseline applied regardless of attachment */
 	rtpcs_931x_sds_10g_ana_pre(sds);
 
-	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x0, 11, 10, 0x3); /* FRC_CMU_EN */
+	rtpcs_sds_write_mask(sds, PAGE_ANA_MISC, 0x0, RTL93XX_FRC_CMU_EN_MASK,
+			     RTL93XX_FRC_CMU_EN_FORCE_ON);
 	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x0, 1, 0, 0x1);  /* FRC_V2ANALOG */
 
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xf, 5, 0, 0x4);
@@ -3893,9 +3898,11 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 		  hw_mode == RTPCS_SDS_MODE_XSGMII ||
 		  hw_mode == RTPCS_SDS_MODE_USXGMII);
 
-	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x0, 11, 10, 0x0);
+	rtpcs_sds_write_mask(sds, PAGE_ANA_MISC, 0x0, RTL93XX_FRC_CMU_EN_MASK,
+			     RTL93XX_FRC_CMU_EN_UNFORCED);
 	rtpcs_sds_write_bits(sds, PAGE_ANA_5G0, 0x7, 15, 15, is_dac ? 0x1 : 0x0);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x0, 11, 10, 0x3);
+	rtpcs_sds_write_mask(sds, PAGE_ANA_MISC, 0x0, RTL93XX_FRC_CMU_EN_MASK,
+			     RTL93XX_FRC_CMU_EN_FORCE_ON);
 
 	switch (attachment) {
 	case RTPCS_SDS_ATTACH_DAC_SHORT:
@@ -3921,12 +3928,13 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 	if (is_10g)
 		rtpcs_931x_sds_10g_ana_post(sds);
 
-	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x0, 11, 10, 0x3); /* FRC_CMU_EN */
 	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x0, 1, 0, 0x0); /* FRC_V2ANALOG */
 	rtpcs_sds_write_bits(sds, PAGE_ANA_5G0, 0x12, 7, 6, 0x3);
 
-	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x0, 11, 10, 0x1);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x0, 11, 10, 0x3);
+	rtpcs_sds_write_mask(sds, PAGE_ANA_MISC, 0x0, RTL93XX_FRC_CMU_EN_MASK,
+			     RTL93XX_FRC_CMU_EN_FORCE_OFF);
+	rtpcs_sds_write_mask(sds, PAGE_ANA_MISC, 0x0, RTL93XX_FRC_CMU_EN_MASK,
+			     RTL93XX_FRC_CMU_EN_FORCE_ON);
 
 	/* clear pending SerDes RX idle interrupt flag */
 	regmap_write_bits(sds->ctrl->map, RTPCS_931X_ISR_SERDES_RXIDLE,

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -175,6 +175,15 @@ enum rtpcs_page {
 #define RTL93XX_FRC_RX_EN_ON		FIELD_PREP(RTL93XX_FRC_RX_EN_MASK, 0x3)
 #define RTL93XX_FRC_RX_EN_OFF		FIELD_PREP(RTL93XX_FRC_RX_EN_MASK, 0x1)
 
+/* DIGI_1(WDIG), reg 0x01 */
+/*
+ * Gates a digital clock inside the SerDes. The exact block is unknown — it
+ * appears to be used by all modes except USXGMII and 10GBASE-R. The bit name
+ * is inherited from an earlier SerDes generation and has not been verified
+ * on RTL931x. GLI could mean "GMII Line Interface" or "Gigabit Line Interface".
+ */
+#define RTL931X_STOP_GLI_CLK		BIT(0)
+
 enum rtpcs_sds_type {
 	RTPCS_SDS_TYPE_UNKNOWN,
 	RTPCS_SDS_TYPE_5G,
@@ -3415,6 +3424,11 @@ static int rtpcs_931x_sds_deactivate(struct rtpcs_serdes *sds)
 	if (ret)
 		return ret;
 
+	ret = rtpcs_sds_write_mask(sds, DIGI_1(PAGE_WDIG), 0x1, RTL931X_STOP_GLI_CLK,
+				   RTL931X_STOP_GLI_CLK);
+	if (ret)
+		return ret;
+
 	ret = rtpcs_931x_sds_power(sds, false);
 	if (ret)
 		return ret;
@@ -3425,6 +3439,13 @@ static int rtpcs_931x_sds_deactivate(struct rtpcs_serdes *sds)
 static int rtpcs_931x_sds_activate(struct rtpcs_serdes *sds)
 {
 	int ret;
+
+	if (sds->hw_mode != RTPCS_SDS_MODE_USXGMII &&
+	    sds->hw_mode != RTPCS_SDS_MODE_10GBASER) {
+		ret = rtpcs_sds_write_mask(sds, DIGI_1(PAGE_WDIG), 0x1, RTL931X_STOP_GLI_CLK, 0x0);
+		if (ret)
+			return ret;
+	}
 
 	ret = rtpcs_sds_write_mask(sds, PAGE_ANA_MISC, 0x0,
 				   RTL93XX_FRC_PDOWN_MASK | RTL93XX_FRC_RX_EN_MASK,
@@ -3840,13 +3861,6 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 	bool is_dac, is_10g;
 	int ret;
 
-	/*
-	 * SDK identifies this as some kind of gating. It's enabled
-	 * here and later deactivated for non-10G and XSGMII.
-	 * (from DMS1250 SDK)
-	 */
-	rtpcs_sds_write_bits(sds, DIGI_1(PAGE_WDIG), 0x1, 0, 0, 0x1);
-
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xe, 13, 11, 0x0);
 	if (hw_mode != RTPCS_SDS_MODE_XSGMII)
 		rtpcs_931x_sds_reset_leq_dfe(sds);
@@ -3917,10 +3931,6 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 	/* clear pending SerDes RX idle interrupt flag */
 	regmap_write_bits(sds->ctrl->map, RTPCS_931X_ISR_SERDES_RXIDLE,
 			  BIT(sds->id - 2), BIT(sds->id - 2));
-
-	/* Gating as mentioned above, deactivated here for non-10G and XSGMII */
-	if (!is_10g || hw_mode == RTPCS_SDS_MODE_XSGMII)
-		rtpcs_sds_write_bits(sds, DIGI_1(PAGE_WDIG), 0x1, 0, 0, 0x0);
 
 	return 0;
 }

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <linux/bitfield.h>
 #include <linux/delay.h>
 #include <linux/mdio.h>
 #include <linux/mfd/syscon.h>
@@ -167,6 +168,13 @@ enum rtpcs_page {
 #define DIGI_1(page)	((page) + 0x40)
 #define DIGI_2(page)	((page) + 0x80)
 
+#define RTL93XX_FRC_PDOWN_MASK		GENMASK(7, 6)
+#define RTL93XX_FRC_PDOWN_DOWN		FIELD_PREP(RTL93XX_FRC_PDOWN_MASK, 0x3)
+#define RTL93XX_FRC_PDOWN_UNFORCED	FIELD_PREP(RTL93XX_FRC_PDOWN_MASK, 0x0)
+#define RTL93XX_FRC_RX_EN_MASK		GENMASK(5, 4)
+#define RTL93XX_FRC_RX_EN_ON		FIELD_PREP(RTL93XX_FRC_RX_EN_MASK, 0x3)
+#define RTL93XX_FRC_RX_EN_OFF		FIELD_PREP(RTL93XX_FRC_RX_EN_MASK, 0x1)
+
 enum rtpcs_sds_type {
 	RTPCS_SDS_TYPE_UNKNOWN,
 	RTPCS_SDS_TYPE_5G,
@@ -237,6 +245,9 @@ struct rtpcs_sds_ops {
 		    int bithigh, int bitlow);
 	int (*write)(struct rtpcs_serdes *sds, enum rtpcs_page page, int regnum,
 		     int bithigh, int bitlow, u16 value);
+	/* write an arbitrary, possibly non-contiguous bitmask in a single call */
+	int (*write_mask)(struct rtpcs_serdes *sds, enum rtpcs_page page, int regnum,
+			  u16 mask, u16 value);
 
 	/* optional */
 	int (*xsg_write)(struct rtpcs_serdes *sds, enum rtpcs_page page, int regnum,
@@ -401,21 +412,31 @@ static int __rtpcs_sds_read_raw(struct rtpcs_ctrl *ctrl, int sds_id, enum rtpcs_
 	return (val & mask) >> bitlow;
 }
 
+static int __rtpcs_sds_write_mask(struct rtpcs_ctrl *ctrl, int sds_id, enum rtpcs_page page,
+				  int regnum, u16 mask, u16 set)
+{
+	int mmd_regnum = rtpcs_sds_to_mmd(page, regnum);
+
+	if (mask == 0xffff)
+		return mdiobus_c45_write(ctrl->bus, sds_id, MDIO_MMD_VEND1, mmd_regnum, set);
+
+	return mdiobus_c45_modify(ctrl->bus, sds_id, MDIO_MMD_VEND1, mmd_regnum, mask, set);
+}
+
 static int __rtpcs_sds_write_raw(struct rtpcs_ctrl *ctrl, int sds_id, enum rtpcs_page page,
 				 int regnum, int bithigh, int bitlow, u16 value)
 {
-	int mmd_regnum = rtpcs_sds_to_mmd(page, regnum);
 	u16 mask, set;
 
 	if (WARN_ON(bithigh < bitlow))
 		return -EINVAL;
 
 	if (bithigh == 15 && bitlow == 0)
-		return mdiobus_c45_write(ctrl->bus, sds_id, MDIO_MMD_VEND1, mmd_regnum, value);
+		return __rtpcs_sds_write_mask(ctrl, sds_id, page, regnum, 0xffff, value);
 
 	mask = GENMASK(bithigh, bitlow);
 	set = (value << bitlow) & mask;
-	return mdiobus_c45_modify(ctrl->bus, sds_id, MDIO_MMD_VEND1, mmd_regnum, mask, set);
+	return __rtpcs_sds_write_mask(ctrl, sds_id, page, regnum, mask, set);
 }
 
 /* Generic implementations, if no special behavior is needed */
@@ -432,6 +453,12 @@ static int rtpcs_generic_sds_op_write(struct rtpcs_serdes *sds, enum rtpcs_page 
 	return __rtpcs_sds_write_raw(sds->ctrl, sds->id, page, regnum, bithigh, bitlow, value);
 }
 
+static int rtpcs_generic_sds_op_write_mask(struct rtpcs_serdes *sds, enum rtpcs_page page,
+					   int regnum, u16 mask, u16 value)
+{
+	return __rtpcs_sds_write_mask(sds->ctrl, sds->id, page, regnum, mask, value);
+}
+
 /* Convenience helpers */
 
 static int rtpcs_sds_read_bits(struct rtpcs_serdes *sds, enum rtpcs_page page, int regnum,
@@ -444,6 +471,12 @@ static int rtpcs_sds_write_bits(struct rtpcs_serdes *sds, enum rtpcs_page page, 
 				int bithigh, int bitlow, u16 value)
 {
 	return sds->ops->write(sds, page, regnum, bithigh, bitlow, value);
+}
+
+static int rtpcs_sds_write_mask(struct rtpcs_serdes *sds, enum rtpcs_page page, int regnum,
+				u16 mask, u16 value)
+{
+	return sds->ops->write_mask(sds, page, regnum, mask, value);
 }
 
 static int rtpcs_sds_read(struct rtpcs_serdes *sds, enum rtpcs_page page, int regnum)
@@ -1708,6 +1741,14 @@ static int rtpcs_930x_sds_op_write(struct rtpcs_serdes *sds, enum rtpcs_page pag
 	return __rtpcs_sds_write_raw(sds->ctrl, sds_id, page, regnum, bithigh, bitlow, value);
 }
 
+static int rtpcs_930x_sds_op_write_mask(struct rtpcs_serdes *sds, enum rtpcs_page page,
+					int regnum, u16 mask, u16 value)
+{
+	int sds_id = rtpcs_930x_sds_get_phys_sds_id(sds->id, page);
+
+	return __rtpcs_sds_write_mask(sds->ctrl, sds_id, page, regnum, mask, value);
+}
+
 /*
  * Realtek uses some nasty logic for digital parts of SerDes 2 and 3.
  *
@@ -1830,11 +1871,14 @@ static int rtpcs_930x_sds_wait_clock_ready(struct rtpcs_serdes *sds)
 
 static void rtpcs_930x_sds_set_power(struct rtpcs_serdes *sds, bool on)
 {
-	int power_down = on ? 0x0 : 0x3;
-	int rx_enable = on ? 0x3 : 0x1;
+	int power_down, rx_enable;
 
-	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x00, 7, 6, power_down);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x00, 5, 4, rx_enable);
+	power_down = on ? RTL93XX_FRC_PDOWN_UNFORCED : RTL93XX_FRC_PDOWN_DOWN;
+	rx_enable = on ? RTL93XX_FRC_RX_EN_ON : RTL93XX_FRC_RX_EN_OFF;
+
+	rtpcs_sds_write_mask(sds, PAGE_ANA_MISC, 0x00,
+			     RTL93XX_FRC_PDOWN_MASK | RTL93XX_FRC_RX_EN_MASK,
+			     power_down | rx_enable);
 }
 
 static int rtpcs_930x_sds_reconfigure_to_pll(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type pll)
@@ -3795,7 +3839,12 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 
 	/* SDK: media none behavior - baseline applied regardless of attachment */
 	rtpcs_931x_sds_10g_ana_pre(sds);
-	rtpcs_sds_write(sds, PAGE_ANA_MISC, 0x0, 0xcd1); /* from 930x: [7:6] POWER_DOWN OF ?? */
+
+	rtpcs_sds_write_mask(sds, PAGE_ANA_MISC, 0x0,
+			     RTL93XX_FRC_PDOWN_MASK | RTL93XX_FRC_RX_EN_MASK,
+			     RTL93XX_FRC_PDOWN_DOWN | RTL93XX_FRC_RX_EN_OFF);
+	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x0, 11, 10, 0x3); /* FRC_CMU_EN */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x0, 1, 0, 0x1);  /* FRC_V2ANALOG */
 
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xf, 5, 0, 0x4);
 	rtpcs_sds_write_bits(sds, PAGE_ANA_5G0, 0x12, 7, 6, 0x1);
@@ -3847,7 +3896,11 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 	if (is_10g)
 		rtpcs_931x_sds_10g_ana_post(sds);
 
-	rtpcs_sds_write(sds, PAGE_ANA_MISC, 0x0, 0xc30);			/* from 930x: [7:6] POWER_DOWN OF ?? */
+	rtpcs_sds_write_mask(sds, PAGE_ANA_MISC, 0x0,
+			     RTL93XX_FRC_PDOWN_MASK | RTL93XX_FRC_RX_EN_MASK,
+			     RTL93XX_FRC_PDOWN_UNFORCED | RTL93XX_FRC_RX_EN_ON);
+	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x0, 11, 10, 0x3); /* FRC_CMU_EN */
+	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x0, 1, 0, 0x0); /* FRC_V2ANALOG */
 	rtpcs_sds_write_bits(sds, PAGE_ANA_5G0, 0x12, 7, 6, 0x3);
 
 	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x0, 11, 10, 0x1);
@@ -4474,6 +4527,7 @@ static const struct phylink_pcs_ops rtpcs_838x_pcs_ops = {
 static const struct rtpcs_sds_ops rtpcs_838x_sds_ops = {
 	.read			= rtpcs_generic_sds_op_read,
 	.write			= rtpcs_generic_sds_op_write,
+	.write_mask		= rtpcs_generic_sds_op_write_mask,
 	.set_autoneg		= rtpcs_generic_sds_set_autoneg,
 	.restart_autoneg	= rtpcs_generic_sds_restart_autoneg,
 	.deactivate		= rtpcs_838x_sds_deactivate,
@@ -4509,6 +4563,7 @@ static const struct phylink_pcs_ops rtpcs_839x_pcs_ops = {
 static const struct rtpcs_sds_ops rtpcs_839x_sds_ops = {
 	.read			= rtpcs_generic_sds_op_read,
 	.write			= rtpcs_generic_sds_op_write,
+	.write_mask		= rtpcs_generic_sds_op_write_mask,
 	.set_autoneg		= rtpcs_generic_sds_set_autoneg,
 	.restart_autoneg	= rtpcs_generic_sds_restart_autoneg,
 	.deactivate		= rtpcs_839x_sds_deactivate,
@@ -4543,6 +4598,7 @@ static const struct phylink_pcs_ops rtpcs_930x_pcs_ops = {
 static const struct rtpcs_sds_ops rtpcs_930x_sds_ops = {
 	.read			= rtpcs_930x_sds_op_read,
 	.write			= rtpcs_930x_sds_op_write,
+	.write_mask		= rtpcs_930x_sds_op_write_mask,
 	.xsg_write		= rtpcs_930x_sds_op_xsg_write,
 	.set_autoneg		= rtpcs_93xx_sds_set_autoneg,
 	.restart_autoneg	= rtpcs_generic_sds_restart_autoneg,
@@ -4585,6 +4641,7 @@ static const struct phylink_pcs_ops rtpcs_931x_pcs_ops = {
 static const struct rtpcs_sds_ops rtpcs_931x_sds_ops = {
 	.read			= rtpcs_generic_sds_op_read,
 	.write			= rtpcs_generic_sds_op_write,
+	.write_mask		= rtpcs_generic_sds_op_write_mask,
 	.xsg_write		= rtpcs_931x_sds_op_xsg_write,
 	.set_autoneg		= rtpcs_93xx_sds_set_autoneg,
 	.restart_autoneg	= rtpcs_generic_sds_restart_autoneg,

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3847,9 +3847,7 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 	if (is_10g)
 		rtpcs_931x_sds_10g_ana_post(sds);
 
-	/* FIXME: is this redundant with the writes below? */
 	rtpcs_sds_write(sds, PAGE_ANA_MISC, 0x0, 0xc30);			/* from 930x: [7:6] POWER_DOWN OF ?? */
-	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x0, 9, 0, 0x30);
 	rtpcs_sds_write_bits(sds, PAGE_ANA_5G0, 0x12, 7, 6, 0x3);
 
 	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x0, 11, 10, 0x1);

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3409,6 +3409,12 @@ static int rtpcs_931x_sds_deactivate(struct rtpcs_serdes *sds)
 {
 	int ret;
 
+	ret = rtpcs_sds_write_mask(sds, PAGE_ANA_MISC, 0x0,
+				   RTL93XX_FRC_PDOWN_MASK | RTL93XX_FRC_RX_EN_MASK,
+				   RTL93XX_FRC_PDOWN_DOWN | RTL93XX_FRC_RX_EN_OFF);
+	if (ret)
+		return ret;
+
 	ret = rtpcs_931x_sds_power(sds, false);
 	if (ret)
 		return ret;
@@ -3418,6 +3424,14 @@ static int rtpcs_931x_sds_deactivate(struct rtpcs_serdes *sds)
 
 static int rtpcs_931x_sds_activate(struct rtpcs_serdes *sds)
 {
+	int ret;
+
+	ret = rtpcs_sds_write_mask(sds, PAGE_ANA_MISC, 0x0,
+				   RTL93XX_FRC_PDOWN_MASK | RTL93XX_FRC_RX_EN_MASK,
+				   RTL93XX_FRC_PDOWN_UNFORCED | RTL93XX_FRC_RX_EN_ON);
+	if (ret)
+		return ret;
+
 	return rtpcs_931x_sds_power(sds, true);
 }
 
@@ -3840,9 +3854,6 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 	/* SDK: media none behavior - baseline applied regardless of attachment */
 	rtpcs_931x_sds_10g_ana_pre(sds);
 
-	rtpcs_sds_write_mask(sds, PAGE_ANA_MISC, 0x0,
-			     RTL93XX_FRC_PDOWN_MASK | RTL93XX_FRC_RX_EN_MASK,
-			     RTL93XX_FRC_PDOWN_DOWN | RTL93XX_FRC_RX_EN_OFF);
 	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x0, 11, 10, 0x3); /* FRC_CMU_EN */
 	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x0, 1, 0, 0x1);  /* FRC_V2ANALOG */
 
@@ -3896,9 +3907,6 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 	if (is_10g)
 		rtpcs_931x_sds_10g_ana_post(sds);
 
-	rtpcs_sds_write_mask(sds, PAGE_ANA_MISC, 0x0,
-			     RTL93XX_FRC_PDOWN_MASK | RTL93XX_FRC_RX_EN_MASK,
-			     RTL93XX_FRC_PDOWN_UNFORCED | RTL93XX_FRC_RX_EN_ON);
 	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x0, 11, 10, 0x3); /* FRC_CMU_EN */
 	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x0, 1, 0, 0x0); /* FRC_V2ANALOG */
 	rtpcs_sds_write_bits(sds, PAGE_ANA_5G0, 0x12, 7, 6, 0x3);

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3424,7 +3424,6 @@ static void rtpcs_931x_sds_rxcal_leq_adapt(struct rtpcs_serdes *sds)
 
 	rtpcs_931x_sds_rxeq_leq_set_adapt(sds, false);
 	rtpcs_931x_sds_rx_reset(sds);
-	msleep(10);
 	rtpcs_931x_sds_rxeq_leq_set_adapt(sds, true);
 	msleep(100);
 

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3377,21 +3377,30 @@ static int rtpcs_931x_sds_activate(struct rtpcs_serdes *sds)
 	return rtpcs_931x_sds_power(sds, true);
 }
 
+static void rtpcs_931x_sds_10g_ana_pre(struct rtpcs_serdes *sds)
+{
+	rtpcs_sds_write(sds, PAGE_ANA_10G, 0x12, 0x2740);
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0, 15, 12, 0x0);
+	rtpcs_sds_write(sds, PAGE_ANA_10G_EXT, 0x2, 0x2010);
+}
+
+static void rtpcs_931x_sds_10g_ana_post(struct rtpcs_serdes *sds)
+{
+	rtpcs_sds_write(sds, PAGE_ANA_10G, 0x12, 0x27c0);
+	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0, 15, 12, 0xc);
+	rtpcs_sds_write(sds, PAGE_ANA_10G_EXT, 0x2, 0x6010);
+}
+
 static void rtpcs_931x_sds_rx_reset(struct rtpcs_serdes *sds)
 {
 	if (sds->type != RTPCS_SDS_TYPE_10G)
 		return;
 
-	rtpcs_sds_write(sds, PAGE_ANA_10G, 0x12, 0x2740);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0, 15, 12, 0x0);
-	rtpcs_sds_write(sds, PAGE_ANA_10G_EXT, 0x2, 0x2010);
+	rtpcs_931x_sds_10g_ana_pre(sds);
 	rtpcs_sds_write(sds, PAGE_ANA_MISC, 0x0, 0xc10);
 
-	rtpcs_sds_write(sds, PAGE_ANA_10G, 0x12, 0x27c0);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0, 15, 12, 0xc);
-	rtpcs_sds_write(sds, PAGE_ANA_10G_EXT, 0x2, 0x6010);
+	rtpcs_931x_sds_10g_ana_post(sds);
 	rtpcs_sds_write(sds, PAGE_ANA_MISC, 0x0, 0xc30);
-
 	msleep(50);
 }
 
@@ -3785,16 +3794,8 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 	if (hw_mode != RTPCS_SDS_MODE_XSGMII)
 		rtpcs_931x_sds_reset_leq_dfe(sds);
 
-	/*
-	 * SDK says: media none behavior
-	 *
-	 * - the first three calls are the same as in rx_reset
-	 * - the last one slightly differs in the value. Something is taken into power down
-	 *   while rx_reset doesn't do this.
-	 */
-	rtpcs_sds_write(sds, PAGE_ANA_10G, 0x12, 0x2740);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0, 15, 12, 0x0);
-	rtpcs_sds_write(sds, PAGE_ANA_10G_EXT, 0x2, 0x2010);
+	/* SDK: media none behavior - baseline applied regardless of attachment */
+	rtpcs_931x_sds_10g_ana_pre(sds);
 	rtpcs_sds_write(sds, PAGE_ANA_MISC, 0x0, 0xcd1); /* from 930x: [7:6] POWER_DOWN OF ?? */
 
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xf, 5, 0, 0x4);
@@ -3844,11 +3845,8 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 	/* LINKDW_SEL? (same semantics as 930x) */
 	rtpcs_sds_write_bits(sds, PAGE_TGR_PRO_0, 0xd, 6, 6, is_dac ? 0x0 : 0x1);
 
-	if (is_10g) {
-		rtpcs_sds_write(sds, PAGE_ANA_10G, 0x12, 0x27c0);
-		rtpcs_sds_write_bits(sds, PAGE_ANA_10G_EXT, 0x0, 15, 12, 0xc);
-		rtpcs_sds_write(sds, PAGE_ANA_10G_EXT, 0x2, 0x6010);
-	}
+	if (is_10g)
+		rtpcs_931x_sds_10g_ana_post(sds);
 
 	/* FIXME: is this redundant with the writes below? */
 	rtpcs_sds_write(sds, PAGE_ANA_MISC, 0x0, 0xc30);			/* from 930x: [7:6] POWER_DOWN OF ?? */

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -168,6 +168,12 @@ enum rtpcs_page {
 #define DIGI_1(page)	((page) + 0x40)
 #define DIGI_2(page)	((page) + 0x80)
 
+/* TGR_PRO_0, reg 0x0d */
+#define RTL93XX_LINKDW_SEL		BIT(6)
+#define RTL93XX_LINKDW_SEL_DAC		0x0
+#define RTL93XX_LINKDW_SEL_NON_DAC	BIT(6)
+
+/* ANA_MISC, reg 0x00 */
 #define RTL93XX_FRC_CMU_EN_MASK		GENMASK(11, 10)
 #define RTL93XX_FRC_CMU_EN_UNFORCED	FIELD_PREP(RTL93XX_FRC_CMU_EN_MASK, 0x0)
 #define RTL93XX_FRC_CMU_EN_FORCE_OFF	FIELD_PREP(RTL93XX_FRC_CMU_EN_MASK, 0x1)
@@ -178,6 +184,9 @@ enum rtpcs_page {
 #define RTL93XX_FRC_RX_EN_MASK		GENMASK(5, 4)
 #define RTL93XX_FRC_RX_EN_ON		FIELD_PREP(RTL93XX_FRC_RX_EN_MASK, 0x3)
 #define RTL93XX_FRC_RX_EN_OFF		FIELD_PREP(RTL93XX_FRC_RX_EN_MASK, 0x1)
+#define RTL93XX_FRC_V2ANALOG_MASK	GENMASK(1, 0)
+#define RTL93XX_FRC_V2ANALOG_UNFORCED	FIELD_PREP(RTL93XX_FRC_V2ANALOG_MASK, 0x0)
+#define RTL93XX_FRC_V2ANALOG_FORCE_OFF	FIELD_PREP(RTL93XX_FRC_V2ANALOG_MASK, 0x1)
 
 /* DIGI_1(WDIG), reg 0x01 */
 /*
@@ -3876,7 +3885,8 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 
 	rtpcs_sds_write_mask(sds, PAGE_ANA_MISC, 0x0, RTL93XX_FRC_CMU_EN_MASK,
 			     RTL93XX_FRC_CMU_EN_FORCE_ON);
-	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x0, 1, 0, 0x1);  /* FRC_V2ANALOG */
+	rtpcs_sds_write_mask(sds, PAGE_ANA_MISC, 0x0, RTL93XX_FRC_V2ANALOG_MASK,
+			     RTL93XX_FRC_V2ANALOG_FORCE_OFF);
 
 	rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xf, 5, 0, 0x4);
 	rtpcs_sds_write_bits(sds, PAGE_ANA_5G0, 0x12, 7, 6, 0x1);
@@ -3924,13 +3934,14 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 		break;
 	}
 
-	/* LINKDW_SEL? (same semantics as 930x) */
-	rtpcs_sds_write_bits(sds, PAGE_TGR_PRO_0, 0xd, 6, 6, is_dac ? 0x0 : 0x1);
+	rtpcs_sds_write_mask(sds, PAGE_TGR_PRO_0, 0xd, RTL93XX_LINKDW_SEL,
+			     is_dac ? RTL93XX_LINKDW_SEL_DAC : RTL93XX_LINKDW_SEL_NON_DAC);
 
 	if (is_10g)
 		rtpcs_931x_sds_10g_ana_post(sds);
 
-	rtpcs_sds_write_bits(sds, PAGE_ANA_MISC, 0x0, 1, 0, 0x0); /* FRC_V2ANALOG */
+	rtpcs_sds_write_mask(sds, PAGE_ANA_MISC, 0x0, RTL93XX_FRC_V2ANALOG_MASK,
+			     RTL93XX_FRC_V2ANALOG_UNFORCED);
 	rtpcs_sds_write_bits(sds, PAGE_ANA_5G0, 0x12, 7, 6, 0x3);
 
 	rtpcs_sds_write_mask(sds, PAGE_ANA_MISC, 0x0, RTL93XX_FRC_CMU_EN_MASK,

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3858,16 +3858,6 @@ static int rtpcs_931x_sds_config_tx(struct rtpcs_serdes *sds,
 					     tx_cfg->post_amp);
 }
 
-/**
- * rtpcs_931x_sds_config_rx - Configure static RX path parameters
- */
-static int rtpcs_931x_sds_config_rx(struct rtpcs_serdes *sds,
-				    enum rtpcs_sds_attachment attachment)
-{
-	/* TODO: Put all static RX configuration here */
-	return 0;
-}
-
 static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 					    enum rtpcs_sds_attachment attachment,
 					    enum rtpcs_sds_mode hw_mode)
@@ -3899,11 +3889,6 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 	if (ret < 0)
 		return ret;
 
-	/* config SerDes RX path (LEQ, DFE, etc.) */
-	ret = rtpcs_931x_sds_config_rx(sds, attachment);
-	if (ret < 0)
-		return ret;
-
 	is_dac = (attachment == RTPCS_SDS_ATTACH_DAC_SHORT ||
 		  attachment == RTPCS_SDS_ATTACH_DAC_LONG);
 	is_10g = (hw_mode == RTPCS_SDS_MODE_10GBASER ||
@@ -3919,17 +3904,17 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 	switch (attachment) {
 	case RTPCS_SDS_ATTACH_DAC_SHORT:
 	case RTPCS_SDS_ATTACH_DAC_LONG:
-		rtpcs_sds_write(sds, PAGE_ANA_COM, 0x19, 0xf0a5);	/* from XS1930-10 SDK */
-		rtpcs_sds_write(even_sds, PAGE_ANA_10G, 0x8, 0x02a0); /* [10:7] impedance */
+		rtpcs_sds_write(sds, PAGE_ANA_COM, 0x19, 0xf0a5);
+		rtpcs_sds_write(even_sds, PAGE_ANA_10G, 0x8, 0x02a0); /* [10:7] TX impedance */
 		break;
 
 	case RTPCS_SDS_ATTACH_FIBER:
 		if (is_10g)
-			rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xf, 5, 0, 0x2); /* from DMS1250 SDK */
+			rtpcs_sds_write_bits(sds, PAGE_ANA_10G, 0xf, 5, 0, 0x2);
 
 		fallthrough;
 	default:
-		rtpcs_sds_write(sds, PAGE_ANA_COM, 0x19, 0xf0f0); /* from XS1930 SDK */
+		rtpcs_sds_write(sds, PAGE_ANA_COM, 0x19, 0xf0f0);
 		rtpcs_sds_write(even_sds, PAGE_ANA_10G, 0x8, 0x0294); /* [10:7] TX impedance */
 		break;
 	}
@@ -3950,10 +3935,8 @@ static int rtpcs_931x_sds_config_attachment(struct rtpcs_serdes *sds,
 			     RTL93XX_FRC_CMU_EN_FORCE_ON);
 
 	/* clear pending SerDes RX idle interrupt flag */
-	regmap_write_bits(sds->ctrl->map, RTPCS_931X_ISR_SERDES_RXIDLE,
-			  BIT(sds->id - 2), BIT(sds->id - 2));
-
-	return 0;
+	return regmap_write_bits(sds->ctrl->map, RTPCS_931X_ISR_SERDES_RXIDLE,
+				 BIT(sds->id - 2), BIT(sds->id - 2));
 }
 
 /*


### PR DESCRIPTION
Another series with several improvements to the PCS driver, covering:
- some cleanups to improve readability or drop redundancies
- slight functional changes regarding the power lifecycling during SerDes configuration
- a new mask-based write helper intended to assist in giving several register writes real meaning