### PR TITLE
mvebu: enable UAS for Turris Omnia and Turris MOX

### DIFF
--- a/target/linux/mvebu/image/cortexa53.mk
+++ b/target/linux/mvebu/image/cortexa53.mk
@@ -6,7 +6,7 @@ define Device/cznic_turris-mox
     kmod-rtc-ds1307 kmod-i2c-pxa kmod-dsa kmod-dsa-mv88e6xxx kmod-sfp \
     kmod-phy-marvell kmod-phy-marvell-10g kmod-ath10k ath10k-board-qca988x \
     ath10k-firmware-qca988x kmod-mt7915e kmod-mt7915-firmware mwlwifi-firmware-88w8997 \
-    wpad-basic-mbedtls kmod-mwifiex-sdio kmod-btmrvl
+    wpad-basic-mbedtls kmod-mwifiex-sdio kmod-btmrvl kmod-usb-storage-uas
   SOC := armada-3720
   BOOT_SCRIPT := turris-mox
 endef

--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -108,7 +108,7 @@ define Device/cznic_turris-omnia
     wpad-basic-mbedtls kmod-ath9k kmod-ath10k-ct ath10k-firmware-qca988x-ct \
     kmod-mt7915-firmware partx-utils kmod-i2c-mux-pca954x kmod-leds-turris-omnia \
     kmod-turris-omnia-mcu kmod-gpio-button-hotplug omnia-eeprom omnia-mcu-firmware \
-    omnia-mcutool kmod-dsa-mv88e6xxx
+    omnia-mcutool kmod-dsa-mv88e6xxx kmod-usb-storage-uas
   IMAGES := sysupgrade.img.gz
   IMAGE/sysupgrade.img.gz := boot-scr | boot-img | sdcard-img | libdeflate-gzip | append-metadata
   SUPPORTED_DEVICES += armada-385-turris-omnia


### PR DESCRIPTION
Add kmod-usb-storage-uas to the default package set for the Turris
Omnia and Turris MOX.

Both devices provide USB host ports that can be used with fast USB
storage devices such as SSDs. UAS provides a more efficient transport
than the legacy USB Mass Storage Bulk-Only Transport and allows such
devices to better utilize the available USB bandwidth.

Without the UAS driver installed, compatible devices silently fall
back to the legacy transport, which can limit storage performance.
**Users may not realize that kmod-usb-storage-uas needs to be installed
separately.**

The package is only about 10 KiB and remains a loadable kernel module,
so users can remove it independently if a particular USB storage
device has compatibility issues.