### PR TITLE
qualcommax: pcs: qca-uniphy: force the channel on every UNIPHY

### DIFF
--- a/target/linux/generic/backport-6.12/704-v7.3-net-phylink-treat-PSGMII-as-an-inband-capable-interface.patch
+++ b/target/linux/generic/backport-6.12/704-v7.3-net-phylink-treat-PSGMII-as-an-inband-capable-interface.patch
@@ -1,0 +1,71 @@
+From 5ba017f9efef3cf65cc60005aae4cbbf70b9b2b8 Mon Sep 17 00:00:00 2001
+From: Sandeep Sondagar <sandeepsondagar@gmail.com>
+Date: Sun, 9 Aug 2026 21:31:41 +0530
+Subject: [PATCH] net: phylink: treat PSGMII as an inband capable interface
+
+PSGMII (the Qualcomm 5-port SGMII) conveys the link negotiation result
+from the PHY back to the MAC through per-channel in-band SGMII words,
+exactly like SGMII and QSGMII.
+
+However, PHY_INTERFACE_MODE_PSGMII is missing from
+phylink_get_inband_type(), so phylink reports INBAND_NONE for it and
+phylink_pcs_neg_mode() falls back to PHYLINK_PCS_NEG_NONE. The PCS is
+then programmed in force mode and its control-register speed bits (which
+default to 1000base) are used, so a slower copper link - e.g. 100base-T
+- is reported as 1Gbps and cannot pass traffic.
+
+Classify PSGMII alongside SGMII and QSGMII as INBAND_CISCO_SGMII so the
+PCS negotiates in-band and the resolved link speed comes from the PHY
+in-band word.
+
+Also add PSGMII to the generic clause 22 PCS helper functions which
+handle the SGMII in-band word. Without this, a PCS using these helpers
+would still fall through to the default handling and force the link
+state to false in phylink_mii_c22_pcs_decode_state(), fail to encode
+the SGMII advertisement, and get rejected by phylink_get_link_timer_ns().
+
+Signed-off-by: Sandeep Sondagar <sandeepsondagar@gmail.com>
+Reviewed-by: Nicolai Buchwitz <nb@tipi-net.de>
+Link: https://patch.msgid.link/20260809-phylink-psgmii-v3-1-908dcd3a9e3d@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/phy/phylink.c | 3 +++
+ include/linux/phylink.h   | 1 +
+ 2 files changed, 4 insertions(+)
+
+--- a/drivers/net/phy/phylink.c
++++ b/drivers/net/phy/phylink.c
+@@ -1171,6 +1171,7 @@ static enum inband_type phylink_get_inba
+ {
+ 	switch (interface) {
+ 	case PHY_INTERFACE_MODE_SGMII:
++	case PHY_INTERFACE_MODE_PSGMII:
+ 	case PHY_INTERFACE_MODE_QSGMII:
+ 	case PHY_INTERFACE_MODE_QUSGMII:
+ 	case PHY_INTERFACE_MODE_USXGMII:
+@@ -3956,6 +3957,7 @@ void phylink_mii_c22_pcs_decode_state(st
+ 		break;
+ 
+ 	case PHY_INTERFACE_MODE_SGMII:
++	case PHY_INTERFACE_MODE_PSGMII:
+ 	case PHY_INTERFACE_MODE_QSGMII:
+ 		phylink_decode_sgmii_word(state, lpa);
+ 		break;
+@@ -4031,6 +4033,7 @@ int phylink_mii_c22_pcs_encode_advertise
+ 			adv |= ADVERTISE_1000XPSE_ASYM;
+ 		return adv;
+ 	case PHY_INTERFACE_MODE_SGMII:
++	case PHY_INTERFACE_MODE_PSGMII:
+ 	case PHY_INTERFACE_MODE_QSGMII:
+ 		return 0x0001;
+ 	default:
+--- a/include/linux/phylink.h
++++ b/include/linux/phylink.h
+@@ -674,6 +674,7 @@ static inline int phylink_get_link_timer
+ {
+ 	switch (interface) {
+ 	case PHY_INTERFACE_MODE_SGMII:
++	case PHY_INTERFACE_MODE_PSGMII:
+ 	case PHY_INTERFACE_MODE_QSGMII:
+ 	case PHY_INTERFACE_MODE_USXGMII:
+ 	case PHY_INTERFACE_MODE_10G_QXGMII:

--- a/target/linux/generic/backport-6.18/704-v7.3-net-phylink-treat-PSGMII-as-an-inband-capable-interface.patch
+++ b/target/linux/generic/backport-6.18/704-v7.3-net-phylink-treat-PSGMII-as-an-inband-capable-interface.patch
@@ -1,0 +1,71 @@
+From 5ba017f9efef3cf65cc60005aae4cbbf70b9b2b8 Mon Sep 17 00:00:00 2001
+From: Sandeep Sondagar <sandeepsondagar@gmail.com>
+Date: Sun, 9 Aug 2026 21:31:41 +0530
+Subject: [PATCH] net: phylink: treat PSGMII as an inband capable interface
+
+PSGMII (the Qualcomm 5-port SGMII) conveys the link negotiation result
+from the PHY back to the MAC through per-channel in-band SGMII words,
+exactly like SGMII and QSGMII.
+
+However, PHY_INTERFACE_MODE_PSGMII is missing from
+phylink_get_inband_type(), so phylink reports INBAND_NONE for it and
+phylink_pcs_neg_mode() falls back to PHYLINK_PCS_NEG_NONE. The PCS is
+then programmed in force mode and its control-register speed bits (which
+default to 1000base) are used, so a slower copper link - e.g. 100base-T
+- is reported as 1Gbps and cannot pass traffic.
+
+Classify PSGMII alongside SGMII and QSGMII as INBAND_CISCO_SGMII so the
+PCS negotiates in-band and the resolved link speed comes from the PHY
+in-band word.
+
+Also add PSGMII to the generic clause 22 PCS helper functions which
+handle the SGMII in-band word. Without this, a PCS using these helpers
+would still fall through to the default handling and force the link
+state to false in phylink_mii_c22_pcs_decode_state(), fail to encode
+the SGMII advertisement, and get rejected by phylink_get_link_timer_ns().
+
+Signed-off-by: Sandeep Sondagar <sandeepsondagar@gmail.com>
+Reviewed-by: Nicolai Buchwitz <nb@tipi-net.de>
+Link: https://patch.msgid.link/20260809-phylink-psgmii-v3-1-908dcd3a9e3d@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/phy/phylink.c | 3 +++
+ include/linux/phylink.h   | 1 +
+ 2 files changed, 4 insertions(+)
+
+--- a/drivers/net/phy/phylink.c
++++ b/drivers/net/phy/phylink.c
+@@ -1036,6 +1036,7 @@ static enum inband_type phylink_get_inba
+ {
+ 	switch (interface) {
+ 	case PHY_INTERFACE_MODE_SGMII:
++	case PHY_INTERFACE_MODE_PSGMII:
+ 	case PHY_INTERFACE_MODE_QSGMII:
+ 	case PHY_INTERFACE_MODE_QUSGMII:
+ 	case PHY_INTERFACE_MODE_USXGMII:
+@@ -4093,6 +4094,7 @@ void phylink_mii_c22_pcs_decode_state(st
+ 		break;
+ 
+ 	case PHY_INTERFACE_MODE_SGMII:
++	case PHY_INTERFACE_MODE_PSGMII:
+ 	case PHY_INTERFACE_MODE_QSGMII:
+ 		if (neg_mode == PHYLINK_PCS_NEG_INBAND_ENABLED)
+ 			phylink_decode_sgmii_word(state, lpa);
+@@ -4173,6 +4175,7 @@ int phylink_mii_c22_pcs_encode_advertise
+ 			adv |= ADVERTISE_1000XPSE_ASYM;
+ 		return adv;
+ 	case PHY_INTERFACE_MODE_SGMII:
++	case PHY_INTERFACE_MODE_PSGMII:
+ 	case PHY_INTERFACE_MODE_QSGMII:
+ 		return 0x0001;
+ 	default:
+--- a/include/linux/phylink.h
++++ b/include/linux/phylink.h
+@@ -762,6 +762,7 @@ static inline int phylink_get_link_timer
+ {
+ 	switch (interface) {
+ 	case PHY_INTERFACE_MODE_SGMII:
++	case PHY_INTERFACE_MODE_PSGMII:
+ 	case PHY_INTERFACE_MODE_QSGMII:
+ 	case PHY_INTERFACE_MODE_USXGMII:
+ 	case PHY_INTERFACE_MODE_10G_QXGMII:

--- a/target/linux/generic/pending-6.12/706-net-phy-populate-host_interfaces-when-attaching-PHY.patch
+++ b/target/linux/generic/pending-6.12/706-net-phy-populate-host_interfaces-when-attaching-PHY.patch
@@ -20,7 +20,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/phylink.c
 +++ b/drivers/net/phy/phylink.c
-@@ -2314,7 +2314,7 @@ int phylink_fwnode_phy_connect(struct ph
+@@ -2315,7 +2315,7 @@ int phylink_fwnode_phy_connect(struct ph
  {
  	struct fwnode_handle *phy_fwnode;
  	struct phy_device *phy_dev;
@@ -29,7 +29,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  
  	/* Fixed links and 802.3z are handled without needing a PHY */
  	if (pl->cfg_link_an_mode == MLO_AN_FIXED ||
-@@ -2344,6 +2344,25 @@ int phylink_fwnode_phy_connect(struct ph
+@@ -2345,6 +2345,25 @@ int phylink_fwnode_phy_connect(struct ph
  	if (pl->config->mac_requires_rxc)
  		flags |= PHY_F_RXC_ALWAYS_ON;
  

--- a/target/linux/generic/pending-6.12/770-01-net-phylink-keep-and-use-MAC-supported_interfaces-in.patch
+++ b/target/linux/generic/pending-6.12/770-01-net-phylink-keep-and-use-MAC-supported_interfaces-in.patch
@@ -41,7 +41,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
  	if (state->interface == PHY_INTERFACE_MODE_NA)
  		return phylink_validate_mask(pl, NULL, supported, state,
-@@ -1948,6 +1953,9 @@ struct phylink *phylink_create(struct ph
+@@ -1949,6 +1954,9 @@ struct phylink *phylink_create(struct ph
  	mutex_init(&pl->state_mutex);
  	INIT_WORK(&pl->resolve, phylink_resolve);
  
@@ -51,7 +51,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	pl->config = config;
  	if (config->type == PHYLINK_NETDEV) {
  		pl->netdev = to_net_dev(config->dev);
-@@ -2092,7 +2100,7 @@ static int phylink_validate_phy(struct p
+@@ -2093,7 +2101,7 @@ static int phylink_validate_phy(struct p
  		 * those which the host supports.
  		 */
  		phy_interface_and(interfaces, phy->possible_interfaces,
@@ -60,7 +60,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
  		if (phy_interface_empty(interfaces)) {
  			phylink_err(pl, "PHY has no common interfaces\n");
-@@ -3566,14 +3574,14 @@ static int phylink_sfp_config_optical(st
+@@ -3567,14 +3575,14 @@ static int phylink_sfp_config_optical(st
  
  	phylink_dbg(pl, "optical SFP: interfaces=[mac=%*pbl, sfp=%*pbl]\n",
  		    (int)PHY_INTERFACE_MODE_MAX,
@@ -77,7 +77,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  			  pl->sfp_interfaces);
  	if (phy_interface_empty(interfaces)) {
  		phylink_err(pl, "unsupported SFP module: no common interface modes\n");
-@@ -3731,7 +3739,7 @@ static int phylink_sfp_connect_phy(void
+@@ -3732,7 +3740,7 @@ static int phylink_sfp_connect_phy(void
  
  	/* Set the PHY's host supported interfaces */
  	phy_interface_and(phy->host_interfaces, phylink_sfp_interfaces,

--- a/target/linux/generic/pending-6.12/770-02-net-phylink-introduce-internal-phylink-PCS-handling.patch
+++ b/target/linux/generic/pending-6.12/770-02-net-phylink-introduce-internal-phylink-PCS-handling.patch
@@ -189,7 +189,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  		return 0;
  
  	return phylink_pcs_inband_caps(pcs, interface);
-@@ -1397,10 +1444,36 @@ static void phylink_major_config(struct
+@@ -1398,10 +1445,36 @@ static void phylink_major_config(struct
  			pl->major_config_failed = true;
  			return;
  		}
@@ -227,7 +227,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	phylink_pcs_neg_mode(pl, pcs, state->interface, state->advertising);
  
  	phylink_dbg(pl, "major config, active %s/%s/%s\n",
-@@ -1427,11 +1500,13 @@ static void phylink_major_config(struct
+@@ -1428,11 +1501,13 @@ static void phylink_major_config(struct
  	if (pcs_changed) {
  		phylink_pcs_disable(pl->pcs);
  
@@ -245,7 +245,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
  		pl->pcs = pcs;
  	}
-@@ -1909,6 +1984,44 @@ int phylink_set_fixed_link(struct phylin
+@@ -1910,6 +1985,44 @@ int phylink_set_fixed_link(struct phylin
  }
  EXPORT_SYMBOL_GPL(phylink_set_fixed_link);
  
@@ -290,7 +290,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  /**
   * phylink_create() - create a phylink instance
   * @config: a pointer to the target &struct phylink_config
-@@ -1931,6 +2044,7 @@ struct phylink *phylink_create(struct ph
+@@ -1932,6 +2045,7 @@ struct phylink *phylink_create(struct ph
  			       const struct phylink_mac_ops *mac_ops)
  {
  	bool using_mac_select_pcs = false;
@@ -298,7 +298,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	struct phylink *pl;
  	int ret;
  
-@@ -1952,9 +2066,21 @@ struct phylink *phylink_create(struct ph
+@@ -1953,9 +2067,21 @@ struct phylink *phylink_create(struct ph
  
  	mutex_init(&pl->state_mutex);
  	INIT_WORK(&pl->resolve, phylink_resolve);
@@ -320,7 +320,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
  	pl->config = config;
  	if (config->type == PHYLINK_NETDEV) {
-@@ -2025,10 +2151,16 @@ EXPORT_SYMBOL_GPL(phylink_create);
+@@ -2026,10 +2152,16 @@ EXPORT_SYMBOL_GPL(phylink_create);
   */
  void phylink_destroy(struct phylink *pl)
  {
@@ -337,7 +337,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	cancel_work_sync(&pl->resolve);
  	kfree(pl);
  }
-@@ -2473,6 +2605,7 @@ static irqreturn_t phylink_link_handler(
+@@ -2474,6 +2606,7 @@ static irqreturn_t phylink_link_handler(
   */
  void phylink_start(struct phylink *pl)
  {
@@ -345,7 +345,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	bool poll = false;
  
  	ASSERT_RTNL();
-@@ -2499,6 +2632,10 @@ void phylink_start(struct phylink *pl)
+@@ -2500,6 +2633,10 @@ void phylink_start(struct phylink *pl)
  
  	pl->pcs_state = PCS_STATE_STARTED;
  
@@ -356,7 +356,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	phylink_enable_and_run_resolve(pl, PHYLINK_DISABLE_STOPPED);
  
  	if (pl->cfg_link_an_mode == MLO_AN_FIXED && pl->link_gpio) {
-@@ -2543,6 +2680,8 @@ EXPORT_SYMBOL_GPL(phylink_start);
+@@ -2544,6 +2681,8 @@ EXPORT_SYMBOL_GPL(phylink_start);
   */
  void phylink_stop(struct phylink *pl)
  {
@@ -365,7 +365,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	ASSERT_RTNL();
  
  	if (pl->sfp_bus)
-@@ -2560,6 +2699,14 @@ void phylink_stop(struct phylink *pl)
+@@ -2561,6 +2700,14 @@ void phylink_stop(struct phylink *pl)
  	pl->pcs_state = PCS_STATE_DOWN;
  
  	phylink_pcs_disable(pl->pcs);

--- a/target/linux/generic/pending-6.12/770-03-net-phylink-add-phylink_release_pcs-to-externally-re.patch
+++ b/target/linux/generic/pending-6.12/770-03-net-phylink-add-phylink_release_pcs-to-externally-re.patch
@@ -93,7 +93,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static unsigned int phylink_pcs_inband_caps(struct phylink_pcs *pcs,
  				    phy_interface_t interface)
  {
-@@ -1818,6 +1868,10 @@ static void phylink_resolve(struct work_
+@@ -1819,6 +1869,10 @@ static void phylink_resolve(struct work_
  		if (pl->phydev)
  			link_state.link &= pl->phy_state.link;
  
@@ -104,7 +104,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  		/* Only update if the PHY link is up */
  		if (pl->phydev && pl->phy_state.link) {
  			/* If the interface has changed, force a link down
-@@ -1852,7 +1906,7 @@ static void phylink_resolve(struct work_
+@@ -1853,7 +1907,7 @@ static void phylink_resolve(struct work_
  		phylink_apply_manual_flow(pl, &link_state);
  
  	if ((mac_config && link_state.interface != pl->link_config.interface) ||
@@ -113,7 +113,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  		/* The interface has changed or a forced major configuration
  		 * was requested, so force the link down and then reconfigure.
  		 */
-@@ -1863,6 +1917,7 @@ static void phylink_resolve(struct work_
+@@ -1864,6 +1918,7 @@ static void phylink_resolve(struct work_
  		phylink_major_config(pl, false, &link_state);
  		pl->link_config.interface = link_state.interface;
  		pl->force_major_config = false;

--- a/target/linux/generic/pending-6.12/770-05-net-phylink-support-late-PCS-provider-attach.patch
+++ b/target/linux/generic/pending-6.12/770-05-net-phylink-support-late-PCS-provider-attach.patch
@@ -110,7 +110,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
  	/* What interface are supported by the current link.
  	 * Can change on removal or addition of new PCS.
-@@ -2077,6 +2079,51 @@ out:
+@@ -2078,6 +2080,51 @@ out:
  	return ret;
  }
  
@@ -162,7 +162,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  /**
   * phylink_create() - create a phylink instance
   * @config: a pointer to the target &struct phylink_config
-@@ -2137,6 +2184,11 @@ struct phylink *phylink_create(struct ph
+@@ -2138,6 +2185,11 @@ struct phylink *phylink_create(struct ph
  				 pl->supported_interfaces,
  				 pcs->supported_interfaces);
  

--- a/target/linux/generic/pending-6.12/770-07-net-phylink-add-.pcs_link_down-PCS-OP.patch
+++ b/target/linux/generic/pending-6.12/770-07-net-phylink-add-.pcs_link_down-PCS-OP.patch
@@ -35,7 +35,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  /* Query inband for a specific interface mode, asking the MAC for the
   * PCS which will be used to handle the interface mode.
   */
-@@ -1817,6 +1823,8 @@ static void phylink_link_down(struct phy
+@@ -1818,6 +1824,8 @@ static void phylink_link_down(struct phy
  
  	if (ndev)
  		netif_carrier_off(ndev);

--- a/target/linux/generic/pending-6.12/770-08-net-phylink-link-the-PCS-list-before-the-initial-con.patch
+++ b/target/linux/generic/pending-6.12/770-08-net-phylink-link-the-PCS-list-before-the-initial-con.patch
@@ -1,0 +1,72 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Julius Bairaktaris <julius@bairaktaris.de>
+Date: Sat, 23 Aug 2026 18:30:00 +0200
+Subject: [PATCH] net: phylink: link the PCS list before the initial config
+
+A PCS taken from the phylink PCS list is attached to its phylink
+instance in phylink_start() after phylink_mac_initial_config() has
+already run .pcs_config() on it, so that first call sees a NULL
+pcs->phylink. The .mac_select_pcs() route has no such window:
+phylink_major_config() sets pcs->phylink before it configures the PCS,
+which is what phylink did for every PCS before the list existed.
+
+DSA has no .mac_select_pcs, so every DSA port whose PCS comes from a
+pcs-handle takes the list route. pcs-qca-uniphy reads the
+back-reference in .pcs_config(), through phylink_expects_phy(), to tell
+a fixed link from a PHY that simply does not negotiate in band, and a
+Zyxel NBG7815 panics on the wan port as netifd brings it up:
+
+  qca-ppe 3a000000.ppe wan: configuring for phy/2500base-x link mode
+  Unable to handle kernel access to user memory outside uaccess routines
+    at virtual address 0000000000000044
+  pc : phylink_expects_phy+0x0/0x38
+  lr : qca_uniphy_pcs_config_mode.isra.0+0x398/0x45c
+  Call trace:
+   phylink_expects_phy+0x0/0x38 (P)
+   qca_uniphy_pcs_config+0xec/0x13c
+   phylink_major_config+0x1e8/0x670
+   phylink_mac_initial_config+0xb8/0x14c
+   phylink_start+0x4c/0x280
+   dsa_port_enable_rt+0x48/0xb0
+
+Link the list where pl->pcs_state has just become PCS_STATE_STARTING,
+so the guarantee holds on both routes. A .pcs_change() from a PCS that
+is now linked earlier still resolves to nothing: phylink_run_resolve()
+does nothing while phylink_disable_state holds PHYLINK_DISABLE_STOPPED,
+which only the phylink_enable_and_run_resolve() below clears. The other
+two phylink_mac_initial_config() callers are unaffected, both running
+with the list already linked - phylink_resume() only takes that path
+when it did not stop, and phylink_sfp_set_config() is gated on not
+being stopped.
+
+Fixes: 18cbd83a1443 ("generic: 6.18: import updated standalone PCS handling")
+Link: https://github.com/JuliusBairaktaris/openwrt-nss-edma/issues/23
+Assisted-by: Claude:claude-opus-5
+Signed-off-by: Julius Bairaktaris <julius@bairaktaris.de>
+---
+--- a/drivers/net/phy/phylink.c
++++ b/drivers/net/phy/phylink.c
+@@ -2735,6 +2735,12 @@ void phylink_start(struct phylink *pl)
+ 
+ 	pl->pcs_state = PCS_STATE_STARTING;
+ 
++	/* Link the available PCS to the phylink instance before the initial
++	 * config below runs .pcs_config() on the one it selects.
++	 */
++	list_for_each_entry(pcs, &pl->pcs_list, list)
++		pcs->phylink = pl;
++
+ 	/* Apply the link configuration to the MAC when starting. This allows
+ 	 * a fixed-link to start with the correct parameters, and also
+ 	 * ensures that we set the appropriate advertisement for Serdes links.
+@@ -2747,10 +2753,6 @@ void phylink_start(struct phylink *pl)
+ 
+ 	pl->pcs_state = PCS_STATE_STARTED;
+ 
+-	/* link available PCS to phylink struct */
+-	list_for_each_entry(pcs, &pl->pcs_list, list)
+-		pcs->phylink = pl;
+-
+ 	phylink_enable_and_run_resolve(pl, PHYLINK_DISABLE_STOPPED);
+ 
+ 	if (pl->cfg_link_an_mode == MLO_AN_FIXED && pl->link_gpio) {

--- a/target/linux/generic/pending-6.12/770-08-net-phylink-link-the-PCS-list-before-the-initial-con.patch
+++ b/target/linux/generic/pending-6.12/770-08-net-phylink-link-the-PCS-list-before-the-initial-con.patch
@@ -46,7 +46,7 @@ Signed-off-by: Julius Bairaktaris <julius@bairaktaris.de>
 ---
 --- a/drivers/net/phy/phylink.c
 +++ b/drivers/net/phy/phylink.c
-@@ -2735,6 +2735,12 @@ void phylink_start(struct phylink *pl)
+@@ -2736,6 +2736,12 @@ void phylink_start(struct phylink *pl)
  
  	pl->pcs_state = PCS_STATE_STARTING;
  
@@ -59,7 +59,7 @@ Signed-off-by: Julius Bairaktaris <julius@bairaktaris.de>
  	/* Apply the link configuration to the MAC when starting. This allows
  	 * a fixed-link to start with the correct parameters, and also
  	 * ensures that we set the appropriate advertisement for Serdes links.
-@@ -2747,10 +2753,6 @@ void phylink_start(struct phylink *pl)
+@@ -2748,10 +2754,6 @@ void phylink_start(struct phylink *pl)
  
  	pl->pcs_state = PCS_STATE_STARTED;
  

--- a/target/linux/generic/pending-6.18/706-net-phy-populate-host_interfaces-when-attaching-PHY.patch
+++ b/target/linux/generic/pending-6.18/706-net-phy-populate-host_interfaces-when-attaching-PHY.patch
@@ -20,7 +20,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/phylink.c
 +++ b/drivers/net/phy/phylink.c
-@@ -2283,7 +2283,7 @@ int phylink_fwnode_phy_connect(struct ph
+@@ -2284,7 +2284,7 @@ int phylink_fwnode_phy_connect(struct ph
  {
  	struct fwnode_handle *phy_fwnode;
  	struct phy_device *phy_dev;
@@ -29,7 +29,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  
  	/* Fixed links and 802.3z are handled without needing a PHY */
  	if (pl->cfg_link_an_mode == MLO_AN_FIXED ||
-@@ -2313,6 +2313,25 @@ int phylink_fwnode_phy_connect(struct ph
+@@ -2314,6 +2314,25 @@ int phylink_fwnode_phy_connect(struct ph
  	if (pl->config->mac_requires_rxc)
  		flags |= PHY_F_RXC_ALWAYS_ON;
  

--- a/target/linux/generic/pending-6.18/737-01-net-phylink-keep-and-use-MAC-supported_interfaces-in.patch
+++ b/target/linux/generic/pending-6.18/737-01-net-phylink-keep-and-use-MAC-supported_interfaces-in.patch
@@ -41,7 +41,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
  	if (state->interface == PHY_INTERFACE_MODE_NA)
  		return phylink_validate_mask(pl, NULL, supported, state,
-@@ -1857,6 +1862,9 @@ struct phylink *phylink_create(struct ph
+@@ -1858,6 +1863,9 @@ struct phylink *phylink_create(struct ph
  	mutex_init(&pl->state_mutex);
  	INIT_WORK(&pl->resolve, phylink_resolve);
  
@@ -51,7 +51,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	pl->config = config;
  	if (config->type == PHYLINK_NETDEV) {
  		pl->netdev = to_net_dev(config->dev);
-@@ -2016,7 +2024,7 @@ static int phylink_validate_phy(struct p
+@@ -2017,7 +2025,7 @@ static int phylink_validate_phy(struct p
  		 * those which the host supports.
  		 */
  		phy_interface_and(interfaces, phy->possible_interfaces,
@@ -60,7 +60,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
  		if (phy_interface_empty(interfaces)) {
  			phylink_err(pl, "PHY has no common interfaces\n");
-@@ -2758,12 +2766,12 @@ static phy_interface_t phylink_sfp_selec
+@@ -2759,12 +2767,12 @@ static phy_interface_t phylink_sfp_selec
  		return interface;
  	}
  
@@ -75,7 +75,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  		return PHY_INTERFACE_MODE_NA;
  	}
  
-@@ -3691,14 +3699,14 @@ static int phylink_sfp_config_optical(st
+@@ -3692,14 +3700,14 @@ static int phylink_sfp_config_optical(st
  
  	phylink_dbg(pl, "optical SFP: interfaces=[mac=%*pbl, sfp=%*pbl]\n",
  		    (int)PHY_INTERFACE_MODE_MAX,
@@ -92,7 +92,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  			  pl->sfp_interfaces);
  	if (phy_interface_empty(pl->sfp_interfaces)) {
  		phylink_err(pl, "unsupported SFP module: no common interface modes\n");
-@@ -3869,7 +3877,7 @@ static int phylink_sfp_connect_phy(void
+@@ -3870,7 +3878,7 @@ static int phylink_sfp_connect_phy(void
  
  	/* Set the PHY's host supported interfaces */
  	phy_interface_and(phy->host_interfaces, phylink_sfp_interfaces,

--- a/target/linux/generic/pending-6.18/737-02-net-phylink-introduce-internal-phylink-PCS-handling.patch
+++ b/target/linux/generic/pending-6.18/737-02-net-phylink-introduce-internal-phylink-PCS-handling.patch
@@ -196,7 +196,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  		return 0;
  
  	return phylink_pcs_inband_caps(pcs, interface);
-@@ -1261,10 +1310,36 @@ static void phylink_major_config(struct
+@@ -1262,10 +1311,36 @@ static void phylink_major_config(struct
  			pl->major_config_failed = true;
  			return;
  		}
@@ -234,7 +234,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	phylink_pcs_neg_mode(pl, pcs, state->interface, state->advertising);
  
  	phylink_dbg(pl, "major config, active %s/%s/%s\n",
-@@ -1291,11 +1366,13 @@ static void phylink_major_config(struct
+@@ -1292,11 +1367,13 @@ static void phylink_major_config(struct
  	if (pcs_changed) {
  		phylink_pcs_disable(pl->pcs);
  
@@ -252,7 +252,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
  		pl->pcs = pcs;
  	}
-@@ -1823,6 +1900,44 @@ int phylink_set_fixed_link(struct phylin
+@@ -1824,6 +1901,44 @@ int phylink_set_fixed_link(struct phylin
  }
  EXPORT_SYMBOL_GPL(phylink_set_fixed_link);
  
@@ -297,7 +297,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  /**
   * phylink_create() - create a phylink instance
   * @config: a pointer to the target &struct phylink_config
-@@ -1844,6 +1959,7 @@ struct phylink *phylink_create(struct ph
+@@ -1845,6 +1960,7 @@ struct phylink *phylink_create(struct ph
  			       phy_interface_t iface,
  			       const struct phylink_mac_ops *mac_ops)
  {
@@ -305,7 +305,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	struct phylink *pl;
  	int ret;
  
-@@ -1861,9 +1977,21 @@ struct phylink *phylink_create(struct ph
+@@ -1862,9 +1978,21 @@ struct phylink *phylink_create(struct ph
  	mutex_init(&pl->phydev_mutex);
  	mutex_init(&pl->state_mutex);
  	INIT_WORK(&pl->resolve, phylink_resolve);
@@ -327,7 +327,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
  	pl->config = config;
  	if (config->type == PHYLINK_NETDEV) {
-@@ -1943,10 +2071,16 @@ EXPORT_SYMBOL_GPL(phylink_create);
+@@ -1944,10 +2072,16 @@ EXPORT_SYMBOL_GPL(phylink_create);
   */
  void phylink_destroy(struct phylink *pl)
  {
@@ -344,7 +344,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	cancel_work_sync(&pl->resolve);
  	kfree(pl);
  }
-@@ -2448,6 +2582,7 @@ static irqreturn_t phylink_link_handler(
+@@ -2449,6 +2583,7 @@ static irqreturn_t phylink_link_handler(
   */
  void phylink_start(struct phylink *pl)
  {
@@ -352,7 +352,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	bool poll = false;
  
  	ASSERT_RTNL();
-@@ -2474,6 +2609,10 @@ void phylink_start(struct phylink *pl)
+@@ -2475,6 +2610,10 @@ void phylink_start(struct phylink *pl)
  
  	pl->pcs_state = PCS_STATE_STARTED;
  
@@ -363,7 +363,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	phylink_enable_and_run_resolve(pl, PHYLINK_DISABLE_STOPPED);
  
  	if (pl->cfg_link_an_mode == MLO_AN_FIXED && pl->link_gpio) {
-@@ -2518,6 +2657,8 @@ EXPORT_SYMBOL_GPL(phylink_start);
+@@ -2519,6 +2658,8 @@ EXPORT_SYMBOL_GPL(phylink_start);
   */
  void phylink_stop(struct phylink *pl)
  {
@@ -372,7 +372,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	ASSERT_RTNL();
  
  	if (pl->sfp_bus)
-@@ -2535,6 +2676,14 @@ void phylink_stop(struct phylink *pl)
+@@ -2536,6 +2677,14 @@ void phylink_stop(struct phylink *pl)
  	pl->pcs_state = PCS_STATE_DOWN;
  
  	phylink_pcs_disable(pl->pcs);

--- a/target/linux/generic/pending-6.18/737-03-net-phylink-add-phylink_release_pcs-to-externally-re.patch
+++ b/target/linux/generic/pending-6.18/737-03-net-phylink-add-phylink_release_pcs-to-externally-re.patch
@@ -93,7 +93,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static unsigned int phylink_pcs_inband_caps(struct phylink_pcs *pcs,
  				    phy_interface_t interface)
  {
-@@ -1732,6 +1782,10 @@ static void phylink_resolve(struct work_
+@@ -1733,6 +1783,10 @@ static void phylink_resolve(struct work_
  		if (phy)
  			link_state.link &= pl->phy_state.link;
  
@@ -104,7 +104,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  		/* Only update if the PHY link is up */
  		if (phy && pl->phy_state.link) {
  			/* If the interface has changed, force a link down
-@@ -1766,7 +1820,7 @@ static void phylink_resolve(struct work_
+@@ -1767,7 +1821,7 @@ static void phylink_resolve(struct work_
  		phylink_apply_manual_flow(pl, &link_state);
  
  	if ((mac_config && link_state.interface != pl->link_config.interface) ||
@@ -113,7 +113,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  		/* The interface has changed or a forced major configuration
  		 * was requested, so force the link down and then reconfigure.
  		 */
-@@ -1777,6 +1831,7 @@ static void phylink_resolve(struct work_
+@@ -1778,6 +1832,7 @@ static void phylink_resolve(struct work_
  		phylink_major_config(pl, false, &link_state);
  		pl->link_config.interface = link_state.interface;
  		pl->force_major_config = false;

--- a/target/linux/generic/pending-6.18/737-05-net-phylink-support-late-PCS-provider-attach.patch
+++ b/target/linux/generic/pending-6.18/737-05-net-phylink-support-late-PCS-provider-attach.patch
@@ -110,7 +110,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
  	/* What interface are supported by the current link.
  	 * Can change on removal or addition of new PCS.
-@@ -1993,6 +1995,51 @@ out:
+@@ -1994,6 +1996,51 @@ out:
  	return ret;
  }
  
@@ -162,7 +162,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  /**
   * phylink_create() - create a phylink instance
   * @config: a pointer to the target &struct phylink_config
-@@ -2048,6 +2095,11 @@ struct phylink *phylink_create(struct ph
+@@ -2049,6 +2096,11 @@ struct phylink *phylink_create(struct ph
  				 pl->supported_interfaces,
  				 pcs->supported_interfaces);
  

--- a/target/linux/generic/pending-6.18/737-07-net-phylink-add-.pcs_link_down-PCS-OP.patch
+++ b/target/linux/generic/pending-6.18/737-07-net-phylink-add-.pcs_link_down-PCS-OP.patch
@@ -35,7 +35,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  static void phylink_pcs_disable_eee(struct phylink_pcs *pcs)
  {
  	if (pcs && pcs->ops->pcs_disable_eee)
-@@ -1725,6 +1731,8 @@ static void phylink_link_down(struct phy
+@@ -1726,6 +1732,8 @@ static void phylink_link_down(struct phy
  
  	phylink_deactivate_lpi(pl);
  

--- a/target/linux/generic/pending-6.18/737-10-net-phylink-link-the-PCS-list-before-the-initial-con.patch
+++ b/target/linux/generic/pending-6.18/737-10-net-phylink-link-the-PCS-list-before-the-initial-con.patch
@@ -1,0 +1,72 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Julius Bairaktaris <julius@bairaktaris.de>
+Date: Sat, 23 Aug 2026 18:30:00 +0200
+Subject: [PATCH] net: phylink: link the PCS list before the initial config
+
+A PCS taken from the phylink PCS list is attached to its phylink
+instance in phylink_start() after phylink_mac_initial_config() has
+already run .pcs_config() on it, so that first call sees a NULL
+pcs->phylink. The .mac_select_pcs() route has no such window:
+phylink_major_config() sets pcs->phylink before it configures the PCS,
+which is what phylink did for every PCS before the list existed.
+
+DSA has no .mac_select_pcs, so every DSA port whose PCS comes from a
+pcs-handle takes the list route. pcs-qca-uniphy reads the
+back-reference in .pcs_config(), through phylink_expects_phy(), to tell
+a fixed link from a PHY that simply does not negotiate in band, and a
+Zyxel NBG7815 panics on the wan port as netifd brings it up:
+
+  qca-ppe 3a000000.ppe wan: configuring for phy/2500base-x link mode
+  Unable to handle kernel access to user memory outside uaccess routines
+    at virtual address 0000000000000044
+  pc : phylink_expects_phy+0x0/0x38
+  lr : qca_uniphy_pcs_config_mode.isra.0+0x398/0x45c
+  Call trace:
+   phylink_expects_phy+0x0/0x38 (P)
+   qca_uniphy_pcs_config+0xec/0x13c
+   phylink_major_config+0x1e8/0x670
+   phylink_mac_initial_config+0xb8/0x14c
+   phylink_start+0x4c/0x280
+   dsa_port_enable_rt+0x48/0xb0
+
+Link the list where pl->pcs_state has just become PCS_STATE_STARTING,
+so the guarantee holds on both routes. A .pcs_change() from a PCS that
+is now linked earlier still resolves to nothing: phylink_run_resolve()
+does nothing while phylink_disable_state holds PHYLINK_DISABLE_STOPPED,
+which only the phylink_enable_and_run_resolve() below clears. The other
+two phylink_mac_initial_config() callers are unaffected, both running
+with the list already linked - phylink_resume() only takes that path
+when it did not stop, and phylink_sfp_set_config() is gated on not
+being stopped.
+
+Fixes: 18cbd83a1443 ("generic: 6.18: import updated standalone PCS handling")
+Link: https://github.com/JuliusBairaktaris/openwrt-nss-edma/issues/23
+Assisted-by: Claude:claude-opus-5
+Signed-off-by: Julius Bairaktaris <julius@bairaktaris.de>
+---
+--- a/drivers/net/phy/phylink.c
++++ b/drivers/net/phy/phylink.c
+@@ -2712,6 +2712,12 @@ void phylink_start(struct phylink *pl)
+ 
+ 	pl->pcs_state = PCS_STATE_STARTING;
+ 
++	/* Link the available PCS to the phylink instance before the initial
++	 * config below runs .pcs_config() on the one it selects.
++	 */
++	list_for_each_entry(pcs, &pl->pcs_list, list)
++		pcs->phylink = pl;
++
+ 	/* Apply the link configuration to the MAC when starting. This allows
+ 	 * a fixed-link to start with the correct parameters, and also
+ 	 * ensures that we set the appropriate advertisement for Serdes links.
+@@ -2724,10 +2730,6 @@ void phylink_start(struct phylink *pl)
+ 
+ 	pl->pcs_state = PCS_STATE_STARTED;
+ 
+-	/* link available PCS to phylink struct */
+-	list_for_each_entry(pcs, &pl->pcs_list, list)
+-		pcs->phylink = pl;
+-
+ 	phylink_enable_and_run_resolve(pl, PHYLINK_DISABLE_STOPPED);
+ 
+ 	if (pl->cfg_link_an_mode == MLO_AN_FIXED && pl->link_gpio) {

--- a/target/linux/generic/pending-6.18/737-10-net-phylink-link-the-PCS-list-before-the-initial-con.patch
+++ b/target/linux/generic/pending-6.18/737-10-net-phylink-link-the-PCS-list-before-the-initial-con.patch
@@ -46,7 +46,7 @@ Signed-off-by: Julius Bairaktaris <julius@bairaktaris.de>
 ---
 --- a/drivers/net/phy/phylink.c
 +++ b/drivers/net/phy/phylink.c
-@@ -2712,6 +2712,12 @@ void phylink_start(struct phylink *pl)
+@@ -2713,6 +2713,12 @@ void phylink_start(struct phylink *pl)
  
  	pl->pcs_state = PCS_STATE_STARTING;
  
@@ -59,7 +59,7 @@ Signed-off-by: Julius Bairaktaris <julius@bairaktaris.de>
  	/* Apply the link configuration to the MAC when starting. This allows
  	 * a fixed-link to start with the correct parameters, and also
  	 * ensures that we set the appropriate advertisement for Serdes links.
-@@ -2724,10 +2730,6 @@ void phylink_start(struct phylink *pl)
+@@ -2725,10 +2731,6 @@ void phylink_start(struct phylink *pl)
  
  	pl->pcs_state = PCS_STATE_STARTED;
  

--- a/target/linux/qualcommax/files/drivers/net/pcs/pcs-qca-uniphy.c
+++ b/target/linux/qualcommax/files/drivers/net/pcs/pcs-qca-uniphy.c
@@ -302,13 +302,13 @@ static void qca_uniphy_pcs_get_state_sgmii(struct qca_uniphy *uniphy,
 	state->duplex = (val & UNIPHY_CH_STS_DUPLEX) ? DUPLEX_FULL : DUPLEX_HALF;
 
 	switch (FIELD_GET(UNIPHY_CH_STS_SPEED_MODE, val)) {
-	case 0:
+	case UNIPHY_CH_SPEED_10:
 		state->speed = SPEED_10;
 		break;
-	case 1:
+	case UNIPHY_CH_SPEED_100:
 		state->speed = SPEED_100;
 		break;
-	case 2:
+	case UNIPHY_CH_SPEED_1000:
 		state->speed = SPEED_1000;
 		break;
 	default:
@@ -456,6 +456,15 @@ static void qca_uniphy_pcs_get_state(struct phylink_pcs *pcs,
 	}
 }
 
+/* A fixed link carries no in-band negotiation for the channel to take its
+ * speed from, so the channel is forced and reads UNIPHY_CH_CTRL instead.
+ */
+static bool uniphy_ch_forced(struct phylink_pcs *pcs, unsigned int neg_mode)
+{
+	return neg_mode == PHYLINK_PCS_NEG_OUTBAND &&
+	       !phylink_expects_phy(pcs->phylink);
+}
+
 static int qca_uniphy_pcs_config_mode(struct phylink_pcs *pcs,
 				      unsigned int neg_mode,
 				      phy_interface_t interface,
@@ -524,14 +533,17 @@ static int qca_uniphy_pcs_config_mode(struct phylink_pcs *pcs,
 			clk_prepare_enable(uniphy->ref_clk.hw.clk);
 	}
 
-	/* TODO: Fix for IPQ6018 and IPQ8074 */
-	if (uniphy->data->uniphy_type == UNIPHY_IPQ5018) {
-		//set force mode for fixed link
-		if (neg_mode == PHYLINK_PCS_NEG_OUTBAND && !phylink_expects_phy(pcs->phylink)) {
-			regmap_set_bits(uniphy->regmap,
-					UNIPHY_CH_CTRL(upcs->channel),
-					UNIPHY_CH_FORCE_MODE);
-		}
+	/* The XPCS modes drive the channel from the XPCS and never read the
+	 * force bit.
+	 */
+	if (mode_ctrl != UNIPHY_XPCS_MODE) {
+		ret = regmap_update_bits(uniphy->regmap,
+					 UNIPHY_CH_CTRL(upcs->channel),
+					 UNIPHY_CH_FORCE_MODE,
+					 uniphy_ch_forced(pcs, neg_mode) ?
+					 UNIPHY_CH_FORCE_MODE : 0);
+		if (ret)
+			return ret;
 	}
 
 	if (uniphy->interface == interface)
@@ -712,12 +724,14 @@ static int qca_uniphy_pcs_config(struct phylink_pcs *pcs,
 }
 
 static int uniphy_link_up_sgmii(struct phylink_pcs *pcs,
+				unsigned int neg_mode,
 				phy_interface_t interface,
 				int speed)
 {
 	struct qca_uniphy_pcs *upcs = to_qca_uniphy_pcs(pcs);
 	struct qca_uniphy *uniphy = upcs->uniphy;
 	unsigned long uniphy_rate;
+	u32 speed_mode;
 	int ret;
 
 	switch (interface) {
@@ -727,12 +741,15 @@ static int uniphy_link_up_sgmii(struct phylink_pcs *pcs,
 		switch (speed) {
 		case SPEED_10:
 			uniphy_rate = 2500000;
+			speed_mode = UNIPHY_CH_SPEED_10;
 			break;
 		case SPEED_100:
 			uniphy_rate = 25000000;
+			speed_mode = UNIPHY_CH_SPEED_100;
 			break;
 		case SPEED_1000:
 			uniphy_rate = 125000000;
+			speed_mode = UNIPHY_CH_SPEED_1000;
 			break;
 		default:
 			dev_err(uniphy->dev, "Invalid SGMII speed %d\n", speed);
@@ -743,6 +760,7 @@ static int uniphy_link_up_sgmii(struct phylink_pcs *pcs,
 		switch (speed) {
 		case SPEED_1000:
 			uniphy_rate = 125000000;
+			speed_mode = UNIPHY_CH_SPEED_1000;
 			break;
 		default:
 			dev_err(uniphy->dev, "Invalid 1000BaseX speed %d\n", speed);
@@ -753,6 +771,11 @@ static int uniphy_link_up_sgmii(struct phylink_pcs *pcs,
 		switch (speed) {
 		case SPEED_2500:
 			uniphy_rate = 312500000;
+			/* The field has no 2500 encoding: SGMII+ carries the
+			 * rate in the mode and leaves this at the vendor's
+			 * 1000 reset value.
+			 */
+			speed_mode = UNIPHY_CH_SPEED_1000;
 			break;
 		default:
 			dev_err(uniphy->dev, "Invalid 2500BaseX speed %d\n", speed);
@@ -765,6 +788,19 @@ static int uniphy_link_up_sgmii(struct phylink_pcs *pcs,
 
 	clk_set_rate(uniphy->clks[port_rx_clk_idx(upcs)].clk, uniphy_rate);
 	clk_set_rate(uniphy->clks[port_tx_clk_idx(upcs)].clk, uniphy_rate);
+
+	/* Only a forced channel takes its speed from here; otherwise the
+	 * in-band word carries it and the field is not consumed.
+	 */
+	if (uniphy_ch_forced(pcs, neg_mode)) {
+		ret = regmap_update_bits(uniphy->regmap,
+					 UNIPHY_CH_CTRL(upcs->channel),
+					 UNIPHY_CH_SPEED_MODE,
+					 FIELD_PREP(UNIPHY_CH_SPEED_MODE,
+						    speed_mode));
+		if (ret)
+			return ret;
+	}
 
 	ret = regmap_clear_bits(uniphy->regmap, UNIPHY_CH_CTRL(upcs->channel),
 				UNIPHY_CH_ADP_SW_RSTN);
@@ -842,7 +878,7 @@ static void qca_uniphy_pcs_link_up(struct phylink_pcs *pcs,
 	case PHY_INTERFACE_MODE_PSGMII:
 	case PHY_INTERFACE_MODE_1000BASEX:
 	case PHY_INTERFACE_MODE_2500BASEX:
-		ret = uniphy_link_up_sgmii(pcs, interface, speed);
+		ret = uniphy_link_up_sgmii(pcs, neg_mode, interface, speed);
 		break;
 	case PHY_INTERFACE_MODE_USXGMII:
 	case PHY_INTERFACE_MODE_10GBASER:

--- a/target/linux/qualcommax/files/include/linux/pcs/pcs-qca-uniphy.h
+++ b/target/linux/qualcommax/files/include/linux/pcs/pcs-qca-uniphy.h
@@ -44,6 +44,10 @@
 
 #define UNIPHY_CH_CTRL(ch)		(UNIPHY_CH_BASE(ch) + 0x0)
 #define   UNIPHY_CH_SPEED_MODE		GENMASK(2, 1)
+/* Encoding shared with UNIPHY_CH_STS_SPEED_MODE */
+#define     UNIPHY_CH_SPEED_10		0
+#define     UNIPHY_CH_SPEED_100		1
+#define     UNIPHY_CH_SPEED_1000	2
 #define   UNIPHY_CH_FORCE_MODE		BIT(3)
 #define   UNIPHY_CH_AN_ENABLE		BIT(6)
 #define   UNIPHY_CH_AN_RESTART		BIT(7)


### PR DESCRIPTION
A fixed link has no in-band word for the UNIPHY channel to take its speed from,
so the channel has to be forced. The driver does that on IPQ5018 only. It never
writes the speed field beside the force bit either, and that field is where a
forced channel reads its speed.

    target/linux/qualcommax/files/drivers/net/pcs/pcs-qca-uniphy.c,
    qca_uniphy_pcs_config_mode(), before this series:

        /* TODO: Fix for IPQ6018 and IPQ8074 */
        if (uniphy->data->uniphy_type == UNIPHY_IPQ5018) {
                //set force mode for fixed link
                if (neg_mode == PHYLINK_PCS_NEG_OUTBAND && !phylink_expects_phy(pcs->phylink)) {
                        regmap_set_bits(uniphy->regmap,
                                        UNIPHY_CH_CTRL(upcs->channel),
                                        UNIPHY_CH_FORCE_MODE);
                }
        }

qca-ssdk writes that same UNIPHY_CH_CTRL bit on all three SoCs, so my
understanding is there is nothing SoC-specific here. The last commit drops the
SoC test, clears the bit for a port that is not a fixed link, and programs
UNIPHY_CH_SPEED_MODE from the speed `pcs_link_up()` is handed. Neither write is
made in USXGMII or 10GBASE-R, where the XPCS drives the channel.

That needs a PSGMII port to report an outband neg_mode, and it does not:
`phylink_get_inband_type()` omits PSGMII, so phylink reports
`PHYLINK_PCS_NEG_NONE` for it. The second commit backports 5ba017f9efef ("net:
phylink: treat PSGMII as an inband capable interface") into both kernel copies
the tree carries.

No board in the tree declares `managed = "in-band-status"` on a PSGMII port, so
every PSGMII port moves to `PHYLINK_PCS_NEG_OUTBAND`, PHY-managed and fixed
links alike. A PCS tells the two apart with `phylink_expects_phy()`:

    target/linux/qualcommax/files/drivers/net/pcs/pcs-qca-uniphy.c:462

        static bool uniphy_ch_forced(struct phylink_pcs *pcs, unsigned int neg_mode)
        {
                return neg_mode == PHYLINK_PCS_NEG_OUTBAND &&
                       !phylink_expects_phy(pcs->phylink);
        }

Reading `pcs->phylink` there is what the first commit makes safe: the PCS list
is linked only after `phylink_mac_initial_config()` has run `.pcs_config()`, so
that first call sees NULL. DSA has no `.mac_select_pcs()`, so a DSA port with a
pcs-handle takes that route and a Zyxel NBG7815 panics on wan as netifd brings
it up. That patch moves the link above the initial config.

Fixes: 18cbd83a1443 ("generic: 6.18: import updated standalone PCS handling")
Report: https://github.com/JuliusBairaktaris/openwrt-nss-edma/issues/23
Rebased above #24186, which restructured `qca_uniphy_pcs_config_mode()`.

On a Xiaomi AX3600 (IPQ8074, kernel 6.18, four PSGMII channels on one UNIPHY)
every channel reads UNIPHY_CH_CTRL 0x844 after the clear: FORCE_MODE clear,
SPEED_MODE at its 1000 reset value, and a port linked at 100 Mbps holds that
value. All four ports pass traffic and dmesg carries no Oops or BUG. I have no
NBG7815, so the reported panic itself is not reproduced here.

No in-tree IPQ6018 or IPQ8074 board has a fixed link on a UNIPHY, so I exercised
the set side with a modified device tree on the AX3600: FORCE_MODE set,
SPEED_MODE following the declared speed. The eleven IPQ5018 boards already on
that path all declare 1000 Mbps, the value the field already holds.

I used AI to help me write the change. Can anyone with a fixed link on an
IPQ6018 or IPQ8074 UNIPHY read UNIPHY_CH_CTRL back with this applied?
