### PR TITLE
images: ubifs: add zstd compression support

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -203,7 +203,7 @@ menu "Target Images"
 
 		choice
 			prompt "compression"
-			default TARGET_UBIFS_COMPRESSION_ZLIB
+			default TARGET_UBIFS_COMPRESSION_ZSTD
 			depends on TARGET_ROOTFS_UBIFS
 			help
 			  Select compression type
@@ -216,6 +216,9 @@ menu "Target Images"
 
 			config TARGET_UBIFS_COMPRESSION_ZLIB
 				bool "zlib"
+
+			config TARGET_UBIFS_COMPRESSION_ZSTD
+				bool "zstd"
 		endchoice
 
 		config TARGET_UBIFS_FREE_SPACE_FIXUP

--- a/include/image.mk
+++ b/include/image.mk
@@ -313,6 +313,7 @@ define Image/mkfs/ubifs
 		$(if $(CONFIG_TARGET_UBIFS_COMPRESSION_NONE),--compr=none) \
 		$(if $(CONFIG_TARGET_UBIFS_COMPRESSION_LZO),--compr=lzo) \
 		$(if $(CONFIG_TARGET_UBIFS_COMPRESSION_ZLIB),--compr=zlib) \
+		$(if $(CONFIG_TARGET_UBIFS_COMPRESSION_ZSTD),--compr=zstd) \
 		$(if $(shell echo $(CONFIG_TARGET_UBIFS_JOURNAL_SIZE)),--jrn-size=$(CONFIG_TARGET_UBIFS_JOURNAL_SIZE)) \
 		--squash-uids \
 		-o $@ -d $(call mkfs_target_dir,$(1))

--- a/tools/mtd-utils/Makefile
+++ b/tools/mtd-utils/Makefile
@@ -33,7 +33,7 @@ HOST_CONFIGURE_ARGS+= \
 	--without-tests \
 	--without-crypto \
 	--without-xattr \
-	--without-zstd \
+	--with-zstd \
 	--without-lzo \
 	--with-lzma
 


### PR DESCRIPTION
zstd results in smaller UBIFS volumes.