### PR TITLE
mediatek: fix SPI bus-width property spelling

### DIFF
--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -2,6 +2,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_VERSION:=2026.07
+PKG_RELEASE:=1
 PKG_HASH:=78e8bfc382fe388f9b55aa1daf8c563522a037779b5d4c349d1415e381f1243e
 PKG_BUILD_DEPENDS:=!(TARGET_ramips||TARGET_mediatek_mt7623):arm-trusted-firmware-tools/host
 

--- a/package/boot/uboot-mediatek/patches/439-add-zyxel_ex5601-t0.patch
+++ b/package/boot/uboot-mediatek/patches/439-add-zyxel_ex5601-t0.patch
@@ -273,8 +273,8 @@
 +		compatible = "spi-nand";
 +		reg = <0>;
 +		spi-max-frequency = <20000000>;
-+		spi-tx-buswidth = <4>;
-+		spi-rx-buswidth = <4>;
++		spi-tx-bus-width = <4>;
++		spi-rx-bus-width = <4>;
 +
 +		partitions {
 +			compatible = "fixed-partitions";

--- a/package/boot/uboot-mediatek/patches/471-add-zyzel-wx5600-t0.patch
+++ b/package/boot/uboot-mediatek/patches/471-add-zyzel-wx5600-t0.patch
@@ -302,8 +302,8 @@
 +		compatible = "spi-nand";
 +		reg = <0>;
 +		spi-max-frequency = <52000000>;
-+		spi-tx-buswidth = <4>;
-+		spi-rx-buswidth = <4>;
++		spi-tx-bus-width = <4>;
++		spi-rx-bus-width = <4>;
 +
 +		partitions {
 +			compatible = "fixed-partitions";

--- a/target/linux/mediatek/dts/mt7981a-teltonika-rutc50.dts
+++ b/target/linux/mediatek/dts/mt7981a-teltonika-rutc50.dts
@@ -312,8 +312,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		mediatek,nmbm;
 		mediatek,bmt-max-ratio = <1>;

--- a/target/linux/mediatek/dts/mt7981a-teltonika-rutc50.dts
+++ b/target/linux/mediatek/dts/mt7981a-teltonika-rutc50.dts
@@ -363,8 +363,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <4000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/mediatek/dts/mt7981b-iptime-ax3000q.dts
+++ b/target/linux/mediatek/dts/mt7981b-iptime-ax3000q.dts
@@ -115,8 +115,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		spi-cal-enable;
 		spi-cal-mode = "read-data";

--- a/target/linux/mediatek/dts/mt7981b-iptime-ax3000se.dts
+++ b/target/linux/mediatek/dts/mt7981b-iptime-ax3000se.dts
@@ -101,8 +101,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		spi-cal-enable;
 		spi-cal-mode = "read-data";

--- a/target/linux/mediatek/dts/mt7981b-iptime-ax3000sm.dts
+++ b/target/linux/mediatek/dts/mt7981b-iptime-ax3000sm.dts
@@ -124,8 +124,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		spi-cal-enable;
 		spi-cal-mode = "read-data";

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kap-630.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kap-630.dtsi
@@ -133,8 +133,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		mediatek,nmbm;
 		mediatek,bmt-max-ratio = <1>;

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3711.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3711.dts
@@ -206,8 +206,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		mediatek,nmbm;
 		mediatek,bmt-max-ratio = <1>;

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3811.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3811.dts
@@ -222,8 +222,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		mediatek,nmbm;
 		mediatek,bmt-max-ratio = <1>;

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3911.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3911.dts
@@ -169,8 +169,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		mediatek,nmbm;
 		mediatek,bmt-max-ratio = <1>;

--- a/target/linux/mediatek/dts/mt7981b-livinet-li320.dts
+++ b/target/linux/mediatek/dts/mt7981b-livinet-li320.dts
@@ -156,8 +156,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		spi-cal-enable;
 		spi-cal-mode = "read-data";

--- a/target/linux/mediatek/dts/mt7981b-mercusys-mr85x-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-mercusys-mr85x-common.dtsi
@@ -197,8 +197,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		partitions: partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/mediatek/dts/mt7981b-routerich-ax3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-routerich-ax3000-v1.dts
@@ -171,8 +171,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		spi-cal-enable;
 		spi-cal-mode = "read-data";

--- a/target/linux/mediatek/dts/mt7981b-tplink-f65v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-tplink-f65v1.dts
@@ -68,8 +68,8 @@
 		compatible = "spi-nand";
 		reg = <0>;
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 		mediatek,nmbm;
 		mediatek,bmt-max-ratio = <1>;
 		mediatek,bmt-max-reserved-blocks = <64>;

--- a/target/linux/mediatek/dts/mt7981b-unielec-u7981-01-nand.dts
+++ b/target/linux/mediatek/dts/mt7981b-unielec-u7981-01-nand.dts
@@ -21,8 +21,6 @@
 		compatible = "spi-nand";
 		reg = <0>;
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
 
 		mediatek,nmbm;
 		mediatek,bmt-max-ratio = <1>;

--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax-v2.dts
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax-v2.dts
@@ -172,8 +172,6 @@
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
 
 		mediatek,nmbm;
 		mediatek,bmt-max-ratio = <1>;

--- a/target/linux/mediatek/dts/mt7986a-iptime-ax7800m-6e.dts
+++ b/target/linux/mediatek/dts/mt7986a-iptime-ax7800m-6e.dts
@@ -181,8 +181,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
Renames `spi-tx-buswidth` / `spi-rx-buswidth` to the forms Linux and U-Boot actually parse. `of_spi_parse_dt` only reads the hyphenated `spi-tx-bus-width` / `spi-rx-bus-width` and defaults to 1-bit when the property is missing; U-Boot's `spi-uclass.c` reads the same hyphenated form. Nothing was reading the old spelling, so every affected board has been stuck at 1-bit regardless of the `<4>` in its DTS.

Split per board now, grouped by what backs the rename, so a bad one reverts on its own.

Tested on hardware: the Teltonika RUTC50's NOR flash and its SPI-NAND (two chips, two commits, either reverts on its own), TP-Link F65v1, Mercusys MR85X (covers both the stock and -ubi image through the shared dtsi), four iptime boards (AX3000Q, AX3000SE, AX3000SM, AX7800M-6E), and the Zyxel EX5601-T0 U-Boot patch, each with its own `Tested-by:`. Keenetic KN-3811 is my own board and my own test, so it's `Signed-off-by:` only - no separate `Tested-by:` since I'm also the author.

Renamed on vendor evidence, no test on my end. KN-3711, KN-3911, and the shared kap-630 dtsi (also covers the Netcraze NAP-630) match Keenetic's own `keenetic/keenetic-sdk` DTS, spelled correctly there; their firmware runs these boards in quad.

Renamed on community evidence, no test on my end either. The Livinet Li320 and the Zyxel WX5600-T0 U-Boot patch match a community U-Boot build (`Yuzhii0718/bl-mt798x-dhcpd`, not a vendor source) that sets `support_quad` and carries the same typo, so that bootloader already runs quad on this wiring.

Routerich AX3000-v1 is renamed on my own sign-off and my own measurement, so no separate `Tested-by:` either. Reading its NAND goes from 4.71 to 11.39 MiB/s. One line at the declared 52 MHz cannot carry more than 6.2 MiB/s, so the higher figure needs more than one line in use.

Unielec U7981-01-NAND and Zbtlink Z8102AX-v2 get the property dropped instead of renamed. No test, no vendor evidence, so the DTS stops claiming quad it doesn't run. Each gets its own draft PR for whoever can test it.

