### PR TITLE
tools: gnulib: remove stale gl_-prefixed macros from staging

### DIFF
--- a/tools/gnulib/Makefile
+++ b/tools/gnulib/Makefile
@@ -23,6 +23,7 @@ endef
 
 define Host/Uninstall
 	rm -rf $(STAGING_DIR_HOST)/bin/gnulib-tool $(STAGING_DIR_HOST)/share/gnulib
+	rm -f $(STAGING_DIR_HOST)/share/aclocal/gl_*.m4
 endef
 
 $(eval $(call HostBuild))


### PR DESCRIPTION
Fixes macOS host builds broken by the gnulib stable-202507 update (#24247).

c820f097e0 temporarily installed gnulib autoconf macros as `gl_*.m4`. Although this was reverted in cda598a595, the previously installed files were never removed from `share/aclocal`.

On affected build trees, aclocal picks up both the stale `gl_*.m4` files and the current macros. The stale definitions can then win and cause elfutils' regenerated `ctype.h` to contain empty `#if` expressions on macOS.

This patch removes the stale `gl_*.m4` files from Host/Uninstall. Since Host/Install calls it first, existing build trees are automatically cleaned up on the next gnulib reinstall.

Verified on macOS (Apple Silicon): the stale files reproduce the elfutils build failure, while the cleanup allows a clean gnulib + elfutils rebuild to succeed.
