### PR TITLE
[25.12] mediatek: filogic: comfast cf-wr632ax: fix nmbm configuration mismatch

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-comfast-cf-wr632ax.dts
+++ b/target/linux/mediatek/dts/mt7981b-comfast-cf-wr632ax.dts
@@ -11,6 +11,7 @@
 	mediatek,nmbm;
 	mediatek,bmt-max-ratio = <1>;
 	mediatek,bmt-max-reserved-blocks = <64>;
+	mediatek,bmt-mtd-overridden-oobsize = <64>;
 };
 
 &ubi {


### PR DESCRIPTION
cherry-picked from commit https://github.com/openwrt/openwrt/commit/7a4d6eaf145bc46932660d41ca6703a2fd2c5040 (Link: https://github.com/openwrt/openwrt/pull/24552)