### PR TITLE
[24.10] kernel: xhci: fix USB3 port events with a single roothub

### DIFF
--- a/target/linux/generic/backport-6.6/891-v7.3-usb-xhci-handle-port-events-when-there-is-one-roothub.patch
+++ b/target/linux/generic/backport-6.6/891-v7.3-usb-xhci-handle-port-events-when-there-is-one-roothub.patch
@@ -1,6 +1,6 @@
-From eb8cfe27aef67b30299aaf2a1ac538cf905135f2 Mon Sep 17 00:00:00 2001
+From 3e91ec3e7d80a327fb558207613c80415d3bf756 Mon Sep 17 00:00:00 2001
 From: Semih Baskan <strst.gs@gmail.com>
-Date: Mon, 3 Aug 2026 07:08:11 +0300
+Date: Thu, 6 Aug 2026 17:21:12 +0300
 Subject: [PATCH] usb: xhci: Handle USB3 port events when there is one roothub
 
 handle_port_status() drops every USB3 port event when xhci->shared_hcd is
@@ -12,9 +12,11 @@ either root hub has no ports") that is no longer true. A controller whose
 USB2 root hub has no ports gets a single roothub, the USB3 rhub is served
 by the main hcd, and shared_hcd stays NULL for the lifetime of the device.
 Every SuperSpeed port event is then thrown away as bogus behind a debug
-message, so devices never enumerate even though the port reports them:
+message, so devices never enumerate even though the port sees the device
+and its change bits stay set:
 
   0x006a1203 Powered Connected Enabled Link:U0 PortSpeed:4
+  Change: CSC WRC PRC PLC
 
 Broadcom Northstar is such a controller. USB3 works there up to 5.15 and
 stops working from 5.19 onwards.
@@ -23,9 +25,21 @@ Ask xhci_get_usb3_hcd() instead. It returns the shared hcd when there is
 one, the main hcd when the USB2 root hub has no ports, and NULL once the
 shared hcd is gone, which keeps the original meaning of the check.
 
+Tested on an Asus RT-N18U (BCM47081), which has a single roothub. Before
+the change nothing enumerates on the USB3 port; after it SuperSpeed
+devices enumerate normally over repeated connect and disconnect cycles,
+the change bits shown above clear, and USB2 is unaffected on both ports.
+
 Fixes: 4736ebd7fcaf ("usb: host: xhci-plat: omit shared hcd if either root hub has no ports")
+Cc: stable@vger.kernel.org
 Signed-off-by: Semih Baskan <strst.gs@gmail.com>
+Signed-off-by: Mathias Nyman <mathias.nyman@linux.intel.com>
+Link: https://patch.msgid.link/20260806142113.2436238-17-mathias.nyman@linux.intel.com
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
 ---
+ drivers/usb/host/xhci-ring.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 --- a/drivers/usb/host/xhci-ring.c
 +++ b/drivers/usb/host/xhci-ring.c
 @@ -2010,7 +2010,7 @@ static void handle_port_status(struct xh

--- a/target/linux/generic/pending-6.6/891-usb-xhci-handle-port-events-when-there-is-one-roothub.patch
+++ b/target/linux/generic/pending-6.6/891-usb-xhci-handle-port-events-when-there-is-one-roothub.patch
@@ -1,0 +1,39 @@
+From eb8cfe27aef67b30299aaf2a1ac538cf905135f2 Mon Sep 17 00:00:00 2001
+From: Semih Baskan <strst.gs@gmail.com>
+Date: Mon, 3 Aug 2026 07:08:11 +0300
+Subject: [PATCH] usb: xhci: Handle USB3 port events when there is one roothub
+
+handle_port_status() drops every USB3 port event when xhci->shared_hcd is
+NULL. The check dates from a time when xhci-plat always created a shared
+hcd, so a NULL one could only mean the hcd had been removed.
+
+Since commit 4736ebd7fcaf ("usb: host: xhci-plat: omit shared hcd if
+either root hub has no ports") that is no longer true. A controller whose
+USB2 root hub has no ports gets a single roothub, the USB3 rhub is served
+by the main hcd, and shared_hcd stays NULL for the lifetime of the device.
+Every SuperSpeed port event is then thrown away as bogus behind a debug
+message, so devices never enumerate even though the port reports them:
+
+  0x006a1203 Powered Connected Enabled Link:U0 PortSpeed:4
+
+Broadcom Northstar is such a controller. USB3 works there up to 5.15 and
+stops working from 5.19 onwards.
+
+Ask xhci_get_usb3_hcd() instead. It returns the shared hcd when there is
+one, the main hcd when the USB2 root hub has no ports, and NULL once the
+shared hcd is gone, which keeps the original meaning of the check.
+
+Fixes: 4736ebd7fcaf ("usb: host: xhci-plat: omit shared hcd if either root hub has no ports")
+Signed-off-by: Semih Baskan <strst.gs@gmail.com>
+---
+--- a/drivers/usb/host/xhci-ring.c
++++ b/drivers/usb/host/xhci-ring.c
+@@ -2010,7 +2010,7 @@ static void handle_port_status(struct xh
+ 	}
+ 
+ 	/* We might get interrupts after shared_hcd is removed */
+-	if (port->rhub == &xhci->usb3_rhub && xhci->shared_hcd == NULL) {
++	if (port->rhub == &xhci->usb3_rhub && xhci_get_usb3_hcd(xhci) == NULL) {
+ 		xhci_dbg(xhci, "ignore port event for removed USB3 hcd\n");
+ 		bogus_port_status = true;
+ 		goto cleanup;


### PR DESCRIPTION
USB3 port events are dropped whenever the controller has only one roothub. The check that guards them treats a missing shared hcd as proof the hcd was removed, which stopped being true with upstream commit 4736ebd7fcaf ("usb: host: xhci-plat: omit shared hcd if either root hub has no ports"). A controller whose USB2 root hub has no ports gets a single roothub and never has a shared one, so every SuperSpeed event is thrown away and nothing enumerates even though the port reports the device:

  0x006a1203 Powered Connected Enabled Link:U0 PortSpeed:4

Broadcom Northstar is such a controller. USB3 works there up to 5.15 and stops from 5.19 onwards.

Tested on an Asus RT-N18U with kernel 6.18, seven SuperSpeed enumerations, USB2 unaffected on both ports.

Link: https://github.com/openwrt/openwrt/issues/19592
Link: https://github.com/openwrt/openwrt/pull/24547
(cherry picked from commit f6bc2a3b294b3d6b298cf5a625e9923459d64edd)
