### PR TITLE
imx: backport dts fixes from linux-7.2 for Kontron OSM-S/BL i.MX8MP

### DIFF
--- a/target/linux/imx/patches-6.12/520-v7.2-Revert-arm64-dts-imx8mp-kontron-Add-support-for-reading-SD_VSEL-signal.patch
+++ b/target/linux/imx/patches-6.12/520-v7.2-Revert-arm64-dts-imx8mp-kontron-Add-support-for-reading-SD_VSEL-signal.patch
@@ -1,0 +1,60 @@
+From 22465a195af370ed6311be3adee479fb7c683685 Mon Sep 17 00:00:00 2001
+From: Peng Fan <peng.fan@nxp.com>
+Date: Fri, 3 Apr 2026 17:57:02 +0800
+Subject: Revert "arm64: dts: imx8mp-kontron: Add support for reading SD_VSEL
+ signal"
+
+This reverts commit 39e4189d9d63a0b6fc15458ce0136e99ecdfb1b8.
+
+The board uses SDHC VSELECT to automatically switch between 1.8v and
+3.3v. It does not use GPIO to control the PMIC SD_VSEL signal.
+The original commit intends to read back SD_VSEL value from GPIO,
+but it is wrong. When MUX is configured as SDHC VSELECT, it is
+impossible to read back the value from GPIO controller. Setting SION
+could only enable the input path for the mux function. It could not
+redirect the input to GPIO.
+
+Fixes: 39e4189d9d63a ("arm64: dts: imx8mp-kontron: Add support for reading SD_VSEL signal")
+Signed-off-by: Peng Fan <peng.fan@nxp.com>
+Signed-off-by: Frank Li <Frank.Li@nxp.com>
+---
+ arch/arm64/boot/dts/freescale/imx8mp-kontron-osm-s.dtsi | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+--- a/arch/arm64/boot/dts/freescale/imx8mp-kontron-osm-s.dtsi
++++ b/arch/arm64/boot/dts/freescale/imx8mp-kontron-osm-s.dtsi
+@@ -311,7 +311,6 @@
+ 				regulator-name = "NVCC_SD (LDO5)";
+ 				regulator-min-microvolt = <1800000>;
+ 				regulator-max-microvolt = <3300000>;
+-				sd-vsel-gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
+ 			};
+ 		};
+ 	};
+@@ -815,7 +814,7 @@
+ 			MX8MP_IOMUXC_SD2_DATA1__USDHC2_DATA1		0x1d0 /* SDIO_A_D1 */
+ 			MX8MP_IOMUXC_SD2_DATA2__USDHC2_DATA2		0x1d0 /* SDIO_A_D2 */
+ 			MX8MP_IOMUXC_SD2_DATA3__USDHC2_DATA3		0x1d0 /* SDIO_A_D3 */
+-			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT		0x400001d0
++			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT		0x1d0
+ 		>;
+ 	};
+ 
+@@ -827,7 +826,7 @@
+ 			MX8MP_IOMUXC_SD2_DATA1__USDHC2_DATA1		0x1d4 /* SDIO_A_D1 */
+ 			MX8MP_IOMUXC_SD2_DATA2__USDHC2_DATA2		0x1d4 /* SDIO_A_D2 */
+ 			MX8MP_IOMUXC_SD2_DATA3__USDHC2_DATA3		0x1d4 /* SDIO_A_D3 */
+-			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT		0x400001d0
++			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT		0x1d0
+ 		>;
+ 	};
+ 
+@@ -839,7 +838,7 @@
+ 			MX8MP_IOMUXC_SD2_DATA1__USDHC2_DATA1		0x1d6 /* SDIO_A_D1 */
+ 			MX8MP_IOMUXC_SD2_DATA2__USDHC2_DATA2		0x1d6 /* SDIO_A_D2 */
+ 			MX8MP_IOMUXC_SD2_DATA3__USDHC2_DATA3		0x1d6 /* SDIO_A_D3 */
+-			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT		0x400001d0
++			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT		0x1d0
+ 		>;
+ 	};
+ 

