### PR TITLE
ipq40xx: enable display feature on generic subtarget

### DIFF
--- a/target/linux/ipq40xx/generic/target.mk
+++ b/target/linux/ipq40xx/generic/target.mk
@@ -1,3 +1,3 @@
 BOARDNAME:=Generic
-FEATURES+=emmc nand
+FEATURES+=display emmc nand
 DEFAULT_PACKAGES += ath10k-board-qca4019


### PR DESCRIPTION
The Ubiquiti UniFi Travel Router lists kmod-drm-panel-mipi-dbi and kmod-backlight-pwm in DEVICE_PACKAGES. Both resolve through packages gated on @DISPLAY_SUPPORT, which is only selected when the target advertises the 'display' feature. Without it those packages are never built, and the image step fails with:

  ERROR: unable to select packages:
    kmod-backlight-pwm (no such package)
    kmod-drm-panel-mipi-dbi (no such package)

This has broken every ipq40xx/generic snapshot build since r35795.
