### PR TITLE
busybox: sysntpd: restart on ifup until first sync

### DIFF
--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=busybox
 PKG_VERSION:=1.38.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_FLAGS:=essential
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
@@ -166,6 +166,9 @@ ifneq ($(CONFIG_BUSYBOX_$(BUSYBOX_SYM)_NTPD),)
 	$(INSTALL_DIR) $(1)/etc/capabilities $(1)/usr/share/acl.d
 	$(INSTALL_DATA) ./files/ntpd.capabilities $(1)/etc/capabilities/ntpd.json
 	$(INSTALL_DATA) ./files/ntpd_acl.json $(1)/usr/share/acl.d/ntpd.json
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface $(1)/etc/hotplug.d/ntp
+	$(INSTALL_DATA) ./files/ntpd.iface-hotplug $(1)/etc/hotplug.d/iface/20-ntpd
+	$(INSTALL_DATA) ./files/ntpd.ntp-hotplug $(1)/etc/hotplug.d/ntp/10-ntpd-sync-state
 endif
 	-rm -rf $(1)/lib64
 endef

--- a/package/utils/busybox/files/ntpd.iface-hotplug
+++ b/package/utils/busybox/files/ntpd.iface-hotplug
@@ -1,0 +1,6 @@
+[ "$ACTION" = ifup ] || exit 0
+[ "$INTERFACE" = loopback ] && exit 0
+[ -f /var/state/ntpd-synced ] && exit 0
+/etc/init.d/sysntpd enabled || exit 0
+/etc/init.d/sysntpd running || exit 0
+/etc/init.d/sysntpd restart >/dev/null 2>&1 &

--- a/package/utils/busybox/files/ntpd.ntp-hotplug
+++ b/package/utils/busybox/files/ntpd.ntp-hotplug
@@ -1,0 +1,5 @@
+case "$ACTION" in
+	step|stratum)
+		touch /var/state/ntpd-synced
+	;;
+esac


### PR DESCRIPTION
busybox ntpd retries failed server hostname lookups with a backoff that saturates at 252 seconds, so an instance started before WAN connectivity exists can take minutes to notice that its servers became resolvable. The existing procd interface trigger does deliver the ifup event, but it only performs a reload, which procd treats as a no-op service set unless the computed command line changed; that only happens when the DHCP lease actually delivered option 42 NTP servers. With a lease not carrying option 42, or a statically configured interface providing the default route, the command line stays byte-identical and the running ntpd is left untouched. Devices without an RTC therefore keep a wildly wrong clock for minutes after connectivity arrives, which also stalls protocols requiring monotonic wall time across reboots, such as WireGuard handshakes.

This adds an iface hotplug script restarting sysntpd on ifup while the clock has not been synchronised yet, no matter which interface provides connectivity, and records the first synchronisation through the hotplug.d/ntp mechanism, following the dnsmasq 25-dnsmasqsec precedent. Once synchronised, ntpd recovers on its own and is left untouched on routine interface events.

An unconditional restart trigger was considered and rejected: it would bounce ntpd on every interface update, including DHCP renews and route changes, discarding its clock discipline state each time.

An equivalent hotplug script pair has been in production on RTC-less lantiq/xrx200 CPEs behind WiFi uplinks, and the exact scripts from this PR were verified end-to-end on a 25.12.5 device: ifup while unsynchronised restarts ntpd, the first synchronisation records the marker through the jailed ntpd → ubus (ACL-gated) → procd hotplug.ntp path, and subsequent ifup events leave the synchronised instance untouched.
