### PR TITLE
dropbear: drop legacy compat default

### DIFF
--- a/package/network/services/dropbear/Config.in
+++ b/package/network/services/dropbear/Config.in
@@ -13,15 +13,13 @@ config DROPBEAR_STATIC_BUILD
 
 config DROPBEAR_LEGACY_COMPAT
 	bool "Enable legacy options and features"
-	## TODO: remove "default y" in 2026
-	default y
 	help
 		Enable legacy options to be accessible.
 
 		This enables options which are improve backward compatibility
 		but are also known to have negative security impact.
 
-		Default: enabled.
+		Default: disabled.
 
 config DROPBEAR_SMALL_CODE
 	bool "Small code"


### PR DESCRIPTION
Legacy algorithms have defaulted to disabled since the Dropbear configuration refactor. That refactor kept DROPBEAR_LEGACY_COMPAT enabled temporarily and scheduled its default removal for 2026.

Remove the default selection now. Legacy options stay available to builders who explicitly enable compatibility, and existing selections remain unchanged.