### PR TITLE
econet: en7528: add support for four JioFiber EN7528 ONTs

### DIFF
--- a/target/linux/econet/base-files/etc/board.d/02_network
+++ b/target/linux/econet/base-files/etc/board.d/02_network
@@ -10,6 +10,7 @@ econet_setup_interfaces()
 	dasan,h660gm-a-airtel|\
 	dasan,h660gm-a-generic|\
 	econet,en7528-generic|\
+	jiofiber,jcow407|\
 	jiofiber,jcow414)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		;;

--- a/target/linux/econet/base-files/etc/board.d/02_network
+++ b/target/linux/econet/base-files/etc/board.d/02_network
@@ -9,7 +9,8 @@ econet_setup_interfaces()
 	case "$board" in
 	dasan,h660gm-a-airtel|\
 	dasan,h660gm-a-generic|\
-	econet,en7528-generic)
+	econet,en7528-generic|\
+	jiofiber,jcow414)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		;;
 	*)

--- a/target/linux/econet/base-files/lib/upgrade/platform.sh
+++ b/target/linux/econet/base-files/lib/upgrade/platform.sh
@@ -4,7 +4,8 @@ platform_check_image() {
 	case "$board" in
 	chinamobile,gs3101|\
 	dasan,h660gm-a-airtel|\
-	dasan,h660gm-a-generic)
+	dasan,h660gm-a-generic|\
+	jiofiber,jcow414)
 		return 0
 		;;
 	esac
@@ -18,7 +19,8 @@ platform_do_upgrade() {
 	case "$board" in
 	chinamobile,gs3101|\
 	dasan,h660gm-a-airtel|\
-	dasan,h660gm-a-generic)
+	dasan,h660gm-a-generic|\
+	jiofiber,jcow414)
 		CI_KERNPART="tclinux_kernel"
 		nand_do_upgrade "$1"
 		;;

--- a/target/linux/econet/base-files/lib/upgrade/platform.sh
+++ b/target/linux/econet/base-files/lib/upgrade/platform.sh
@@ -5,6 +5,7 @@ platform_check_image() {
 	chinamobile,gs3101|\
 	dasan,h660gm-a-airtel|\
 	dasan,h660gm-a-generic|\
+	jiofiber,jcow407|\
 	jiofiber,jcow414)
 		return 0
 		;;
@@ -20,6 +21,7 @@ platform_do_upgrade() {
 	chinamobile,gs3101|\
 	dasan,h660gm-a-airtel|\
 	dasan,h660gm-a-generic|\
+	jiofiber,jcow407|\
 	jiofiber,jcow414)
 		CI_KERNPART="tclinux_kernel"
 		nand_do_upgrade "$1"

--- a/target/linux/econet/base-files/sbin/en75_chboot
+++ b/target/linux/econet/base-files/sbin/en75_chboot
@@ -164,6 +164,14 @@ main() {
         code_openwrt=0000
         code_factory=0101
         ;;
+    jiofiber,jcow414)
+        part=$(part_named '"reservearea"')
+        offset_blocks=16
+        block_size=$((1024 * 128))
+        code_offset=0
+        code_openwrt=30
+        code_factory=31
+        ;;
     chinamobile,gs3101)
         part=$(part_named '"reservearea"')
         offset_blocks=12

--- a/target/linux/econet/base-files/sbin/en75_chboot
+++ b/target/linux/econet/base-files/sbin/en75_chboot
@@ -164,6 +164,7 @@ main() {
         code_openwrt=0000
         code_factory=0101
         ;;
+    jiofiber,jcow407|\
     jiofiber,jcow414)
         part=$(part_named '"reservearea"')
         offset_blocks=16

