### PR TITLE
realtek: rtl930x: add support for Hasivo S600WP-5GT-2S+

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -105,6 +105,7 @@ realtek_setup_macs()
 	hasivo,f1100wp-4sx-4xgt-512mb|\
 	hasivo,f5800w-12s-plus|\
 	hasivo,s1300wp-8xgt-4s-plus|\
+	hasivo,s600wp-5gt-2s-plus|\
 	tplink,tl-st1008f-v2|\
 	zyxel,xgs1010-12-a1|\
 	zyxel,xgs1010-12-b1)

--- a/target/linux/realtek/base-files/etc/uci-defaults/99_fwenv-store-ethaddr
+++ b/target/linux/realtek/base-files/etc/uci-defaults/99_fwenv-store-ethaddr
@@ -47,6 +47,7 @@ hasivo,f1100wp-4sx-4xgt|\
 hasivo,f1100wp-4sx-4xgt-512mb|\
 hasivo,f5800w-12s-plus|\
 hasivo,s1300wp-8xgt-4s-plus|\
+hasivo,s600wp-5gt-2s-plus|\
 tplink,tl-st1008f-v2)
 	env_ethaddr=$(macaddr_canonicalize "$(fw_printenv -n ethaddr 2>/dev/null)")
 	ethaddr_prefix=$(echo "$env_ethaddr" | cut -d: -f1-5)

