### PR TITLE
ramips: add Xiaomi Mi Router TR60x series

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/ramips
+++ b/package/boot/uboot-tools/uboot-envtools/files/ramips
@@ -96,7 +96,10 @@ wifire,s1500-nbn)
 bolt,arion|\
 xiaomi,mi-router-cr6606|\
 xiaomi,mi-router-cr6608|\
-xiaomi,mi-router-cr6609)
+xiaomi,mi-router-cr6609|\
+xiaomi,mi-router-tr606|\
+xiaomi,mi-router-tr608|\
+xiaomi,mi-router-tr609)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x20000"
 	;;
 buffalo,wsr-1166dhp|\

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-tr606.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-tr606.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_xiaomi_mi-router-cr660x.dtsi"
+
+/ {
+	compatible = "xiaomi,mi-router-tr606", "mediatek,mt7621-soc";
+	model = "Xiaomi Mi Router TR606";
+};

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-tr608.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-tr608.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_xiaomi_mi-router-cr660x.dtsi"
+
+/ {
+	compatible = "xiaomi,mi-router-tr608", "mediatek,mt7621-soc";
+	model = "Xiaomi Mi Router TR608";
+};

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-tr609.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-tr609.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_xiaomi_mi-router-cr660x.dtsi"
+
+/ {
+	compatible = "xiaomi,mi-router-tr609", "mediatek,mt7621-soc";
+	model = "Xiaomi Mi Router TR609";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -3640,6 +3640,24 @@ define Device/xiaomi_mi-router-cr6609
 endef
 TARGET_DEVICES += xiaomi_mi-router-cr6609
 
+define Device/xiaomi_mi-router-tr606
+  $(Device/xiaomi_mi-router-cr660x)
+  DEVICE_MODEL := Mi Router TR606
+endef
+TARGET_DEVICES += xiaomi_mi-router-tr606
+
+define Device/xiaomi_mi-router-tr608
+  $(Device/xiaomi_mi-router-cr660x)
+  DEVICE_MODEL := Mi Router TR608
+endef
+TARGET_DEVICES += xiaomi_mi-router-tr608
+
+define Device/xiaomi_mi-router-tr609
+  $(Device/xiaomi_mi-router-cr660x)
+  DEVICE_MODEL := Mi Router TR609
+endef
+TARGET_DEVICES += xiaomi_mi-router-tr609
+
 define Device/xiaomi_redmi-router-ac2100
   $(Device/xiaomi_nand_separate)
   DEVICE_MODEL := Redmi Router AC2100

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -257,7 +257,10 @@ xiaomi,mi-router-ac2100)
 	;;
 xiaomi,mi-router-cr6606|\
 xiaomi,mi-router-cr6608|\
-xiaomi,mi-router-cr6609)
+xiaomi,mi-router-cr6609|\
+xiaomi,mi-router-tr606|\
+xiaomi,mi-router-tr608|\
+xiaomi,mi-router-tr609)
 	ucidef_set_led_netdev "internet" "Internet" "blue:net" "wan"
 	;;
 xiaomi,redmi-router-ac2100)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -33,6 +33,9 @@ ramips_setup_interfaces()
 	xiaomi,mi-router-cr6606|\
 	xiaomi,mi-router-cr6608|\
 	xiaomi,mi-router-cr6609|\
+	xiaomi,mi-router-tr606|\
+	xiaomi,mi-router-tr608|\
+	xiaomi,mi-router-tr609|\
 	xiaomi,redmi-router-ac2100|\
 	z-router,zr-2660|\
 	z-router,zr-2662|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -156,6 +156,9 @@ platform_do_upgrade() {
 	xiaomi,mi-router-cr6606|\
 	xiaomi,mi-router-cr6608|\
 	xiaomi,mi-router-cr6609|\
+	xiaomi,mi-router-tr606|\
+	xiaomi,mi-router-tr608|\
+	xiaomi,mi-router-tr609|\
 	xiaomi,redmi-router-ac2100|\
 	z-router,zr-2660|\
 	z-router,zr-2662|\


### PR DESCRIPTION
Add support for Xiaomi Mi Router TR60x series (TR606/TR608/TR609). The TR60x series shares the exact same hardware layout as the CR6606/CR6608/CR6609 series.