### PR TITLE
mediatek: add support for Zbtlink ZBT-Z8103AX-PRO

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8103ax-pro.dts
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8103ax-pro.dts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "mt7981b-zbtlink-zbt-z8103ax.dtsi"
+
+/ {
+	model = "Zbtlink ZBT-Z8103AX-PRO";
+	compatible = "zbtlink,zbt-z8103ax-pro", "mediatek,mt7981b";
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	reg_5v: regulator-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-5V";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+};
+
+&int_gbe_phy {
+	status = "disabled";
+};
+
+/* Fix MAC addr conflicts */
+&spi0 {
+	spi_nand@0 {
+		partitions {
+			partition@180000 {
+				nvmem-layout {
+					macaddr_factory_24: macaddr@24 {
+						reg = <0x24 0x6>;
+						compatible = "mac-base";
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&wifi {
+	band@1 {
+		nvmem-cells = <&macaddr_factory_a 0>;
+	};
+};
+
+&switch {
+	ports {
+		port@0 {
+			nvmem-cells = <&macaddr_factory_24 0>;
+		};
+
+		port@1 {
+			nvmem-cells = <&macaddr_factory_24 1>;
+		};
+
+		port@2 {
+			nvmem-cells = <&macaddr_factory_24 2>;
+		};
+	};
+};
+
+/* WAN via external 2.5G PHY (Maxlinear Ethernet GPY211C) */
+&mdio_bus {
+	reset-gpios = <&pio 14 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <600>;
+	reset-post-delay-us = <20000>;
+
+	phy5: phy@5 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <5>;
+	};
+};
+
+&gmac1 {
+	phy-mode = "2500base-x";
+	phy-handle = <&phy5>;
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&xhci {
+	/* Only a physical USB2 Port */
+	phys = <&u2port0 PHY_TYPE_USB2>;
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&reg_5v>;
+	mediatek,u3p-dis-msk = <0x01>;
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -366,6 +366,7 @@ xiaomi,redmi-router-ax6000-ubootmod)
 	;;
 zbtlink,zbt-z8103ax|\
 zbtlink,zbt-z8103ax-c|\
+zbtlink,zbt-z8103ax-pro|\
 zbtlink,zbt-z8803be)
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "eth1" "link tx rx"
 	;;

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -20,7 +20,8 @@ mediatek_setup_interfaces()
 	mercusys,mr80x-v3|\
 	routerich,ax3000-v1|\
 	zbtlink,zbt-z8103ax|\
-	zbtlink,zbt-z8103ax-c)
+	zbtlink,zbt-z8103ax-c|\
+	zbtlink,zbt-z8103ax-pro)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" eth1
 		;;
 	zbtlink,zbt-z8803be)

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -3914,6 +3914,23 @@ define Device/zbtlink_zbt-z8103ax-c
 endef
 TARGET_DEVICES += zbtlink_zbt-z8103ax-c
 
+define Device/zbtlink_zbt-z8103ax-pro
+  DEVICE_VENDOR := Zbtlink
+  DEVICE_MODEL := ZBT-Z8103AX-PRO
+  DEVICE_DTS := mt7981b-zbtlink-zbt-z8103ax-pro
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  KERNEL_IN_UBI := 1
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 65536k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | check-size $$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += zbtlink_zbt-z8103ax-pro
+
 define Device/zbtlink_zbt-z8106ax-s
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-Z8106AX-S


### PR DESCRIPTION
mediatek: add support for Zbtlink ZBT-Z8103AX-PRO

Hardware specifications:
- SoC: MediaTek MT7981B
- RAM: 256 MiB
- Flash: SPI-NAND 128 MiB
- Switch: MediaTek MT7531 (3x 1G LAN)
- External PHY: Maxlinear GPY211C (1x 2.5G WAN)
- WiFi: MediaTek MT7976CN (2.4/5 GHz, 802.11ax)
- Buttons: Reset, Mesh
- Power: DC 12V 1A
- USB: 1x USB2.0
- LEDs: 5.8G, LAN1, LAN2, LAN3, WAN, 2.4G,
        Mesh, Power
- UART: 3V3, RX, TX, GND; 115200n8

MAC address assignment:
- WAN:  F8:5E:3C:xx:xx:xx (Factory 0x2a + 0)
        Match the label on the device
- LAN1: F8:5E:3C:xx:xx:xx (Factory 0x24 + 0)
- LAN2: F8:5E:3C:xx:xx:xx (Factory 0x24 + 1)
- LAN3: F8:5E:3C:xx:xx:xx (Factory 0x24 + 2)
- 2.4G: F8:5E:3C:xx:xx:xx (Factory 0x04 + 0)
- 5G:   F8:5E:3C:xx:xx:xx (Factory 0x0a + 0)

Installation:
A. Via OpenWrt Sysupgrade
If the device is already running OpenWrt,
upgrade via the web interface:
1. Go to System → Backup / Flash Firmware
2. Flash the OpenWrt factory image

B. Via TFTP (UART console)
1. Connect a USB-to-Serial adapter to the UART header
   (do NOT connect VCC)
2. Power on the device and access the U-Boot console
3. Interrupt autoboot (press Ctrl+C repeatedly)
4. Type "bootmenu" and press Enter
5. Press "2" to select "Upgrade firmware"
6. Press "Y" for "Run image after upgrading?"
7. Press "0" and Enter to select TFTP client
8. Fill in the U-Boot IP and TFTP server IP
9. Enter the firmware filename and confirm

C. Via MediaTek Web Recovery
1. Power off the device
2. Connect a network cable to a LAN port
3. Hold the Reset button while connecting
   the power cable
4. After ~10 seconds, release the Reset button
5. Set your PC IP to 192.168.1.2
6. Browse to http://192.168.1.1/
7. Upload the OpenWrt firmware and wait for
   the device to reboot