### PR TITLE
octeon: add support for Ubiquiti UniFi Security Gateway Pro (USG-Pro-4)

### DIFF
--- a/target/linux/octeon/base-files/etc/board.d/01_network
+++ b/target/linux/octeon/base-files/etc/board.d/01_network
@@ -21,6 +21,9 @@ ubnt,edgerouter-6p)
 cisco,vedge1000)
 	ucidef_set_interfaces_lan_wan "mgmt0" "lan0"
 	;;
+ubnt,usg-pro-4)
+  ucidef_set_interfaces_lan_wan "eth0 eth1" "eth2 eth3"
+  ;;
 *)
 	ucidef_set_interfaces_lan_wan "eth0" "eth1"
 	;;

--- a/target/linux/octeon/base-files/etc/board.d/01_network
+++ b/target/linux/octeon/base-files/etc/board.d/01_network
@@ -22,8 +22,8 @@ cisco,vedge1000)
 	ucidef_set_interfaces_lan_wan "mgmt0" "lan0"
 	;;
 ubnt,usg-pro-4)
-  ucidef_set_interfaces_lan_wan "eth0 eth1" "eth2 eth3"
-  ;;
+	ucidef_set_interfaces_lan_wan "eth0 eth1" "eth2 eth3"
+	;;
 *)
 	ucidef_set_interfaces_lan_wan "eth0" "eth1"
 	;;

--- a/target/linux/octeon/base-files/etc/board.d/01_network
+++ b/target/linux/octeon/base-files/etc/board.d/01_network
@@ -21,6 +21,9 @@ ubnt,edgerouter-6p)
 cisco,vedge1000)
 	ucidef_set_interfaces_lan_wan "mgmt0" "lan0"
 	;;
+ubnt,usg-pro-4)
+	ucidef_set_interfaces_lan_wan "eth0 eth1" "eth2 eth3"
+	;;
 *)
 	ucidef_set_interfaces_lan_wan "eth0" "eth1"
 	;;

--- a/target/linux/octeon/base-files/lib/preinit/01_sysinfo
+++ b/target/linux/octeon/base-files/lib/preinit/01_sysinfo
@@ -8,9 +8,16 @@ do_sysinfo_octeon() {
 	# Sadly for whatever reason the N821 (Cisco Viptela vEdge 1000) uses the
 	# same supposedly unique board ID as the EdgeRouter. This is bad, so
 	# we override what cpuinfo gives us using the device tree as a hint.
+	# Also, UniFi Security Gateway Pro (USG-Pro-4) and EdgeRouter Pro use the same board ID (UBNT_E220),
+	# so we need to override that as well.
 	case "$of_machine" in
 	"cisco,vedge1000"*)
 		return 0
+		;;
+
+	"ubnt,usg-pro-4"*)
+		return 0
+		;;
 	esac
 
 	case "$machine" in

--- a/target/linux/octeon/base-files/lib/upgrade/platform.sh
+++ b/target/linux/octeon/base-files/lib/upgrade/platform.sh
@@ -56,7 +56,8 @@ platform_copy_config() {
 		;;
 	er|\
 	ubnt,edgerouter-4|\
-	ubnt,edgerouter-6p)
+	ubnt,edgerouter-6p|\
+	ubnt,usg-pro-4)
 		platform_copy_config_helper /dev/mmcblk0p1 vfat
 		;;
 	cisco,vedge1000)
@@ -129,7 +130,8 @@ platform_do_upgrade() {
 	case "$board" in
 	er | \
 	ubnt,edgerouter-4 | \
-	ubnt,edgerouter-6p)
+	ubnt,edgerouter-6p | \
+	ubnt,usg-pro-4)
 		kernel=/dev/mmcblk0p1
 		;;
 	ubnt,erlite|\
@@ -164,6 +166,7 @@ platform_check_image() {
 	itus,shield-router | \
 	ubnt,edgerouter-4 | \
 	ubnt,edgerouter-6p | \
+	ubnt,usg-pro-4 | \
 	ubnt,erlite | \
 	ubnt,usg | \
 	cisco,vedge1000)

--- a/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn6120_ubnt_usg-pro-4.dts
+++ b/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn6120_ubnt_usg-pro-4.dts
@@ -186,8 +186,8 @@
 			#size-cells = <0>;
 			interrupts = <1 19 0 0x3f>;
 			