--- a/target/linux/econet/dts/en7528_jiofiber.dtsi
+++ b/target/linux/econet/dts/en7528_jiofiber.dtsi
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+
+#include "en7528.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x1c000000>;
+	};
+
+	chosen {
+		stdout-path = "/serial@1fbf0000:115200";
+		linux,usable-memory-range = <0x00020000 0x1bfe0000>;
+	};
+
+	reg_usb1_vbus: regulator-usb1-vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "usb1-vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
+	/* Second USB port VBUS, no DT consumer, enabled unconditionally */
+	reg_usb2_vbus: regulator-usb2-vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "usb2-vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&rootA &root1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ubi";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
+};
+
+&usb {
+	status = "okay";
+	vbus-supply = <&reg_usb1_vbus>;
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&pcie1 {
+	status = "okay";
+};
+
+&slot0 {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&macaddr_bl 2>, <&eeprom_reservearea_1c0000>;
+		nvmem-cell-names = "mac-address", "eeprom";
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&slot1 {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&macaddr_bl 3>, <&eeprom_reservearea_4b000>;
+		nvmem-cell-names = "mac-address", "eeprom";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&gmac0 {
+	status = "okay";
+	nvmem-cells = <&macaddr_bl 1>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch {
+	status = "okay";
+};
+
+&gsw_port1 {
+	label = "lan1";
+	status = "okay";
+};
+
+&gsw_port2 {
+	label = "lan2";
+	status = "okay";
+};
+
+&gsw_port3 {
+	label = "lan3";
+	status = "okay";
+};
+
+&gsw_port4 {
+	label = "lan4";
+	status = "okay";
+};
+
+&nand {
+	status = "okay";
+	econet,bmt;
+	econet,bbt-table-size = <250>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "bootloader";
+			reg = <0x0 0x40000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_bl: macaddr@3fe48 {
+					compatible = "mac-base";
+					reg = <0x3fe48 0x6>;
+					#nvmem-cell-cells = <1>;
+				};
+			};
+		};
+
+		partition@40000 {
+			label = "romfile";
+			reg = <0x40000 0x40000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "tclinux";
+			reg = <0x80000 0x2800000>;
+			econet,enable-remap;
+		};
+
+		/* Nested inside of tclinux */
+		partition1@80000 {
+			label = "tclinux_kernel";
+			reg = <0x80000 0x400000>;
+			econet,enable-remap;
+		};
+
+		/* Concatenated with "unknown" to form the UBI volume */
+		rootA: partition1@480000 {
+			label = "tclinux_rootfs";
+			reg = <0x480000 0x2400000>;
+		};
+
+		partition@2880000 {
+			label = "tclinux_slave";
+			reg = <0x2880000 0x2800000>;
+		};
+
+		partition@5080000 {
+			label = "opt0";
+			reg = <0x5080000 0x800000>;
+		};
+
+		partition@5880000 {
+			label = "opt1";
+			reg = <0x5880000 0x800000>;
+		};
+
+		partition@6080000 {
+			label = "ubifs";
+			reg = <0x6080000 0x1a00000>;
+		};
+
+		partition@7a80000 {
+			label = "config";
+			reg = <0x7a80000 0x200000>;
+		};
+
+		partition@7c80000 {
+			label = "ubifs2";
+			reg = <0x7c80000 0x5a00000>;
+		};
+
+		/* Concatenated with tclinux_rootfs to form the UBI volume */
+		root1: partition@d680000 {
+			label = "unknown";
+			reg = <0xd680000 0x740000>;
+		};
+
+		partition@ddc0000 {
+			label = "reservearea";
+			reg = <0xddc0000 0x240000>;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				/* 5GHz */
+				eeprom_reservearea_4b000: eeprom@4b000 {
+					reg = <0x4b000 0x4da8>;
+				};
+
+				/* 2.4GHz */
+				eeprom_reservearea_1c0000: eeprom@1c0000 {
+					reg = <0x1c0000 0x400>;
+				};
+			};
+		};
+	};
+};

