### PR TITLE
kernel: fix kmod-fb/kmod-backlight dependency direction on 6.18

### DIFF
--- a/package/kernel/linux/modules/video.mk
+++ b/package/kernel/linux/modules/video.mk
@@ -59,7 +59,7 @@ $(eval $(call KernelPackage,acpi-video))
 define KernelPackage/backlight
 	SUBMENU:=$(VIDEO_MENU)
 	TITLE:=Backlight support
-	DEPENDS:=@DISPLAY_SUPPORT +kmod-fb
+	DEPENDS:=@DISPLAY_SUPPORT +LINUX_6_12:kmod-fb
 	HIDDEN:=1
 	KCONFIG:=CONFIG_BACKLIGHT_CLASS_DEVICE \
 		CONFIG_BACKLIGHT_LCD_SUPPORT=y \
@@ -113,7 +113,7 @@ $(eval $(call KernelPackage,backlight-pwm))
 define KernelPackage/fb
   SUBMENU:=$(VIDEO_MENU)
   TITLE:=Framebuffer and framebuffer console support
-  DEPENDS:=@DISPLAY_SUPPORT
+  DEPENDS:=@DISPLAY_SUPPORT +PACKAGE_kmod-backlight:kmod-backlight
   KCONFIG:= \
 	CONFIG_FB \
 	CONFIG_FB_DEVICE=y \


### PR DESCRIPTION
Since 6.18, fb.ko calls into the backlight class rather than the reverse, so it depends on backlight.ko when CONFIG_FB_BACKLIGHT is set, which in-tree only happens via FB_TFT's select. Building kmod-fb-tft on a 6.18 target with DISPLAY_SUPPORT therefore fails with:

```
 Package kmod-fb is missing dependencies for the following libraries:
 backlight.ko
```

Declare the dependency on kmod-fb, conditional on kmod-backlight being built. An unconditional +kmod-backlight would form a recursive dependency with KernelPackage/backlight's +kmod-fb, both as a kconfig select cycle and as a circular PACK_ prerequisite that make resolves by dropping an edge.

backlight.ko only references fb.ko on 6.12, so narrow that reverse dependency to +LINUX_6_12:kmod-fb, which leaves a single edge on 6.18.