### PR TITLE
ncurses: disable widec for host build

### DIFF
--- a/package/libs/ncurses/Makefile
+++ b/package/libs/ncurses/Makefile
@@ -89,6 +89,7 @@ CONFIGURE_VARS += \
 HOST_CFLAGS += $(HOST_FPIC)
 
 HOST_CONFIGURE_ARGS += \
+	--disable-widec \
 	--enable-pc-files \
 	--without-cxx \
 	--without-cxx-binding \


### PR DESCRIPTION
The ncurses 6.6 update inherits the ABI 6 default of enabling
wide-character support. This silently changes host ncurses from narrow
to wide and conflicts with the packages feed's narrow-host assumption.

Python 3.13 then enables its wide-character curses path without matching
declarations and fails with:

```
error: implicit declaration of function 'wget_wch'
```

Explicitly disable widec for host builds. Target builds remain
explicitly wide-character.

The failure was reproduced on x86/64 in a clean GitHub-hosted build:
https://github.com/mgz0227/OpenWrt_x86/actions/runs/32355019702

Checked with `./scripts/checkpatch.pl --strict`.
