### PR TITLE
ramips: mt7620: fix direct call failures

### DIFF
--- a/target/linux/ramips/patches-6.18/333-mt7620-use-long-calls.patch
+++ b/target/linux/ramips/patches-6.18/333-mt7620-use-long-calls.patch
@@ -1,0 +1,60 @@
+From: Gleb Pesin <dormancygrace@gmail.com>
+Date: Wed, 29 Jul 2026 21:00:00 +0000
+Subject: [PATCH] mt7620: use long calls in affected objects
+
+MT7620 can sporadically execute direct J-type calls with an incorrect high
+address nibble.  Linux 6.18 code generation and layout exposed failures in
+the entropy bootstrap, SPI core and IPv6 UDP code.
+
+Build only the objects containing the observed failure functions with long
+calls.  Applying -mlong-calls to the whole kernel was tested on MT7620N
+hardware and prevents PDMA from processing its first transmit descriptor.
+The targeted workaround boots and passes sustained bidirectional traffic
+while retaining the known-good frame-engine code generation.
+
+Signed-off-by: Gleb Pesin <dormancygrace@gmail.com>
+---
+ drivers/char/Makefile | 4 ++++
+ drivers/spi/Makefile  | 4 ++++
+ net/ipv6/Makefile     | 4 ++++
+ 3 files changed, 12 insertions(+)
+
+--- a/drivers/char/Makefile
++++ b/drivers/char/Makefile
+@@ -3,6 +3,10 @@
+ # Makefile for the kernel character device drivers.
+ #
+ 
++ifdef CONFIG_NET_RALINK_MT7620
++CFLAGS_random.o			+= -mlong-calls
++endif
++
+ obj-y				+= mem.o random.o
+ obj-$(CONFIG_TTY_PRINTK)	+= ttyprintk.o
+ obj-y				+= misc.o
+--- a/drivers/spi/Makefile
++++ b/drivers/spi/Makefile
+@@ -5,6 +5,10 @@
+ 
+ ccflags-$(CONFIG_SPI_DEBUG) := -DDEBUG
+ 
++ifdef CONFIG_NET_RALINK_MT7620
++CFLAGS_spi.o				+= -mlong-calls
++endif
++
+ # small core, mostly translating board-specific
+ # config declarations into driver model code
+ obj-$(CONFIG_SPI_MASTER)		+= spi.o
+--- a/net/ipv6/Makefile
++++ b/net/ipv6/Makefile
+@@ -5,6 +5,10 @@
+ 
+ obj-$(CONFIG_IPV6) += ipv6.o
+ 
++ifdef CONFIG_NET_RALINK_MT7620
++CFLAGS_udp.o += -mlong-calls
++endif
++
+ ipv6-y :=	af_inet6.o anycast.o ip6_output.o ip6_input.o addrconf.o \
+ 		addrlabel.o \
+ 		route.o ip6_fib.o ipv6_sockglue.o ndisc.o udp.o udplite.o \

--- a/target/linux/ramips/patches-6.18/821-SPI-ralink-add-Ralink-SoC-spi-driver.patch
+++ b/target/linux/ramips/patches-6.18/821-SPI-ralink-add-Ralink-SoC-spi-driver.patch
@@ -29,7 +29,7 @@ Acked-by: John Crispin <blogic@openwrt.org>
  	depends on (PLAT_SAMSUNG || ARCH_S5PV210 || ARCH_EXYNOS || COMPILE_TEST)
 --- a/drivers/spi/Makefile
 +++ b/drivers/spi/Makefile
-@@ -128,6 +128,7 @@ obj-$(CONFIG_MACH_REALTEK_RTL)		+= spi-r
+@@ -132,6 +132,7 @@ obj-$(CONFIG_MACH_REALTEK_RTL)		+= spi-r
  obj-$(CONFIG_SPI_REALTEK_SNAND)		+= spi-realtek-rtl-snand.o
  obj-$(CONFIG_SPI_RPCIF)			+= spi-rpc-if.o
  obj-$(CONFIG_SPI_RSPI)			+= spi-rspi.o


### PR DESCRIPTION
## Summary

Fix three MT7620 direct-call failures observed after moving the target to Linux 6.18:

- the entropy bootstrap can issue a direct `jal` to `mix_pool_bytes()` with the wrong high address nibble and crash during early boot;
- calls involving `spi_finalize_current_message()` and `udp6_ehashfn()` can fail for the same reason later in boot or under network activity.

Compile only `random.o`, the SPI core `spi.o`, and the IPv6 `udp.o` with `-mlong-calls` on MT7620.  This covers every direct call in the affected objects without carrying target-specific function-pointer indirection in generic random code.

Applying `-mlong-calls` globally is deliberately avoided: on tested MT7620N hardware it changes frame-engine code generation enough to leave PDMA stuck on the first TX descriptor.

## Build and static verification

- clean `target/linux/compile` completed for ramips/mt7620 with Linux 6.18.44 and GCC 14.4;
- the final `random.o`, `spi.o`, and IPv6 `udp.o` were inspected with `readelf -rW` and `objdump -dr`;
- calls targeting `mix_pool_bytes`, `spi_finalize_current_message`, and external calls to `udp6_ehashfn` use full-address `HI16`/`LO16` relocations followed by `jalr`; none uses a direct `R_MIPS_26` relocation to the target function.

## Hardware testing

The same object-level fix was built for Linux 6.12.94 with GCC 16.2 and tested on a D-Link DWR-921 C3 (MT7620N rev 2 eco 6, 64 MiB RAM).

The candidate Zstd kernel was first loaded through U-Boot TFTP and booted from RAM without writing flash.  It reached userspace and passed concurrent stress consisting of:

- 64 MiB read from `/dev/urandom`;
- eight complete, hash-verified reads of every SPI MTD partition;
- four parallel IPv6 UDP streams for 20 seconds: 156,081 datagrams and 38.1 MiB with zero loss.

The kernel log contained no panic, Oops, reserved instruction, call trace, page fault, or unaligned-access report.  The same image was then written to flash; its readable kernel partition matches the candidate byte-for-byte and the normal flash boot completed with Ethernet, DSA, PPE, SPI, IPv6, and CRNG initialization intact.

Related: #20553  
Extracted from: #24493