--- a/target/linux/realtek/dts/rtl9303_hasivo_s600wp-5gt-2s-plus.dts
+++ b/target/linux/realtek/dts/rtl9303_hasivo_s600wp-5gt-2s-plus.dts
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "rtl930x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "hasivo,s600wp-5gt-2s-plus", "realtek,rtl9303-soc";
+	model = "Hasivo S600WP-5GT-2S+";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>; /* 256 MiB */
+	};
+
+	aliases {
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+		i2c0 = &i2c_scl23_sda22;
+		i2c1 = &i2c_sfp0;
+		i2c2 = &i2c_sfp1;
+	};
+
+	chosen {
+		stdout-path = "serial0:38400n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinmux_disable_sys_led>, <&pinmux_enable_led_sync>;
+
+		led_sys: led-0 {
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			linux,default-trigger = "heartbeat";
+		};
+	};
+
+	led_set {
+		compatible = "realtek,rtl9300-leds";
+
+		/* Port 25 is unused but present in the HC595 shift
+		 * register chain. Force it into the serial LED stream
+		 * to align all LED positions correctly.
+		 */
+		realtek,led-set0-force-port-mask = <(1 << 25)>;
+
+		/*
+		 * RJ45 LED0 (green): 1G/LINK/ACT
+		 * RJ45 LED1 (green): 10M/100M/LINK/ACT
+		 * RJ45 LED2 (orange): 2.5G/LINK/ACT
+		 */
+		led_set0 = <(RTL93XX_LED_SET_1G | RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+			    (RTL93XX_LED_SET_10M | RTL93XX_LED_SET_100M |
+			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+			    (RTL93XX_LED_SET_2P5G | RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)>;
+
+		/*
+		 * SFP+ LED0: 10G/LINK/ACT
+		 * SFP+ LED1: 1G/LINK/ACT
+		 * SFP+ LED2: spacer to keep 3 slots per port
+		 */
+		led_set1 = <(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+			    (RTL93XX_LED_SET_1G | RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+			    (RTL93XX_LED_SET_NONE)>;
+	};
+
+	/* I2C bus to the on-board HS104 PSE controller (PoE) and STC8 LED MCU. */
+	i2c_scl23_sda22: i2c-scl23-sda22 {
+		compatible = "i2c-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		scl-gpios = <&gpio0 23 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		sda-gpios = <&gpio0 22 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		clock-frequency = <100000>;
+
+		pse0: ethernet-pse@d {
+			compatible = "hasivo,hs104";
+			reg = <0x0d>;
+			poll-interval-ms = <500>;
+			status = "okay";
+
+			pse-pis {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				pse0_pi0: pse-pi@0 {
+					reg = <0>;
+					#pse-cells = <0>;
+				};
+				pse0_pi1: pse-pi@1 {
+					reg = <1>;
+					#pse-cells = <0>;
+				};
+				pse0_pi2: pse-pi@2 {
+					reg = <2>;
+					#pse-cells = <0>;
+				};
+				pse0_pi3: pse-pi@3 {
+					reg = <3>;
+					#pse-cells = <0>;
+				};
+			};
+		};
+
+		stc8: stc8@4d {
+			compatible = "hasivo,stc8-mfd", "syscon";
+			reg = <0x4d>;
+			#address-cells = <2>;
+			#size-cells = <0>;
+			hasivo,execute-bit = <0x40>;
+			hasivo,execute-bit-registers = <0x01 0x02>;
+			status = "okay";
+
+			led_lan1_poe: led@1,0 {
+				compatible = "register-bit-led";
+				reg = <0x01 0x00>;
+				mask = <0x08>;
+				color = <LED_COLOR_ID_ORANGE>;
+				function = "poe";
+				function-enumerator = <1>;
+				linux,default-trigger = "pse-0-000d:port0:delivering";
+				default-state = "off";
+			};
+
+			led_lan2_poe: led@1,1 {
+				compatible = "register-bit-led";
+				reg = <0x01 0x01>;
+				mask = <0x04>;
+				color = <LED_COLOR_ID_ORANGE>;
+				function = "poe";
+				function-enumerator = <2>;
+				linux,default-trigger = "pse-0-000d:port1:delivering";
+				default-state = "off";
+			};
+
+			led_lan3_poe: led@1,2 {
+				compatible = "register-bit-led";
+				reg = <0x01 0x02>;
+				mask = <0x02>;
+				color = <LED_COLOR_ID_ORANGE>;
+				function = "poe";
+				function-enumerator = <3>;
+				linux,default-trigger = "pse-0-000d:port2:delivering";
+				default-state = "off";
+			};
+
+			led_lan4_poe: led@1,3 {
+				compatible = "register-bit-led";
+				reg = <0x01 0x03>;
+				mask = <0x01>;
+				color = <LED_COLOR_ID_ORANGE>;
+				function = "poe";
+				function-enumerator = <4>;
+				linux,default-trigger = "pse-0-000d:port3:delivering";
+				default-state = "off";
+			};
+		};
+	};
+
+	i2c_sfp0: i2c-sfp0 {
+		compatible = "i2c-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		scl-gpios = <&gpio0 7 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		sda-gpios = <&gpio0 6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <50>;
+	};
+
+	i2c_sfp1: i2c-sfp1 {
+		compatible = "i2c-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		scl-gpios = <&gpio0 11 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		sda-gpios = <&gpio0 10 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <50>;
+	};
+
+	sfp0: sfp-p26 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c_sfp0>;
+		mod-def0-gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+		tx-disable-gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2500>;
+	};
+
+	sfp1: sfp-p27 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c_sfp1>;
+		mod-def0-gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		maximum-power-milliwatt = <2500>;
+		/*
+		 * Stock firmware wires tx-disable to GPIO 12 (FB_TXDIS_1).
+		 * The pin is not claimed by the hardware I2C controller
+		 * (SDA pinmux is in GPIO mode) but still cannot be driven
+		 * HIGH for unknown reasons. Omitted for now.
+		 */
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			/* stock is LOADER */
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0000000 0x00e0000>;
+				read-only;
+			};
+
+			/* stock is BDINFO */
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0x00e0000 0x0010000>;
+			};
+
+			/* stock is SYSINFO */
+			partition@f0000 {
+				label = "u-boot-env2";
+				reg = <0x00f0000 0x0010000>;
+			};
+
+			/* stock is CFG JFFS2 */
+			partition@100000 {
+				label = "jffs";
+				reg = <0x0100000 0x0100000>;
+			};
+
+			/* stock is LOG JFFS2 */
+			partition@200000 {
+				label = "jffs2";
+				reg = <0x0200000 0x0100000>;
+			};
+
+			/* stock is RUNTIME and RUNTIME2
+			 * RUNTIME is <0x0300000 0x0700000>
+			 * RUNTIME2 is <0x0a00000 0x1600000>
+			 */
+			partition@300000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				reg = <0x0300000 0x1d00000>;
+			};
+		};
+	};
+};
+
+&mdio_bus0 {
+	/* External RTL8221B-VB-CG PHYs */
+	PHY_C45_PSE(0, 1, pse0_pi0)
+	PHY_C45_PSE(8, 2, pse0_pi1)
+	PHY_C45_PSE(16, 3, pse0_pi2)
+	PHY_C45_PSE(20, 4, pse0_pi3)
+};
+
+&mdio_bus1 {
+	/* External RTL8221B-VB-CG PHY */
+	PHY_C45(24, 1)
+};
+
+&switch0 {
+	ethernet-ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+			pcs-handle = <&serdes2 0>;
+			phy-handle = <&phy0>;
+			phy-mode = "sgmii";
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@8 {
+			reg = <8>;
+			label = "lan2";
+			pcs-handle = <&serdes3 0>;
+			phy-handle = <&phy8>;
+			phy-mode = "sgmii";
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@16 {
+			reg = <16>;
+			label = "lan3";
+			pcs-handle = <&serdes4 0>;
+			phy-handle = <&phy16>;
+			phy-mode = "sgmii";
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@20 {
+			reg = <20>;
+			label = "lan4";
+			pcs-handle = <&serdes5 0>;
+			phy-handle = <&phy20>;
+			phy-mode = "sgmii";
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@24 {
+			reg = <24>;
+			label = "lan5";
+			pcs-handle = <&serdes6 0>;
+			phy-handle = <&phy24>;
+			phy-mode = "sgmii";
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		SWITCH_PORT_SFP(26, 6, 8, 1, 0)
+		SWITCH_PORT_SFP(27, 7, 9, 1, 1)
+
+		/* Internal SoC */
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&thermal_zones {
+	sfp-thermal {
+		polling-delay-passive = <10000>;
+		polling-delay = <10000>;
+		thermal-sensors = <&sfp0>, <&sfp1>;
+		trips {
+			sfp-crit {
+				temperature = <110000>;
+				hysteresis = <1000>;
+				type = "critical";
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -103,6 +103,16 @@ define Device/hasivo_s1100wp-8xgt-se
 endef
 TARGET_DEVICES += hasivo_s1100wp-8xgt-se
 
+define Device/hasivo_s600wp-5gt-2s-plus
+  SOC := rtl9303
+  DEVICE_VENDOR := Hasivo
+  DEVICE_MODEL := S600WP-5GT-2S+
+  DEVICE_PACKAGES := kmod-pse-hasivo-hs104 kmod-mfd-hasivo-stc8
+  IMAGE_SIZE := 29696k
+  $(Device/kernel-lzma)
+endef
+TARGET_DEVICES += hasivo_s600wp-5gt-2s-plus
+
 define Device/hasivo_s600wp-5gt-2sx-se
   SOC := rtl9303
   DEVICE_VENDOR := Hasivo


### PR DESCRIPTION
This commit adds support for the Hasivo S600WP-5GT-2S+ switch with SFP+ and PoE.
Based on board revision `RTL_5GT-2SX+ v1.02`.

This device is nearly identical to Hasivo S600WP-5GT-2SX-SE, except:
- More RAM and flash
- RJ45 console port
- Model name scheme, `2S+` vs `2SX`
- No case cut-out for the PoE LEDs
- No MAC address in nvmem

Hardware
--------

|          |                                                                |
|----------|----------------------------------------------------------------|
| SoC      | RTL9303 rev B                                                  |
| RAM      | 256 MB Samsung K4B2G1646F DDR3L                                |
| Flash    | 32 MB Macronix MX25L25645G SPI NOR, 29 MB usable by OpenWrt    |
| Ethernet | 5x RJ45 via 5x RTL8221B-VB-CG PHYs (2.5G/1G/100M/10M),         |
|          | 2x SFP+ via SoC (10G/2.5G/1G)                                  |
| PoE      | 1x 802.3bt 90 W (port 1)                                       |
|          | 3x 802.3at 30 W (ports 2, 3, 4)                                |
|          | via daughter board with Hasivo HS104PTI controller             |
| LEDs     | 5x orange/green 2.5G/1G link, 5x green 100M/10M link           |
|          | 4x orange internal PoE, 2x green 10G link, 2x green 1G link    |
|          | 1x green system, 1x green power                                |
| Button   | Reset                                                          |
| Console  | RJ45 38400 bps 8n1                                             |
| Power    | Barrel jack 48V, shipped PSU is 52V/1.25A                      |

Installing OpenWrt
------------------

1. Attach to RJ45 serial console port using a cisco cable.
2. Attach your computer to any RJ45 port.
3. Serve initramfs-kernel.bin on TFTP 192.168.1.111.
4. Power on the device.
5. Interrupt U-Boot by pressing `Ctrl+C`, then `Z`, then `H`, during 3 second countdown.
6. Run: `rtk network on`
7. Run: `tftpboot 0x84f00000 initramfs-kernel.bin ; bootm 0x84f00000`
8. Use `mtd dump` to make backups of all flash partitions.
9. Use SCP to copy `squashfs-sysupgrade.bin` to the device, then run `sysupgrade`.

Restoring factory firmware
--------------------------

OpenWrt uses the `RUNTIME` and `RUNTIME2` partitions as one combined partition.
To restore them from backups, boot from `initramfs-kernel.bin` just like during
the installation, then use `mtd write` to write your backups of the factory
`mtd5` and `mtd6` partitions.

Notes/Quirks
------------

- U-Boot interruption is obfuscated. Press `Ctrl+C`, then `Z`, then `H`,
  during the 3 second countdown.
- MAC address is stored on the `RUNTIME` or `RUNTIME2` partitions, which are used by OpenWrt.
  Instead, we generate one random MAC address and store it in the U-Boot environment.
- The PoE LEDs under each RJ45 port work correctly, but there's no cut-out in the case,
  so these LEDs are only barely visible.
- Under certain circumstances, the RJ45 ports can come up dead on boot.
  See https://github.com/openwrt/openwrt/issues/22140