### PR TITLE
kernel: backport adt7470 PWM/thermal support from v7.3

### DIFF
--- a/target/linux/bcm27xx/patches-6.18/0310-hwmon-Add-RP1-ADC-and-temperature-driver.patch
+++ b/target/linux/bcm27xx/patches-6.18/0310-hwmon-Add-RP1-ADC-and-temperature-driver.patch
@@ -21,7 +21,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
 
 --- a/drivers/hwmon/Kconfig
 +++ b/drivers/hwmon/Kconfig
-@@ -2663,6 +2663,13 @@ config SENSORS_INTEL_M10_BMC_HWMON
+@@ -2664,6 +2664,13 @@ config SENSORS_INTEL_M10_BMC_HWMON
  	  sensors monitor various telemetry data of different components on the
  	  card, e.g. board temperature, FPGA core temperature/voltage/current.
  

--- a/target/linux/generic/backport-6.18/851-01-v7.3-dt-bindings-hwmon-add-adi-adt7470.patch
+++ b/target/linux/generic/backport-6.18/851-01-v7.3-dt-bindings-hwmon-add-adi-adt7470.patch
@@ -1,0 +1,84 @@
+From 9f446d82bdbcea89c2795a8a6ce7a7c2cac02129 Mon Sep 17 00:00:00 2001
+From: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Date: Wed, 5 Aug 2026 10:15:17 -0300
+Subject: [PATCH 1/4] dt-bindings: hwmon: add adi,adt7470
+
+The Analog Devices ADT7470 is a multichannel temperature sensor and
+PWM fan controller. It supports monitoring up to 10 external
+temperature sensors and controlling up to 4 fans.
+
+Add the device tree binding documentation for it. This includes
+support for the thermal framework by defining the "#thermal-sensor-cells"
+property, and models the fan control lines as PWM channels by
+defining the "#pwm-cells" property.
+
+Reviewed-by: Krzysztof Kozlowski <krzysztof.kozlowski@oss.qualcomm.com>
+Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Link: https://lore.kernel.org/r/20260805-adt7470_thermalzone-v6-1-5605a5f95467@gmail.com
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+---
+ .../bindings/hwmon/adi,adt7470.yaml           | 58 +++++++++++++++++++
+ 1 file changed, 58 insertions(+)
+ create mode 100644 Documentation/devicetree/bindings/hwmon/adi,adt7470.yaml
+
+--- /dev/null
++++ b/Documentation/devicetree/bindings/hwmon/adi,adt7470.yaml
+@@ -0,0 +1,58 @@
++# SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
++%YAML 1.2
++---
++$id: http://devicetree.org/schemas/hwmon/adi,adt7470.yaml#
++$schema: http://devicetree.org/meta-schemas/core.yaml#
++
++title: Analog Devices ADT7470 hwmon sensor
++
++maintainers:
++  - Luiz Angelo Daros de Luca <luizluca@gmail.com>
++
++description:
++  Multi-channel temperature monitor and PWM fan controller.
++  It supports monitoring up to 10 external temperature sensors and
++  controlling up to 4 fans. The fan control lines are modeled
++  as standard PWM channels.
++
++properties:
++  compatible:
++    const: adi,adt7470
++
++  reg:
++    maxItems: 1
++
++  "#pwm-cells":
++    const: 3
++
++  "#thermal-sensor-cells":
++    const: 1
++    description:
++      Valid index values are 0 to 9, corresponding to temp1 through temp10.
++
++required:
++  - compatible
++  - reg
++
++allOf:
++  - if:
++      required:
++        - "#thermal-sensor-cells"
++    then:
++      $ref: /schemas/thermal/thermal-sensor.yaml#
++
++unevaluatedProperties: false
++
++examples:
++  - |
++    i2c {
++        #address-cells = <1>;
++        #size-cells = <0>;
++
++        hwmon@2f {
++            compatible = "adi,adt7470";
++            reg = <0x2f>;
++            #pwm-cells = <3>;
++            #thermal-sensor-cells = <1>;
++        };
++    };

