### PR TITLE
kernel: mtd: pending upstream patches to restore mx25l128 support

### DIFF
--- a/target/linux/ath79/patches-6.18/450-mtd-spi-nor-macronix-locking-support-for-mx25l64-ser.patch
+++ b/target/linux/ath79/patches-6.18/450-mtd-spi-nor-macronix-locking-support-for-mx25l64-ser.patch
@@ -26,7 +26,7 @@ Signed-off-by: Shiji Yang <yangshiji66@outlook.com>
  static int
  mx25l25635_post_bfpt_fixups(struct spi_nor *nor,
  			    const struct sfdp_parameter_header *bfpt_header,
-@@ -83,6 +88,10 @@ mx25l3255e_late_init_fixups(struct spi_n
+@@ -102,6 +107,10 @@ mx25l12805d_4pp3b_post_sfdp_fixups(struc
  	return 0;
  }
  
@@ -37,7 +37,7 @@ Signed-off-by: Shiji Yang <yangshiji66@outlook.com>
  static const struct spi_nor_fixups mx25l25635_fixups = {
  	.post_bfpt = mx25l25635_post_bfpt_fixups,
  	.post_sfdp = macronix_qpp4b_post_sfdp_fixups,
-@@ -128,7 +137,9 @@ static const struct flash_info macronix_
+@@ -151,7 +160,9 @@ static const struct flash_info macronix_
  		.id = SNOR_ID(0xc2, 0x20, 0x17),
  		.name = "mx25l6405d",
  		.size = SZ_8M,
@@ -45,5 +45,5 @@ Signed-off-by: Shiji Yang <yangshiji66@outlook.com>
  		.no_sfdp_flags = SECT_4K,
 +		.fixups = &mx25l64_fixups,
  	}, {
- 		/* MX25L12805D */
+ 		/* MX25L12805D, MX25L12833F, MX25L12845G */
  		.id = SNOR_ID(0xc2, 0x20, 0x18),

--- a/target/linux/generic/pending-6.18/498-mtd-spi-nor-Add-support-for-MX25L12833F-and-MX25L128.patch
+++ b/target/linux/generic/pending-6.18/498-mtd-spi-nor-Add-support-for-MX25L12833F-and-MX25L128.patch
@@ -1,0 +1,78 @@
+From f4ba49b2f4f1fe47be1aa0281db345007a4f70d1 Mon Sep 17 00:00:00 2001
+From: Cheng Ming Lin <chengminglin@mxic.com.tw>
+Date: Fri, 5 Jun 2026 16:48:36 +0800
+Subject: [PATCH 1/2] mtd: spi-nor: Add support for MX25L12833F and MX25L12845G
+
+Add support for Macronix MX25L12833F and MX25L12845G SPI NOR flashes.
+These parts share the same JEDEC ID (0xc2, 0x20, 0x18) as the legacy
+MX25L12805D.
+
+The newer flashes support SFDP and 1-4-4 Page Program in 3-byte address
+mode, but this 4PP capability is not defined in their SFDP tables.
+Conversely, the legacy MX25L12805D lacks SFDP support entirely and does
+not support 4PP.
+
+To safely enable 4PP for the newer flashes without breaking the legacy
+part, introduce a post_sfdp fixup. Since the legacy MX25L12805D does
+not support SFDP, it falls back to static parameters and will never
+execute the post_sfdp hook. The newer flashes will successfully parse
+the SFDP, trigger the hook, and safely append the SNOR_HWCAPS_PP_1_4_4
+capability.
+
+Signed-off-by: Cheng Ming Lin <chengminglin@mxic.com.tw>
+Reviewed-by: Michael Walle <mwalle@kernel.org>
+---
+ drivers/mtd/spi-nor/macronix.c | 26 +++++++++++++++++++++++++-
+ 1 file changed, 25 insertions(+), 1 deletion(-)
+
+--- a/drivers/mtd/spi-nor/macronix.c
++++ b/drivers/mtd/spi-nor/macronix.c
+@@ -83,6 +83,25 @@ mx25l3255e_late_init_fixups(struct spi_n
+ 	return 0;
+ }
+ 
++static int
++mx25l12805d_4pp3b_post_sfdp_fixups(struct spi_nor *nor)
++{
++	struct spi_nor_flash_parameter *params = nor->params;
++
++	/*
++	 * JEDEC ID 0xc22018 is shared by MX25L12805D (no SFDP, no 4PP) and
++	 * MX25L12833F/MX25L12845G (support SFDP and 4PP in 3-byte mode).
++	 * The legacy 05D lacks SFDP and will not execute this hook. For
++	 * the newer flashes, 3-byte 1-4-4 PP is not defined in SFDP, so
++	 * we safely enable it here.
++	 */
++	params->hwcaps.mask |= SNOR_HWCAPS_PP_1_4_4;
++	spi_nor_set_pp_settings(&params->page_programs[SNOR_CMD_PP_1_4_4],
++				SPINOR_OP_PP_1_4_4, SNOR_PROTO_1_4_4);
++
++	return 0;
++}
++
+ static const struct spi_nor_fixups mx25l25635_fixups = {
+ 	.post_bfpt = mx25l25635_post_bfpt_fixups,
+ 	.post_sfdp = macronix_qpp4b_post_sfdp_fixups,
+@@ -96,6 +115,10 @@ static const struct spi_nor_fixups mx25l
+ 	.late_init = mx25l3255e_late_init_fixups,
+ };
+ 
++static const struct spi_nor_fixups mx25l12805d_4pp3b_fixups = {
++	.post_sfdp = mx25l12805d_4pp3b_post_sfdp_fixups,
++};
++
+ static const struct flash_info macronix_nor_parts[] = {
+ 	{
+ 		.id = SNOR_ID(0xc2, 0x20, 0x10),
+@@ -130,9 +153,10 @@ static const struct flash_info macronix_
+ 		.size = SZ_8M,
+ 		.no_sfdp_flags = SECT_4K,
+ 	}, {
+-		/* MX25L12805D */
++		/* MX25L12805D, MX25L12833F, MX25L12845G */
+ 		.id = SNOR_ID(0xc2, 0x20, 0x18),
+ 		.flags = SPI_NOR_HAS_LOCK | SPI_NOR_4BIT_BP,
++		.fixups = &mx25l12805d_4pp3b_fixups,
+ 	}, {
+ 		/* MX25L25635E, MX25L25645G */
+ 		.id = SNOR_ID(0xc2, 0x20, 0x19),

--- a/target/linux/generic/pending-6.18/499-mtd-spi-nor-macronix-Restore-fallback-parameters-for.patch
+++ b/target/linux/generic/pending-6.18/499-mtd-spi-nor-macronix-Restore-fallback-parameters-for.patch
@@ -1,0 +1,43 @@
+From 60c5957d22e054357ee4c7aa263e0962356026f5 Mon Sep 17 00:00:00 2001
+From: Cheng Ming Lin <chengminglin@mxic.com.tw>
+Date: Fri, 5 Jun 2026 16:48:37 +0800
+Subject: [PATCH 2/2] mtd: spi-nor: macronix: Restore fallback parameters for
+ MX25L12805D
+
+In a previous effort to drop flash_info fields and rely on SFDP, the
+static size and no_sfdp_flags were removed from the MX25L12805D entry
+(JEDEC ID 0xc22018).
+
+At that time, the legacy MX25L12805D was already EOL and unavailable
+for physical testing. Verification was inadvertently performed using
+the newer MX25L12833F, which shares the same JEDEC ID but supports
+SFDP. As a result, the probe succeeded during testing, leading to
+the mistaken removal of the fallback parameters.
+
+Since the actual MX25L12805D lacks SFDP support entirely, it strictly
+requires these static parameters.
+
+Restore .size = SZ_16M and .no_sfdp_flags = SECT_4K to this entry
+to fix the probe failure for the legacy part.
+
+Fixes: 947c86e481a0 ("mtd: spi-nor: macronix: Drop the redundant flash info fields")
+Cc: stable@vger.kernel.org
+Signed-off-by: Cheng Ming Lin <chengminglin@mxic.com.tw>
+Reviewed-by: Michael Walle <mwalle@kernel.org>
+Reviewed-by: Miquel Raynal <miquel.raynal@bootlin.com>
+---
+ drivers/mtd/spi-nor/macronix.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/drivers/mtd/spi-nor/macronix.c
++++ b/drivers/mtd/spi-nor/macronix.c
+@@ -155,7 +155,9 @@ static const struct flash_info macronix_
+ 	}, {
+ 		/* MX25L12805D, MX25L12833F, MX25L12845G */
+ 		.id = SNOR_ID(0xc2, 0x20, 0x18),
++		.size = SZ_16M,
+ 		.flags = SPI_NOR_HAS_LOCK | SPI_NOR_4BIT_BP,
++		.no_sfdp_flags = SECT_4K,
+ 		.fixups = &mx25l12805d_4pp3b_fixups,
+ 	}, {
+ 		/* MX25L25635E, MX25L25645G */


### PR DESCRIPTION
The transition of ath79 from 6.12.x to 6.18.x caused some buffalo,wzr-600dhp with the affected spi-nor chips to bootloop because a patch (947c86e481a) applied to the 6.18.x kernel removed needed support for the chip. This series of patches is pending upstream to correct that problem.

  https://lore.kernel.org/all/20260605084837.1875896-1-linchengming884@gmail.com/

Signed-off-by: Russell Senior <russell@personaltelco.net>