### PR TITLE
generic: make the threaded NAPI poll loop yield on every exit

### DIFF
--- a/target/linux/generic/pending-6.18/684-net-yield-on-both-exits-of-threaded-NAPI-poll-loop.patch
+++ b/target/linux/generic/pending-6.18/684-net-yield-on-both-exits-of-threaded-NAPI-poll-loop.patch
@@ -1,0 +1,74 @@
+From 72bc090b453fbc425a2f107eb22b24947fa56042 Mon Sep 17 00:00:00 2001
+From: Vitaliy Sochnev <sochnev.v.74@gmail.com>
+Date: Fri, 14 Aug 2026 23:04:27 +0100
+Subject: [PATCH] net: yield the CPU on every exit of the threaded NAPI poll loop
+
+napi_threaded_poll_loop() only reaches cond_resched() when it is about to
+iterate again. When __napi_poll() clears repoll the loop breaks first, so
+the last iteration returns without any voluntary preemption point.
+
+Control then goes back to napi_threaded_poll(), which calls
+napi_thread_wait(). If work is already pending that helper returns without
+ever calling schedule(). Under a receive load that keeps arriving at least
+as fast as it is drained, this repeats indefinitely and the kthread holds
+its CPU without a single reschedule. On CONFIG_PREEMPT_NONE - which every
+affected OpenWrt target uses - nothing else on that CPU gets to run.
+
+Everything that waits for deferred work on that CPU then blocks: RCU grace
+periods, per-CPU work items and RCU callbacks. Deleting a network device
+hits all three - synchronize_net(), flush_all_backlogs() -> flush_work()
+and rcu_barrier() from netdev_run_todo(). In practice this shows up as
+"ip link" and network reconfiguration hanging for tens of seconds while
+the board forwards or terminates traffic at line rate.
+
+rcu_softirq_qs_periodic() does not help here. It reports a quiescent state
+but does not schedule, so the work items and the callbacks still wait, and
+it is skipped on the exit path anyway.
+
+Measured on a Nokia XG-040G-MF (Airoha AN7583) terminating a 985 Mbit/s
+TCP receive load, 60 minute runs, timing "ip link del":
+
+                    before        after
+  mean               1.22 s       0.10 s
+  worst             60.32 s       0.19 s
+  over 1 s        7 of 172      0 of 179
+  RCU stalls             2            0
+  packet rate   82094 p/s    82073 p/s
+
+The packet rate is the control: the same work is done in both runs. A
+separate pair of 60 minute runs on an AN7581 board took the worst case
+from 241.55 s to 0.41 s.
+
+Reproducing it needs the loop to be re-entered tens of thousands of times
+a second, so it depends on the driver and on the shape of the load. It
+did not reproduce on mtk_eth_soc, whose net_dim moderation coalesces the
+same packet rate into far fewer interrupts.
+
+This is against the 6.18 code, where the loop breaks before reaching
+rcu_softirq_qs_periodic() and cond_resched(). Upstream has since gained a
+busy-poll parameter and reordered the tail, so the version sent to netdev
+looks different while making the same change - the yield happens on both
+exits instead of only on the iterating one. That version was run on the
+same board for an hour against the same baseline and came out equally
+clean (worst 0.16 s). Drop this patch once it lands in net.
+
+Link: https://lore.kernel.org/netdev/20260814220427.623427-1-sochnev.v.74@gmail.com/
+Fixes: 29863d41bb6e ("net: implement threaded-able napi poll loop support")
+Signed-off-by: Vitaliy Sochnev <sochnev.v.74@gmail.com>
+
+--- a/net/core/dev.c
++++ b/net/core/dev.c
+@@ -7775,11 +7775,12 @@ static void napi_threaded_poll_loop(stru
+ 		bpf_net_ctx_clear(bpf_net_ctx);
+ 		local_bh_enable();
+ 
++		cond_resched();
++
+ 		if (!repoll)
+ 			break;
+ 
+ 		rcu_softirq_qs_periodic(last_qs);
+-		cond_resched();
+ 	}
+ }
+ 