--- a/target/linux/generic/backport-6.18/851-02-v7.3-hwmon-adt7470-Add-ADT7470_PWM_MAX-macro.patch
+++ b/target/linux/generic/backport-6.18/851-02-v7.3-hwmon-adt7470-Add-ADT7470_PWM_MAX-macro.patch
@@ -1,0 +1,51 @@
+From bdec2083b9d8a4a29b717686e573e7113f8d9470 Mon Sep 17 00:00:00 2001
+From: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Date: Wed, 5 Aug 2026 10:15:18 -0300
+Subject: [PATCH 2/4] hwmon: (adt7470) Add ADT7470_PWM_MAX macro
+
+Instead of a magic 255, use a macro to refer to it.
+
+Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Link: https://lore.kernel.org/r/20260805-adt7470_thermalzone-v6-2-5605a5f95467@gmail.com
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+---
+ drivers/hwmon/adt7470.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+--- a/drivers/hwmon/adt7470.c
++++ b/drivers/hwmon/adt7470.c
+@@ -100,6 +100,7 @@ static const unsigned short normal_i2c[]
+ #define ADT7470_REG_FAN_MAX(x)	(ADT7470_REG_FAN_MAX_BASE_ADDR + ((x) * 2))
+ 
+ #define ADT7470_PWM_COUNT	4
++#define ADT7470_PWM_MAX		255
+ #define ADT7470_REG_PWM(x)	(ADT7470_REG_PWM_BASE_ADDR + (x))
+ #define ADT7470_REG_PWM_MAX(x)	(ADT7470_REG_PWM_MAX_BASE_ADDR + (x))
+ #define ADT7470_REG_PWM_MIN(x)	(ADT7470_REG_PWM_MIN_BASE_ADDR + (x))
+@@ -850,7 +851,7 @@ static int adt7470_pwm_write(struct devi
+ 
+ 	switch (attr) {
+ 	case hwmon_pwm_input:
+-		val = clamp_val(val, 0, 255);
++		val = clamp_val(val, 0, ADT7470_PWM_MAX);
+ 		mutex_lock(&data->lock);
+ 		err = regmap_write(data->regmap, ADT7470_REG_PWM(channel),
+ 				   val);
+@@ -910,7 +911,7 @@ static ssize_t pwm_max_store(struct devi
+ 	if (kstrtol(buf, 10, &temp))
+ 		return -EINVAL;
+ 
+-	temp = clamp_val(temp, 0, 255);
++	temp = clamp_val(temp, 0, ADT7470_PWM_MAX);
+ 
+ 	mutex_lock(&data->lock);
+ 	data->pwm_max[attr->index] = temp;
+@@ -945,7 +946,7 @@ static ssize_t pwm_min_store(struct devi
+ 	if (kstrtol(buf, 10, &temp))
+ 		return -EINVAL;
+ 
+-	temp = clamp_val(temp, 0, 255);
++	temp = clamp_val(temp, 0, ADT7470_PWM_MAX);
+ 
+ 	mutex_lock(&data->lock);
+ 	data->pwm_min[attr->index] = temp;

--- a/target/linux/generic/backport-6.18/851-03-v7.3-hwmon-adt7470-Expose-fan-control-via-PWM-framework.patch
+++ b/target/linux/generic/backport-6.18/851-03-v7.3-hwmon-adt7470-Expose-fan-control-via-PWM-framework.patch
@@ -1,0 +1,299 @@
+From 8d1e8f8deefe7a5b00c5b3535b3eb63f23133d51 Mon Sep 17 00:00:00 2001
+From: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Date: Wed, 5 Aug 2026 10:15:19 -0300
+Subject: [PATCH 3/4] hwmon: (adt7470) Expose fan control via PWM framework
+
+The ADT7470 features four PWM outputs designed to control fans.
+Previously, these were only accessible through the legacy hwmon
+sysfs interface.
+
+Expose the ADT7470 fan control lines through the generic PWM framework.
+This allows generic PWM consumers described in Device Tree, such as
+"pwm-fan", to use the device through the "#pwm-cells" property.  This is
+particularly necessary for boards where the ADT7470 external temperature
+sensors are not populated and the chip is used strictly as a fan
+controller (e.g., Edgecore ECS-2100-52T switches). In such setups,
+delegating control to the generic PWM subsystem allows the kernel's
+thermal framework to manage the fans based on unrelated temperature
+zones, such as internal SoC sensors.
+
+When a PWM consumer applies a new PWM state, the driver automatically
+switches the corresponding PWM channel to manual mode so that the
+requested duty cycle takes effect. The duty cycle specified by the PWM
+framework is internally converted to the 0-255 scale expected by the
+hardware registers.
+
+To prevent conflicting access, the hwmon PWM sysfs attributes are hidden
+when the device is registered with PWM framework support (i.e. when
+"#pwm-cells" is present in DT and CONFIG_PWM is reachable).
+
+Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Link: https://lore.kernel.org/r/20260805-adt7470_thermalzone-v6-3-5605a5f95467@gmail.com
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+---
+ drivers/hwmon/Kconfig   |   1 +
+ drivers/hwmon/adt7470.c | 194 +++++++++++++++++++++++++++++++++++++++-
+ 2 files changed, 194 insertions(+), 1 deletion(-)
+
+--- a/drivers/hwmon/Kconfig
++++ b/drivers/hwmon/Kconfig
+@@ -224,6 +224,7 @@ config SENSORS_ADT7462
+ config SENSORS_ADT7470
+ 	tristate "Analog Devices ADT7470"
+ 	depends on I2C
++	depends on PWM || PWM=n
+ 	select REGMAP_I2C
+ 	help
+ 	  If you say yes here you get support for the Analog Devices
+--- a/drivers/hwmon/adt7470.c
++++ b/drivers/hwmon/adt7470.c
+@@ -22,6 +22,9 @@
+ #include <linux/sched.h>
+ #include <linux/slab.h>
+ #include <linux/util_macros.h>
++#include <linux/pwm.h>
++#include <linux/cleanup.h>
++#include <linux/math64.h>
+ 
+ /* Addresses to scan */
+ static const unsigned short normal_i2c[] = { 0x2C, 0x2E, 0x2F, I2C_CLIENT_END };
+@@ -164,6 +167,7 @@ struct adt7470_data {
+ 	char			limits_valid;
+ 	unsigned long		sensors_last_updated;	/* In jiffies */
+ 	unsigned long		limits_last_updated;	/* In jiffies */
++	bool			use_pwm_framework;
+ 
+ 	int			num_temp_sensors;	/* -1 = probe */
+ 	int			temperatures_probed;
+@@ -887,6 +891,133 @@ static int adt7470_pwm_write(struct devi
+ 	return err;
+ }
+ 
++struct adt7470_pwm_wfhw {
++	u8 val;
++};
++
++static int adt7470_pwm_round_waveform_tohw(struct pwm_chip *chip,
++					   struct pwm_device *pwm,
++					   const struct pwm_waveform *wf,
++					   void *_wfhw)
++{
++	struct adt7470_data *data = pwmchip_get_drvdata(chip);
++	struct adt7470_pwm_wfhw *wfhw = _wfhw;
++	u64 actual_period;
++
++	if (wf->duty_length_ns == 0) {
++		wfhw->val = 0;
++		return 0;
++	}
++
++	/*
++	 * The PWM frequency (period) is a single chip-wide setting shared by
++	 * all 4 channels, so it cannot be changed on a per-pwm_device basis
++	 * through this API. The duty cycle is rounded against the currently
++	 * configured hardware period rather than the period requested in
++	 * @wf; round_waveform_fromhw() reports the actual resulting
++	 * waveform back so the core/consumer can detect a mismatch.
++	 */
++	actual_period = DIV_ROUND_UP_ULL(NSEC_PER_SEC, data->pwm_freq);
++
++	if (actual_period > wf->period_length_ns)
++		/* period too short */
++		return 1;
++
++	if (wf->duty_length_ns >= actual_period) {
++		wfhw->val = ADT7470_PWM_MAX;
++	} else {
++		wfhw->val = mul_u64_u64_div_u64(wf->duty_length_ns,
++						ADT7470_PWM_MAX,
++						actual_period);
++	}
++
++	return 0;
++}
++
++static int adt7470_pwm_round_waveform_fromhw(struct pwm_chip *chip,
++					     struct pwm_device *pwm,
++					     const void *_wfhw,
++					     struct pwm_waveform *wf)
++{
++	struct adt7470_data *data = pwmchip_get_drvdata(chip);
++	const struct adt7470_pwm_wfhw *wfhw = _wfhw;
++
++	wf->period_length_ns = DIV_ROUND_UP_ULL(NSEC_PER_SEC, data->pwm_freq);
++	wf->duty_offset_ns = 0;
++	wf->duty_length_ns = DIV_ROUND_UP_ULL((u64)wfhw->val * wf->period_length_ns,
++					      ADT7470_PWM_MAX);
++	return 0;
++}
++
++static int adt7470_pwm_read_waveform(struct pwm_chip *chip,
++				     struct pwm_device *pwm,
++				     void *_wfhw)
++{
++	struct adt7470_data *data = pwmchip_get_drvdata(chip);
++	struct device *dev = regmap_get_device(data->regmap);
++	struct adt7470_pwm_wfhw *wfhw = _wfhw;
++
++	data = adt7470_update_device(dev);
++	if (IS_ERR(data))
++		return PTR_ERR(data);
++
++	/*
++	 * No lock needed: like the other hwmon_ops read callbacks in this
++	 * driver (e.g. adt7470_pwm_read()), this only does a single byte
++	 * read from the cache populated by adt7470_update_device().
++	 */
++	wfhw->val = data->pwm[pwm->hwpwm];
++
++	return 0;
++}
++
++static int adt7470_pwm_write_waveform(struct pwm_chip *chip,
++				      struct pwm_device *pwm,
++				      const void *_wfhw)
++{
++	struct adt7470_data *data = pwmchip_get_drvdata(chip);
++	const struct adt7470_pwm_wfhw *wfhw = _wfhw;
++	unsigned int pwm_auto_reg_mask;
++	int err;
++
++	if (pwm->hwpwm % 2)
++		pwm_auto_reg_mask = ADT7470_PWM2_AUTO_MASK;
++	else
++		pwm_auto_reg_mask = ADT7470_PWM1_AUTO_MASK;
++
++	guard(mutex)(&data->lock);
++
++	if (data->pwm[pwm->hwpwm] == wfhw->val &&
++	    data->pwm_automatic[pwm->hwpwm] == 0)
++		return 0;
++
++	/* Put the PWM channel in manual mode before updating it. */
++	err = regmap_update_bits(data->regmap,
++				 ADT7470_REG_PWM_CFG(pwm->hwpwm),
++				 pwm_auto_reg_mask, 0);
++	if (err < 0)
++		return err;
++
++	data->pwm_automatic[pwm->hwpwm] = 0;
++
++	err = regmap_write(data->regmap,
++			   ADT7470_REG_PWM(pwm->hwpwm), wfhw->val);
++	if (err < 0)
++		return err;
++
++	data->pwm[pwm->hwpwm] = wfhw->val;
++
++	return 0;
++}
++
++static const struct pwm_ops adt7470_pwm_ops = {
++	.sizeof_wfhw = sizeof(struct adt7470_pwm_wfhw),
++	.round_waveform_tohw = adt7470_pwm_round_waveform_tohw,
++	.round_waveform_fromhw = adt7470_pwm_round_waveform_fromhw,
++	.read_waveform = adt7470_pwm_read_waveform,
++	.write_waveform = adt7470_pwm_write_waveform,
++};
++
+ static ssize_t pwm_max_show(struct device *dev,
+ 			    struct device_attribute *devattr, char *buf)
+ {
+@@ -1107,6 +1238,10 @@ static struct attribute *adt7470_attrs[]
+ 	&dev_attr_alarm_mask.attr,
+ 	&dev_attr_num_temp_sensors.attr,
+ 	&dev_attr_auto_update_interval.attr,
++	NULL
++};
++
++static struct attribute *adt7470_pwm_attrs[] = {
+ 	&sensor_dev_attr_force_pwm_max.dev_attr.attr,
+ 	&sensor_dev_attr_pwm1_auto_point1_pwm.dev_attr.attr,
+ 	&sensor_dev_attr_pwm2_auto_point1_pwm.dev_attr.attr,
+@@ -1131,7 +1266,32 @@ static struct attribute *adt7470_attrs[]
+ 	NULL
+ };
+ 
+-ATTRIBUTE_GROUPS(adt7470);
++static const struct attribute_group adt7470_group = {
++	.attrs = adt7470_attrs,
++};
++
++static umode_t adt7470_pwm_is_visible(struct kobject *kobj,
++				      struct attribute *attr, int index)
++{
++	struct device *dev = kobj_to_dev(kobj);
++	struct adt7470_data *data = dev_get_drvdata(dev);
++
++	if (data->use_pwm_framework)
++		return 0;
++
++	return attr->mode;
++}
++
++static const struct attribute_group adt7470_pwm_group = {
++		.attrs = adt7470_pwm_attrs,
++		.is_visible = adt7470_pwm_is_visible,
++};
++
++static const struct attribute_group *adt7470_groups[] = {
++		&adt7470_group,
++		&adt7470_pwm_group,
++		NULL,
++};
+ 
+ static int adt7470_read(struct device *dev, enum hwmon_sensor_types type, u32 attr,
+ 			int channel, long *val)
+@@ -1166,6 +1326,7 @@ static int adt7470_write(struct device *
+ static umode_t adt7470_is_visible(const void *_data, enum hwmon_sensor_types type,
+ 				  u32 attr, int channel)
+ {
++	const struct adt7470_data *data = _data;
+ 	umode_t mode = 0;
+ 
+ 	switch (type) {
+@@ -1198,6 +1359,14 @@ static umode_t adt7470_is_visible(const
+ 		}
+ 		break;
+ 	case hwmon_pwm:
++		/* Hide all pwm attributes if this device is exposed to the PWM
++		 * framework
++		 */
++		if (data->use_pwm_framework) {
++			mode = 0;
++			break;
++		}
++
+ 		switch (attr) {
+ 		case hwmon_pwm_input:
+ 		case hwmon_pwm_enable:
+@@ -1328,6 +1497,29 @@ static int adt7470_probe(struct i2c_clie
+ 
+ 	data->pwm_freq = (u32)freq_val;
+ 
++	data->use_pwm_framework = false;
++
++	if (device_property_present(dev, "#pwm-cells")) {
++		if (IS_REACHABLE(CONFIG_PWM)) {
++			struct pwm_chip *chip;
++
++			chip = devm_pwmchip_alloc(dev, ADT7470_PWM_COUNT, 0);
++			if (IS_ERR(chip))
++				return PTR_ERR(chip);
++
++			chip->ops = &adt7470_pwm_ops;
++			pwmchip_set_drvdata(chip, data);
++
++			err = devm_pwmchip_add(dev, chip);
++			if (err)
++				return dev_err_probe(dev, err, "failed to register PWM chip\n");
++
++			data->use_pwm_framework = true;
++		} else {
++			dev_warn(dev, "#pwm-cells present but CONFIG_PWM disabled. HWMON PWM attributes not hidden.\n");
++		}
++	}
++
+ 	/* Register sysfs hooks */
+ 	hwmon_dev = devm_hwmon_device_register_with_info(dev, client->name, data,
+ 							 &adt7470_chip_info,

--- a/target/linux/generic/backport-6.18/851-04-v7.3-hwmon-adt7470-Add-thermal-zone-sensor-support.patch
+++ b/target/linux/generic/backport-6.18/851-04-v7.3-hwmon-adt7470-Add-thermal-zone-sensor-support.patch
@@ -1,0 +1,25 @@
+From f18a46518561205cd6ff775a488a0c9d9d5edbfb Mon Sep 17 00:00:00 2001
+From: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Date: Wed, 5 Aug 2026 10:15:20 -0300
+Subject: [PATCH 4/4] hwmon: (adt7470) Add thermal zone sensor support
+
+Register the ADT7470 temperature channels as thermal zone sensors.
+
+Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Link: https://lore.kernel.org/r/20260805-adt7470_thermalzone-v6-4-5605a5f95467@gmail.com
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+---
+ drivers/hwmon/adt7470.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/drivers/hwmon/adt7470.c
++++ b/drivers/hwmon/adt7470.c
+@@ -1396,6 +1396,8 @@ static const struct hwmon_ops adt7470_hw
+ };
+ 
+ static const struct hwmon_channel_info * const adt7470_info[] = {
++	HWMON_CHANNEL_INFO(chip,
++			   HWMON_C_REGISTER_TZ),
+ 	HWMON_CHANNEL_INFO(temp,
+ 			   HWMON_T_INPUT | HWMON_T_MIN | HWMON_T_MAX | HWMON_T_ALARM,
+ 			   HWMON_T_INPUT | HWMON_T_MIN | HWMON_T_MAX | HWMON_T_ALARM,

--- a/target/linux/microchipsw/patches-6.18/0010-v7.1-hwmon-sparx5-Make-it-selectable-for-ARCH_LAN969X.patch
+++ b/target/linux/microchipsw/patches-6.18/0010-v7.1-hwmon-sparx5-Make-it-selectable-for-ARCH_LAN969X.patch
@@ -15,7 +15,7 @@ Signed-off-by: Guenter Roeck <linux@roeck-us.net>
 
 --- a/drivers/hwmon/Kconfig
 +++ b/drivers/hwmon/Kconfig
-@@ -632,7 +632,7 @@ config SENSORS_I5K_AMB
+@@ -633,7 +633,7 @@ config SENSORS_I5K_AMB
  
  config SENSORS_SPARX5
  	tristate "Sparx5 SoC temperature sensor"

--- a/target/linux/mvebu/patches-6.18/903-drivers-hwmon-Add-the-IEI-WT61P803-PUZZLE-HWMON-driv.patch
+++ b/target/linux/mvebu/patches-6.18/903-drivers-hwmon-Add-the-IEI-WT61P803-PUZZLE-HWMON-driv.patch
@@ -26,7 +26,7 @@ Cc: Robert Marko <robert.marko@sartura.hr>
 
 --- a/drivers/hwmon/Kconfig
 +++ b/drivers/hwmon/Kconfig
-@@ -889,6 +889,14 @@ config SENSORS_IBMPOWERNV
+@@ -890,6 +890,14 @@ config SENSORS_IBMPOWERNV
  	  This driver can also be built as a module. If so, the module
  	  will be called ibmpowernv.
  

--- a/target/linux/realtek/patches-6.18/813-add-hasivo-mcu-sensor.patch
+++ b/target/linux/realtek/patches-6.18/813-add-hasivo-mcu-sensor.patch
@@ -69,7 +69,7 @@ Signed-off-by: Carlo Szelinsky <github@szelinsky.de>
 +    };
 --- a/drivers/hwmon/Kconfig
 +++ b/drivers/hwmon/Kconfig
-@@ -819,6 +819,21 @@ config SENSORS_GXP_FAN_CTRL
+@@ -820,6 +820,21 @@ config SENSORS_GXP_FAN_CTRL
  	  The GXP controls fan function via the CPLD through the use of PWM
  	  registers. This driver reports status and pwm setting of the fans.
  


### PR DESCRIPTION
Backport a series of upstream patches for the adt7470 hwmon driver, accepted for kernel v7.3. It exposes the fan control lines via the generic PWM framework and thermal zone sensors.

Instead of relying on userland scripts, the kernel can now control the fan speed directly through standard cooling maps and PWM fans configured in the DTS. Currently in the tree, only edgecore_ecs4100-12ph seems to use this chip.