--- a/target/linux/imx/patches-6.12/521-v7.2-arm64-dts-imx8mp-kontron-Reduce-EERAM-SPI-clock-frequency.patch
+++ b/target/linux/imx/patches-6.12/521-v7.2-arm64-dts-imx8mp-kontron-Reduce-EERAM-SPI-clock-frequency.patch
@@ -1,0 +1,27 @@
+From 95f5bc1632ab8f243e517357b5da0dd28d1c6c92 Mon Sep 17 00:00:00 2001
+From: Frieder Schrempf <frieder.schrempf@kontron.de>
+Date: Wed, 13 May 2026 15:25:31 +0200
+Subject: arm64: dts: imx8mp-kontron: Reduce EERAM SPI clock frequency
+
+There is an onboard level shifter for the SPI signals that causes
+additional propagation delay and renders the SPI transmission
+unreliable at 20 MHz. Reduce the clock frequency to a safe value.
+
+Fixes: 946ab10e3f40 ("arm64: dts: Add support for Kontron OSM-S i.MX8MP SoM and BL carrier board")
+Signed-off-by: Frieder Schrempf <frieder.schrempf@kontron.de>
+Signed-off-by: Frank Li <Frank.Li@nxp.com>
+---
+ arch/arm64/boot/dts/freescale/imx8mp-kontron-bl-osm-s.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/arch/arm64/boot/dts/freescale/imx8mp-kontron-bl-osm-s.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mp-kontron-bl-osm-s.dts
+@@ -63,7 +63,7 @@
+ 	eeram@0 {
+ 		compatible = "microchip,48l640";
+ 		reg = <0>;
+-		spi-max-frequency = <20000000>;
++		spi-max-frequency = <16000000>;
+ 	};
+ };
+ 

--- a/target/linux/imx/patches-6.12/522-v7.2-arm64-dts-imx8mp-kontron-Fix-GPIO-for-display-power-switch.patch
+++ b/target/linux/imx/patches-6.12/522-v7.2-arm64-dts-imx8mp-kontron-Fix-GPIO-for-display-power-switch.patch
@@ -1,0 +1,59 @@
+From 5b19ca527471903920d713bc48518a036a95bf6b Mon Sep 17 00:00:00 2001
+From: Frieder Schrempf <frieder.schrempf@kontron.de>
+Date: Thu, 28 May 2026 12:15:56 +0200
+Subject: arm64: dts: imx8mp-kontron: Fix GPIO for display power switch
+
+The GPIO that controls the power supply for the LVDS display
+connector has changed between early prototypes and the current
+production design of the hardware. Reflect this change in the
+devicetree to properly switch on the panel supply.
+
+This was working before even with the wrong GPIO due to the
+bidirectional level shifter used on the board which drives the EN
+signal high even when the input has a (weak) pull down configured as
+reset condition of the SoC pad. As a result the display was working
+but the supply was always on.
+
+Tested on BL i.MX8MP to show the correct voltage level on the level
+shifter input.
+
+Fixes: 946ab10e3f40 ("arm64: dts: Add support for Kontron OSM-S i.MX8MP SoM and BL carrier board")
+Signed-off-by: Frieder Schrempf <frieder.schrempf@kontron.de>
+Signed-off-by: Frank Li <Frank.Li@nxp.com>
+---
+ arch/arm64/boot/dts/freescale/imx8mp-kontron-bl-osm-s.dts | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+--- a/arch/arm64/boot/dts/freescale/imx8mp-kontron-bl-osm-s.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mp-kontron-bl-osm-s.dts
+@@ -49,7 +49,9 @@
+ 
+ 	reg_vcc_panel: regulator-vcc-panel {
+ 		compatible = "regulator-fixed";
+-		gpio = <&gpio4 3 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_reg_vcc_panel>;
++		gpio = <&gpio5 3 GPIO_ACTIVE_HIGH>;
+ 		enable-active-high;
+ 		regulator-max-microvolt = <3300000>;
+ 		regulator-min-microvolt = <3300000>;
+@@ -172,7 +174,7 @@
+ &gpio5 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pinctrl_gpio5>;
+-	gpio-line-names = "I2S_BITCLK", "I2S_A_DATA_OUT", "I2S_MCLK", "PWM_2",
++	gpio-line-names = "I2S_BITCLK", "I2S_A_DATA_OUT", "I2S_MCLK", "VCC_PANEL_EN",
+ 			  "PWM_1", "PWM_0", "SPI_A_SCK", "CAN_ADDR1",
+ 			  "CAN_ADDR0", "SPI_A_CS0", "SPI_B_SCK", "SPI_B_SDO",
+ 			  "SPI_B_SDI", "SPI_B_CS0", "I2C_A_SCL", "I2C_A_SDA",
+@@ -329,4 +331,10 @@
+ 			MX8MP_IOMUXC_ECSPI1_MISO__GPIO5_IO08		0x46 /* CAN_ADR1 */
+ 		>;
+ 	};
++
++	pinctrl_reg_vcc_panel: regvccpanelgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SPDIF_TX__GPIO5_IO03		0x46
++		>;
++	};
+ };


### PR DESCRIPTION
This backports the latest dts fixes for the Kontron OSM-S/BL i.MX8MP.
