### PR TITLE
libunwind: enable on musl/powerpc using libucontext

### DIFF
--- a/package/libs/libunwind/Makefile
+++ b/package/libs/libunwind/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libunwind
 PKG_VERSION:=1.8.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/libunwind/libunwind/releases/download/v$(PKG_VERSION)/
@@ -32,7 +32,7 @@ define Package/libunwind
   CATEGORY:=Libraries
   TITLE:=The libunwind project
   URL:=https://www.nongnu.org/libunwind/
-  DEPENDS:=@!(USE_MUSL&&(powerpc)) +zlib
+  DEPENDS:=+zlib +(USE_MUSL&&powerpc||USE_MUSL&&powerpc64):libucontext
   ABI_VERSION:=8
 endef
 
@@ -46,6 +46,10 @@ CONFIGURE_ARGS += \
 	--disable-minidebuginfo
 
 TARGET_LDFLAGS += $(if $(CONFIG_USE_MUSL),-lssp_nonshared)
+# On powerpc/powerpc64 libunwind maps unw_getcontext() onto the libc
+# getcontext(), which musl does not implement.  Other architectures ship
+# their own getcontext.S, so they are unaffected.
+TARGET_LDFLAGS += $(if $(CONFIG_USE_MUSL),$(if $(filter powerpc powerpc64,$(ARCH)),-lucontext))
 
 define Package/libunwind/install
 	$(INSTALL_DIR) $(1)/usr/lib


### PR DESCRIPTION
On powerpc and powerpc64, libunwind implements `unw_tdep_getcontext()` using
libc's `getcontext()`:

```
#define unw_tdep_getcontext(uc)  (getcontext (uc), 0)
```

Unlike aarch64, arm, mips, riscv or x86_64, the powerpc ports do not ship
their own `getcontext.S`. musl declares `getcontext()` in `ucontext.h` but
does not implement it, so `libunwind.so` contains an undefined `getcontext`
symbol and linking a consumer against it fails:

```
ld: libunwind.so: undefined reference to `getcontext'
```

This restriction was originally added to work around that issue. Depend on
libucontext instead, which provides the SysV ucontext API for musl and
supports both ppc and ppc64.

The previous restriction only covered 32-bit powerpc, while powerpc64
resolves `unw_tdep_getcontext()` through libc in the same way, so the
libucontext dependency now covers both.

This also unblocks packages that already depend on libunwind
unconditionally, such as libjemalloc.

Verified on mpc85xx/p2020 (Turris 1.x, e500v2, musl):

* libucontext and libunwind both build, and `libunwind.so.8` gains
  `DT_NEEDED libucontext.so.1`
* linking a consumer against the packaged libunwind succeeds; without this
  change it fails with the undefined reference above
* `unw_backtrace()` and unwinding from a signal handler both return correct
  call chains on the device

powerpc64 was not build-tested; that part is based on `libunwind-ppc64.h`
resolving `unw_tdep_getcontext()` through libc in the same way.

cc: @blocktrron
Suggested-by: @neheb in https://github.com/openwrt/openwrt/commit/fca63d04b5075723d001eff788973edd88bcb636#commitcomment-167037367
