### PR TITLE
lantiq: xrx200: fix fiber led on AVM FRITZ!Box 5490/5491

### DIFF
--- a/target/linux/lantiq/dts/vr9_avm_fritz5490.dtsi
+++ b/target/linux/lantiq/dts/vr9_avm_fritz5490.dtsi
@@ -10,14 +10,13 @@
 };
 
 &aliases {
-	led-dsl = &led_info_green;
-	led-internet = &led_internet;
 	led-wifi = &led_wifi;
 };
 
 &leds {
-	led_fiber: fiber {
-		label = "green:fiber";
+	fiber {
+		function = "fiber";
+		color = <LED_COLOR_ID_GREEN>;
 		gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
 	};
 
@@ -27,8 +26,9 @@
 		gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
 	};
 
-	led_internet: internet {
-		label = "green:internet";
+	fon {
+		function = "fon";
+		color = <LED_COLOR_ID_GREEN>;
 		gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
 	};
 };

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
@@ -48,11 +48,13 @@ avm,fritz3370-rev2-micron|\
 avm,fritz3390|\
 avm,fritz3490|\
 avm,fritz3490-micron|\
-avm,fritz5490|\
-avm,fritz5490-micron|\
 avm,fritz7490|\
 avm,fritz7490-micron)
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x17"
+	;;
+avm,fritz5490|\
+avm,fritz5490-micron)
+	ucidef_set_led_netdev "fiber" "fiber" "green:fiber" "wan" "link"
 	;;
 bt,homehub-v5a)
 	ucidef_set_led_default "dimmed" "dimmed" "dimmed" "0"


### PR DESCRIPTION
The AVM 5490 and 5491 do not have Internet, LAN and DSL LEDs. Instead, they have a fiber and FON LED. This commit adds a trigger for the fiber LED and removes triggers for the LAN, DSL and Internet LEDs.

Fixes: 48b2df5a4164 ("lantiq: add support for AVM Fritzbox 5490/5491")
Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>