### PR TITLE
ramips: add support for ASUS RT-AC52U B1

### DIFF
--- a/target/linux/ramips/dts/mt7620a_asus_rt-ac52u-b1.dts
+++ b/target/linux/ramips/dts/mt7620a_asus_rt-ac52u-b1.dts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a_asus_rt-ac5x.dtsi"
+
+/ {
+	compatible = "asus,rt-ac52u-b1", "ralink,mt7620a-soc";
+	model = "Asus RT-AC52U B1";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	rtl8367rb {
+		compatible = "realtek,rtl8367b";
+		realtek,extif = <6 1 0 1 1 1 1 1 1 2>;
+		mii-bus = <&mdio0>;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uartf", "wled", "ephy", "spi refclk";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins &mdio_pins>;
+
+	port@5 {
+		status = "okay";
+		mediatek,fixed-link = <1000 1 1 1>;
+		phy-mode = "rgmii";
+	};
+
+	mdio0: mdio-bus {
+		status = "okay";
+	};
+};
+
+&gsw {
+	mediatek,ephy-base = /bits/ 8 <8>;
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -109,6 +109,17 @@ define Device/asus_rt-ac51u
 endef
 TARGET_DEVICES += asus_rt-ac51u
 
+define Device/asus_rt-ac52u-b1
+  SOC := mt7620a
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := ASUS
+  DEVICE_MODEL := RT-AC52U
+  DEVICE_VARIANT := B1
+  DEVICE_PACKAGES := kmod-mt76x0e kmod-usb2 kmod-usb-ohci \
+	kmod-usb-ledtrig-usbport kmod-switch-rtl8367b
+endef
+TARGET_DEVICES += asus_rt-ac52u-b1
+
 define Device/asus_rt-ac54u
   SOC := mt7620a
   IMAGE_SIZE := 16064k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -153,6 +153,7 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan:3" "2:lan:2" "3:lan:1" "4:wan" "6@eth0"
 		;;
+	asus,rt-ac52u-b1|\
 	edimax,br-6478ac-v2|\
 	lb-link,bl-w1200|\
 	tplink,archer-c2-v1)


### PR DESCRIPTION
RT-AC52U B1 Dual-Band Wi-Fi Router with two antennas and USB port

Specification:
- CPU: MediaTek MT7620A @ 580 MHz
- RAM: 64MB
- Flash: GigaDevice GD25Q128CSIG (16MB)
- WLAN: MT7620A(n) + MT7610E(ac) 2R/2T,
  - 802.11ac/n AC750 433Mbps (ac) + 300Mbps (n)
- Switch: Realtek RTL8367RB
- 4x 10/100/1000 Mbps Ethernet
- 1x 10/100/1000 Mbps WAN
- USB: USB 2.0 Controller
- 6x LED, 2x button

Installation (TFTP):
1. Power off the router.
2. Press and hold the Reset button.
3. Power on the router.
4. Wait 5 seconds, then release the Reset button.
5. Connect your PC to the router with Ethernet cable.
6. Configure a static IP address to `192.168.1.75/24`
7. Configure your TFTP client to use binary (octet) transfer mode.
8. Upload the firmware image (OpenWrt, stock, or Padavan) to `192.168.1.1`. The TFTP server accepts any filename.
9. Wait for the firmware flashing process to complete.

Known issues:
- Unable to control all LEDs while some of them are not wired to GPIO
  - I wasn't able to find the right one even if I loop over all available 