### PR TITLE
[25.12] kernel: add FM25G01B/FM25G02B spi-nand support + Quad I/O fix

### DIFF
--- a/target/linux/generic/backport-6.12/436-v7.3-mtd-spinand-fmsh-add-support-for-FM25G01B-FM25G02B.patch
+++ b/target/linux/generic/backport-6.12/436-v7.3-mtd-spinand-fmsh-add-support-for-FM25G01B-FM25G02B.patch
@@ -1,0 +1,142 @@
+From d5a5c9eb2ee9ff5b4cc0be15ac7f4879d4c2f247 Mon Sep 17 00:00:00 2001
+From: Ziyang Huang <hzyitc@outlook.com>
+Date: Tue, 23 Jun 2026 22:54:22 +0800
+Subject: mtd: spinand: fmsh: add support for FM25G{01,02}B
+
+Add support for FudanMicro FM25G01B SPI NAND and FudanMicro FM25G02B SPI
+NAND.
+
+FM25G01B datasheet: https://www.fmsh.com/nvm/FM25G01B_ds_eng.pdf
+FM25G02B datasheet: https://www.fmsh.com/nvm/FM25G02B_ds_eng.pdf
+
+Signed-off-by: Ziyang Huang <hzyitc@outlook.com>
+Signed-off-by: Miquel Raynal <miquel.raynal@bootlin.com>
+---
+ drivers/mtd/nand/spi/fmsh.c | 95 +++++++++++++++++++++++++++++++++++++
+ 1 file changed, 95 insertions(+)
+
+--- a/drivers/mtd/nand/spi/fmsh.c
++++ b/drivers/mtd/nand/spi/fmsh.c
+@@ -9,6 +9,16 @@
+ #include <linux/kernel.h>
+ #include <linux/mtd/spinand.h>
+ 
++#define FM25G01B_STATUS_ECC_MASK		(7 << 4)
++	#define FM25G01B_STATUS_ECC_NO_BITFLIPS		(0 << 4)
++	#define FM25G01B_STATUS_ECC_1_3_BITFLIPS	(1 << 4)
++	#define FM25G01B_STATUS_ECC_4_BITFLIPS		(2 << 4)
++	#define FM25G01B_STATUS_ECC_5_BITFLIPS		(3 << 4)
++	#define FM25G01B_STATUS_ECC_6_BITFLIPS		(4 << 4)
++	#define FM25G01B_STATUS_ECC_7_BITFLIPS		(5 << 4)
++	#define FM25G01B_STATUS_ECC_8_BITFLIPS		(6 << 4)
++	#define FM25G01B_STATUS_ECC_UNCOR_ERROR		(7 << 4)
++
+ #define FM25S01BI3_STATUS_ECC_MASK		(7 << 4)
+ 	#define FM25S01BI3_STATUS_ECC_NO_BITFLIPS	(0 << 4)
+ 	#define FM25S01BI3_STATUS_ECC_1_3_BITFLIPS	(1 << 4)
+@@ -34,6 +44,66 @@ static SPINAND_OP_VARIANTS(update_cache_
+ 		SPINAND_PROG_LOAD_X4(false, 0, NULL, 0),
+ 		SPINAND_PROG_LOAD(false, 0, NULL, 0));
+ 
++static int fm25g01b_ooblayout_ecc(struct mtd_info *mtd, int section,
++				  struct mtd_oob_region *region)
++{
++	if (section)
++		return -ERANGE;
++
++	region->offset = 64;
++	region->length = 64;
++
++	return 0;
++}
++
++static int fm25g01b_ooblayout_free(struct mtd_info *mtd, int section,
++				   struct mtd_oob_region *region)
++{
++	if (section)
++		return -ERANGE;
++
++	/* reserve 2 bytes for the BBM */
++	region->offset = 2;
++	region->length = 62;
++
++	return 0;
++}
++
++static int fm25g01b_ecc_get_status(struct spinand_device *spinand,
++				   u8 status)
++{
++	switch (status & FM25G01B_STATUS_ECC_MASK) {
++	case FM25G01B_STATUS_ECC_NO_BITFLIPS:
++		return 0;
++
++	case FM25G01B_STATUS_ECC_1_3_BITFLIPS:
++		return 3;
++
++	case FM25G01B_STATUS_ECC_4_BITFLIPS:
++		return 4;
++
++	case FM25G01B_STATUS_ECC_5_BITFLIPS:
++		return 5;
++
++	case FM25G01B_STATUS_ECC_6_BITFLIPS:
++		return 6;
++
++	case FM25G01B_STATUS_ECC_7_BITFLIPS:
++		return 7;
++
++	case FM25G01B_STATUS_ECC_8_BITFLIPS:
++		return 8;
++
++	case FM25G01B_STATUS_ECC_UNCOR_ERROR:
++		return -EBADMSG;
++
++	default:
++		break;
++	}
++
++	return -EINVAL;
++}
++
+ static int fm25s01a_ooblayout_ecc(struct mtd_info *mtd, int section,
+ 				  struct mtd_oob_region *region)
+ {
+@@ -102,6 +172,11 @@ static int fm25s01bi3_ooblayout_free(str
+ 	return 0;
+ }
+ 
++static const struct mtd_ooblayout_ops fm25g01b_ooblayout = {
++	.ecc = fm25g01b_ooblayout_ecc,
++	.free = fm25g01b_ooblayout_free,
++};
++
+ static const struct mtd_ooblayout_ops fm25s01a_ooblayout = {
+ 	.ecc = fm25s01a_ooblayout_ecc,
+ 	.free = fm25s01a_ooblayout_free,
+@@ -113,6 +188,26 @@ static const struct mtd_ooblayout_ops fm
+ };
+ 
+ static const struct spinand_info fmsh_spinand_table[] = {
++	SPINAND_INFO("FM25G01B",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xd1),
++		     NAND_MEMORG(1, 2048, 128, 64, 1024, 21, 1, 1, 1),
++		     NAND_ECCREQ(8, 528),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&fm25g01b_ooblayout,
++				     fm25g01b_ecc_get_status)),
++	SPINAND_INFO("FM25G02B",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xd2),
++		     NAND_MEMORG(1, 2048, 128, 64, 2048, 41, 1, 1, 1),
++		     NAND_ECCREQ(8, 528),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&fm25g01b_ooblayout,
++				     fm25g01b_ecc_get_status)),
+ 	SPINAND_INFO("FM25S01A",
+ 		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xE4),
+ 		     NAND_MEMORG(1, 2048, 64, 64, 1024, 20, 1, 1, 1),

