### PR TITLE
[25.12] ppp: fix precompiled filter option

### DIFF
--- a/package/network/services/ppp/Makefile
+++ b/package/network/services/ppp/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ppp
 PKG_VERSION:=2.5.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/ppp-project/ppp

--- a/package/network/services/ppp/patches/310-precompile_filter.patch
+++ b/package/network/services/ppp/patches/310-precompile_filter.patch
@@ -13,17 +13,21 @@ Signed-off-by: Jo-Philipp Wich <jo@mein.io>
 
 --- a/configure.ac
 +++ b/configure.ac
-@@ -306,6 +306,9 @@ AM_CONDITIONAL(PPP_WITH_PAM, test "x${wi
+@@ -306,6 +306,13 @@ AM_CONDITIONAL(PPP_WITH_PAM, test "x${wi
  # With libpcap support, activate pppd on network activity
  AX_CHECK_PCAP
  
 +# internal statically linked pcap
 +AM_CONDITIONAL(PPP_WITH_PRECOMPILED_FILTER, test "x${with_static_pcap}" = "xyes")
++AM_COND_IF([PPP_WITH_PRECOMPILED_FILTER], [
++    AC_DEFINE([PPP_WITH_PRECOMPILED_FILTER], 1, [Have precompiled packet activity filter support])
++    AC_DEFINE([PPP_WITH_FILTER], 1, [Have packet activity filter support])
++])
 +
  #
  # SunOS provides a version of libpcap that would work, but SunOS has no support for activity filter
  AM_CONDITIONAL([PPP_WITH_FILTER], [ test "x${with_pcap}" = "xyes" && test "x${build_sunos}" != "xyes" ])
-@@ -348,6 +351,7 @@ $PACKAGE_NAME version $PACKAGE_VERSION
+@@ -348,6 +355,7 @@ $PACKAGE_NAME version $PACKAGE_VERSION
      With libatm..........: ${with_atm:-no}
      With libpam..........: ${with_pam:-no}
      With libpcap.........: ${with_pcap:-no}

--- a/package/network/services/ppp/patches/500-add-pptp-plugin.patch
+++ b/package/network/services/ppp/patches/500-add-pptp-plugin.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -333,6 +333,7 @@ AC_CONFIG_FILES([
+@@ -337,6 +337,7 @@ AC_CONFIG_FILES([
      pppd/plugins/pppoatm/Makefile
      pppd/plugins/pppol2tp/Makefile
      pppd/plugins/radius/Makefile


### PR DESCRIPTION
[ Upstream commit f59200bc56a4250028df060c893b64d82f561055 ]

The upgrade to 2.5.0 accidentally dropped the CPP defines, so the precompiled-active-filter option has been missing and the demand dialing option in uci has been broken since then. Add the missing defines.

Fixes: 9cecf2b16e0ea8560e50ef6719938bd80b963704 ("ppp: update to 2.5.0")
Closes: #24454