### PR TITLE
ath79: add support for TP-Link TL-WR942N v1

### DIFF
--- a/target/linux/ath79/dts/qca9561_tplink_tl-wr942n-v1.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_tl-wr942n-v1.dts
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "tplink,tl-wr942n-v1", "qca,qca9561";
+	model = "TP-Link TL-WR942N v1";
+
+	aliases {
+		led-boot = &status;
+		led-failsafe = &status;
+		led-running = &status;
+		led-upgrade = &status;
+		label-mac-device = &wmac;
+	};
+
+	led_spi {
+		compatible = "spi-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sck-gpios = <&gpio 18 GPIO_ACTIVE_HIGH>;	// 74HC595 SRCLK
+		mosi-gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;	// 74HC595 SER
+		cs-gpios = <&gpio 20 GPIO_ACTIVE_LOW>;	// 74HC595 RCLK
+		num-chipselects = <1>;
+
+		led_gpio: led_gpio@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			registers-number = <1>;
+			spi-max-frequency = <10000000>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_shift_register_hub_reset {
+			gpio-export,name = "tp-link:power:usb";
+			gpio-export,output = <1>;
+			gpios = <&led_gpio 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_shift_register_oe {
+			gpio-export,name = "tp-link:oe:sr";
+			gpio-export,output = <0>;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_shift_register_reset {
+			gpio-export,name = "tp-link:reset:sr";
+			gpio-export,output = <1>;
+			gpios = <&gpio 19 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		status: status_led {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "heartbeat";
+		};
+
+		wifi {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
+			gpios = <&led_gpio 6 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		lan1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			gpios = <&led_gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&led_gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			gpios = <&led_gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		lan4 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <4>;
+			gpios = <&led_gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&led_gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_amber {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&led_gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WPS;
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+		};
+
+		usb1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_USB;
+			function-enumerator = <1>;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		usb2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_USB;
+			function-enumerator = <2>;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		rfkill {
+			label = "RFKILL button";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x020000 0xe20000>;
+			};
+
+			product_info: partition@e40000 {
+				label = "product-info";
+				reg = <0xe40000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_product_info: macaddr@c {
+						compatible = "mac-base";
+						reg = <0xc 0x11>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@e50000 {
+				label = "partition-table";
+				reg = <0xe50000 0x010000>;
+				read-only;
+			};
+
+			partition@e60000 {
+				label = "oem-config";
+				reg = <0xe60000 0x040000>;
+				read-only;
+			};
+
+			partition@ea0000 {
+				label = "oem-vars";
+				reg = <0xea0000 0x150000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb1 {
+	status = "okay";
+};
+
+&eth0 {
+	nvmem-cells = <&macaddr_product_info 1>;
+	nvmem-cell-names = "mac-address";
+	status = "okay";
+	phy-handle = <&swphy0>;
+
+	gmac-config {
+		device = <&gmac>;
+
+		switch-phy-addr-swap = <1>;
+		switch-phy-swap = <1>;
+	};
+};
+
+&eth1 {
+	nvmem-cells = <&macaddr_product_info 0>;
+	nvmem-cell-names = "mac-address";
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+	nvmem-cells = <&macaddr_product_info 0>, <&cal_art_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -418,6 +418,15 @@ tplink,tl-wr1043n-v5)
 	ucidef_set_led_switch "lan3" "LAN3" "green:lan3" "switch0" "0x04"
 	ucidef_set_led_switch "lan4" "LAN4" "green:lan4" "switch0" "0x02"
 	;;
+tplink,tl-wr942n-v1)
+	ucidef_set_led_switch "lan1" "LAN1" "green:lan-1" "switch0" "0x04"
+	ucidef_set_led_switch "lan2" "LAN2" "green:lan-2" "switch0" "0x08"
+	ucidef_set_led_switch "lan3" "LAN3" "green:lan-3" "switch0" "0x10"
+	ucidef_set_led_switch "lan4" "LAN4" "green:lan-4" "switch0" "0x02"
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
+	ucidef_set_led_usbport "usb_lower" "USB (lower)" "green:usb-1" "1-1-port2"
+	ucidef_set_led_usbport "usb_upper" "USB (upper)" "green:usb-2" "1-1-port1"
+	;;
 tplink,archer-c6-v2|\
 tplink,archer-c6-v2-us)
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x3c"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -554,7 +554,8 @@ ath79_setup_interfaces()
 		;;
 	tplink,tl-wr841hp-v2|\
 	tplink,tl-wr842n-v2|\
-	tplink,tl-wr941hp-v1)
+	tplink,tl-wr941hp-v1|\
+	tplink,tl-wr942n-v1)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:4" "2:lan:1" "3:lan:2" "4:lan:3"

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -882,6 +882,18 @@ define Device/tplink_tl-wr941hp-v1
 endef
 TARGET_DEVICES += tplink_tl-wr941hp-v1
 
+define Device/tplink_tl-wr942n-v1
+  $(Device/tplink-safeloader-uimage)
+  SOC := qca9561
+  IMAGE_SIZE := 14464k
+  DEVICE_MODEL := TL-WR942N
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport
+  TPLINK_BOARD_ID := TLWR942NV1
+  SUPPORTED_DEVICES += tl-wr942n-v1
+endef
+TARGET_DEVICES += tplink_tl-wr942n-v1
+
 define Device/tplink_wbs210-v1
   $(Device/tplink-safeloader-okli)
   SOC := ar9344

--- a/target/linux/generic/pending-6.18/809-01-nvmem-core-generalize-mac-base-cells-handling.patch
+++ b/target/linux/generic/pending-6.18/809-01-nvmem-core-generalize-mac-base-cells-handling.patch
@@ -13,15 +13,19 @@ exposing a common helper.
 Such helper will change the nvmem_info_cell and apply the correct post
 process function to correctly parse the mac address.
 
+OpenWrt also normalizes hyphen-separated ASCII MAC addresses before
+parsing them, as used by some TP-Link devices.
+
 Since the API requires OF and is only related to layout, move the
 function in layouts.c to correctly handle non-OF NVMEM.
 
 Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+Signed-off-by: Gleb Pesin <dormancygrace@gmail.com>
 ---
  drivers/nvmem/core.c           | 79 +--------------------------------
- drivers/nvmem/layouts.c        | 80 ++++++++++++++++++++++++++++++++++
+ drivers/nvmem/layouts.c        | 87 ++++++++++++++++++++++++++++++++++
  include/linux/nvmem-provider.h |  4 ++
- 3 files changed, 86 insertions(+), 77 deletions(-)
+ 3 files changed, 93 insertions(+), 77 deletions(-)
 
 --- a/drivers/nvmem/core.c
 +++ b/drivers/nvmem/core.c
@@ -142,7 +146,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  #include <linux/nvmem-consumer.h>
  #include <linux/nvmem-provider.h>
  #include <linux/of.h>
-@@ -21,6 +24,83 @@
+@@ -21,6 +24,90 @@
  #define to_nvmem_layout_device(_dev) \
  	container_of((_dev), struct nvmem_layout, dev)
  
@@ -162,11 +166,18 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 +				     void *buf, size_t bytes)
 +{
 +	u8 mac[ETH_ALEN];
++	char macstr[3 * ETH_ALEN] = {};
++	int i;
 +
 +	if (WARN_ON(bytes != 3 * ETH_ALEN - 1))
 +		return -EINVAL;
 +
-+	if (!mac_pton(buf, mac))
++	memcpy(macstr, buf, sizeof(macstr) - 1);
++	for (i = 2; i < sizeof(macstr) - 1; i += 3)
++		if (macstr[i] == '-')
++			macstr[i] = ':';
++
++	if (!mac_pton(macstr, mac))
 +		return -EINVAL;
 +
 +	if (index)


### PR DESCRIPTION
## Hardware

- Qualcomm Atheros QCA9561 at 775 MHz (DDR/AHB at 650/258 MHz)
- 128 MiB DDR2 RAM
- 16 MiB SPI NOR flash
- 2.4 GHz 3x3 802.11n Wi-Fi
- 4x 10/100 Mbps LAN and 1x 10/100 Mbps WAN
- 2x USB 2.0
- 11 LEDs, most controlled through a 74HC595 shift register
- Reset and Wi-Fi buttons
- 12 VDC, 1.5 A power supply

## Origin

This device was supported by the legacy ar71xx target before the OpenWrt 21.02 transition. This PR ports the board to ath79.

## MAC address layout

The base MAC is stored at offset `0xc` in the `product-info` partition as an ASCII record using hyphen-separated octets. The generic `mac-base` parser is extended for this format, so Ethernet and Wi-Fi receive their factory MAC addresses during driver probe without UCI overrides.

- LAN (`eth0`): base + 0
- WAN (`eth1`): base + 1
- Wi-Fi: base + 0

## Serial console

A UART header is present on the PCB. Production OEM U-Boot and firmware disable the serial console and use GPIOs 14 and 15 to control the two USB LEDs. The pinout and baud rate are not documented for production units; serial access therefore requires a UART-enabled U-Boot build.

## Installation

### Vendor web interface

Upload the generated factory image through the normal firmware upgrade page.

### U-Boot TFTP recovery

1. Configure the host as `192.168.0.66/24` and start a TFTP server.
2. Rename the factory image to `WR942v1_recovery.bin` and place it in the TFTP root.
3. Hold Reset while powering on and release it when the WPS LED turns on.

The recovery mode is unavailable in beta OEM firmware.

### UART-enabled U-Boot

1. Interrupt autoboot with `tpl`.
2. Configure the router and TFTP server addresses.
3. Run:

```
tftp 0x81000000 openwrt-ath79-generic-tplink_tl-wr942n-v1-squashfs-sysupgrade.bin
erase 0x9f020000 +$filesize
cp.b 0x81000000 0x9f020000 $filesize
reset
```

## Tested

- Booted on TL-WR942N v1 hardware
- Factory MAC addresses on LAN, WAN and Wi-Fi
- LAN switch and WAN interface enumeration
- Both USB ports and their activity LEDs
- Open Wi-Fi AP on the LAN bridge
- Wi-Fi button generates rfkill events and toggles the radio
- WPS/Reset button reboots the device on a short press