-			mmc_slot0:mmc-slot@0 {
-				compatible = "cavium,octeon-6130-mmc-slot", "mmc-spi-slot";
+			mmc_slot0: mmc-slot@0 {
+				compatible = "cavium,octeon-6130-mmc-slot";
 				reg = <0>;
 				spi-max-frequency = <26000000>;
 				voltage-ranges = <3300 3300>;

--- a/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn6120_ubnt_usg-pro-4.dts
+++ b/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn6120_ubnt_usg-pro-4.dts
@@ -125,22 +125,14 @@
 			#size-cells = <0>;
 			interrupts = <1 19 0 0x3f>;
 
-			mmc_slot0:mmc-slot@0 {
-				compatible = "cavium,octeon-6130-mmc-slot", "mmc-spi-slot";
+			mmc_slot0: mmc-slot@0 {
+				compatible = "cavium,octeon-6130-mmc-slot";
 				reg = <0>;
 				spi-max-frequency = <26000000>;
 				voltage-ranges = <3300 3300>;
 				cavium,bus-max-width = <8>;
 			};
 		};
-
-		/* Board-specific USB controller. Note this coexists with
-		 * the dtsi's "usbn" node (different name/unit-address, so
-		 * it isn't merged/replaced by this). If usbn is not present
-		 * on this SoC variant, consider deleting it explicitly with
-		 * /delete-node/ &usbn; to avoid a phantom, non-functional
-		 * node in the compiled tree.
-		 */
 
 		uctl: uctl@118006f000000 {
 			compatible = "cavium,octeon-6335-uctl";
@@ -176,14 +168,14 @@
 			 * trimmed to just the differing lines.
 			 */
 
-			ranges = <0 0  0x00 0x1f400000  0xc00000>,
-			<1 0  0x00 0x10000     0x30000000>,
-			<2 0  0x00 0x1d040000  0x10000>,
-			<3 0  0x00 0x1d050000  0x10000>,
-			<4 0  0x00 0x1d020000  0x10000>,
-			<5 0  0x00 0x10000     0x40000000>,
-			<6 0  0x00 0x10000     0x50000000>,
-			<7 0  0x00 0x10000     0x90000000>;
+			ranges = <0 0 0x00 0x1f400000 0xc00000>,
+            	 <1 0 0x00 0x10000 0x30000000>,
+            	 <2 0 0x00 0x1d040000 0x10000>,
+            	 <3 0 0x00 0x1d050000 0x10000>,
+            	 <4 0 0x00 0x1d020000 0x10000>,
+            	 <5 0 0x00 0x10000 0x40000000>,
+            	 <6 0 0x00 0x10000 0x50000000>,
+            	 <7 0 0x00 0x10000 0x90000000>;
 
 			cavium,cs-config@0 {
 				cavium,t-adr = <10>;
@@ -196,7 +188,6 @@
 				cavium,t-page = <25>;
 			};
 
-			/* cs2/cs3 do not exist in the dtsi - new chip selects */
 			cavium,cs-config@2 {
 				compatible = "cavium,octeon-3860-bootbus-config";
 				cavium,cs-index = <2>;
@@ -244,6 +235,10 @@
 				cavium,t-page = <300>;
 				cavium,t-rd-dly = <10>;
 			};
+
+			/delete-node/ cavium,cs-config@5;
+
+			/delete-node/ cavium,cs-config@6;
 		};
 	};
 

--- a/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn6120_ubnt_usg-pro-4.dts
+++ b/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn6120_ubnt_usg-pro-4.dts
@@ -1,104 +1,83 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
-* Device tree source for Ubiquiti UniFi Security Gateway Pro (USG-Pro-4).
-*
-* Written by: Niko Huuskonen <niko.huuskonen.00@gmail.com>
-*/
+ * Device tree source for Ubiquiti UniFi Security Gateway Pro (USG-Pro-4).
+ *
+ * Written by: Niko Huuskonen <niko.huuskonen.00@gmail.com>
+ */
 
 /include/ "octeon_3xxx.dtsi"
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/leds/common.h>
 
+/* octeon,6120 is an Octeon II (CN61xx-class) part, which exposes USB via
+ * EHCI/OHCI behind UCTL (defined below) - not the older 5750-generation
+ * USBN/USBC OTG block the dtsi provides for CN5xxx-class chips. That block
+ * doesn't correspond to real hardware on this SoC, so drop it rather than
+ * leaving a dead node in the compiled tree.
+ */
+
+/delete-node/ &usbn;
+
 / {
 	compatible = "ubnt,usg-pro-4", "cavium,octeon-6120";
 	model = "Ubiquiti UniFi Security Gateway Pro (USG-Pro-4)";
-	interrupt-parent = <&ciu>;
-	
-	
-	&soc@0 {
-		
+
+	soc@0 {
 		smi0: mdio@1180000001800 {
-			compatible = "cavium,octeon-3860-mdio";
-			reg = <0x11800 0x1800 0x00 0x40>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			
 			phy_eth0: ethernet-phy@4 {
 				compatible = "ethernet-phy-ieee802.3-c22";
 				reg = <4>;
 				interrupt-parent = <&gpio>;
 			};
-			
+
 			phy_eth1: ethernet-phy@5 {
 				compatible = "ethernet-phy-ieee802.3-c22";
 				reg = <5>;
 				interrupt-parent = <&gpio>;
 			};
 		};
-		
+
 		smi1: mdio@1180000001900 {
 			compatible = "cavium,octeon-3860-mdio";
 			reg = <0x11800 0x1900 0x00 0x40>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			
+
 			phy_eth2: ethernet-phy@0 {
 				compatible = "ethernet-phy-ieee802.3-c22";
 				reg = <0>;
 				interrupt-parent = <&gpio>;
 			};
-			
+
 			phy_eth3: ethernet-phy@1 {
 				compatible = "ethernet-phy-ieee802.3-c22";
 				reg = <1>;
 				interrupt-parent = <&gpio>;
 			};
 		};
-		
+
 		pip: pip@11800a0000000 {
-			compatible = "cavium,octeon-3860-pip";
-			reg = <0x11800 0xa0000000 0x00 0x2000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			
-			interface@1 {
-				compatible = "cavium,octeon-3860-pip-interface";
-				reg = <1>;
-				#address-cells = <1>;
-				#size-cells = <0>;
-			};
-			
 			interface@0 {
-				compatible = "cavium,octeon-3860-pip-interface";
-				reg = <0>;
-				#address-cells = <1>;
-				#size-cells = <0>;
-				
 				ethernet@0 {
-					compatible = "cavium,octeon-3860-pip-port";
-					reg = <0>;
 					phy-handle = <&phy_eth0>;
 					rx-delay = <0>;
 					tx-delay = <0x10>;
 				};
-				
+
 				ethernet@1 {
-					compatible = "cavium,octeon-3860-pip-port";
-					reg = <1>;
 					phy-handle = <&phy_eth1>;
 					rx-delay = <0>;
 					tx-delay = <0x10>;
 				};
-				
+
 				ethernet@2 {
-					compatible = "cavium,octeon-3860-pip-port";
-					reg = <2>;
 					phy-handle = <&phy_eth2>;
 					rx-delay = <0>;
 					tx-delay = <0x10>;
 				};
-				
+
+				/* Port 3 does not exist in the dtsi - new port */
 				ethernet@3 {
 					compatible = "cavium,octeon-3860-pip-port";
 					reg = <3>;
@@ -108,11 +87,11 @@
 				};
 			};
 		};
-		
-		&uart0: serial@1180000000800 {
+
+		uart0: serial@1180000000800 {
 			clock-frequency = <600000000>;
 		};
-		
+
 		uart1: serial@1180000000c00 {
 			compatible = "cavium,octeon-3860-uart", "ns16550";
 			reg = <0x11800 0xc00 0x00 0x400>;
@@ -121,11 +100,7 @@
 			current-speed = <115200>;
 			interrupts = <0 35>;
 		};
-		
-		&twsi0 {
-			reg = <0x11800 0x1000 0x00 0x200>;
-		};
-		
+
 		twsi1: i2c@1180000001200 {
 			compatible = "cavium,octeon-3860-twsi";
 			reg = <0x11800 0x1200 0x00 0x200>;
@@ -134,7 +109,7 @@
 			clock-frequency = <100000>;
 			interrupts = <0 59>;
 		};
-		
+
 		spi: spi@1070000001000 {
 			compatible = "cavium,octeon-3010-spi";
 			reg = <0x10700 0x1000 0x00 0x100>;
@@ -142,23 +117,31 @@
 			#size-cells = <0>;
 			interrupts = <0 58>;
 		};
-		
+
 		mmc0: mmc@1180000002000 {
 			compatible = "cavium,octeon-6130-mmc";
 			reg = <0x11800 0x2000 0x00 0x100 0x11800 0x168 0x00 0x20>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			interrupts = <1 19 0 0x3f>;
-			
-			mmc_slot0: mmc-slot@0 {
-				compatible = "cavium,octeon-6130-mmc-slot";
+
+			mmc_slot0:mmc-slot@0 {
+				compatible = "cavium,octeon-6130-mmc-slot", "mmc-spi-slot";
 				reg = <0>;
 				spi-max-frequency = <26000000>;
 				voltage-ranges = <3300 3300>;
 				cavium,bus-max-width = <8>;
 			};
 		};
-		
+
+		/* Board-specific USB controller. Note this coexists with
+		 * the dtsi's "usbn" node (different name/unit-address, so
+		 * it isn't merged/replaced by this). If usbn is not present
+		 * on this SoC variant, consider deleting it explicitly with
+		 * /delete-node/ &usbn; to avoid a phantom, non-functional
+		 * node in the compiled tree.
+		 */
+
 		uctl: uctl@118006f000000 {
 			compatible = "cavium,octeon-6335-uctl";
 			reg = <0x11800 0x6f000000 0x00 0x100>;
@@ -167,14 +150,14 @@
 			ranges;
 			refclk-frequency = <12000000>;
 			refclk-type = "crystal";
-			
+
 			ehci0: ehci@16f0000000000 {
 				compatible = "cavium,octeon-6335-ehci", "usb-ehci";
 				reg = <0x16f00 0x00 0x00 0x100>;
 				interrupts = <0 56>;
 				big-endian-regs;
 			};
-			
+
 			ohci0: ohci@16f0000000400 {
 				compatible = "cavium,octeon-6335-ohci", "usb-ohci";
 				reg = <0x16f00 0x400 0x00 0x100>;
@@ -182,8 +165,17 @@
 				big-endian-regs;
 			};
 		};
-		
-		&bootbus {
+
+		bootbus: bootbus@1180000000000 {
+			/* Values sourced from a live devicetree dump on this
+			 * board's EdgeRouter Pro-based OpenWrt install, so
+			 * kept verbatim even though several entries differ
+			 * from the dtsi's generic ones. A DT property is
+			 * replaced as a whole (not merged entry-by-entry), so
+			 * the full list has to stay here rather than being
+			 * trimmed to just the differing lines.
+			 */
+
 			ranges = <0 0  0x00 0x1f400000  0xc00000>,
 			<1 0  0x00 0x10000     0x30000000>,
 			<2 0  0x00 0x1d040000  0x10000>,
@@ -192,24 +184,19 @@
 			<5 0  0x00 0x10000     0x40000000>,
 			<6 0  0x00 0x10000     0x50000000>,
 			<7 0  0x00 0x10000     0x90000000>;
-			
+
 			cavium,cs-config@0 {
-				compatible = "cavium,octeon-3860-bootbus-config";
-				cavium,cs-index = <0>;
-				cavium,bus-width = <8>;
 				cavium,t-adr = <10>;
 				cavium,t-ce = <50>;
 				cavium,t-oe = <50>;
 				cavium,t-we = <35>;
 				cavium,t-rd-hld = <25>;
 				cavium,t-wr-hld = <35>;
-				cavium,t-pause = <0>;
 				cavium,t-wait = <300>;
 				cavium,t-page = <25>;
-				cavium,pages = <0>;
-				cavium,t-rd-dly = <0>;
 			};
-			
+
+			/* cs2/cs3 do not exist in the dtsi - new chip selects */
 			cavium,cs-config@2 {
 				compatible = "cavium,octeon-3860-bootbus-config";
 				cavium,cs-index = <2>;
@@ -226,7 +213,7 @@
 				cavium,pages = <0>;
 				cavium,t-rd-dly = <0>;
 			};
-			
+
 			cavium,cs-config@3 {
 				compatible = "cavium,octeon-3860-bootbus-config";
 				cavium,cs-index = <3>;
@@ -244,11 +231,8 @@
 				cavium,pages = <0>;
 				cavium,t-rd-dly = <0>;
 			};
-			
+
 			cavium,cs-config@4 {
-				compatible = "cavium,octeon-3860-bootbus-config";
-				cavium,cs-index = <4>;
-				cavium,bus-width = <8>;
 				cavium,t-adr = <10>;
 				cavium,t-ce = <10>;
 				cavium,t-oe = <160>;
@@ -258,22 +242,21 @@
 				cavium,t-pause = <50>;
 				cavium,t-wait = <300>;
 				cavium,t-page = <300>;
-				cavium,pages = <0>;
 				cavium,t-rd-dly = <10>;
 			};
 		};
 	};
-	
+
 	leds {
 		compatible = "gpio-leds";
-		
+
 		led_blue: logo_blue {
 			color = <LED_COLOR_ID_BLUE>;
 			function = "logo";
 			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
 			default-state = "off";
 		};
-		
+
 		led_white: logo_white {
 			color = <LED_COLOR_ID_WHITE>;
 			function = "logo";
@@ -281,11 +264,11 @@
 			default-state = "on";
 		};
 	};
-	
+
 	keys {
 		compatible = "gpio-keys-polled";
 		poll-interval = <20>;
-		
+
 		button-reset {
 			label = "reset";
 			linux,code = <KEY_RESTART>;
@@ -293,7 +276,7 @@
 			debounce-interval = <60>;
 		};
 	};
-	
+
 	aliases {
 		flash0 = &flash0;
 		gpio-controller = &gpio;
@@ -311,7 +294,7 @@
 		uart0 = &uart0;
 		uart1 = &uart1;
 	};
-	
+
 	memory@0 {
 		device_type = "memory";
 		reg = <0x00 0x00 0x00 0x10000000 0x00 0x20000000 0x00 0x70000000>;

--- a/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn6120_ubnt_usg-pro-4.dts
+++ b/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn6120_ubnt_usg-pro-4.dts
@@ -315,13 +315,15 @@
 		compatible = "gpio-leds";
 		
 		led_blue: led-14 {
-			label = "ubnt:blue:logo";
+			color = <LED_COLOR_ID_BLUE>;
+			function = "logo";
 			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
 			default-state = "off";
 		};
-		
+
 		led_white: led-15 {
-			label = "ubnt:white:logo";
+			color = <LED_COLOR_ID_WHITE>;
+			function = "logo";
 			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
 			default-state = "on";
 		};

--- a/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn6120_ubnt_usg-pro-4.dts
+++ b/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn6120_ubnt_usg-pro-4.dts
@@ -8,41 +8,15 @@
 /include/ "octeon_3xxx.dtsi"
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
 
 / {
 	compatible = "ubnt,usg-pro-4", "cavium,octeon-6120";
 	model = "Ubiquiti UniFi Security Gateway Pro (USG-Pro-4)";
 	interrupt-parent = <&ciu>;
 	
-	soc@0 {
-		ciu: interrupt-controller@1070000000000 {
-			compatible = "cavium,octeon-3860-ciu";
-			interrupt-controller;
-			#interrupt-cells = <2>;
-			reg = <0x10700 0x00 0x00 0x7000>;
-		};
-		
-		gpio: gpio-controller@1070000000800 {
-			compatible = "cavium,octeon-3860-gpio";
-			reg = <0x10700 0x800 0x00 0x100>;
-			gpio-controller;
-			#gpio-cells = <2>;
-			interrupt-controller;
-			#interrupt-cells = <2>;
-			interrupts = <0 16>;
-		};
-		
-		dma0: dma-engine@1180000000100 {
-			compatible = "cavium,octeon-5750-bootbus-dma";
-			reg = <0x11800 0x100 0x00 0x08>;
-			interrupts = <0 63>;
-		};
-		
-		dma1: dma-engine@1180000000108 {
-			compatible = "cavium,octeon-5750-bootbus-dma";
-			reg = <0x11800 0x108 0x00 0x08>;
-			interrupts = <0 63>;
-		};
+	
+	&soc@0 {
 		
 		smi0: mdio@1180000001800 {
 			compatible = "cavium,octeon-3860-mdio";
@@ -51,13 +25,13 @@
 			#size-cells = <0>;
 			
 			phy_eth0: ethernet-phy@4 {
-				compatible = "broadcom,bcm", "ethernet-phy-ieee802.3-c22";
+				compatible = "ethernet-phy-ieee802.3-c22";
 				reg = <4>;
 				interrupt-parent = <&gpio>;
 			};
 			
 			phy_eth1: ethernet-phy@5 {
-				compatible = "broadcom,bcm", "ethernet-phy-ieee802.3-c22";
+				compatible = "ethernet-phy-ieee802.3-c22";
 				reg = <5>;
 				interrupt-parent = <&gpio>;
 			};
@@ -70,13 +44,13 @@
 			#size-cells = <0>;
 			
 			phy_eth2: ethernet-phy@0 {
-				compatible = "broadcom,bcm", "ethernet-phy-ieee802.3-c22";
+				compatible = "ethernet-phy-ieee802.3-c22";
 				reg = <0>;
 				interrupt-parent = <&gpio>;
 			};
 			
 			phy_eth3: ethernet-phy@1 {
-				compatible = "broadcom,bcm", "ethernet-phy-ieee802.3-c22";
+				compatible = "ethernet-phy-ieee802.3-c22";
 				reg = <1>;
 				interrupt-parent = <&gpio>;
 			};
@@ -135,13 +109,8 @@
 			};
 		};
 		
-		uart0: serial@1180000000800 {
-			compatible = "cavium,octeon-3860-uart", "ns16550";
-			reg = <0x11800 0x800 0x00 0x400>;
-			reg-shift = <3>;
+		&uart0: serial@1180000000800 {
 			clock-frequency = <600000000>;
-			current-speed = <115200>;
-			interrupts = <0 34>;
 		};
 		
 		uart1: serial@1180000000c00 {
@@ -153,13 +122,8 @@
 			interrupts = <0 35>;
 		};
 		
-		twsi0: i2c@1180000001000 {
-			compatible = "cavium,octeon-3860-twsi";
+		&twsi0 {
 			reg = <0x11800 0x1000 0x00 0x200>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			clock-frequency = <100000>;
-			interrupts = <0 45>;
 		};
 		
 		twsi1: i2c@1180000001200 {
@@ -219,11 +183,7 @@
 			};
 		};
 		
-		bootbus: bootbus@1180000000000 {
-			compatible = "cavium,octeon-3860-bootbus";
-			reg = <0x11800 0x00 0x00 0x200>;
-			#address-cells = <2>;
-			#size-cells = <1>;
+		&bootbus {
 			ranges = <0 0  0x00 0x1f400000  0xc00000>,
 			<1 0  0x00 0x10000     0x30000000>,
 			<2 0  0x00 0x1d040000  0x10000>,
@@ -232,13 +192,6 @@
 			<5 0  0x00 0x10000     0x40000000>,
 			<6 0  0x00 0x10000     0x50000000>,
 			<7 0  0x00 0x10000     0x90000000>;
-			
-			flash0: nor@0,0 {
-				compatible = "cfi-flash";
-				reg = <0 0 0x800000>;
-				#address-cells = <1>;
-				#size-cells = <1>;
-			};
 			
 			cavium,cs-config@0 {
 				compatible = "cavium,octeon-3860-bootbus-config";
@@ -314,14 +267,14 @@
 	leds {
 		compatible = "gpio-leds";
 		
-		led_blue: led-14 {
+		led_blue: logo_blue {
 			color = <LED_COLOR_ID_BLUE>;
 			function = "logo";
 			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
 			default-state = "off";
 		};
-
-		led_white: led-15 {
+		
+		led_white: logo_white {
 			color = <LED_COLOR_ID_WHITE>;
 			function = "logo";
 			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
@@ -330,12 +283,14 @@
 	};
 	
 	keys {
-		compatible = "gpio-keys";
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
 		
-		reset {
+		button-reset {
 			label = "reset";
-			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
 		};
 	};
 	

--- a/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn6120_ubnt_usg-pro-4.dts
+++ b/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn6120_ubnt_usg-pro-4.dts
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+* Device tree source for Ubiquiti UniFi Security Gateway Pro (USG-Pro-4).
+*
+* Written by: Niko Huuskonen <niko.huuskonen.00@gmail.com>
+*/
+
+/include/ "octeon_3xxx.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "ubnt,usg-pro-4", "cavium,octeon-6120";
+	model = "Ubiquiti UniFi Security Gateway Pro (USG-Pro-4)";
+	interrupt-parent = <&ciu>;
+	
+	soc@0 {
+		ciu: interrupt-controller@1070000000000 {
+			compatible = "cavium,octeon-3860-ciu";
+			interrupt-controller;
+			#interrupt-cells = <2>;
+			reg = <0x10700 0x00 0x00 0x7000>;
+		};
+		
+		gpio: gpio-controller@1070000000800 {
+			compatible = "cavium,octeon-3860-gpio";
+			reg = <0x10700 0x800 0x00 0x100>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			interrupt-controller;
+			#interrupt-cells = <2>;
+			interrupts = <0 16>;
+		};
+		
+		dma0: dma-engine@1180000000100 {
+			compatible = "cavium,octeon-5750-bootbus-dma";
+			reg = <0x11800 0x100 0x00 0x08>;
+			interrupts = <0 63>;
+		};
+		
+		dma1: dma-engine@1180000000108 {
+			compatible = "cavium,octeon-5750-bootbus-dma";
+			reg = <0x11800 0x108 0x00 0x08>;
+			interrupts = <0 63>;
+		};
+		
+		smi0: mdio@1180000001800 {
+			compatible = "cavium,octeon-3860-mdio";
+			reg = <0x11800 0x1800 0x00 0x40>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			
+			phy_eth0: ethernet-phy@4 {
+				compatible = "broadcom,bcm", "ethernet-phy-ieee802.3-c22";
+				reg = <4>;
+				interrupt-parent = <&gpio>;
+			};
+			
+			phy_eth1: ethernet-phy@5 {
+				compatible = "broadcom,bcm", "ethernet-phy-ieee802.3-c22";
+				reg = <5>;
+				interrupt-parent = <&gpio>;
+			};
+		};
+		
+		smi1: mdio@1180000001900 {
+			compatible = "cavium,octeon-3860-mdio";
+			reg = <0x11800 0x1900 0x00 0x40>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			
+			phy_eth2: ethernet-phy@0 {
+				compatible = "broadcom,bcm", "ethernet-phy-ieee802.3-c22";
+				reg = <0>;
+				interrupt-parent = <&gpio>;
+			};
+			
+			phy_eth3: ethernet-phy@1 {
+				compatible = "broadcom,bcm", "ethernet-phy-ieee802.3-c22";
+				reg = <1>;
+				interrupt-parent = <&gpio>;
+			};
+		};
+		
+		pip: pip@11800a0000000 {
+			compatible = "cavium,octeon-3860-pip";
+			reg = <0x11800 0xa0000000 0x00 0x2000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			
+			interface@1 {
+				compatible = "cavium,octeon-3860-pip-interface";
+				reg = <1>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+			};
+			
+			interface@0 {
+				compatible = "cavium,octeon-3860-pip-interface";
+				reg = <0>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				
+				ethernet@0 {
+					compatible = "cavium,octeon-3860-pip-port";
+					reg = <0>;
+					phy-handle = <&phy_eth0>;
+					rx-delay = <0>;
+					tx-delay = <0x10>;
+				};
+				
+				ethernet@1 {
+					compatible = "cavium,octeon-3860-pip-port";
+					reg = <1>;
+					phy-handle = <&phy_eth1>;
+					rx-delay = <0>;
+					tx-delay = <0x10>;
+				};
+				
+				ethernet@2 {
+					compatible = "cavium,octeon-3860-pip-port";
+					reg = <2>;
+					phy-handle = <&phy_eth2>;
+					rx-delay = <0>;
+					tx-delay = <0x10>;
+				};
+				
+				ethernet@3 {
+					compatible = "cavium,octeon-3860-pip-port";
+					reg = <3>;
+					phy-handle = <&phy_eth3>;
+					rx-delay = <0>;
+					tx-delay = <0x10>;
+				};
+			};
+		};
+		
+		uart0: serial@1180000000800 {
+			compatible = "cavium,octeon-3860-uart", "ns16550";
+			reg = <0x11800 0x800 0x00 0x400>;
+			reg-shift = <3>;
+			clock-frequency = <600000000>;
+			current-speed = <115200>;
+			interrupts = <0 34>;
+		};
+		
+		uart1: serial@1180000000c00 {
+			compatible = "cavium,octeon-3860-uart", "ns16550";
+			reg = <0x11800 0xc00 0x00 0x400>;
+			reg-shift = <3>;
+			clock-frequency = <600000000>;
+			current-speed = <115200>;
+			interrupts = <0 35>;
+		};
+		
+		twsi0: i2c@1180000001000 {
+			compatible = "cavium,octeon-3860-twsi";
+			reg = <0x11800 0x1000 0x00 0x200>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clock-frequency = <100000>;
+			interrupts = <0 45>;
+		};
+		
+		twsi1: i2c@1180000001200 {
+			compatible = "cavium,octeon-3860-twsi";
+			reg = <0x11800 0x1200 0x00 0x200>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clock-frequency = <100000>;
+			interrupts = <0 59>;
+		};
+		
+		spi: spi@1070000001000 {
+			compatible = "cavium,octeon-3010-spi";
+			reg = <0x10700 0x1000 0x00 0x100>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <0 58>;
+		};
+		
+		mmc0: mmc@1180000002000 {
+			compatible = "cavium,octeon-6130-mmc";
+			reg = <0x11800 0x2000 0x00 0x100 0x11800 0x168 0x00 0x20>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <1 19 0 0x3f>;
+			
+			mmc_slot0:mmc-slot@0 {
+				compatible = "cavium,octeon-6130-mmc-slot", "mmc-spi-slot";
+				reg = <0>;
+				spi-max-frequency = <26000000>;
+				voltage-ranges = <3300 3300>;
+				cavium,bus-max-width = <8>;
+			};
+		};
+		
+		uctl: uctl@118006f000000 {
+			compatible = "cavium,octeon-6335-uctl";
+			reg = <0x11800 0x6f000000 0x00 0x100>;
+			#address-cells = <2>;
+			#size-cells = <2>;
+			ranges;
+			refclk-frequency = <12000000>;
+			refclk-type = "crystal";
+			
+			ehci0: ehci@16f0000000000 {
+				compatible = "cavium,octeon-6335-ehci", "usb-ehci";
+				reg = <0x16f00 0x00 0x00 0x100>;
+				interrupts = <0 56>;
+				big-endian-regs;
+			};
+			
+			ohci0: ohci@16f0000000400 {
+				compatible = "cavium,octeon-6335-ohci", "usb-ohci";
+				reg = <0x16f00 0x400 0x00 0x100>;
+				interrupts = <0 56>;
+				big-endian-regs;
+			};
+		};
+		
+		bootbus: bootbus@1180000000000 {
+			compatible = "cavium,octeon-3860-bootbus";
+			reg = <0x11800 0x00 0x00 0x200>;
+			#address-cells = <2>;
+			#size-cells = <1>;
+			ranges = <0 0  0x00 0x1f400000  0xc00000>,
+			<1 0  0x00 0x10000     0x30000000>,
+			<2 0  0x00 0x1d040000  0x10000>,
+			<3 0  0x00 0x1d050000  0x10000>,
+			<4 0  0x00 0x1d020000  0x10000>,
+			<5 0  0x00 0x10000     0x40000000>,
+			<6 0  0x00 0x10000     0x50000000>,
+			<7 0  0x00 0x10000     0x90000000>;
+			
+			flash0: nor@0,0 {
+				compatible = "cfi-flash";
+				reg = <0 0 0x800000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+			};
+			
+			cavium,cs-config@0 {
+				compatible = "cavium,octeon-3860-bootbus-config";
+				cavium,cs-index = <0>;
+				cavium,bus-width = <8>;
+				cavium,t-adr = <10>;
+				cavium,t-ce = <50>;
+				cavium,t-oe = <50>;
+				cavium,t-we = <35>;
+				cavium,t-rd-hld = <25>;
+				cavium,t-wr-hld = <35>;
+				cavium,t-pause = <0>;
+				cavium,t-wait = <300>;
+				cavium,t-page = <25>;
+				cavium,pages = <0>;
+				cavium,t-rd-dly = <0>;
+			};
+			
+			cavium,cs-config@2 {
+				compatible = "cavium,octeon-3860-bootbus-config";
+				cavium,cs-index = <2>;
+				cavium,bus-width = <16>;
+				cavium,t-adr = <0>;
+				cavium,t-ce = <300>;
+				cavium,t-oe = <125>;
+				cavium,t-we = <150>;
+				cavium,t-rd-hld = <100>;
+				cavium,t-wr-hld = <300>;
+				cavium,t-pause = <0>;
+				cavium,t-wait = <300>;
+				cavium,t-page = <300>;
+				cavium,pages = <0>;
+				cavium,t-rd-dly = <0>;
+			};
+			
+			cavium,cs-config@3 {
+				compatible = "cavium,octeon-3860-bootbus-config";
+				cavium,cs-index = <3>;
+				cavium,bus-width = <16>;
+				cavium,t-adr = <0>;
+				cavium,t-ce = <30>;
+				cavium,t-oe = <125>;
+				cavium,t-we = <150>;
+				cavium,t-rd-hld = <100>;
+				cavium,t-wr-hld = <30>;
+				cavium,t-pause = <0>;
+				cavium,t-wait = <30>;
+				cavium,wait-mode;
+				cavium,t-page = <300>;
+				cavium,pages = <0>;
+				cavium,t-rd-dly = <0>;
+			};
+			
+			cavium,cs-config@4 {
+				compatible = "cavium,octeon-3860-bootbus-config";
+				cavium,cs-index = <4>;
+				cavium,bus-width = <8>;
+				cavium,t-adr = <10>;
+				cavium,t-ce = <10>;
+				cavium,t-oe = <160>;
+				cavium,t-we = <100>;
+				cavium,t-rd-hld = <0>;
+				cavium,t-wr-hld = <0>;
+				cavium,t-pause = <50>;
+				cavium,t-wait = <300>;
+				cavium,t-page = <300>;
+				cavium,pages = <0>;
+				cavium,t-rd-dly = <10>;
+			};
+		};
+	};
+	
+	leds {
+		compatible = "gpio-leds";
+		
+		led_blue: led-14 {
+			label = "ubnt:blue:logo";
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+		
+		led_white: led-15 {
+			label = "ubnt:white:logo";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+	};
+	
+	keys {
+		compatible = "gpio-keys";
+		
+		reset {
+			label = "reset";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+	
+	aliases {
+		flash0 = &flash0;
+		gpio-controller = &gpio;
+		led-boot = &led_white;
+		led-failsafe = &led_white;
+		led-running = &led_blue;
+		led-upgrade = &led_blue;
+		mmc0 = &mmc_slot0;
+		pip = &pip;
+		smi0 = &smi0;
+		smi1 = &smi1;
+		spi = &spi;
+		twsi0 = &twsi0;
+		twsi1 = &twsi1;
+		uart0 = &uart0;
+		uart1 = &uart1;
+	};
+	
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00 0x00 0x00 0x10000000 0x00 0x20000000 0x00 0x70000000>;
+	};
+};

--- a/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn6120_ubnt_usg-pro-4.dts
+++ b/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn6120_ubnt_usg-pro-4.dts
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Device tree source for Ubiquiti UniFi Security Gateway Pro (USG-Pro-4).
+ *
+ * Written by: Niko Huuskonen <niko.huuskonen.00@gmail.com>
+ */
+
+/include/ "octeon_3xxx.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/* octeon,6120 is an Octeon II (CN61xx-class) part, which exposes USB via
+ * EHCI/OHCI behind UCTL (defined below) - not the older 5750-generation
+ * USBN/USBC OTG block the dtsi provides for CN5xxx-class chips. That block
+ * doesn't correspond to real hardware on this SoC, so drop it rather than
+ * leaving a dead node in the compiled tree.
+ */
+
+/delete-node/ &usbn;
+
+/ {
+	compatible = "ubnt,usg-pro-4", "cavium,octeon-6120";
+	model = "Ubiquiti UniFi Security Gateway Pro (USG-Pro-4)";
+
+	soc@0 {
+		smi0: mdio@1180000001800 {
+			phy_eth0: ethernet-phy@4 {
+				compatible = "ethernet-phy-ieee802.3-c22";
+				reg = <4>;
+			};
+
+			phy_eth1: ethernet-phy@5 {
+				compatible = "ethernet-phy-ieee802.3-c22";
+				reg = <5>;
+			};
+		};
+
+		smi1: mdio@1180000001900 {
+			compatible = "cavium,octeon-3860-mdio";
+			reg = <0x11800 0x1900 0x00 0x40>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			phy_eth2: ethernet-phy@0 {
+				compatible = "ethernet-phy-ieee802.3-c22";
+				reg = <0>;
+			};
+
+			phy_eth3: ethernet-phy@1 {
+				compatible = "ethernet-phy-ieee802.3-c22";
+				reg = <1>;
+			};
+		};
+
+		pip: pip@11800a0000000 {
+			interface@0 {
+				ethernet@0 {
+					phy-handle = <&phy_eth0>;
+					rx-delay = <0>;
+					tx-delay = <0x10>;
+				};
+
+				ethernet@1 {
+					phy-handle = <&phy_eth1>;
+					rx-delay = <0>;
+					tx-delay = <0x10>;
+				};
+
+				ethernet@2 {
+					phy-handle = <&phy_eth2>;
+					rx-delay = <0>;
+					tx-delay = <0x10>;
+				};
+
+				/* Port 3 does not exist in the dtsi - new port.
+				 * octeon_fill_mac_addresses() in
+				 * arch/mips/cavium-octeon/octeon-platform.c only
+				 * patches a MAC into nodes that already carry a
+				 * 6-byte all-zero local-mac-address placeholder
+				 * (see ethernet@0-2 inherited from the dtsi);
+				 * without one here this port silently fell back
+				 * to a random address every boot.
+				 */
+				ethernet@3 {
+					compatible = "cavium,octeon-3860-pip-port";
+					reg = <3>;
+					local-mac-address = [00 00 00 00 00 00];
+					phy-handle = <&phy_eth3>;
+					rx-delay = <0>;
+					tx-delay = <0x10>;
+				};
+			};
+		};
+
+		uart0: serial@1180000000800 {
+			clock-frequency = <600000000>;
+		};
+
+		uart1: serial@1180000000c00 {
+			compatible = "cavium,octeon-3860-uart", "ns16550";
+			reg = <0x11800 0xc00 0x00 0x400>;
+			reg-shift = <3>;
+			clock-frequency = <600000000>;
+			current-speed = <115200>;
+			interrupts = <0 35>;
+		};
+
+		twsi1: i2c@1180000001200 {
+			compatible = "cavium,octeon-3860-twsi";
+			reg = <0x11800 0x1200 0x00 0x200>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clock-frequency = <100000>;
+			interrupts = <0 59>;
+		};
+
+		spi: spi@1070000001000 {
+			compatible = "cavium,octeon-3010-spi";
+			reg = <0x10700 0x1000 0x00 0x100>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <0 58>;
+		};
+
+		mmc0: mmc@1180000002000 {
+			compatible = "cavium,octeon-6130-mmc";
+			reg = <0x11800 0x2000 0x00 0x100 0x11800 0x168 0x00 0x20>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <1 19 0 0x3f>;
+
+			mmc_slot0: mmc-slot@0 {
+				compatible = "cavium,octeon-6130-mmc-slot";
+				reg = <0>;
+				spi-max-frequency = <26000000>;
+				voltage-ranges = <3300 3300>;
+				cavium,bus-max-width = <8>;
+			};
+		};
+
+		uctl: uctl@118006f000000 {
+			compatible = "cavium,octeon-6335-uctl";
+			reg = <0x11800 0x6f000000 0x00 0x100>;
+			#address-cells = <2>;
+			#size-cells = <2>;
+			ranges;
+			refclk-frequency = <12000000>;
+			refclk-type = "crystal";
+
+			ehci0: ehci@16f0000000000 {
+				compatible = "cavium,octeon-6335-ehci", "usb-ehci";
+				reg = <0x16f00 0x00 0x00 0x100>;
+				interrupts = <0 56>;
+				big-endian-regs;
+			};
+
+			ohci0: ohci@16f0000000400 {
+				compatible = "cavium,octeon-6335-ohci", "usb-ohci";
+				reg = <0x16f00 0x400 0x00 0x100>;
+				interrupts = <0 56>;
+				big-endian-regs;
+			};
+		};
+
+		bootbus: bootbus@1180000000000 {
+			/* Chip-select-to-address assignment taken from a live
+			 * devicetree dump on this board's EdgeRouter Pro-based
+			 * OpenWrt install; several entries differ from the
+			 * dtsi's generic ones. A DT property is replaced as a
+			 * whole (not merged entry-by-entry), so the full list
+			 * has to stay here rather than being trimmed to just
+			 * the differing lines.
+			 */
+
+			ranges = <0 0 0x00 0x1f400000 0xc00000>,
+				 <1 0 0x10000 0x30000000 0x00>,
+				 <2 0 0x00 0x1d040000 0x10000>,
+				 <3 0 0x00 0x1d050000 0x10000>,
+				 <4 0 0x00 0x1d020000 0x10000>,
+				 <5 0 0x10000 0x40000000 0x00>,
+				 <6 0 0x10000 0x50000000 0x00>,
+				 <7 0 0x10000 0x90000000 0x00>;
+
+			cavium,cs-config@0 {
+				cavium,t-adr = <10>;
+				cavium,t-ce = <50>;
+				cavium,t-oe = <50>;
+				cavium,t-we = <35>;
+				cavium,t-rd-hld = <25>;
+				cavium,t-wr-hld = <35>;
+				cavium,t-wait = <300>;
+				cavium,t-page = <25>;
+			};
+
+			cavium,cs-config@2 {
+				compatible = "cavium,octeon-3860-bootbus-config";
+				cavium,cs-index = <2>;
+				cavium,bus-width = <16>;
+				cavium,t-adr = <0>;
+				cavium,t-ce = <300>;
+				cavium,t-oe = <125>;
+				cavium,t-we = <150>;
+				cavium,t-rd-hld = <100>;
+				cavium,t-wr-hld = <300>;
+				cavium,t-pause = <0>;
+				cavium,t-wait = <300>;
+				cavium,t-page = <300>;
+				cavium,pages = <0>;
+				cavium,t-rd-dly = <0>;
+			};
+
+			cavium,cs-config@3 {
+				compatible = "cavium,octeon-3860-bootbus-config";
+				cavium,cs-index = <3>;
+				cavium,bus-width = <16>;
+				cavium,t-adr = <0>;
+				cavium,t-ce = <30>;
+				cavium,t-oe = <125>;
+				cavium,t-we = <150>;
+				cavium,t-rd-hld = <100>;
+				cavium,t-wr-hld = <30>;
+				cavium,t-pause = <0>;
+				cavium,t-wait = <30>;
+				cavium,wait-mode;
+				cavium,t-page = <300>;
+				cavium,pages = <0>;
+				cavium,t-rd-dly = <0>;
+			};
+
+			cavium,cs-config@4 {
+				cavium,t-adr = <10>;
+				cavium,t-ce = <10>;
+				cavium,t-oe = <160>;
+				cavium,t-we = <100>;
+				cavium,t-rd-hld = <0>;
+				cavium,t-wr-hld = <0>;
+				cavium,t-pause = <50>;
+				cavium,t-wait = <300>;
+				cavium,t-page = <300>;
+				cavium,t-rd-dly = <10>;
+			};
+
+			/delete-node/ cavium,cs-config@5;
+
+			/delete-node/ cavium,cs-config@6;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_blue: logo_blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = "logo";
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		led_white: logo_white {
+			color = <LED_COLOR_ID_WHITE>;
+			function = "logo";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	aliases {
+		flash0 = &flash0;
+		gpio-controller = &gpio;
+		led-boot = &led_white;
+		led-failsafe = &led_white;
+		led-running = &led_blue;
+		led-upgrade = &led_blue;
+		mmc0 = &mmc_slot0;
+		pip = &pip;
+		smi0 = &smi0;
+		smi1 = &smi1;
+		spi = &spi;
+		twsi0 = &twsi0;
+		twsi1 = &twsi1;
+		uart0 = &uart0;
+		uart1 = &uart1;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00 0x00 0x00 0x10000000 0x00 0x20000000 0x00 0x70000000>;
+	};
+};

--- a/target/linux/octeon/image/Makefile
+++ b/target/linux/octeon/image/Makefile
@@ -61,7 +61,7 @@ define Device/ubnt_usg-pro-4
   CMDLINE := $(ER_CMDLINE) ubnt_board=usg-pro-4
   KERNEL := kernel-bin | patch-cmdline | append-dtb-to-elf
   KERNEL_DEPENDS := $$(wildcard $(DTS_DIR)/$(DEVICE_DTS).dts)
-  DEVICE_PACKAGES := kmod-leds-gpio kmod-gpio-button-hotplug kmod-sfp kmod-phy-broadcom kmod-of-mdio
+  DEVICE_PACKAGES += kmod-gpio-button-hotplug kmod-leds-gpio kmod-of-mdio kmod-phy-broadcom kmod-sfp
   SUPPORTED_DEVICES += ubnt,usg-pro-4
 endef
 TARGET_DEVICES += ubnt_usg-pro-4

--- a/target/linux/octeon/image/Makefile
+++ b/target/linux/octeon/image/Makefile
@@ -58,7 +58,7 @@ define Device/ubnt_usg-pro-4
   DEVICE_MODEL := UniFi Security Gateway Pro (USG-Pro-4)
   DEVICE_DTS := cn6120_ubnt_usg-pro-4
   BOARD_NAME := ubnt,usg-pro-4
-  CMDLINE := $(ER_CMDLINE) ubnt_board=usg-pro-4
+  CMDLINE := $(ER_CMDLINE)
   KERNEL := kernel-bin | patch-cmdline | append-dtb-to-elf
   KERNEL_DEPENDS := $$(wildcard $(DTS_DIR)/$(DEVICE_DTS).dts)
   DEVICE_PACKAGES += kmod-gpio-button-hotplug kmod-leds-gpio kmod-of-mdio kmod-phy-broadcom kmod-sfp

--- a/target/linux/octeon/image/Makefile
+++ b/target/linux/octeon/image/Makefile
@@ -53,19 +53,6 @@ define Device/ubnt_edgerouter
 endef
 TARGET_DEVICES += ubnt_edgerouter
 
-define Device/ubnt_usg-pro-4
-  DEVICE_VENDOR := Ubiquiti
-  DEVICE_MODEL := UniFi Security Gateway Pro (USG-Pro-4)
-  DEVICE_DTS := cn6120_ubnt_usg-pro-4
-  BOARD_NAME := ubnt,usg-pro-4
-  CMDLINE := $(ER_CMDLINE)
-  KERNEL := kernel-bin | patch-cmdline | append-dtb-to-elf
-  KERNEL_DEPENDS := $$(wildcard $(DTS_DIR)/$(DEVICE_DTS).dts)
-  DEVICE_PACKAGES += kmod-gpio-button-hotplug kmod-leds-gpio kmod-of-mdio kmod-phy-broadcom kmod-sfp
-  SUPPORTED_DEVICES += ubnt,usg-pro-4
-endef
-TARGET_DEVICES += ubnt_usg-pro-4
-
 define Device/ubnt_edgerouter-e300
   DEVICE_VENDOR := Ubiquiti
   DEVICE_PACKAGES += kmod-gpio-button-hotplug kmod-leds-gpio kmod-of-mdio kmod-sfp kmod-usb3 kmod-usb-dwc3 kmod-usb-storage-uas
@@ -111,6 +98,19 @@ define Device/ubnt_unifi-usg
   SUPPORTED_DEVICES += ubnt,usg
 endef
 TARGET_DEVICES += ubnt_unifi-usg
+
+define Device/ubnt_unifi-usg-pro-4
+  DEVICE_VENDOR := Ubiquiti
+  DEVICE_MODEL := UniFi Security Gateway Pro (USG-Pro-4)
+  DEVICE_DTS := cn6120_ubnt_usg-pro-4
+  BOARD_NAME := ubnt,usg-pro-4
+  CMDLINE := $(ER_CMDLINE)
+  KERNEL := kernel-bin | patch-cmdline | append-dtb-to-elf
+  KERNEL_DEPENDS := $$(wildcard $(DTS_DIR)/$(DEVICE_DTS).dts)
+  DEVICE_PACKAGES += kmod-gpio-button-hotplug kmod-leds-gpio kmod-of-mdio kmod-phy-broadcom kmod-sfp
+  SUPPORTED_DEVICES += ubnt,usg-pro-4
+endef
+TARGET_DEVICES += ubnt_unifi-usg-pro-4
 
 define Device/cisco_vedge1000
   DEVICE_VENDOR := Cisco Viptela

--- a/target/linux/octeon/image/Makefile
+++ b/target/linux/octeon/image/Makefile
@@ -53,6 +53,19 @@ define Device/ubnt_edgerouter
 endef
 TARGET_DEVICES += ubnt_edgerouter
 
+define Device/ubnt_usg-pro-4
+  DEVICE_VENDOR := Ubiquiti
+  DEVICE_MODEL := UniFi Security Gateway Pro (USG-Pro-4)
+  DEVICE_DTS := cn6120_ubnt_usg-pro-4
+  BOARD_NAME := ubnt,usg-pro-4
+  CMDLINE := $(ER_CMDLINE) ubnt_board=usg-pro-4
+  KERNEL := kernel-bin | patch-cmdline | append-dtb-to-elf
+  KERNEL_DEPENDS := $$(wildcard $(DTS_DIR)/$(DEVICE_DTS).dts)
+  DEVICE_PACKAGES := kmod-leds-gpio kmod-gpio-button-hotplug kmod-sfp kmod-phy-broadcom kmod-of-mdio
+  SUPPORTED_DEVICES += ubnt,usg-pro-4
+endef
+TARGET_DEVICES += ubnt_usg-pro-4
+
 define Device/ubnt_edgerouter-e300
   DEVICE_VENDOR := Ubiquiti
   DEVICE_PACKAGES += kmod-gpio-button-hotplug kmod-leds-gpio kmod-of-mdio kmod-sfp kmod-usb3 kmod-usb-dwc3 kmod-usb-storage-uas

--- a/target/linux/octeon/image/Makefile
+++ b/target/linux/octeon/image/Makefile
@@ -99,6 +99,19 @@ define Device/ubnt_unifi-usg
 endef
 TARGET_DEVICES += ubnt_unifi-usg
 
+define Device/ubnt_unifi-usg-pro-4
+  DEVICE_VENDOR := Ubiquiti
+  DEVICE_MODEL := UniFi Security Gateway Pro (USG-Pro-4)
+  DEVICE_DTS := cn6120_ubnt_usg-pro-4
+  BOARD_NAME := ubnt,usg-pro-4
+  CMDLINE := $(ER_CMDLINE)
+  KERNEL := kernel-bin | patch-cmdline | append-dtb-to-elf
+  KERNEL_DEPENDS := $$(wildcard $(DTS_DIR)/$(DEVICE_DTS).dts)
+  DEVICE_PACKAGES += kmod-gpio-button-hotplug kmod-leds-gpio kmod-of-mdio kmod-phy-broadcom kmod-sfp
+  SUPPORTED_DEVICES += ubnt,usg-pro-4
+endef
+TARGET_DEVICES += ubnt_unifi-usg-pro-4
+
 define Device/cisco_vedge1000
   DEVICE_VENDOR := Cisco Viptela
   DEVICE_MODEL := vEdge 1000


### PR DESCRIPTION
The Ubiquiti UniFi Security Gateway Pro 4 (USG-Pro-4) is a 1U rackmount
enterprise router powered by the Cavium Octeon CN6120 SoC. Previously
partially supported by the EdgeRouter Pro target.

## Specification:
- SoC: Cavium Octeon CN6120 (2 cores @ 1.0 GHz)
- RAM: 2 GB DDR3
- Flash: 8 MB NOR flash (U-Boot + eeprom) + 4 GB eMMC (/dev/mmcblk0)
- Ethernet: 4x 10/100/1000 Mbps
  - eth0 (LAN1): Broadcom PHY on SMI0
  - eth1 (LAN2): Broadcom PHY on SMI0
  - eth2 (WAN1): Broadcom PHY on SMI1 (RJ45 / SFP combo)
  - eth3 (WAN2): Broadcom PHY on SMI1 (RJ45 / SFP combo)
- Serial: RJ45 console, 115200 8N1 (standard RJ45-to-DB9 rollover cable)
- LEDs: 2x GPIO LEDs (white / blue logo)
- Buttons: 1x reset (GPIO 0)
- Power: 110-240 VAC input, internal AC/DC adapter, 60 W (24 V, 2.5 A)
  output, ~40 W max consumption, single (non-redundant) supply

### MAC address layout:
U-Boot loads a per-unit base MAC address into the Cavium boot descriptor
handed to the kernel. octeon_fill_mac_addresses() in
arch/mips/cavium-octeon/octeon-platform.c walks the pip interface's
ethernet@N child nodes in ascending order and, for each node whose
local-mac-address property is present, is exactly 6 bytes, and is not
already a valid address, patches in base+n and advances the counter; a
node with no such placeholder property is left untouched entirely.
octeon_3xxx.dtsi already carries a zero placeholder on ethernet@0-2, so
eth0/eth1/eth2 receive base+0/base+1/base+2 automatically. ethernet@3
(eth3/WAN2) is a new port this DTS adds and had no placeholder, so it
silently fell back to a random locally-administered address on every
boot; this DTS gives it the same zero placeholder so it receives base+3
from the same per-unit sequence as the other three ports.

## Installation via U-Boot:
1. Transfer openwrt-octeon-generic-ubnt_unifi-usg-pro-4-initramfs-kernel.bin
   to a USB drive
2. Intercept U-Boot on the serial console and load the image:
   - usb start
   - usb part 0
   - fatload usb 0:1 $loadaddr openwrt-octeon-generic-ubnt_unifi-usg-pro-4-initramfs-kernel.bin
3. Boot the initramfs image: bootoctlinux 0 numcores=2 endbootargs mem=0
4. Once booted into OpenWrt, perform a standard sysupgrade to install to
   the internal eMMC flash (/dev/mmcblk0)

Signed-off-by: Niko Huuskonen <niko.huuskonen.00@gmail.com>