### PR TITLE
ramips: add support for Cudy RE1800 v2

### DIFF
--- a/target/linux/ramips/dts/mt7621_cudy_re1800-v2-16m.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_re1800-v2-16m.dts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "cudy,re1800-v2-16m", "mediatek,mt7621-soc";
+	model = "Cudy RE1800 v2 (16 MiB)";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_wifi_red;
+		led-running = &led_power;
+		led-upgrade = &led_wifi_red;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_wifi_blue: wifi_blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wifi_red: wifi_red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WLAN;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wps {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WPS;
+			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0xe00>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xf80000>;
+			};
+
+			partition@fd0000 {
+				label = "debug";
+				reg = <0xfd0000 0x10000>;
+				read-only;
+			};
+
+			partition@fe0000 {
+				label = "backup";
+				reg = <0xfe0000 0x10000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "bdinfo";
+				reg = <0xff0000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_bdinfo_de00: macaddr@de00 {
+						compatible = "mac-base";
+						reg = <0xde00 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_bdinfo_de00 1>;
+		nvmem-cell-names = "eeprom", "mac-address";
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_bdinfo_de00 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@3 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>, <&rgmii1_pins>;
+};
+
+&state_default {
+	gpio {
+		groups = "wdt", "uart3", "rgmii2";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/dts/mt7621_cudy_re1800-v2.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_re1800-v2.dts
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "cudy,re1800-v2", "mediatek,mt7621-soc";
+	model = "Cudy RE1800 v2";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_wifi_red;
+		led-running = &led_power;
+		led-upgrade = &led_wifi_red;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_wifi_blue: wifi_blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wifi_red: wifi_red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WLAN;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wps {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WPS;
+			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0xe00>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7a0000>;
+			};
+
+			partition@7f0000 {
+				label = "bdinfo";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_bdinfo_de00: macaddr@de00 {
+						compatible = "mac-base";
+						reg = <0xde00 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_bdinfo_de00 1>;
+		nvmem-cell-names = "eeprom", "mac-address";
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_bdinfo_de00 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@3 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>, <&rgmii1_pins>;
+};
+
+&state_default {
+	gpio {
+		groups = "wdt", "uart3", "rgmii2";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -816,6 +816,30 @@ define Device/cudy_r700
 endef
 TARGET_DEVICES += cudy_r700
 
+define Device/cudy_re1800-v2
+  $(Device/dsa-migration)
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := RE1800
+  DEVICE_VARIANT := v2
+  IMAGE_SIZE := 7808k
+  UIMAGE_NAME := R27
+  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  SUPPORTED_DEVICES += R27
+endef
+TARGET_DEVICES += cudy_re1800-v2
+
+define Device/cudy_re1800-v2-16m
+  $(Device/dsa-migration)
+  IMAGE_SIZE := 15872k
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := RE1800
+  DEVICE_VARIANT := v2 (16 MiB)
+  UIMAGE_NAME := R27
+  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  SUPPORTED_DEVICES += R27
+endef
+TARGET_DEVICES += cudy_re1800-v2-16m
+
 define Device/cudy_wr1300-v1
   $(Device/dsa-migration)
   IMAGE_SIZE := 15872k

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -833,7 +833,7 @@ define Device/cudy_re1800-v2-16m
   IMAGE_SIZE := 15872k
   DEVICE_VENDOR := Cudy
   DEVICE_MODEL := RE1800
-  DEVICE_VARIANT := v2 (16 MiB)
+  DEVICE_VARIANT := v2 (16M)
   UIMAGE_NAME := R27
   DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
   SUPPORTED_DEVICES += R27

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -73,7 +73,9 @@ ramips_setup_interfaces()
 	wavlink,wl-wn573hx1|\
 	wodesys,wd-r1802u|\
 	zyxel,nwa50ax|\
-	zyxel,nwa55axe)
+	zyxel,nwa55axe|\
+	cudy,re1800-v2|\
+	cudy,re1800-v2-16m)
 		ucidef_set_interface_lan "lan"
 		;;
 	asiarf,ap7621-001|\

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -42,7 +42,9 @@ case "$board" in
 			macaddr_add $lan_mac_addr 8 > /sys${DEVPATH}/macaddress
 		;;
 	cudy,x6-v1|\
-	cudy,x6-v2)
+	cudy,x6-v2|\
+	cudy,re1800-v2|\
+	cudy,re1800-v2-16m)
 		hw_mac_addr="$(mtd_get_mac_binary bdinfo 0xde00)"
 		[ "$PHYNBR" = "1" ] && \
 		macaddr_setbit_la "$(macaddr_add $hw_mac_addr 0x100000)" > /sys${DEVPATH}/macaddress


### PR DESCRIPTION
## Description

This adds support for the Cudy RE1800 v2 in two flash variants:

1. **8 MiB variant** (`cudy,re1800-v2`) — for units with stock 8 MiB flash
2. **16 MiB variant** (`cudy,re1800-v2-16m`) — for units with original 16 MiB flash restored (e.g. W25Q128JVSIQ replacement)

The Cudy RE1800 v2 is an AX1800 dual-band WiFi 6 range extender based on the MediaTek MT7621A with an MT7915 DBDC radio.

### Specifications
- SoC: MediaTek MT7621AT
- RAM: 128 MB DDR3
- Flash: 8 MiB or 16 MiB SPI NOR
- WiFi: MediaTek MT7915 DBDC (2.4 GHz + 5 GHz, 2x2)
- Ethernet: 1x 1GbE (MT7530 port 3)
- UART: 4-pin header, 115200 8N1

### MAC address layout
The only per-device unique MAC is in the bdinfo partition at 0xDE00. All addresses derive from it:
- Ethernet: label address (unchanged)
- 2.4 GHz: label+1
- 5 GHz: distinct locally-administered address (label + 0x100000 with LA bit set)

### Flash instructions
- **8 MiB variant:** sysupgrade from a running OpenWrt 23.05.5 image (board R27); recovery via U-Boot TFTP.
- **16 MiB variant:** program via SPI programmer (CH341A) to the flash chip. The eeprom bin (`mt7915_eeprom_dbdc.bin`) must be provided if the factory partition is blank.

### Tested-by
Validated on hardware (Cudy RE1800 v2 with W25Q128JVSIQ 16 MiB replacement):
- 8 MiB sysupgrade: booted, config preserved, WiFi functional
- 16 MiB variant: LuCI included, 7.8 MiB overlay, iperf3 383 Mbit/s via 5G backhaul
- 802.11r FT roaming confirmed (auth_alg=ft in logs)
- mt7915 eeprom fix validated (blank factory + baked-in mt7915_eeprom_dbdc.bin)

### Files changed
- `target/linux/ramips/dts/mt7621_cudy_re1800-v2.dts` (8 MiB DTS)
- `target/linux/ramips/dts/mt7621_cudy_re1800-v2-16m.dts` (16 MiB DTS)
- `target/linux/ramips/image/mt7621.mk` (device recipes)
- `target/linux/ramips/mt7621/base-files/etc/board.d/02_network` (network config)
- `target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac` (MAC derivation)

### Relationship to PR #23863
This PR is independent of PR #23863 (by @araujorm), which adds the 8 MiB variant with the `mt7621_small` subtarget approach. This PR adds both variants on the standard `mt7621` subtarget. The 16 MiB variant does not need the small subtarget since LuCI fits comfortably in the larger firmware partition.

Signed-off-by: Ashton Johnson <me@mail.ashtonjohnson.com>