### PR TITLE
ncurses: fix host pkg-config file install location

### DIFF
--- a/package/libs/ncurses/Makefile
+++ b/package/libs/ncurses/Makefile
@@ -12,7 +12,7 @@ PKG_CPE_ID:=cpe:/a:gnu:ncurses
 PKG_VERSION_MAJOR:=6.6
 PKG_SNAPSHOT_DATE:=20260801
 PKG_VERSION:=$(PKG_VERSION_MAJOR)$(if $(PKG_SNAPSHOT_DATE),.$(PKG_SNAPSHOT_DATE),)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/ThomasDickey/ncurses-snapshots.git
@@ -90,6 +90,7 @@ HOST_CFLAGS += $(HOST_FPIC)
 
 HOST_CONFIGURE_ARGS += \
 	--enable-pc-files \
+	--with-pkg-config-libdir=$(STAGING_DIR_HOSTPKG)/lib/pkgconfig \
 	--without-cxx \
 	--without-cxx-binding \
 	--without-ada \
@@ -197,6 +198,27 @@ endef
 define Host/Compile
 	$(MAKE) -C $(HOST_BUILD_DIR) libs
 	$(MAKE) -C $(HOST_BUILD_DIR)/progs tic
+endef
+
+# Trees that built host ncurses before --with-pkg-config-libdir was added
+# have ncurses' *.pc files left over in $(STAGING_DIR_HOST)/lib/pkgconfig,
+# which still shadow the correct copies in $(HOST_BUILD_PREFIX)/lib/pkgconfig
+# since PKG_CONFIG_PATH searches STAGING_DIR_HOST first. Both spellings can
+# be present: the narrow names from 6.4 and older, and the widec names from
+# the 6.6 snapshots. Clean them up whenever host ncurses is (re)installed, so
+# a plain rebuild after pulling this change stops resolving pkg-config
+# ncurses/ncursesw to the stale prefix.
+define Host/CleanStaleHostPkgConfig
+	rm -f $(foreach l,ncurses panel menu form, \
+		$(STAGING_DIR_HOST)/lib/pkgconfig/$(l).pc \
+		$(STAGING_DIR_HOST)/lib/pkgconfig/$(l)w.pc)
+endef
+
+Hooks/HostInstall/Post := Host/CleanStaleHostPkgConfig $(Hooks/HostInstall/Post)
+
+# Also cover the explicit host-clean path.
+define Host/Uninstall
+	$(call Host/CleanStaleHostPkgConfig)
 endef
 
 $(eval $(call HostBuild))


### PR DESCRIPTION
**Maintainer:** @dangowrt

ncurses' own `./configure` determines where to install its generated `*.pc` files by querying pkg-config at configure time, independently of `--prefix`/`HOST_BUILD_PREFIX`. On a typical build host that resolves to `staging_dir/host/lib/pkgconfig`, not `staging_dir/hostpkg/lib/pkgconfig`, which is where `HostBuild.mk` (and everything that depends on a host package via `PKG_BUILD_DEPENDS`/`HOST_BUILD_DEPENDS`) actually expects a package's own pkg-config files to live.

Explicitly pass `--with-pkg-config-libdir=$(STAGING_DIR_HOSTPKG)/lib/pkgconfig` for the host build, mirroring the target build's existing `--with-pkg-config-libdir=/usr/lib/pkgconfig`. Verified directly: after this change `ncurses.pc`/`ncursesw.pc` (and panel/menu/form counterparts) land in `staging_dir/hostpkg/lib/pkgconfig` with the correct embedded prefix, and nothing is installed into `staging_dir/host` any more.

This is independent of the widec/narrow default that started causing host-python3 build failures after 18725c45a3 ("ncurses: bump to 6.6.20260801") — see #24811 for that issue and `lang/python/python3`'s own fix in the packages feed (openwrt/packages, to follow). Even before this change, pkg-config still found ncurses's host `.pc` files via the `staging_dir/host` component of `PKG_CONFIG_PATH`, so this is a hygiene/correctness fix for staying within the intended hostpkg/host separation, not a fix for that failure by itself.