--- a/target/linux/generic/pending-6.18/684-net-yield-on-both-exits-of-threaded-NAPI-poll-loop.patch
+++ b/target/linux/generic/pending-6.18/684-net-yield-on-both-exits-of-threaded-NAPI-poll-loop.patch
@@ -1,0 +1,75 @@
+From 72bc090b453fbc425a2f107eb22b24947fa56042 Mon Sep 17 00:00:00 2001
+From: Vitaliy Sochnev <sochnev.v.74@gmail.com>
+Date: Fri, 14 Aug 2026 23:04:27 +0100
+Subject: [PATCH] net: yield the CPU on every exit of the threaded NAPI poll loop
+
+napi_threaded_poll_loop() only reaches cond_resched() when it is about to
+iterate again. When __napi_poll() clears repoll the loop breaks first, so
+the last iteration returns without any voluntary preemption point.
+
+Control then goes back to napi_threaded_poll(), which calls
+napi_thread_wait(). If work is already pending that helper returns without
+ever calling schedule(). Under a receive load that keeps arriving at least
+as fast as it is drained, this repeats indefinitely and the kthread holds
+its CPU without a single reschedule. On CONFIG_PREEMPT_NONE - which every
+affected OpenWrt target uses - nothing else on that CPU gets to run.
+
+Everything that waits for deferred work on that CPU then blocks: RCU grace
+periods, per-CPU work items and RCU callbacks. Deleting a network device
+hits all three - synchronize_net(), flush_all_backlogs() -> flush_work()
+and rcu_barrier() from netdev_run_todo(). In practice this shows up as
+"ip link" and network reconfiguration hanging for tens of seconds while
+the board forwards or terminates traffic at line rate.
+
+rcu_softirq_qs_periodic() does not help here. It reports a quiescent state
+but does not schedule, so the work items and the callbacks still wait, and
+it is skipped on the exit path anyway.
+
+Measured on a Nokia XG-040G-MF (Airoha AN7583) terminating a 985 Mbit/s
+TCP receive load, 60 minute runs, timing "ip link del":
+
+                    before        after
+  mean               1.22 s       0.10 s
+  worst             60.32 s       0.19 s
+  over 1 s        7 of 172      0 of 179
+  RCU stalls             2            0
+  packet rate   82094 p/s    82073 p/s
+
+The packet rate is the control: the same work is done in both runs. A
+separate pair of 60 minute runs on an AN7581 board took the worst case
+from 241.55 s to 0.41 s.
+
+Reproducing it needs the loop to be re-entered tens of thousands of times
+a second, so it depends on the driver and on the shape of the load. It
+did not reproduce on mtk_eth_soc, whose net_dim moderation coalesces the
+same packet rate into far fewer interrupts.
+
+This is against the 6.18 code, where the loop breaks before reaching
+rcu_softirq_qs_periodic() and cond_resched(). Upstream has since gained a
+busy-poll parameter and reordered the tail, so the version sent to netdev
+looks different while making the same change - the yield happens on both
+exits instead of only on the iterating one. That version was run on the
+same board for an hour against the same baseline and came out equally
+clean (worst 0.16 s), but was not applied. Revisit this patch at the next
+kernel bump rather than waiting for it to land in net.
+
+Link: https://lore.kernel.org/netdev/20260902210053.263070-1-sochnev.v.74@gmail.com/
+Fixes: 29863d41bb6e ("net: implement threaded-able napi poll loop support")
+Signed-off-by: Vitaliy Sochnev <sochnev.v.74@gmail.com>
+
+--- a/net/core/dev.c
++++ b/net/core/dev.c
+@@ -7775,11 +7775,12 @@ static void napi_threaded_poll_loop(stru
+ 		bpf_net_ctx_clear(bpf_net_ctx);
+ 		local_bh_enable();
+ 
++		cond_resched();
++
+ 		if (!repoll)
+ 			break;
+ 
+ 		rcu_softirq_qs_periodic(last_qs);
+-		cond_resched();
+ 	}
+ }
+ 


### PR DESCRIPTION
On boards whose driver runs NAPI in a kernel thread, the poll loop can hold a CPU without ever yielding it. Everything that waits for deferred work on that CPU then blocks — in practice `ip link` and network reconfiguration hang for tens of seconds while the board is passing traffic at line rate.

`napi_threaded_poll_loop()` reaches `cond_resched()` only on the path where `repoll` is true. When the poll drains the queue within its budget the loop breaks first, `napi_thread_wait()` returns without scheduling because work has already been queued again, and the loop is re-entered. Under `CONFIG_PREEMPT_NONE` — which every affected target uses — that path has no preemption point at all.

Three different waits were seen blocking on it, all from `ip link del`:

| wait | why it blocks |
| :-- | :-- |
| `synchronize_net()` | the grace period never completes |
| `flush_all_backlogs()` -> `flush_work()` | the per-CPU worker never runs |
| `netdev_run_todo()` -> `rcu_barrier()` | callbacks never execute |

Which one appears varies by board. They share one cause, so the single `cond_resched()` move covers all three.

## Measurements

Nokia XG-040G-MF, 60 minutes of terminating `iperf3` into a DSA switch port, timing `ip link del` in a loop:

| | without | with |
| :-- | --: | --: |
| mean | 1.22 s | **0.10 s** |
| worst | **60.32 s** | **0.19 s** |
| over 1 s | 7 of 172 | **0 of 179** |
| RCU stalls | 2 | **0** |
| receive | 985 Mbit/s | 985 Mbit/s |
| packet rate | 82 094 p/s | 82 073 p/s |

The packet rate is the control: the same work is done in both runs, so this is not a lighter load. Every A/B pair recorded so far agrees — on XG-040G-MF from other testers (62.70 s -> 0.22 s and 64.90 s -> 0.25 s), here, and on XG-040G-MD where the worst case went from 241.55 s to 0.41 s.

Both halves of every pair come from one build session and record the hash of every kernel patch in the tree with and without the one under test, so each pair is verifiably one patch apart.

