### PR TITLE
uhttpd: run in ujail as an unprivileged user

### DIFF
--- a/package/network/services/uhttpd/Makefile
+++ b/package/network/services/uhttpd/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uhttpd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/uhttpd.git
@@ -32,6 +32,7 @@ endef
 define Package/uhttpd
   $(Package/uhttpd/default)
   DEPENDS:= +USE_GLIBC:libcrypt-compat +libubox +libblobmsg-json +libjson-script +libjson-c
+  USERID:=uhttpd=456:uhttpd=456
 endef
 
 define Package/uhttpd/description
@@ -91,6 +92,8 @@ define Package/uhttpd/install
 	$(INSTALL_CONF) ./files/uhttpd.config $(1)/etc/config/uhttpd
 	$(VERSION_SED_SCRIPT) $(1)/etc/config/uhttpd
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/uhttpd $(1)/usr/sbin/uhttpd
+	$(INSTALL_DIR) $(1)/etc/capabilities
+	$(INSTALL_DATA) ./files/uhttpd.capabilities $(1)/etc/capabilities/uhttpd.json
 endef
 
 define Package/uhttpd-mod-lua/install
@@ -102,6 +105,8 @@ define Package/uhttpd-mod-ubus/install
 	$(INSTALL_DIR) $(1)/usr/lib $(1)/etc/uci-defaults
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/uhttpd_ubus.so $(1)/usr/lib/
 	$(INSTALL_DATA) ./files/ubus.default $(1)/etc/uci-defaults/00_uhttpd_ubus
+	$(INSTALL_DIR) $(1)/usr/share/acl.d
+	$(INSTALL_DATA) ./files/uhttpd_acl.json $(1)/usr/share/acl.d/uhttpd.json
 endef
 
 define Package/uhttpd-mod-ubus/postinst

--- a/package/network/services/uhttpd/files/uhttpd.capabilities
+++ b/package/network/services/uhttpd/files/uhttpd.capabilities
@@ -1,0 +1,19 @@
+{
+	"bounding": [
+		"CAP_NET_BIND_SERVICE",
+		"CAP_SETGID",
+		"CAP_SETUID"
+	],
+	"effective": [
+		"CAP_NET_BIND_SERVICE",
+		"CAP_SETGID",
+		"CAP_SETUID"
+	],
+	"ambient": [],
+	"permitted": [
+		"CAP_NET_BIND_SERVICE",
+		"CAP_SETGID",
+		"CAP_SETUID"
+	],
+	"inheritable": []
+}

--- a/package/network/services/uhttpd/files/uhttpd.init
+++ b/package/network/services/uhttpd/files/uhttpd.init
@@ -122,6 +122,13 @@ start_instance()
 	procd_set_param stderr 1
 	procd_set_param command "$UHTTPD_BIN" -f
 
+	[ -x /sbin/ujail -a -e /etc/capabilities/uhttpd.json ] && {
+		procd_append_param command -Z uhttpd
+		procd_add_jail uhttpd
+		procd_set_param capabilities /etc/capabilities/uhttpd.json
+		procd_set_param no_new_privs 1
+	}
+
 	config_get config "$cfg" config
 	if [ -z "$config" ]; then
 		mkdir -p /var/etc/uhttpd

--- a/package/network/services/uhttpd/files/uhttpd_acl.json
+++ b/package/network/services/uhttpd/files/uhttpd_acl.json
@@ -1,0 +1,111 @@
+{
+	"user": "uhttpd",
+	"access": {
+		"session": {
+			"methods": [
+				"access",
+				"destroy",
+				"get",
+				"login",
+				"set"
+			]
+		},
+		"file": {
+			"methods": [
+				"*"
+			]
+		},
+		"iwinfo": {
+			"methods": [
+				"*"
+			]
+		},
+		"luci": {
+			"methods": [
+				"*"
+			]
+		},
+		"luci-rpc": {
+			"methods": [
+				"*"
+			]
+		},
+		"luci.*": {
+			"methods": [
+				"*"
+			]
+		},
+		"rc": {
+			"methods": [
+				"*"
+			]
+		},
+		"rpc-sys": {
+			"methods": [
+				"*"
+			]
+		},
+		"system": {
+			"methods": [
+				"board",
+				"info",
+				"reboot",
+				"validate_firmware_image"
+			]
+		},
+		"uci": {
+			"methods": [
+				"*"
+			]
+		},
+		"dsl": {
+			"methods": [
+				"metrics",
+				"statistics"
+			]
+		},
+		"fingerprint": {
+			"methods": [
+				"fingerprint"
+			]
+		},
+		"hostapd.*": {
+			"methods": [
+				"del_client",
+				"wps_cancel",
+				"wps_start",
+				"wps_status"
+			]
+		},
+		"log": {
+			"methods": [
+				"read"
+			]
+		},
+		"network": {
+			"methods": [
+				"get_proto_handlers"
+			]
+		},
+		"network.device": {
+			"methods": [
+				"status"
+			]
+		},
+		"network.interface": {
+			"methods": [
+				"dump"
+			]
+		},
+		"network.rrdns": {
+			"methods": [
+				"lookup"
+			]
+		},
+		"service": {
+			"methods": [
+				"list"
+			]
+		}
+	}
+}

