### PR TITLE
ramips: mt7620: disable broken CPU frequency scaling

### DIFF
--- a/target/linux/ramips/dts/mt7620a.dtsi
+++ b/target/linux/ramips/dts/mt7620a.dtsi
@@ -295,7 +295,7 @@
 		};
 
 		systick: systick@d00 {
-			compatible = "ralink,mt7620a-systick", "ralink,cevt-systick";
+			compatible = "ralink,cevt-systick";
 			reg = <0xd00 0x10>;
 
 			interrupt-parent = <&cpuintc>;

--- a/target/linux/ramips/dts/mt7620n.dtsi
+++ b/target/linux/ramips/dts/mt7620n.dtsi
@@ -241,7 +241,7 @@
 		};
 
 		systick: systick@d00 {
-			compatible = "ralink,mt7620a-systick", "ralink,cevt-systick";
+			compatible = "ralink,cevt-systick";
 			reg = <0xd00 0x10>;
 
 			interrupt-parent = <&cpuintc>;

--- a/target/linux/ramips/patches-6.18/312-MIPS-ralink-improve-systick-timer-handling.patch
+++ b/target/linux/ramips/patches-6.18/312-MIPS-ralink-improve-systick-timer-handling.patch
@@ -1,60 +1,36 @@
-From: John Crispin <blogic@openwrt.org>
-Date: Sun, 28 Jul 2013 16:26:41 +0200
-Subject: [PATCH 2/2] MIPS: ralink: add cpu frequency scaling
+From: Gleb Pesin <dormancygrace@gmail.com>
+Date: Sat, 15 Aug 2026 19:30:00 +0300
+Subject: [PATCH] MIPS: ralink: improve systick timer handling
 
-This feature will break udelay() and cause the delay loop to have longer delays
-when the frequency is scaled causing a performance hit.
+Keep the system counter running when the clockevent is shut down, program
+the next event with wrap-safe arithmetic, and register the clocksource and
+clockevent with the modern helpers.
+
+Do not implement MT7620 CPU autosleep here. Its untracked CPU frequency
+changes break delay calibration and timekeeping.
+
+Clear SLEEP_EN during early MT7620 initialization so the result does not
+depend on reset state or on what a bootloader left behind.
+
+This is based on the original MT7620 CPU frequency scaling patch by John
+Crispin and the later systick timer improvements by Michael Lee.
 
 Signed-off-by: John Crispin <blogic@openwrt.org>
+Signed-off-by: Michael Lee <igvtee@gmail.com>
+Signed-off-by: Gleb Pesin <dormancygrace@gmail.com>
 ---
- drivers/clocksource/timer-ralink.c | 117 ++++++++++++++++++++++-------
- 1 file changed, 89 insertions(+), 28 deletions(-)
-
 --- a/drivers/clocksource/timer-ralink.c
 +++ b/drivers/clocksource/timer-ralink.c
-@@ -5,6 +5,7 @@
-  * Copyright (C) 2013 by John Crispin <john@phrozen.org>
-  */
- 
-+#include <asm/mach-ralink/ralink_regs.h>
- #include <linux/clockchips.h>
- #include <linux/clocksource.h>
- #include <linux/interrupt.h>
-@@ -26,6 +27,10 @@
- /* enable the counter */
- #define CFG_CNT_EN		0x1
- 
-+/* mt7620 frequency scaling defines */
-+#define CLK_LUT_CFG	0x40
-+#define SLEEP_EN	BIT(31)
-+
- struct systick_device {
+@@ -30,24 +30,38 @@ struct systick_device {
  	void __iomem *membase;
  	struct clock_event_device dev;
-@@ -33,21 +38,53 @@ struct systick_device {
- 	int freq_scale;
+ 	int irq_requested;
+-	int freq_scale;
  };
  
-+static void (*systick_freq_scaling)(struct systick_device *sdev, int status);
-+
  static int systick_set_oneshot(struct clock_event_device *evt);
  static int systick_shutdown(struct clock_event_device *evt);
  
-+static inline void mt7620_freq_scaling(struct systick_device *sdev, int status)
-+{
-+	if (sdev->freq_scale == status)
-+		return;
-+
-+	sdev->freq_scale = status;
-+
-+	pr_info("%s: %s autosleep mode\n", sdev->dev.name,
-+			(status) ? ("enable") : ("disable"));
-+	if (status)
-+		rt_sysc_w32(rt_sysc_r32(CLK_LUT_CFG) | SLEEP_EN, CLK_LUT_CFG);
-+	else
-+		rt_sysc_w32(rt_sysc_r32(CLK_LUT_CFG) & ~SLEEP_EN, CLK_LUT_CFG);
-+}
-+
 +static inline unsigned int read_count(struct systick_device *sdev)
 +{
 +	return ioread32(sdev->membase + SYSTICK_COUNT);
@@ -90,7 +66,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  }
  
  static void systick_event_handler(struct clock_event_device *dev)
-@@ -57,20 +94,25 @@ static void systick_event_handler(struct
+@@ -57,20 +71,25 @@ static void systick_event_handler(struct
  
  static irqreturn_t systick_interrupt(int irq, void *dev_id)
  {
@@ -124,37 +100,16 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  		.features		= CLOCK_EVT_FEAT_ONESHOT,
  		.set_next_event		= systick_next_event,
  		.set_state_shutdown	= systick_shutdown,
-@@ -88,7 +130,13 @@ static int systick_shutdown(struct clock
+@@ -88,7 +107,7 @@ static int systick_shutdown(struct clock
  	if (sdev->irq_requested)
  		free_irq(systick.dev.irq, &systick.dev);
  	sdev->irq_requested = 0;
 -	iowrite32(0, systick.membase + SYSTICK_CONFIG);
 +	iowrite32(CFG_CNT_EN, systick.membase + SYSTICK_CONFIG);
-+
-+	if (systick_freq_scaling)
-+		systick_freq_scaling(sdev, 0);
-+
-+	if (systick_freq_scaling)
-+		systick_freq_scaling(sdev, 1);
  
  	return 0;
  }
-@@ -113,20 +161,37 @@ static int systick_set_oneshot(struct cl
- 	return 0;
- }
- 
-+static const struct of_device_id systick_match[] = {
-+	{ .compatible = "ralink,mt7620a-systick", .data = mt7620_freq_scaling},
-+	{},
-+};
-+
- static int __init ralink_systick_init(struct device_node *np)
- {
- 	int ret;
-+	const struct of_device_id *match;
-+	int rating = 200;
- 
- 	systick.membase = of_iomap(np, 0);
+@@ -121,12 +140,6 @@ static int __init ralink_systick_init(st
  	if (!systick.membase)
  		return -ENXIO;
  
@@ -164,48 +119,56 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 -	systick.dev.max_delta_ticks = 0x7fff;
 -	systick.dev.min_delta_ns = clockevent_delta2ns(0x3, &systick.dev);
 -	systick.dev.min_delta_ticks = 0x3;
-+	match = of_match_node(systick_match, np);
-+	if (match) {
-+		systick_freq_scaling = match->data;
-+		/*
-+		 * cevt-r4k uses 300, make sure systick
-+		 * gets used if available
-+		 */
-+		rating = 310;
-+	}
-+
-+	/* enable counter than register clock source */
-+	iowrite32(CFG_CNT_EN, systick.membase + SYSTICK_CONFIG);
-+	clocksource_mmio_init(systick.membase + SYSTICK_COUNT, np->name,
-+			SYSTICK_FREQ, rating, 16, clocksource_mmio_readl_up);
-+
-+	/* register clock event */
  	systick.dev.irq = irq_of_parse_and_map(np, 0);
  	if (!systick.dev.irq) {
  		pr_err("%pOFn: request_irq failed", np);
-@@ -134,21 +199,16 @@ static int __init ralink_systick_init(st
+@@ -134,13 +147,19 @@ static int __init ralink_systick_init(st
  		goto err_iounmap;
  	}
  
--	ret = clocksource_mmio_init(systick.membase + SYSTICK_COUNT, np->name,
++	/* enable counter then register clock source */
++	iowrite32(CFG_CNT_EN, systick.membase + SYSTICK_CONFIG);
+ 	ret = clocksource_mmio_init(systick.membase + SYSTICK_COUNT, np->name,
 -				    SYSTICK_FREQ, 301, 16,
--				    clocksource_mmio_readl_up);
--	if (ret)
--		goto err_free_irq;
--
++				    SYSTICK_FREQ, 200, 16,
+ 				    clocksource_mmio_readl_up);
+ 	if (ret)
+ 		goto err_free_irq;
+ 
 -	clockevents_register_device(&systick.dev);
++	/* register clock event */
 +	systick.dev.name = np->name;
-+	systick.dev.rating = rating;
++	systick.dev.rating = 200;
 +	systick.dev.cpumask = cpumask_of(0);
 +	clockevents_config_and_register(&systick.dev, SYSTICK_FREQ, 0x3, 0x7fff);
  
  	pr_info("%pOFn: running - mult: %d, shift: %d\n",
  			np, systick.dev.mult, systick.dev.shift);
+--- a/arch/mips/ralink/mt7620.c
++++ b/arch/mips/ralink/mt7620.c
+@@ -36,6 +36,10 @@
+ #define PMU1_CFG		0x8C
+ #define DIG_SW_SEL		BIT(25)
  
- 	return 0;
++/* CPU sleep */
++#define CLK_LUT_CFG		0x40
++#define SLEEP_EN		BIT(31)
++
+ /* EFUSE bits */
+ #define EFUSE_MT7688		0x100000
  
--err_free_irq:
--	irq_dispose_mapping(systick.dev.irq);
- err_iounmap:
- 	iounmap(systick.membase);
- 	return ret;
+@@ -228,6 +232,14 @@ void __init prom_soc_init(struct ralink_
+ 		"MediaTek %s ver:%u eco:%u",
+ 		name, mt7620_get_soc_ver(), mt7620_get_soc_eco());
+ 
++	if (!is_mt76x8()) {
++		u32 clk_lut_cfg;
++
++		clk_lut_cfg = __raw_readl(MT7620_SYSC_BASE + CLK_LUT_CFG);
++		__raw_writel(clk_lut_cfg & ~SLEEP_EN,
++			     MT7620_SYSC_BASE + CLK_LUT_CFG);
++	}
++
+ 	cfg0 = __raw_readl(MT7620_SYSC_BASE + SYSC_REG_SYSTEM_CONFIG0);
+ 	if (is_mt76x8()) {
+ 		dram_type = cfg0 & DRAM_TYPE_MT7628_MASK;


### PR DESCRIPTION
This revives Shiji Yang's 2023 patch on current `main` and adds hardware validation on an MT7620A WE826.

The MT7620-specific systick path enabled CPU frequency scaling after `SI_Sleep` and raised systick above the stable MIPS clocksource. The clock framework does not observe the resulting CPU clock change, breaking timing assumptions for delay calibration and users such as the Jitter RNG.

This revision removes the unused autosleep callback and its elevated rating, uses the generic systick compatible for MT7620A/N, and explicitly clears `CLK_LUT_CFG.SLEEP_EN` during early MT7620 initialization. The result is independent of reset state and of what a bootloader left behind.

Hardware results on OpenWrt 25.12.5 / Linux 6.12.94:

* before: `SLEEP_EN=1`, systick clocksource, urngd consumed 92-100% of otherwise-idle CPU for several minutes and reported startup at about 204 seconds;
* after: `SLEEP_EN=0`, MIPS clocksource, urngd initialized at 41.5 seconds and slept normally;
* five-run Ethernet throughput remained about 93.9 Mbit/s;
* WireGuard, warm boot, mixed-load stability, and a 30-minute clock-drift run showed no regression.

An isolation build kept systick selected while preventing only `SLEEP_EN`. urngd still consumed 83-91% CPU. Switching that running system to the MIPS clocksource and restarting urngd made it initialize in about six seconds and sleep normally. The effective fix is therefore the combination of a stable MIPS timebase and no untracked CPU-frequency changes.

The change is rebased onto current `main` / Linux 6.18.44. The full ramips patch stack applies cleanly, `git diff --check` is clean, and the modified `timer-ralink.o` and `mt7620.o` compile with the OpenWrt MIPS toolchain. Full 6.18 target builds are left to CI; hardware validation currently remains on 6.12.94.

Original submission:
https://lists.openwrt.org/pipermail/openwrt-devel/2023-July/041232.html

Relationship to openwrt/openwrt#24589: compiling Jitter RNG 3.x with `-O2` is an independent urngd performance fix, while running urngd at `nice=19` is a cross-platform scheduling workaround that keeps a CPU-bound entropy bootstrap from blocking other init services. This PR addresses the MT7620-specific platform root cause: an unstable systick timebase combined with untracked `SI_Sleep` CPU-frequency changes. It therefore does not make the urngd changes obsolete on other slow targets; `nice=19` remains useful defense in depth.
