### PR TITLE
ramips: add support for Midea MORR-QR011

### DIFF
--- a/target/linux/generic/pending-6.18/478-mtd-spi-nor-macronix-restore-mx25l25635e-legacy.patch
+++ b/target/linux/generic/pending-6.18/478-mtd-spi-nor-macronix-restore-mx25l25635e-legacy.patch
@@ -1,0 +1,30 @@
+From: Zhenxiao Wang <85195433@qq.com>
+Date: Tue, 18 Aug 2026 16:00:00 +0800
+Subject: [PATCH] mtd: spi-nor: macronix: restore MX25L25635E legacy parameters
+
+Linux v6.12 described the MX25L25635E with a name, size and legacy read
+capabilities. These parameters were lost while retaining the JEDEC ID and
+chip fixups.
+
+Without a size, spi_nor_needs_sfdp() requires SFDP. Some MX25L25635E chips
+expose a BFPT which cannot be parsed, causing probing to fail. Restore the
+v6.12 parameters so SFDP is optional and the core can use the known 32 MiB
+geometry and read capabilities when BFPT parsing fails.
+
+Signed-off-by: Zhenxiao Wang <85195433@qq.com>
+---
+ drivers/mtd/spi-nor/macronix.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/drivers/mtd/spi-nor/macronix.c
++++ b/drivers/mtd/spi-nor/macronix.c
+@@ -136,6 +136,9 @@ static const struct flash_info macronix_
+ 	}, {
+ 		/* MX25L25635E, MX25L25645G */
+ 		.id = SNOR_ID(0xc2, 0x20, 0x19),
++		.name = "mx25l25635e",
++		.size = SZ_32M,
++		.no_sfdp_flags = SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ,
+ 		.fixups = &mx25l25635_fixups
+ 	}, {
+ 		/* MX66L51235F */

--- a/target/linux/ramips/dts/mt7621_midea_morr-qr011.dts
+++ b/target/linux/ramips/dts/mt7621_midea_morr-qr011.dts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "midea,morr-qr011", "mediatek,mt7621-soc";
+	model = "Midea MORR-QR011";
+
+	aliases {
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+		bootargs-override = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		broken-flash-reset;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_factory_e000: macaddr@e000 {
+						reg = <0xe000 0x6>;
+					};
+
+					macaddr_factory_e006: macaddr@e006 {
+						reg = <0xe006 0x6>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x1fb0000>;
+			};
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_e006>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2268,6 +2268,15 @@ define Device/mercusys_mr70x-v1
 endef
 TARGET_DEVICES += mercusys_mr70x-v1
 
+define Device/midea_morr-qr011
+  $(Device/dsa-migration)
+  IMAGE_SIZE := 32448k
+  DEVICE_VENDOR := Midea
+  DEVICE_MODEL := MORR-QR011
+  DEVICE_PACKAGES := kmod-usb3 -uboot-envtools -wpad-basic-mbedtls
+endef
+TARGET_DEVICES += midea_morr-qr011
+
 define Device/MikroTik
   $(Device/dsa-migration)
   DEVICE_VENDOR := MikroTik


### PR DESCRIPTION
## Summary

Add support for the Midea MORR-QR011, a wired MT7621A router with
256 MiB RAM, 32 MiB SPI NOR, one WAN port, four LAN ports and USB 3.0.

This supersedes #10592. The change is split into two signed-off commits:

1. A generic Linux 6.18 SPI-NOR fix for the MX25L25635E.
2. The ramips device DTS and image definition.

## Root cause of the SPI NOR failure

The MX25L25635E on the tested unit exposes a BFPT that Linux 6.18 cannot
parse. Without a legacy size, `spi_nor_needs_sfdp()` requires SFDP and the
probe returns `-EINVAL`. Ethernet then remains deferred because its MAC
address depends on NVMEM from the factory partition, and squashfs cannot
find its root filesystem.

The generic patch restores the name, 32 MiB size and legacy dual/quad read
capabilities used by Linux 6.12. This makes SFDP optional and permits the
known parameters to be used when BFPT parsing fails.

## Review changes

- Moved the SPI-NOR fix to `target/linux/generic/pending-6.18/` and split it
  from the board-support commit.
- Refreshed the patch against Linux 6.18.44; a second
  `make target/linux/refresh` leaves it unchanged.
- Removed the unused PCIe enablement; hardware logs report no device on any
  PCIe port.
- Removed the unverified `uart3` GPIO mux and retained only `wdt` for the
  reset button on GPIO 18.
- Expanded the device commit with literal Breed boot commands, recovery and
  stock-revert notes, MAC layout, and the known hardware inventory.

## Validation

- Rebased on current `openwrt/openwrt:main` (`7b7cf1454a`).
- `scripts/checkpatch.pl` passes both commits with 0 errors and 0 warnings.
- A clean ramips/mt7621 device-only build completes successfully.
- Both initramfs and squashfs-sysupgrade images are generated.
- The compiled profile reports the expected 32 MiB image limit and
  `midea,morr-qr011` supported-device string.
- Initramfs and squashfs-sysupgrade were boot-tested on hardware; SPI NOR,
  Ethernet links and DHCP work.

The board has one system/status LED, but its GPIO and polarity have not been
traced, so no LED node is guessed. The UART pad order and power-adapter rating
were likewise not recorded on the tested unit.