--- a/package/network/services/uhttpd/patches/100-main-add-Z-to-drop-privileges.patch
+++ b/package/network/services/uhttpd/patches/100-main-add-Z-to-drop-privileges.patch
@@ -1,0 +1,101 @@
+From 9751afbab3c4aca6da54f589c5d460010f953a48 Mon Sep 17 00:00:00 2001
+From: Julius Bairaktaris <julius@bairaktaris.de>
+Date: Thu, 6 Aug 2026 15:21:13 +0200
+Subject: [PATCH] main: add -Z to drop privileges after binding sockets
+
+uhttpd currently requires root for the whole lifetime of the process,
+even though all privileged work (binding the listeners, reading the
+TLS key) happens during startup. Add -Z to drop to an unprivileged
+user once that startup is done, using initgroups/setgid/setresuid so
+no saved-root or supplementary-group state survives. Service managers
+that cannot use a sandbox (plain procd, systemd) can then run the
+daemon unprivileged on privileged ports.
+
+The drop precedes the handler plugin initialization because the ubus
+plugin connects to ubusd there, and ubusd reads the peer credentials
+once, when the connection is accepted: a socket opened before the drop
+stays a uid 0 connection for the life of the process, and ubusd exempts
+uid 0 from every ACL it enforces. Connecting afterwards is what puts
+the daemon's ubus access under /usr/share/acl.d. The plugins need no
+privilege of their own - they dlopen a module and read a handler script
+- whereas the TLS key is read before the drop and keeps its root
+ownership.
+
+Assisted-by: Claude:claude-opus-5
+Signed-off-by: Julius Bairaktaris <julius@bairaktaris.de>
+---
+ main.c | 27 ++++++++++++++++++++++++++-
+ 1 file changed, 26 insertions(+), 1 deletion(-)
+
+--- a/main.c
++++ b/main.c
+@@ -30,7 +30,9 @@
+ 
+ #include <getopt.h>
+ #include <errno.h>
++#include <grp.h>
+ #include <netdb.h>
++#include <pwd.h>
+ #include <signal.h>
+ 
+ #include <libubox/usock.h>
+@@ -135,6 +137,7 @@ static int usage(const char *name)
+ 		"	-f              Do not fork to background\n"
+ 		"	-c file         Configuration file, default is '/etc/httpd.conf'\n"
+ 		"	-p [addr:]port  Bind to specified address and port, multiple allowed\n"
++		"	-Z user         Drop to the given user after binding sockets\n"
+ #ifdef HAVE_TLS
+ 		"	-s [addr:]port  Like -p but provide HTTPS on this port\n"
+ 		"	-C file         ASN.1 server certificate file\n"
+@@ -275,6 +278,7 @@ int main(int argc, char **argv)
+ 	struct alias *alias;
+ 	bool nofork = false;
+ 	char *port;
++	const char *priv_user = NULL;
+ 	int opt, ch;
+ 	int cur_fd;
+ 	int bound = 0;
+@@ -295,7 +299,7 @@ int main(int argc, char **argv)
+ 	init_defaults_pre();
+ 	signal(SIGPIPE, SIG_IGN);
+ 
+-	while ((ch = getopt(argc, argv, "A:ab:C:c:Dd:E:e:fh:H:I:i:K:k:L:l:m:N:n:O:o:P:p:qQ:Rr:Ss:T:t:U:u:Xx:y:")) != -1) {
++	while ((ch = getopt(argc, argv, "A:ab:C:c:Dd:E:e:fh:H:I:i:K:k:L:l:m:N:n:O:o:P:p:qQ:Rr:Ss:T:t:U:u:Xx:y:Z:")) != -1) {
+ 		switch(ch) {
+ #ifdef HAVE_TLS
+ 		case 'C':
+@@ -579,6 +583,10 @@ int main(int argc, char **argv)
+ 			                "ignoring -%c\n", ch);
+ 			break;
+ #endif
++		case 'Z':
++			priv_user = optarg;
++			break;
++
+ 		default:
+ 			return usage(argv[0]);
+ 		}
+@@ -614,6 +622,23 @@ int main(int argc, char **argv)
+ 	}
+ #endif
+ 
++	if (priv_user) {
++		struct passwd *pw = getpwnam(priv_user);
++
++		if (!pw) {
++			fprintf(stderr, "Error: Invalid user %s\n", priv_user);
++			return 1;
++		}
++
++		if (initgroups(priv_user, pw->pw_gid) ||
++		    setgid(pw->pw_gid) ||
++		    setresuid(pw->pw_uid, pw->pw_uid, pw->pw_uid)) {
++			fprintf(stderr, "Error: Failed to drop privileges to %s: %s\n",
++			        priv_user, strerror(errno));
++			return 1;
++		}
++	}
++
+ #ifdef HAVE_LUA
+ 	if (lua_handler || lua_prefix) {
+ 		fprintf(stderr, "Need handler and prefix to enable Lua support\n");


### PR DESCRIPTION
Splits out of #24558, which now carries pppd and odhcpd only. uhttpd needs root
only to bind 80/443 and read the TLS key, then keeps it for the process
lifetime. This runs it in a ujail with `CAP_NET_BIND_SERVICE` for the bind and
`CAP_SETUID` + `CAP_SETGID` for the drop, and passes `-Z` so uhttpd drops to uid
456 once its listeners are up:

    package/network/services/uhttpd/files/uhttpd.init, start_instance():

        [ -x /sbin/ujail -a -e /etc/capabilities/uhttpd.json ] && {
                procd_append_param command -Z uhttpd
                procd_add_jail uhttpd
                procd_set_param capabilities /etc/capabilities/uhttpd.json
                procd_set_param no_new_privs 1
        }

Dropping inside the daemon rather than with procd's `user` parameter is what
keeps the key at `root:root 0600`. The key path is a uci value, so dropping
before `execve()` would mean chowning an operator-supplied path to the
unprivileged user. `-Z` does not exist in the pinned uhttpd, so it rides along
as `100-main-add-Z-to-drop-privileges.patch`, openwrt/uhttpd#40 unchanged, and
goes away at the next `PKG_SOURCE_VERSION` bump that picks it up.

ubusd denies every non-root uid, so `/usr/share/acl.d/uhttpd.json` grants uid
456 what LuCI reaches. It ships with `uhttpd-mod-ubus` rather than the base
package, which links no ubus library and opens no connection to grant.
`session/create`, `grant` and `revoke` are withheld so a compromised uhttpd
cannot mint itself a privileged session.

The other objects rpcd owns get a method wildcard, and my understanding is that
rc, rpc-sys and iwinfo carry no session check of their own, so that wildcard is
safe only under openwrt/rpcd#38, which is not merged:

    package/network/services/uhttpd/files/uhttpd_acl.json:

        "rc": {
                "methods": [
                        "*"
                ]
        },
        "rpc-sys": {
                "methods": [
                        "*"
                ]
        },

On an ipq807x router LuCI login and the overview, flash, network, wireless and
system pages load at uid 456, with no ACL denial and no respawn; each is a
single run. The CGI script `/www/cgi-bin/luci` inherits the server uid, so which
pages read `/etc/config` there rather than through rpcd is unchecked. I used AI
to help me write this change.

Dependencies, in merge order:

1. openwrt/uhttpd#40 - https://github.com/openwrt/uhttpd/pull/40 - adds `-Z`, carried here as a package patch until it merges.
2. openwrt/rpcd#38 - https://github.com/openwrt/rpcd/pull/38 - hard prerequisite. `rpc_file_access()` returns true for a request with no session id, so with the `file` grant this PR adds and #38 out, a non-root uhttpd can call `file exec` untokened. Not before this one.
3. openwrt/rpcd#40 - https://github.com/openwrt/rpcd/pull/40 - `stream: true` on `file exec`, so the backup archive comes back as a descriptor instead of inline.
4. openwrt/cgi-io#6 - https://github.com/openwrt/cgi-io/pull/6 - makes `cgi-backup` and `cgi-exec` dispatch through rpcd instead of forking with uhttpd's uid; until it lands, a backup taken at uid 456 silently omits root-owned files.
5. openwrt/luci#8947 - https://github.com/openwrt/luci/pull/8947 - the session ACL for `sysupgrade --create-backup -`, enforced once #6 dispatches through rpcd.

Would you rather have `rc` and `rpc-sys` named method by method here instead of
wildcarded?