--- a/target/linux/generic/backport-6.12/437-v7.3-mtd-spinand-fmsh-fix-FM25G01B-FM25G02B-Quad-IO-read-dummy-cycles.patch
+++ b/target/linux/generic/backport-6.12/437-v7.3-mtd-spinand-fmsh-fix-FM25G01B-FM25G02B-Quad-IO-read-dummy-cycles.patch
@@ -1,0 +1,60 @@
+From 8211f2d74b356a02fe38aeea5b74030ac156461f Mon Sep 17 00:00:00 2001
+From: Aleksandr Mineev <sanderrrs@gmail.com>
+Date: Fri, 17 Jul 2026 18:50:50 +0300
+Subject: mtd: spinand: fmsh: fix FM25G01B/FM25G02B Quad I/O read dummy cycles
+
+The FM25G01B/FM25G02B datasheets specify a single dummy byte for the
+0xEB Quad I/O read-from-cache operation, but the generic
+read_cache_variants set uses two dummy bytes for the 1S-4S-4S variant.
+The extra dummy byte shifts the data phase and returns corrupted data
+with no ECC error, breaking boot on boards using these chips.
+
+Use a dedicated read-from-cache variant set with ndummy=1 for the
+1S-4S-4S (0xEB) operation.
+
+FM25G01B datasheet: https://www.fmsh.com/nvm/FM25G01B_ds_eng.pdf
+FM25G02B datasheet: https://www.fmsh.com/nvm/FM25G02B_ds_eng.pdf
+
+Fixes: d5a5c9eb2ee9 ("mtd: spinand: fmsh: add support for FM25G{01,02}B")
+Cc: stable@vger.kernel.org
+Signed-off-by: Aleksandr Mineev <sanderrrs@gmail.com>
+Signed-off-by: Miquel Raynal <miquel.raynal@bootlin.com>
+---
+ drivers/mtd/nand/spi/fmsh.c | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+--- a/drivers/mtd/nand/spi/fmsh.c
++++ b/drivers/mtd/nand/spi/fmsh.c
+@@ -44,6 +44,14 @@ static SPINAND_OP_VARIANTS(update_cache_
+ 		SPINAND_PROG_LOAD_X4(false, 0, NULL, 0),
+ 		SPINAND_PROG_LOAD(false, 0, NULL, 0));
+ 
++static SPINAND_OP_VARIANTS(fm25g_read_cache_variants,
++		SPINAND_PAGE_READ_FROM_CACHE_QUADIO_OP(0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_X4_OP(0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_DUALIO_OP(0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_X2_OP(0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_OP(true, 0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_OP(false, 0, 1, NULL, 0));
++
+ static int fm25g01b_ooblayout_ecc(struct mtd_info *mtd, int section,
+ 				  struct mtd_oob_region *region)
+ {
+@@ -192,7 +200,7 @@ static const struct spinand_info fmsh_sp
+ 		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xd1),
+ 		     NAND_MEMORG(1, 2048, 128, 64, 1024, 21, 1, 1, 1),
+ 		     NAND_ECCREQ(8, 528),
+-		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++		     SPINAND_INFO_OP_VARIANTS(&fm25g_read_cache_variants,
+ 					      &write_cache_variants,
+ 					      &update_cache_variants),
+ 		     SPINAND_HAS_QE_BIT,
+@@ -202,7 +210,7 @@ static const struct spinand_info fmsh_sp
+ 		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xd2),
+ 		     NAND_MEMORG(1, 2048, 128, 64, 2048, 41, 1, 1, 1),
+ 		     NAND_ECCREQ(8, 528),
+-		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++		     SPINAND_INFO_OP_VARIANTS(&fm25g_read_cache_variants,
+ 					      &write_cache_variants,
+ 					      &update_cache_variants),
+ 		     SPINAND_HAS_QE_BIT,


### PR DESCRIPTION
Backport of openwrt/openwrt#23864 and openwrt/openwrt#24007 to 25.12.

- kernel: add support for FudanMicro FM25G01B and FM25G02B spi-nand
- kernel: fix FM25G01B/FM25G02B Quad I/O read dummy cycles

Tested on NC-1812/KN-1812 (FM25G02B).
