### PR TITLE
ramips: add unified Xiaomi Mi Router CR660x-TR60x profile

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/ramips
+++ b/package/boot/uboot-tools/uboot-envtools/files/ramips
@@ -94,6 +94,7 @@ wifire,s1500-nbn)
 	ubootenv_add_mtd "u-boot-env" "0x0" "0x1000" "0x20000"
 	;;
 bolt,arion|\
+xiaomi,mi-router-cr660x-tr60x|\
 xiaomi,mi-router-cr6606|\
 xiaomi,mi-router-cr6608|\
 xiaomi,mi-router-cr6609)

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-cr660x-tr60x.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-cr660x-tr60x.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_xiaomi_mi-router-cr660x.dtsi"
+
+/ {
+	compatible = "xiaomi,mi-router-cr660x-tr60x", "mediatek,mt7621-soc";
+	model = "Xiaomi Mi Router CR660x-TR60x";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -3622,6 +3622,12 @@ define Device/xiaomi_mi-router-cr660x
   DEVICE_PACKAGES += kmod-mt7915-firmware
 endef
 
+define Device/xiaomi_mi-router-cr660x-tr60x
+  $(Device/xiaomi_mi-router-cr660x)
+  DEVICE_MODEL := Mi Router CR660x-TR60x
+endef
+TARGET_DEVICES += xiaomi_mi-router-cr660x-tr60x
+
 define Device/xiaomi_mi-router-cr6606
   $(Device/xiaomi_mi-router-cr660x)
   DEVICE_MODEL := Mi Router CR6606

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -255,6 +255,7 @@ xiaomi,mi-router-4a-gigabit-v2)
 xiaomi,mi-router-ac2100)
 	ucidef_set_led_netdev "wan-blue" "WAN (blue)" "blue:wan" "wan"
 	;;
+xiaomi,mi-router-cr660x-tr60x|\
 xiaomi,mi-router-cr6606|\
 xiaomi,mi-router-cr6608|\
 xiaomi,mi-router-cr6609)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -30,6 +30,7 @@ ramips_setup_interfaces()
 	tplink,mr600-v2-eu|\
 	xiaomi,mi-router-3-pro|\
 	xiaomi,mi-router-ac2100|\
+	xiaomi,mi-router-cr660x-tr60x|\
 	xiaomi,mi-router-cr6606|\
 	xiaomi,mi-router-cr6608|\
 	xiaomi,mi-router-cr6609|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -153,6 +153,7 @@ platform_do_upgrade() {
 	xiaomi,mi-router-3-pro|\
 	xiaomi,mi-router-4|\
 	xiaomi,mi-router-ac2100|\
+	xiaomi,mi-router-cr660x-tr60x|\
 	xiaomi,mi-router-cr6606|\
 	xiaomi,mi-router-cr6608|\
 	xiaomi,mi-router-cr6609|\


### PR DESCRIPTION
Add a unified "Xiaomi Mi Router CR660x-TR60x" device profile to provide a generic firmware image compatible across both CR660x and TR60x variants.

The CR660x (CR6606/CR6608/CR6609) and TR60x (TR606/TR608/TR609) series share identical hardware specs. Existing standalone profiles remain untouched.