Without the patch the kernel names the thread itself. This run is on a build with the out-of-tree GPIO button module removed, so nothing taints it:

```
rcu: INFO: rcu_sched self-detected stall on CPU
rcu:  0-....: (5999 ticks this GP) ... (t=6000 jiffies g=913 q=1218 ncpus=4)
CPU: 0 UID: 0 PID: 203 Comm: napi/qdma_eth-0 Not tainted 6.18.44 #0
Hardware name: Nokia XG-040G-MD (UBI) (DT)
pc : __dma_sync_single_for_device+0x8/0xfc
```

That board has four cores. Three of them sat around 65% idle throughout while `ip link del` blocked for 151.92 s, because the deferred work it waits for is tied to the CPU the poll loop holds — spare CPUs do not help.

## Scope

This is narrower than "any threaded NAPI driver", and worth stating plainly:

* `airoha_eth` has no interrupt moderation and re-enters the loop over 12 000 times a second — it triggers reliably.
* `mtk_eth_soc` moderates through `net_dim` and stayed clean for an hour on MT7621 at the same packet rate, so MediaTek boards are not affected in practice.
* The load shape matters as well. The same board stays clean when the queue drains completely on each poll, and when packets arrive in batches large enough that the thread sleeps between them. On the MF the defect appears at roughly 4–7 packets per poll; four `iperf3` streams land inside that band, sixteen do not.

## Preemption models

`cond_resched()` only does anything where the kernel is not preemptible, so the model decides whether this patch matters at all. Since kernel **7.0** upstream has gated the non-preempting models:

```
kernel/Kconfig.preempt
  config PREEMPT_NONE       depends on ARCH_NO_PREEMPT
  config PREEMPT_VOLUNTARY  depends on !ARCH_HAS_PREEMPT_LAZY

kernel/sched/core.c, sched_dynamic_mode()
  "none" and "voluntary" are compiled out under !(PREEMPT_RT || ARCH_HAS_PREEMPT_LAZY)
```

`ARCH_NO_PREEMPT` is selected by m68k, hexagon and alpha; `ARCH_HAS_PREEMPT_LAZY` by x86, arm64, powerpc, s390, riscv and loongarch. On those six there is no way to build, boot or switch into a model where `cond_resched()` is live — `preempt=none` is rejected at boot and at runtime. What keeps `PREEMPT_VOLUNTARY` is arc, arm, csky, microblaze, mips, nios2, openrisc, parisc, sh, sparc and xtensa.

None of that applies to this PR as it stands: 6.18 has no such gating, and `KERNEL_PREEMPT_NONE` is OpenWrt's default on every target.

It matters at the next bump, so the same A/B was run under `PREEMPT_VOLUNTARY` as well — the model the affected architectures keep on 7.x. Same board, untainted, 30 minutes per half:

| | baseline | patched |
| :-- | --: | --: |
| mean `ip link del` | 13.38 s | **0.19 s** |
| worst | **135.95 s** | **0.51 s** |
| over 1 s | 10 of 55 | **0 of 89** |
| RCU stalls | 32 | **0** |
| packet rate | 80 312 p/s | 81 532 p/s |

So the defect is not specific to `PREEMPT_NONE`, and on targets without `PREEMPT_LAZY` no preemption model avoids it short of full `PREEMPT`.

Worth flagging separately, unrelated to this patch: on 7.x [`default KERNEL_PREEMPT_NONE`](https://github.com/openwrt/openwrt/blob/aa66786f38505c80daaec59ed922d420261467fe/config/Config-kernel.in#L1656-L1658) stops being selectable for every target except m68k/hexagon/alpha. kconfig will settle on `PREEMPT_LAZY` for arm64 and x86, and on `PREEMPT_VOLUNTARY` for mips and arm.

## Upstream

Sent to netdev as a fix to `net/core/dev.c`, with `Fixes: 29863d41bb6e ("net: implement threaded-able napi poll loop support")`. **It was not applied**, and the maintainer asked for no further versions — `cond_resched()` is a nop on the architectures netdev cares about, so there is nothing there for the change to fix.

The version sent there is shaped differently, because the loop has since gained a busy-poll parameter and the tail was reordered around it. Both forms make the same change — yield on both exits instead of only on the iterating one — and both were run on this board for an hour against the same baseline:

| | baseline | this patch | upstream form |
| :-- | --: | --: | --: |
| worst `del` | 60.32 s | 0.19 s | 0.16 s |
| over 1 s | 7 of 172 | 0 of 179 | 0 of 179 |
| RCU stalls | 2 | 0 | 0 |
| packet rate | 82 094 p/s | 82 073 p/s | 82 027 p/s |

The form kept here is the one with the hardware behind it — every A/B pair above used it.

This patch is `pending-6.18`. It should not be dropped waiting for an upstream landing that will not come; the point to revisit it is the next kernel bump, where arm64 and x86 targets settle on `PREEMPT_LAZY` and no longer need it, while mips and arm settle on `PREEMPT_VOLUNTARY` and still do. Neither form applies to a kernel that already carries the reordered loop, so the bump is where it has to be re-made or removed anyway.