--- a/target/linux/econet/dts/en7528_jiofiber_jcow407.dts
+++ b/target/linux/econet/dts/en7528_jiofiber_jcow407.dts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/dts-v1/;
+
+#include "en7528_jiofiber.dtsi"
+
+/ {
+	model = "JioFiber JCOW407";
+	compatible = "jiofiber,jcow407", "econet,en7528";
+
+	aliases {
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_blue;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: status-red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: status-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: status-blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan1-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan1-amber {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			gpios = <&gpio0 30 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan2-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan2-amber {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan3-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan3-amber {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan4-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <4>;
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan4-amber {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <4>;
+			gpios = <&gpio1 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		key-reset {
+			label = "reset";
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		key-wps {
+			label = "wps";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};

--- a/target/linux/econet/dts/en7528_jiofiber_jcow414.dts
+++ b/target/linux/econet/dts/en7528_jiofiber_jcow414.dts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/dts-v1/;
+
+#include "en7528_jiofiber.dtsi"
+
+/ {
+	model = "JioFiber JCOW414";
+	compatible = "jiofiber,jcow414", "econet,en7528";
+
+	aliases {
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_blue;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: status-red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio0 27 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: status-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: status-blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan1-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			gpios = <&gpio0 30 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan1-amber {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan2-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan2-amber {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan3-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan3-amber {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan4-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <4>;
+			gpios = <&gpio1 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan4-amber {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <4>;
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		key-reset {
+			label = "reset";
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		key-wps {
+			label = "wps";
+			gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};

--- a/target/linux/econet/image/Makefile
+++ b/target/linux/econet/image/Makefile
@@ -1,6 +1,8 @@
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/image.mk
 
+DEVICE_VARS += TRX_MODEL TRX_LOADADDR
+
 define Target/Description
 	Build firmware images for EcoNet MIPS based boards.
 endef
@@ -9,7 +11,8 @@ endef
 define Build/tclinux-trx
   ./tclinux-trx.sh --kernel $@ --rootfs $(IMAGE_ROOTFS) \
     --version $(VERSION_DIST)-$(REVISION) --endian $(TRX_ENDIAN) \
-    $(if $(TRX_MODEL),--model $(TRX_MODEL)) > $@.new
+    $(if $(TRX_MODEL),--model $(TRX_MODEL)) \
+    $(if $(TRX_LOADADDR),--loadaddr $(TRX_LOADADDR)) > $@.new
 	mv $@.new $@
 endef
 
@@ -17,7 +20,8 @@ endef
 define Build/kernel-trx
   ./tclinux-trx.sh --kernel $@ \
     --version $(VERSION_DIST)-$(REVISION) --endian $(TRX_ENDIAN) \
-    $(if $(TRX_MODEL),--model $(TRX_MODEL)) > $@.new
+    $(if $(TRX_MODEL),--model $(TRX_MODEL)) \
+    $(if $(TRX_LOADADDR),--loadaddr $(TRX_LOADADDR)) > $@.new
 	mv $@.new $@
 endef
 
@@ -31,7 +35,7 @@ define Build/tclinux-free-bootbase-jump
 		$(call ERROR_MESSAGE,WARNING: KERNEL_LOADADDR changed); \
 		rm -f $@; \
 	}
-	printf '\010\000\200\000' > $@.new
+	printf '$(if $(CONFIG_BIG_ENDIAN),\010\000\200\000,\000\200\000\010)' > $@.new
 	dd if=/dev/zero bs=122876 count=1 >> $@.new
 	cat $@ >> $@.new
 	mv $@.new $@
@@ -50,6 +54,8 @@ define Device/Default
   KERNEL_LOADADDR := 0x80020000
   KERNEL := kernel-bin | append-dtb
   UBINIZE_OPTS := -E 5
+  TRX_MODEL :=
+  TRX_LOADADDR :=
 endef
 
 # Kernel in a raw TRX partition, root squashfs in UBI. FACTORY_SIZE must be the

--- a/target/linux/econet/image/en7528.mk
+++ b/target/linux/econet/image/en7528.mk
@@ -29,3 +29,22 @@ define Device/dasan_h660gm-a-generic
   DEVICE_DTS := en7528_dasan_h660gm-a-generic
 endef
 TARGET_DEVICES += dasan_h660gm-a-generic
+
+define Device/jiofiber_en7528
+  $(call Device/tclinux-ubi)
+  DEVICE_VENDOR := JioFiber
+  FACTORY_SIZE := 40m
+  TRX_LOADADDR := 0x80002000
+  KERNEL := kernel-bin | append-dtb | tclinux-free-bootbase-jump | lzma | \
+    kernel-trx
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
+endef
+
+define Device/jiofiber_jcow414
+  $(Device/jiofiber_en7528)
+  DEVICE_MODEL := JCOW414
+  DEVICE_ALT0_VENDOR := JioFiber
+  DEVICE_ALT0_MODEL := JCO4032
+  DEVICE_DTS := en7528_jiofiber_jcow414
+endef
+TARGET_DEVICES += jiofiber_jcow414

--- a/target/linux/econet/image/en7528.mk
+++ b/target/linux/econet/image/en7528.mk
@@ -48,3 +48,12 @@ define Device/jiofiber_jcow414
   DEVICE_DTS := en7528_jiofiber_jcow414
 endef
 TARGET_DEVICES += jiofiber_jcow414
+
+define Device/jiofiber_jcow407
+  $(Device/jiofiber_en7528)
+  DEVICE_MODEL := JCOW407
+  DEVICE_ALT0_VENDOR := JioFiber
+  DEVICE_ALT0_MODEL := JCOW407-IN
+  DEVICE_DTS := en7528_jiofiber_jcow407
+endef
+TARGET_DEVICES += jiofiber_jcow407

--- a/target/linux/econet/image/tclinux-trx.sh
+++ b/target/linux/econet/image/tclinux-trx.sh
@@ -30,6 +30,8 @@ Options:
   --version  Version string, max 31 chars (required)
   --endian   Endianness: 'be' for big endian, 'le' for little endian (default: be)
   --model    Model/platform name, max 31 chars (default: empty)
+  --loadaddr Address the bootloader decompresses the kernel to
+             (default: 0x80020000)
 EOF
     exit 1
 }
@@ -40,6 +42,7 @@ rootfs=""
 version=""
 endian="be"
 model=""
+loadaddr="0x80020000"
 
 # Parse named arguments
 while [ $# -gt 0 ]; do
@@ -62,6 +65,10 @@ while [ $# -gt 0 ]; do
             ;;
         --model)
             model="$2"
+            shift 2
+            ;;
+        --loadaddr)
+            loadaddr="$2"
             shift 2
             ;;
         -h|--help)
@@ -196,8 +203,10 @@ tclinux_trx_hdr() {
         head -c 32 /dev/zero | to_hex
     fi
 
-    # Load address (CONFIG_ZBOOT_LOAD_ADDRESS)
-    hex32 0x80020000
+    # Address the bootloader decompresses to. Note that some bootloaders
+    # read this field from the image in slot A even when booting slot B,
+    # so both slots need the same value.
+    hex32 "$loadaddr"
 
     # "reserved" 128 bytes of zeros
     head -c 128 /dev/zero | to_hex


### PR DESCRIPTION
This adds support for four ISP-provided GPON ONTs , all built on the EcoNet EN7528. They cover two board designs, each with a second product sharing its internals:

| Device              | Covered as                 | Notes                                 |
| ------------------- | -------------------------- | ------------------------------------- |
| JioFiber JCOW414    | primary                    |                                       |
| JioFiber JCO4032    | DEVICE_ALT0 of the JCOW414 | different form factor, same internals |
| JioFiber JCOW407    | primary                    |                                       |
| JioFiber JCOW407-IN | DEVICE_ALT0 of the JCOW407 | second-source SPI NAND                |

**Commits**

1. econet: make the TRX header and jump stub configurable per device

Preparatory, no behaviour change for existing devices:

- tclinux-trx.sh gains --loadaddr; the address the bootloader jumps to  was previously hardcoded to 0x80020000.
- TRX_MODEL and the new TRX_LOADADDR become per-device via DEVICE_VARS, and are reset in Device/Default. TRX_MODEL was a plain global, so the last device to set it won for every device in the target.
- The free-bootbase jump stub is emitted according to CONFIG_BIG_ENDIAN; it was unconditionally big-endian, which is wrong on the little-endian EN7528 subtarget.

2. econet: en7528: add support for JioFiber JCOW414/JCO4032

Introduces en7528_jiofiber.dtsi holding everything common to Jio's EN7528 boards  memory, flash layout, mtd-concat rootfs, PCIe, WiFi, switch and USB , leaving board files to describe only LEDs and buttons.

3. econet: en7528: add support for JioFiber JCOW407/JCOW407-IN

Adds only the second board file plus its device entry; reuses the dtsi unchanged.

**Hardware**

Common to all four:

- SoC EcoNet EN7528
- RAM 512 MiB DDR3
- Flash 256 MiB SPI NAND — Micron MT29F2G01, or Winbond W25M02G on the JCOW407
- WiFi MT7603E 2.4 GHz on PCIe port 0, MT7663 802.11ac 5 GHz on PCIe port 1
- Ethernet 4× 10/100/1000 behind the on-die MT7530 switch
- USB 2 ports
- Other 1× FXS, 1 GPON port

Where the two board designs differ:

|                 | JCOW414 / JCO4032 | JCOW407 / JCOW407-IN |
| --------------- | ----------------- | -------------------- |
| RGB status LED  | GPIO 27 / 25 / 23 | GPIO 2 / 3 / 4       |
| WPS button      | GPIO 4            | GPIO 1               |
| LAN LED colours | green on even pin | green on odd pin     |

**Installation**


Both boards are dual-image. OpenWrt goes in the first slot (tclinux); the bootloader picks the slot from one ASCII byte at flash offset 0x0DFC0000. Which slot the vendor firmware boots from varies between units, so the flag may need moving after flashing.

Full flash instructions : TFTP and XMODEM recovery, permanent install, slot switching from OpenWrt, from the vendor firmware, and from the bootloader , are in the individual commit messages, along with the MAC layout.


**Known limitation**

On the JCOW407 the green LAN LEDs are described in DT but stay dark: that bootloader leaves their pins muxed to the GPHY LED function, so the GPIO output has no effect. They start working once econet pinctrl support lands. The amber LEDs are unaffected, and all eight work on the JCOW414.