### PR TITLE
realtek: pse: replace pending with backport patches

### DIFF
--- a/target/linux/realtek/dts/rtl9301_zyxel_xgs1930-28hp.dts
+++ b/target/linux/realtek/dts/rtl9301_zyxel_xgs1930-28hp.dts
@@ -176,13 +176,6 @@
 		tx-fault-gpio = <&gpio1 28 GPIO_ACTIVE_HIGH>;
 		los-gpio = <&gpio1 24 GPIO_ACTIVE_HIGH>;
 	};
-
-	poe_power: regulator-poe {
-		compatible = "regulator-fixed";
-		regulator-name = "poe-power";
-		gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
 };
 
 &gpio0 {
@@ -204,8 +197,8 @@
 			compatible = "zyxel,xgs1930-28hp-pse", "realtek,pse-mcu-gen2-smbus";
 			reg = <0x20>;
 
-			enable-gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>;
-			power-supply = <&poe_power>;
+			disable-ports-gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+			reset-gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
 
 			pse-pis {
 				#address-cells = <1>;

--- a/target/linux/realtek/dts/rtl9302_zyxel_xmg1915-10ep.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xmg1915-10ep.dts
@@ -29,7 +29,7 @@
 		compatible = "zyxel,xmg1915-10ep-pse", "realtek,pse-mcu-gen2";
 		current-speed = <115200>;
 
-		enable-gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
 
 		pse-pis {
 			#address-cells = <1>;

--- a/target/linux/realtek/dts/rtl9312_plasmacloud_psx28.dts
+++ b/target/linux/realtek/dts/rtl9312_plasmacloud_psx28.dts
@@ -26,7 +26,7 @@
 			compatible = "plasmacloud,psx28-pse", "realtek,pse-mcu-gen2-smbus";
 			reg = <0x20>;
 
-			enable-gpios = <&gpio1 29 GPIO_ACTIVE_HIGH>;
+			reset-gpios = <&gpio1 29 GPIO_ACTIVE_LOW>;
 
 			pse-pis {
 				#address-cells = <1>;

--- a/target/linux/realtek/dts/rtl9313_ubnt_usw-pro-xg-8-poe.dts
+++ b/target/linux/realtek/dts/rtl9313_ubnt_usw-pro-xg-8-poe.dts
@@ -234,7 +234,7 @@
 			compatible = "ubnt,usw-pro-xg-8-poe-pse", "realtek,pse-mcu-gen2-smbus";
 			reg = <0x20>;
 
-			enable-gpios = <&gpio1 15 GPIO_ACTIVE_HIGH>;
+			reset-gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
 
 			pse-pis {
 				#address-cells = <1>;

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12hp.dts
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12hp.dts
@@ -20,13 +20,6 @@
 			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
 		};
 	};
-
-	poe_power: regulator-poe {
-		compatible = "regulator-fixed";
-		regulator-name = "poe-power";
-		gpio = <&gpio0 30 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
 };
 
 &led_set {
@@ -59,8 +52,8 @@
 			compatible = "zyxel,xs1930-12hp-pse", "realtek,pse-mcu-gen2-smbus";
 			reg = <0x20>;
 
-			enable-gpios = <&gpio0 10 GPIO_ACTIVE_HIGH>;
-			power-supply = <&poe_power>;
+			disable-ports-gpios = <&gpio0 30 GPIO_ACTIVE_LOW>;
+			reset-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 
 			pse-pis {
 				#address-cells = <1>;

--- a/target/linux/realtek/patches-6.18/816-01-v7.3-net-pse-pd-add-Realtek-PSE-MCU-core.patch
+++ b/target/linux/realtek/patches-6.18/816-01-v7.3-net-pse-pd-add-Realtek-PSE-MCU-core.patch
@@ -1,7 +1,7 @@
-From cf51089eb907e5cd8f9e50a4054d1d4345563799 Mon Sep 17 00:00:00 2001
+From 44566e614d84a43cb35a14c00f088d6c36b7d5c6 Mon Sep 17 00:00:00 2001
 From: Jonas Jelonek <jelonek.jonas@gmail.com>
-Date: Sun, 5 Jul 2026 22:15:32 +0000
-Subject: [PATCH net-next v7 2/4] net: pse-pd: add Realtek PSE MCU core
+Date: Thu, 13 Aug 2026 22:20:33 +0000
+Subject: [PATCH 1/3] net: pse-pd: add Realtek PSE MCU core
 
 A range of managed Realtek-based PoE switches use a small microcontroller
 on the PCB to front the actual PSE silicon. The host CPU talks to that
@@ -27,24 +27,17 @@ Realtek's own PSE silicon - are both Realtek's, handled by the same shared
 core, each selecting its dialect via the compatible.
 
 Power budgeting is left to the MCU firmware; the driver advertises
-PSE_BUDGET_EVAL_STRAT_DYNAMIC (controller-managed budget) accordingly.
+PSE_BUDGET_EVAL_STRAT_DYNAMIC accordingly.
 
 Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
----
- MAINTAINERS                               |   7 +
- drivers/net/pse-pd/Kconfig                |   6 +
- drivers/net/pse-pd/Makefile               |   1 +
- drivers/net/pse-pd/realtek-pse-mcu-core.c | 995 ++++++++++++++++++++++
- drivers/net/pse-pd/realtek-pse-mcu.h      |  91 ++
- 5 files changed, 1100 insertions(+)
- create mode 100644 drivers/net/pse-pd/realtek-pse-mcu-core.c
- create mode 100644 drivers/net/pse-pd/realtek-pse-mcu.h
+Link: https://patch.msgid.link/20260813222036.873930-3-jelonek.jonas@gmail.com
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
 
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
-@@ -21680,6 +21680,13 @@ S:	Maintained
- F:	include/sound/rt*.h
- F:	sound/soc/codecs/rt*
+@@ -21687,6 +21687,13 @@ S:	Maintained
+ F:	Documentation/devicetree/bindings/watchdog/realtek,otto-wdt.yaml
+ F:	drivers/watchdog/realtek_otto_wdt.c
  
 +REALTEK PSE MCU DRIVER
 +M:	Jonas Jelonek <jelonek.jonas@gmail.com>
@@ -53,9 +46,9 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +F:	Documentation/devicetree/bindings/net/pse-pd/realtek,pse-mcu-gen1.yaml
 +F:	drivers/net/pse-pd/realtek-pse-mcu*
 +
- REALTEK OTTO WATCHDOG
- M:	Sander Vanheule <sander@svanheule.net>
- L:	linux-watchdog@vger.kernel.org
+ REALTEK RTL83xx SMI DSA ROUTER CHIPS
+ M:	Linus Walleij <linus.walleij@linaro.org>
+ M:	Alvin Šipraga <alsi@bang-olufsen.dk>
 --- a/drivers/net/pse-pd/Kconfig
 +++ b/drivers/net/pse-pd/Kconfig
 @@ -13,6 +13,12 @@ menuconfig PSE_CONTROLLER
@@ -83,7 +76,7 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
  obj-$(CONFIG_PSE_SI3474) += si3474.o
 --- /dev/null
 +++ b/drivers/net/pse-pd/realtek-pse-mcu-core.c
-@@ -0,0 +1,995 @@
+@@ -0,0 +1,998 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
 +/*
 + * Driver for the microcontroller (MCU) fronting PSE silicon on various
@@ -124,7 +117,6 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +#include <linux/module.h>
 +#include <linux/property.h>
 +#include <linux/pse-pd/pse.h>
-+#include <linux/regulator/consumer.h>
 +#include <linux/unaligned.h>
 +
 +#include "realtek-pse-mcu.h"
@@ -148,6 +140,12 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +
 +#define RTPSE_MCU_MAX_PORTS			48
 +#define RTPSE_MCU_PORT_MAX_PRIORITY		3
++
++/* Bounded resends when the MCU replies NOT_READY (busy). */
++#define RTPSE_MCU_NOT_READY_RETRIES		3
++
++/* Nominal PSE rail; 802.3at/bt operating range. */
++#define RTPSE_MCU_PSE_VOLTAGE_UV		54000000
 +
 +enum rtpse_mcu_cmd {
 +	RTPSE_MCU_CMD_SET_GLOBAL_STATE,
@@ -181,16 +179,10 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +	u8 max_ports;
 +	bool system_enable;
 +	u16 device_id;
-+	u8 sw_ver;
 +	u8 mcu_type;
-+	u8 config_status;
-+	u8 ext_ver;
 +};
 +
 +struct rtpse_mcu_ext_config {
-+	u8 uvlo;
-+	u8 ovlo;
-+	bool prealloc_enable;
 +	u8 num_of_pses;
 +};
 +
@@ -232,7 +224,6 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +
 +struct rtpse_mcu_chip_info {
 +	const char *name;
-+	u16 device_id;
 +	u32 max_mW_per_port;
 +	enum rtpse_mcu_cmd pw_set_cmd;	/* command used by set_pw_limit */
 +	u32 pw_set_lsb_mW;		/* LSB of pw_set_cmd value, in mW */
@@ -240,7 +231,6 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +};
 +
 +static const struct rtpse_mcu_chip_info rtl8238b_info = {
-+	.device_id = RTPSE_MCU_DEVICE_ID_RTL8238B,
 +	.max_mW_per_port = 30000,
 +	.name = "RTL8238B",
 +	.pw_read_lsb_mW = 200,
@@ -249,7 +239,6 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +};
 +
 +static const struct rtpse_mcu_chip_info rtl8239_info = {
-+	.device_id = RTPSE_MCU_DEVICE_ID_RTL8239,
 +	.max_mW_per_port = 90000,
 +	.name = "RTL8239",
 +	.pw_read_lsb_mW = 400,
@@ -258,7 +247,6 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +};
 +
 +static const struct rtpse_mcu_chip_info rtl8239c_info = {
-+	.device_id = RTPSE_MCU_DEVICE_ID_RTL8239C,
 +	.max_mW_per_port = 90000,
 +	.name = "RTL8239C",
 +	.pw_read_lsb_mW = 400,
@@ -267,7 +255,6 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +};
 +
 +static const struct rtpse_mcu_chip_info bcm59111_info = {
-+	.device_id = RTPSE_MCU_DEVICE_ID_BCM59111,
 +	.max_mW_per_port = 30000,
 +	.name = "BCM59111",
 +	.pw_read_lsb_mW = 200,
@@ -276,7 +263,6 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +};
 +
 +static const struct rtpse_mcu_chip_info bcm59121_info = {
-+	.device_id = RTPSE_MCU_DEVICE_ID_BCM59121,
 +	/*
 +	 * BCM59121 is a 60W Type-3 part, but known boards run it at 802.3at
 +	 * and the Gen1 dialect has only the 8-bit/0.2W set command (<=51W);
@@ -314,36 +300,38 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +static int rtpse_mcu_do_xfer(struct rtpse_mcu_ctrl *pse, struct rtpse_mcu_msg *req,
 +			     struct rtpse_mcu_msg *resp)
 +{
++	unsigned int tries;
 +	int ret;
 +
-+	scoped_guard(mutex, &pse->mutex) {
-+		/* Rolling seq_num so a late reply can't pass as a later one. */
-+		req->seq_num = pse->seq++;
-+		req->checksum = rtpse_mcu_checksum((u8 *)req, RTPSE_MCU_MSG_SIZE - 1);
++	for (tries = 0; ; tries++) {
++		scoped_guard(mutex, &pse->mutex) {
++			/* Rolling seq_num (skip 0) so a stale/all-zero reply can't match. */
++			if (++pse->seq == 0)
++				pse->seq = 1;
++			req->seq_num = pse->seq;
++			req->checksum = rtpse_mcu_checksum((u8 *)req, RTPSE_MCU_MSG_SIZE - 1);
 +
-+		ret = pse->transport->send(pse, req);
-+		if (ret)
-+			return ret;
++			ret = pse->transport->send(pse, req);
++			if (ret)
++				return ret;
 +
-+		/*
-+		 * The MCU needs a fixed amount of time between receiving a request
-+		 * and having the response ready, regardless of how the bytes get to
-+		 * us. Pace the transaction here so each transport can keep its recv
-+		 * path simple: a single bounded wait rather than a generic retry.
-+		 */
++			/* Pace the base reply delay; the transport waits its own way. */
++			msleep(RTPSE_MCU_RESPONSE_MS);
++
++			memset(resp, 0, sizeof(*resp));
++			ret = pse->transport->recv(pse, req, resp);
++			if (ret)
++				return ret;
++		}
++
++		/* NOT_READY: MCU busy, wants the command resent; bounded retry. */
++		if (resp->opcode != RTPSE_MCU_OPCODE_NOT_READY ||
++		    tries >= RTPSE_MCU_NOT_READY_RETRIES)
++			break;
 +		msleep(RTPSE_MCU_RESPONSE_MS);
-+
-+		memset(resp, 0, sizeof(*resp));
-+		ret = pse->transport->recv(pse, req, resp);
-+		if (ret)
-+			return ret;
 +	}
 +
-+	/*
-+	 * Explicit MCU error opcodes (observed on the Gen1 dialect; harmless
-+	 * to check for Gen2 too). Catch these before the generic opcode/CRC
-+	 * mismatch path so callers see a meaningful errno.
-+	 */
++	/* Explicit MCU error opcodes (Gen1); map to a meaningful errno. */
 +	switch (resp->opcode) {
 +	case RTPSE_MCU_OPCODE_INCOMPLETE:
 +		return -EBADE;
@@ -435,9 +423,6 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +	if (ret)
 +		return ret;
 +
-+	config->uvlo = resp.payload[0];
-+	config->ovlo = resp.payload[5];
-+	config->prealloc_enable = (resp.payload[1] == 0x1);
 +	config->num_of_pses = resp.payload[6];
 +
 +	return 0;
@@ -630,11 +615,8 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +		return ret;
 +
 +	/*
-+	 * sts2 holds the class only in the operational states below. In a
-+	 * fault/test state (or a code reserved on the current dialect) it
-+	 * does not, so there is no class to report and we return 0. That is
-+	 * indistinguishable from a real class-0 PD; userspace disambiguates
-+	 * via the power status.
++	 * As per datasheet, the classification result is only valid when in
++	 * one of those operational modes, otherwise not.
 +	 */
 +	switch (status.sts1) {
 +	case RTPSE_MCU_PORT_STS_DISABLED:
@@ -643,6 +625,11 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +	case RTPSE_MCU_PORT_STS_REQUESTING:
 +		return pse->dialect->parse_port_class(&status);
 +	default:
++		/*
++		 * No class to report, return 0 instead. This is indistinguishable
++		 * from a real class-0 PD but userspace disambiguates via the
++		 * power status.
++		 */
 +		return 0;
 +	}
 +}
@@ -674,6 +661,15 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +
 +	/* 64.45mV per LSB */
 +	uV = measurement.voltage_raw * 64450U;
++
++	/*
++	 * Idle ports measure 0V, which the core rejects when turning a power
++	 * limit into a current limit. Fall back to the nominal rail so a limit
++	 * can be set before a PD is attached.
++	 */
++	if (!uV)
++		return RTPSE_MCU_PSE_VOLTAGE_UV;
++
 +	return min_t(u32, uV, INT_MAX);
 +}
 +
@@ -697,7 +693,12 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +	if (ret)
 +		return ret;
 +
-+	return config.max_power * pse->chip->pw_read_lsb_mW;
++	/*
++	 * The MCU's raw max_power byte can scale above the chip's rated cap;
++	 * clamp to the same bound set_pw_limit() and the advertised range use.
++	 */
++	return min_t(u32, config.max_power * pse->chip->pw_read_lsb_mW,
++		     pse->chip->max_mW_per_port);
 +}
 +
 +static int rtpse_mcu_port_set_pw_limit(struct pse_controller_dev *pcdev, int id, int max_mW)
@@ -718,18 +719,21 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +		return -EOPNOTSUPP;
 +
 +	/*
-+	 * Switch the port to user-defined limit mode first, then program the
-+	 * limit value. If the second cmd fails, the port is left in
-+	 * user-defined mode but with the previous limit value; the next
-+	 * successful set_pw_limit call recovers it.
++	 * Round up so a sub-LSB request maps to one LSB, not silently to 0;
++	 * an explicit 0 still yields 0, and LSB-aligned maxima can't overshoot.
 +	 */
-+	ret = rtpse_mcu_port_cmd(pse, id, type_opc->op, RTPSE_MCU_PORT_PW_LIMIT_TYPE_USER);
++	prg_val = min_t(unsigned int, DIV_ROUND_UP(max_mW, chip->pw_set_lsb_mW), U8_MAX);
++
++	/*
++	 * Program the value before switching to user-defined mode. The two
++	 * commands aren't atomic, but this order never leaves a stale cap: a
++	 * failure keeps the previous cap, or (already user mode) the requested.
++	 */
++	ret = rtpse_mcu_port_cmd(pse, id, val_opc->op, prg_val);
 +	if (ret)
 +		return ret;
 +
-+	prg_val = min_t(unsigned int, max_mW / chip->pw_set_lsb_mW, U8_MAX);
-+
-+	return rtpse_mcu_port_cmd(pse, id, val_opc->op, prg_val);
++	return rtpse_mcu_port_cmd(pse, id, type_opc->op, RTPSE_MCU_PORT_PW_LIMIT_TYPE_USER);
 +}
 +
 +static int rtpse_mcu_port_get_pw_limit_ranges(struct pse_controller_dev *pcdev, int id,
@@ -738,7 +742,7 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +	struct rtpse_mcu_ctrl *pse = to_rtpse_mcu_ctrl(pcdev);
 +	struct ethtool_c33_pse_pw_limit_range *range;
 +
-+	range = kzalloc_obj(*range, GFP_KERNEL);
++	range = kzalloc_obj(*range);
 +	if (!range)
 +		return -ENOMEM;
 +
@@ -759,7 +763,8 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +	if (ret)
 +		return ret;
 +
-+	return config.priority;
++	/* Clamp to the advertised max; set_prio() and pis_prio_max use the same bound. */
++	return min_t(u8, config.priority, RTPSE_MCU_PORT_MAX_PRIORITY);
 +}
 +
 +static int rtpse_mcu_port_set_prio(struct pse_controller_dev *pcdev, int id, unsigned int prio)
@@ -851,11 +856,6 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +	return 0;
 +}
 +
-+static void rtpse_mcu_regulator_disable(void *data)
-+{
-+	regulator_disable(data);
-+}
-+
 +static void rtpse_mcu_global_disable(void *data)
 +{
 +	struct rtpse_mcu_ctrl *pse = data;
@@ -866,8 +866,8 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +int rtpse_mcu_register(struct rtpse_mcu_ctrl *pse)
 +{
 +	const struct rtpse_mcu_match_data *match;
-+	struct gpio_desc *enable_gpio;
 +	struct rtpse_mcu_info info;
++	struct gpio_desc *gpiod;
 +	int ret;
 +
 +	BUILD_BUG_ON(sizeof(struct rtpse_mcu_msg) != RTPSE_MCU_MSG_SIZE);
@@ -892,27 +892,29 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +		return dev_err_probe(pse->dev, -EINVAL,
 +				     "dialect for chip is incomplete\n");
 +
-+	pse->poe_supply = devm_regulator_get(pse->dev, "power");
-+	if (IS_ERR(pse->poe_supply))
-+		return dev_err_probe(pse->dev, PTR_ERR(pse->poe_supply),
-+				     "failed to get PoE supply\n");
-+
-+	enable_gpio = devm_gpiod_get_optional(pse->dev, "enable", GPIOD_OUT_HIGH);
-+	if (IS_ERR(enable_gpio))
-+		return dev_err_probe(pse->dev, PTR_ERR(enable_gpio),
-+				     "failed to get enable gpio\n");
++	/*
++	 * Release the MCU from reset before the first transaction; the
++	 * boot-retry loop in discover() waits for it to answer.
++	 */
++	gpiod = devm_gpiod_get_optional(pse->dev, "reset", GPIOD_OUT_LOW);
++	if (IS_ERR(gpiod))
++		return dev_err_probe(pse->dev, PTR_ERR(gpiod),
++				     "failed to get reset gpio\n");
 +
 +	ret = rtpse_mcu_discover(pse, &info);
 +	if (ret)
 +		return ret;
 +
-+	ret = regulator_enable(pse->poe_supply);
-+	if (ret)
-+		return dev_err_probe(pse->dev, ret, "failed to enable PoE supply\n");
-+
-+	ret = devm_add_action_or_reset(pse->dev, rtpse_mcu_regulator_disable, pse->poe_supply);
-+	if (ret)
-+		return ret;
++	/*
++	 * Some boards gate all ports through a hardware line; deassert it only
++	 * after the MCU is confirmed, so a discover failure never ungates the
++	 * ports. It is then left to the MCU - not re-gated on unbind or a later
++	 * probe error - so a driver reload doesn't black out PoE.
++	 */
++	gpiod = devm_gpiod_get_optional(pse->dev, "disable-ports", GPIOD_OUT_LOW);
++	if (IS_ERR(gpiod))
++		return dev_err_probe(pse->dev, PTR_ERR(gpiod),
++				     "failed to get disable-ports gpio\n");
 +
 +	if (!info.system_enable) {
 +		ret = rtpse_mcu_set_global_state(pse, true);
@@ -956,10 +958,7 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +	info->max_ports = payload[1];
 +	info->system_enable = (payload[2] == 0x1);
 +	info->device_id = get_unaligned_be16(&payload[3]);
-+	info->sw_ver = payload[5];
 +	info->mcu_type = payload[6];
-+	info->config_status = payload[7];
-+	info->ext_ver = payload[8];
 +}
 +
 +static int rtpse_mcu_gen2_parse_port_class(const struct rtpse_mcu_port_status *status)
@@ -991,10 +990,7 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +	 */
 +	info->system_enable = !!(payload[7] & BIT(2));
 +	info->device_id = get_unaligned_be16(&payload[3]);
-+	info->sw_ver = payload[5];
 +	info->mcu_type = payload[6];
-+	info->config_status = payload[7];
-+	info->ext_ver = payload[8];
 +}
 +
 +static int rtpse_mcu_gen1_parse_port_class(const struct rtpse_mcu_port_status *status)
@@ -1081,7 +1077,7 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +MODULE_LICENSE("GPL");
 --- /dev/null
 +++ b/drivers/net/pse-pd/realtek-pse-mcu.h
-@@ -0,0 +1,91 @@
+@@ -0,0 +1,94 @@
 +/* SPDX-License-Identifier: GPL-2.0-or-later */
 +
 +#ifndef _REALTEK_PSE_MCU_H
@@ -1104,7 +1100,7 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +
 +/*
 + * Total time to keep retrying the first MCU read at probe, and the pause
-+ * between attempts. Right after enable-gpios is asserted the MCU may not
++ * between attempts. Right after reset-gpios is deasserted the MCU may not
 + * answer on the bus yet; give it a bounded window to come up before
 + * declaring the probe failed.
 + */
@@ -1128,16 +1124,21 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +#define RTPSE_MCU_OPCODE_BAD_CSUM		0xfe	/* -EBADMSG */
 +#define RTPSE_MCU_OPCODE_NOT_READY		0xff	/* -EAGAIN  */
 +
-+/* A polling transport can stop here: the matching reply, or a terminal error. */
++/*
++ * A polling transport can stop here: the reply to this request (opcode and
++ * seq_num) or a terminal error. The seq_num rejects a stale normal reply; the
++ * terminal errors match unconditionally, as a request the MCU couldn't parse
++ * carries no seq_num to correlate against.
++ */
 +static inline bool rtpse_mcu_resp_is_final(const struct rtpse_mcu_msg *req,
 +					   const struct rtpse_mcu_msg *resp)
 +{
-+	return resp->opcode == req->opcode ||
++	return (resp->opcode == req->opcode && resp->seq_num == req->seq_num) ||
 +	       resp->opcode == RTPSE_MCU_OPCODE_INCOMPLETE ||
 +	       resp->opcode == RTPSE_MCU_OPCODE_BAD_CSUM;
 +}
 +
-+/* Opaque to transports; defined in realtek-pse-core.c. */
++/* Opaque to transports; defined in realtek-pse-mcu-core.c. */
 +struct rtpse_mcu_dialect;
 +struct rtpse_mcu_chip_info;
 +struct rtpse_mcu_ctrl;
@@ -1157,13 +1158,11 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +struct rtpse_mcu_ctrl {
 +	struct device *dev;
 +	struct pse_controller_dev pcdev;
-+	struct mutex mutex; /* serializes MCU request/response transactions */
++	struct mutex mutex;	/* serializes MCU request/response transactions */
 +	const struct rtpse_mcu_dialect *dialect;
 +	const struct rtpse_mcu_chip_info *chip;
 +	const struct rtpse_mcu_transport_ops *transport;
 +	u8 seq;			/* rolling request seq_num, echoed by the MCU */
-+
-+	struct regulator *poe_supply;
 +};
 +
 +int rtpse_mcu_register(struct rtpse_mcu_ctrl *pse);

--- a/target/linux/realtek/patches-6.18/816-02-v7.3-net-pse-pd-realtek-pse-mcu-add-I2C-transport.patch
+++ b/target/linux/realtek/patches-6.18/816-02-v7.3-net-pse-pd-realtek-pse-mcu-add-I2C-transport.patch
@@ -1,8 +1,7 @@
-From bed19e2792428be06115a95ee7b23ead7132efc5 Mon Sep 17 00:00:00 2001
+From 4c088d9eb32fe1e935ad651199d1f124f232cfb9 Mon Sep 17 00:00:00 2001
 From: Jonas Jelonek <jelonek.jonas@gmail.com>
-Date: Sun, 5 Jul 2026 22:16:27 +0000
-Subject: [PATCH net-next v7 3/4] net: pse-pd: realtek-pse-mcu: add I2C
- transport
+Date: Thu, 13 Aug 2026 22:20:34 +0000
+Subject: [PATCH 2/3] net: pse-pd: realtek-pse-mcu: add I2C transport
 
 Add the I2C/SMBus transport for the Realtek PSE MCU core. It registers
 the MCU on an I2C bus and provides the send/recv callbacks the core
@@ -11,19 +10,13 @@ uses to exchange the 12-byte frames.
 The MCU firmware expects one of two framings on the I2C bus, and which one
 is part of the compatible: '-smbus' (reads carry a leading command byte
 and a repeated start) or raw '-i2c' (bare block writes and reads). The
-match data flags the raw-I2C case; SMBus is the default.
-
-Because i2c_master_send()/i2c_master_recv() may DMA, the raw-I2C path
-bounces each frame through a heap buffer rather than the core's stack
-buffers; the SMBus path is unaffected.
+match data flags the raw-I2C case; SMBus is the default because that's
+what the majority of devices uses.
 
 Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
----
- drivers/net/pse-pd/Kconfig               |  11 ++
- drivers/net/pse-pd/Makefile              |   1 +
- drivers/net/pse-pd/realtek-pse-mcu-i2c.c | 170 +++++++++++++++++++++++
- 3 files changed, 182 insertions(+)
- create mode 100644 drivers/net/pse-pd/realtek-pse-mcu-i2c.c
+Reviewed-by: Kory Maincent <kory.maincent@bootlin.com>
+Link: https://patch.msgid.link/20260813222036.873930-4-jelonek.jonas@gmail.com
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
 
 --- a/drivers/net/pse-pd/Kconfig
 +++ b/drivers/net/pse-pd/Kconfig
@@ -57,7 +50,7 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
  obj-$(CONFIG_PSE_SI3474) += si3474.o
 --- /dev/null
 +++ b/drivers/net/pse-pd/realtek-pse-mcu-i2c.c
-@@ -0,0 +1,170 @@
+@@ -0,0 +1,148 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
 +
 +#include <linux/delay.h>
@@ -65,8 +58,6 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +#include <linux/module.h>
 +#include <linux/of.h>
 +#include <linux/pse-pd/pse.h>
-+#include <linux/slab.h>
-+#include <linux/string.h>
 +
 +#include "realtek-pse-mcu.h"
 +
@@ -85,7 +76,7 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +
 +	/* Send opcode as SMBus command byte; remaining 11 bytes as block data */
 +	return i2c_smbus_write_i2c_block_data(client, req->opcode, RTPSE_MCU_MSG_SIZE - 1,
-+					      (u8 *)req + 1);
++					      (const u8 *)req + 1);
 +}
 +
 +static int rtpse_mcu_i2c_smbus_recv(struct rtpse_mcu_ctrl *pse, const struct rtpse_mcu_msg *req,
@@ -119,16 +110,9 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +static int rtpse_mcu_i2c_native_send(struct rtpse_mcu_ctrl *pse, const struct rtpse_mcu_msg *req)
 +{
 +	struct i2c_client *client = to_i2c_client(pse->dev);
-+	void *buf;
 +	int ret;
 +
-+	/* i2c_master_send() may DMA, so the buffer must not be on the stack. */
-+	buf = kmemdup(req, RTPSE_MCU_MSG_SIZE, GFP_KERNEL);
-+	if (!buf)
-+		return -ENOMEM;
-+
-+	ret = i2c_master_send(client, buf, RTPSE_MCU_MSG_SIZE);
-+	kfree(buf);
++	ret = i2c_master_send(client, (const u8 *)req, RTPSE_MCU_MSG_SIZE);
 +	if (ret < 0)
 +		return ret;
 +	return ret == RTPSE_MCU_MSG_SIZE ? 0 : -EIO;
@@ -139,32 +123,19 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +{
 +	struct i2c_client *client = to_i2c_client(pse->dev);
 +	int tries, ret;
-+	u8 *buf;
-+
-+	/* i2c_master_recv() may DMA, so read into an off-stack buffer. */
-+	buf = kmalloc(RTPSE_MCU_MSG_SIZE, GFP_KERNEL);
-+	if (!buf)
-+		return -ENOMEM;
 +
 +	for (tries = 0; tries < RTPSE_MCU_I2C_MAX_TRIES; tries++) {
 +		if (tries > 0)
 +			msleep(RTPSE_MCU_I2C_RETRY_MS);
 +
-+		ret = i2c_master_recv(client, buf, RTPSE_MCU_MSG_SIZE);
++		ret = i2c_master_recv(client, (u8 *)resp, RTPSE_MCU_MSG_SIZE);
 +		if (ret < 0)
-+			goto out;
-+		if (ret == RTPSE_MCU_MSG_SIZE) {
-+			memcpy(resp, buf, RTPSE_MCU_MSG_SIZE);
-+			if (rtpse_mcu_resp_is_final(req, resp)) {
-+				ret = 0;
-+				goto out;
-+			}
-+		}
++			return ret;
++		if (ret == RTPSE_MCU_MSG_SIZE && rtpse_mcu_resp_is_final(req, resp))
++			return 0;
 +	}
-+	ret = -ETIMEDOUT;
-+out:
-+	kfree(buf);
-+	return ret;
++
++	return -ETIMEDOUT;
 +}
 +
 +static const struct rtpse_mcu_transport_ops rtpse_mcu_i2c_native_ops = {

--- a/target/linux/realtek/patches-6.18/816-03-v7.3-net-pse-pd-realtek-pse-mcu-add-UART-transport.patch
+++ b/target/linux/realtek/patches-6.18/816-03-v7.3-net-pse-pd-realtek-pse-mcu-add-UART-transport.patch
@@ -1,8 +1,7 @@
-From 65c2e92b6172680ed08735891de038c129705f77 Mon Sep 17 00:00:00 2001
+From 5cc93d9897496bcfde6821579907d309b6883ab7 Mon Sep 17 00:00:00 2001
 From: Jonas Jelonek <jelonek.jonas@gmail.com>
-Date: Sun, 5 Jul 2026 22:19:49 +0000
-Subject: [PATCH net-next v7 4/4] net: pse-pd: realtek-pse-mcu: add UART
- transport
+Date: Thu, 13 Aug 2026 22:20:35 +0000
+Subject: [PATCH 3/3] net: pse-pd: realtek-pse-mcu: add UART transport
 
 Add the serdev (UART) transport for the Realtek PSE MCU core. It registers
 the MCU as a serdev device and provides the send/recv callbacks the core
@@ -13,12 +12,9 @@ The baud rate defaults to 19200 and can be overridden per board with the
 "current-speed" property.
 
 Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
----
- drivers/net/pse-pd/Kconfig                |  11 ++
- drivers/net/pse-pd/Makefile               |   1 +
- drivers/net/pse-pd/realtek-pse-mcu-uart.c | 155 ++++++++++++++++++++++
- 3 files changed, 167 insertions(+)
- create mode 100644 drivers/net/pse-pd/realtek-pse-mcu-uart.c
+Reviewed-by: Kory Maincent <kory.maincent@bootlin.com>
+Link: https://patch.msgid.link/20260813222036.873930-5-jelonek.jonas@gmail.com
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
 
 --- a/drivers/net/pse-pd/Kconfig
 +++ b/drivers/net/pse-pd/Kconfig
@@ -52,7 +48,7 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
  obj-$(CONFIG_PSE_SI3474) += si3474.o
 --- /dev/null
 +++ b/drivers/net/pse-pd/realtek-pse-mcu-uart.c
-@@ -0,0 +1,155 @@
+@@ -0,0 +1,164 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
 +
 +#include <linux/cleanup.h>
@@ -161,6 +157,7 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +	u32 speed = RTPSE_MCU_UART_BAUD_DEFAULT;
 +	struct device *dev = &serdev->dev;
 +	struct rtpse_mcu_uart *ctx;
++	unsigned int baud;
 +	int ret;
 +
 +	ctx = devm_kzalloc(dev, sizeof(*ctx), GFP_KERNEL);
@@ -182,9 +179,17 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +		return dev_err_probe(dev, ret, "failed to open serdev\n");
 +
 +	fwnode_property_read_u32(dev_fwnode(dev), "current-speed", &speed);
-+	serdev_device_set_baudrate(serdev, speed);
++
++	baud = serdev_device_set_baudrate(serdev, speed);
++	if (baud != speed)
++		dev_warn(dev, "could not set baudrate %u, controller uses %u\n",
++			 speed, baud);
++
 +	serdev_device_set_flow_control(serdev, false);
-+	serdev_device_set_parity(serdev, SERDEV_PARITY_NONE);
++
++	ret = serdev_device_set_parity(serdev, SERDEV_PARITY_NONE);
++	if (ret)
++		dev_warn(dev, "could not set parity to none: %d\n", ret);
 +
 +	return rtpse_mcu_register(&ctx->pse);
 +}

--- a/target/linux/realtek/patches-6.18/817-net-pse-pd-realtek-pse-mcu-add-per-por-legacy-detec.patch
+++ b/target/linux/realtek/patches-6.18/817-net-pse-pd-realtek-pse-mcu-add-per-por-legacy-detec.patch
@@ -1,4 +1,4 @@
-From b69e39ba5853c587a594ed0475f873519301f326 Mon Sep 17 00:00:00 2001
+From bbb5e80bbaf0d73b73c4bcd85c7941439436ef5c Mon Sep 17 00:00:00 2001
 From: Jonas Jelonek <jelonek.jonas@gmail.com>
 Date: Tue, 30 Jun 2026 20:46:30 +0000
 Subject: [PATCH] net: pse-pd: realtek-pse-mcu: add per-port legacy-detection
@@ -19,11 +19,11 @@ default. Each port gets a sysfs directory with a detection_legacy file:
 Writing 1 widens detection to accept legacy PDs, 0 restores standard-only
 detection; reads report the current mode decoded from the port config.
 
-The detection-type command and its value encoding are dialect-specific, so
-both are taken from the dialect: the command opcode (0x09 on Realtek, 0x10
-on Broadcom) goes through the opcode table, and the standard/legacy byte
+The detection-type command and its value encoding are dialect-specific,
+so both are taken from the dialect: the command opcode (0x10 on Gen1,
+0x09 on Gen2) goes through the opcode table, and the standard/legacy byte
 values come from the dialect too. These differ - standard detection is 0x0
-on Realtek but 0x2 on Broadcom, where 0x0 instead disables detection - so a
+on Gen2 but 0x2 on Gen1, where 0x0 instead disables detection - so a
 shared value would misprogram one of them. Finer modes the firmware offers
 (disabling detection, force-powering devices that fail classification) are
 deliberately kept out of this stable interface. Each port has its own
@@ -34,7 +34,7 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 
 --- a/drivers/net/pse-pd/realtek-pse-mcu-core.c
 +++ b/drivers/net/pse-pd/realtek-pse-mcu-core.c
-@@ -34,11 +34,13 @@
+@@ -34,10 +34,12 @@
  #include <linux/delay.h>
  #include <linux/gpio/consumer.h>
  #include <linux/jiffies.h>
@@ -43,12 +43,11 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
  #include <linux/module.h>
  #include <linux/property.h>
  #include <linux/pse-pd/pse.h>
- #include <linux/regulator/consumer.h>
 +#include <linux/sysfs.h>
  #include <linux/unaligned.h>
  
  #include "realtek-pse-mcu.h"
-@@ -73,6 +75,7 @@ enum rtpse_mcu_cmd {
+@@ -78,6 +80,7 @@ enum rtpse_mcu_cmd {
  	RTPSE_MCU_CMD_PORT_SET_POWER_LIMIT,
  	RTPSE_MCU_CMD_PORT_SET_POWER_LIMIT_EXT,
  	RTPSE_MCU_CMD_PORT_SET_PRIORITY,
@@ -56,7 +55,7 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
  	RTPSE_MCU_CMD_PORT_GET_STATUS,
  	RTPSE_MCU_CMD_PORT_GET_POWER_STATS,
  	RTPSE_MCU_CMD_PORT_GET_CONFIG,
-@@ -123,6 +126,7 @@ struct rtpse_mcu_port_measurement {
+@@ -122,6 +125,7 @@ struct rtpse_mcu_port_measurement {
  
  struct rtpse_mcu_port_config {
  	bool enable;
@@ -64,15 +63,15 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
  };
  
  struct rtpse_mcu_port_ext_config {
-@@ -142,6 +146,15 @@ struct rtpse_mcu_dialect {
+@@ -141,6 +145,15 @@ struct rtpse_mcu_dialect {
  	void (*parse_system_info)(const u8 *payload, struct rtpse_mcu_info *info);
  	int (*parse_port_class)(const struct rtpse_mcu_port_status *status);
  	const char *(*mcu_type_str)(unsigned int mcu_type);
 +
 +	/*
 +	 * Detection-mode byte written by the per-port legacy-detection knob.
-+	 * The encoding is dialect-specific: standard detection is 0x0 on RTL
-+	 * but 0x2 on BCM (where 0x0 instead disables detection entirely), so
++	 * The encoding is dialect-specific: standard detection is 0x0 on Gen2
++	 * but 0x2 on Gen1 (where 0x0 instead disables detection entirely), so
 +	 * these cannot be shared. Legacy acceptance is the odd value in both.
 +	 */
 +	u8 detect_standard;
@@ -80,7 +79,7 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
  };
  
  struct rtpse_mcu_chip_info {
-@@ -440,6 +453,7 @@ static int rtpse_mcu_port_get_config(str
+@@ -432,6 +445,7 @@ static int rtpse_mcu_port_get_config(str
  		return ret;
  
  	config->enable = (resp.payload[1] == 1);
@@ -88,7 +87,7 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
  
  	return 0;
  }
-@@ -706,6 +720,138 @@ static const struct pse_controller_ops r
+@@ -718,6 +732,138 @@ static const struct pse_controller_ops r
  	.pi_set_prio = rtpse_mcu_port_set_prio,
  };
  
@@ -227,7 +226,7 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
  static int rtpse_mcu_discover(struct rtpse_mcu_ctrl *pse, struct rtpse_mcu_info *info)
  {
  	struct rtpse_mcu_ext_config ext_config;
-@@ -861,7 +1007,11 @@ int rtpse_mcu_register(struct rtpse_mcu_
+@@ -870,7 +1016,11 @@ int rtpse_mcu_register(struct rtpse_mcu_
  	pse->pcdev.pis_prio_max = RTPSE_MCU_PORT_MAX_PRIORITY;
  	pse->pcdev.supp_budget_eval_strategies = PSE_BUDGET_EVAL_STRAT_DYNAMIC;
  
@@ -240,7 +239,7 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
  }
  EXPORT_SYMBOL_GPL(rtpse_mcu_register);
  
-@@ -937,6 +1087,8 @@ static const struct rtpse_mcu_dialect rt
+@@ -940,6 +1090,8 @@ static const struct rtpse_mcu_dialect rt
  	.parse_system_info = rtpse_mcu_gen2_parse_system_info,
  	.parse_port_class  = rtpse_mcu_gen2_parse_port_class,
  	.mcu_type_str      = rtpse_mcu_gen2_mcu_type_str,
@@ -249,7 +248,7 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
  	.opcode = {
  		[RTPSE_MCU_CMD_SET_GLOBAL_STATE]	= RTPSE_MCU_OP(0x00),
  		[RTPSE_MCU_CMD_GET_SYSTEM_INFO]		= RTPSE_MCU_OP(0x40),
-@@ -947,6 +1099,7 @@ static const struct rtpse_mcu_dialect rt
+@@ -950,6 +1102,7 @@ static const struct rtpse_mcu_dialect rt
  		[RTPSE_MCU_CMD_PORT_SET_POWER_LIMIT]	= RTPSE_MCU_OP(0x13),
  		[RTPSE_MCU_CMD_PORT_SET_POWER_LIMIT_EXT] = RTPSE_MCU_OP(0x14),
  		[RTPSE_MCU_CMD_PORT_SET_PRIORITY]	= RTPSE_MCU_OP(0x15),
@@ -257,7 +256,7 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
  		[RTPSE_MCU_CMD_PORT_GET_STATUS]		= RTPSE_MCU_OP(0x42),
  		[RTPSE_MCU_CMD_PORT_GET_POWER_STATS]	= RTPSE_MCU_OP(0x44),
  		[RTPSE_MCU_CMD_PORT_GET_CONFIG]		= RTPSE_MCU_OP(0x48),
-@@ -958,6 +1111,8 @@ static const struct rtpse_mcu_dialect rt
+@@ -961,6 +1114,8 @@ static const struct rtpse_mcu_dialect rt
  	.parse_system_info = rtpse_mcu_gen1_parse_system_info,
  	.parse_port_class  = rtpse_mcu_gen1_parse_port_class,
  	.mcu_type_str      = rtpse_mcu_gen1_mcu_type_str,
@@ -266,7 +265,7 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
  	.opcode = {
  		[RTPSE_MCU_CMD_GET_SYSTEM_INFO]		= RTPSE_MCU_OP(0x20),
  		[RTPSE_MCU_CMD_GET_EXT_CONFIG]		= RTPSE_MCU_OP(0x2b),
-@@ -966,6 +1121,7 @@ static const struct rtpse_mcu_dialect rt
+@@ -969,6 +1124,7 @@ static const struct rtpse_mcu_dialect rt
  		[RTPSE_MCU_CMD_PORT_SET_POWER_LIMIT_TYPE] = RTPSE_MCU_OP(0x15),
  		[RTPSE_MCU_CMD_PORT_SET_POWER_LIMIT]	= RTPSE_MCU_OP(0x16),
  		[RTPSE_MCU_CMD_PORT_SET_PRIORITY]	= RTPSE_MCU_OP(0x1a),

--- a/target/linux/realtek/patches-6.18/819-net-pse-pd-realtek-pse-mcu-ensure-dynamic-power-mana.patch
+++ b/target/linux/realtek/patches-6.18/819-net-pse-pd-realtek-pse-mcu-ensure-dynamic-power-mana.patch
@@ -22,9 +22,9 @@ Signed-off-by: Russell Senior <russell@personaltelco.net>
 
 --- a/drivers/net/pse-pd/realtek-pse-mcu-core.c
 +++ b/drivers/net/pse-pd/realtek-pse-mcu-core.c
-@@ -65,10 +65,14 @@
- #define RTPSE_MCU_MAX_PORTS			48
- #define RTPSE_MCU_PORT_MAX_PRIORITY		3
+@@ -70,10 +70,14 @@
+ /* Nominal PSE rail; 802.3at/bt operating range. */
+ #define RTPSE_MCU_PSE_VOLTAGE_UV		54000000
  
 +/* RTPSE_MCU_CMD_SET_POWER_MANAGEMENT_MODE values */
 +#define RTPSE_MCU_DYNAMIC_POWER_MGMT_PRIO	0x02	/* dynamic, with port priority */
@@ -37,7 +37,7 @@ Signed-off-by: Russell Senior <russell@personaltelco.net>
  
  	RTPSE_MCU_CMD_PORT_ENABLE,
  	RTPSE_MCU_CMD_PORT_SET_POWER_LIMIT_TYPE,
-@@ -390,6 +394,26 @@ static int rtpse_mcu_set_global_state(st
+@@ -382,6 +386,26 @@ static int rtpse_mcu_set_global_state(st
  	return (resp.payload[0] == 0x0) ? 0 : -EIO;
  }
  
@@ -64,9 +64,9 @@ Signed-off-by: Russell Senior <russell@personaltelco.net>
  /* Port operations */
  
  static int rtpse_mcu_port_get_status(struct rtpse_mcu_ctrl *pse, unsigned int port,
-@@ -974,6 +998,11 @@ int rtpse_mcu_register(struct rtpse_mcu_
- 	if (ret)
- 		return ret;
+@@ -983,6 +1007,11 @@ int rtpse_mcu_register(struct rtpse_mcu_
+ 		return dev_err_probe(pse->dev, PTR_ERR(gpiod),
+ 				     "failed to get disable-ports gpio\n");
  
 +	/* Ensure that we run in "Dynamic Power Management Mode with Priority" mode */
 +	ret = rtpse_mcu_set_power_management_mode(pse, RTPSE_MCU_DYNAMIC_POWER_MGMT_PRIO);
@@ -76,7 +76,7 @@ Signed-off-by: Russell Senior <russell@personaltelco.net>
  	if (!info.system_enable) {
  		ret = rtpse_mcu_set_global_state(pse, true);
  		/* Dialects without a global-state concept (e.g. Gen1) return
-@@ -1093,6 +1122,7 @@ static const struct rtpse_mcu_dialect rt
+@@ -1096,6 +1125,7 @@ static const struct rtpse_mcu_dialect rt
  		[RTPSE_MCU_CMD_SET_GLOBAL_STATE]	= RTPSE_MCU_OP(0x00),
  		[RTPSE_MCU_CMD_GET_SYSTEM_INFO]		= RTPSE_MCU_OP(0x40),
  		[RTPSE_MCU_CMD_GET_EXT_CONFIG]		= RTPSE_MCU_OP(0x4a),
@@ -84,7 +84,7 @@ Signed-off-by: Russell Senior <russell@personaltelco.net>
  
  		[RTPSE_MCU_CMD_PORT_ENABLE]		= RTPSE_MCU_OP(0x01),
  		[RTPSE_MCU_CMD_PORT_SET_POWER_LIMIT_TYPE] = RTPSE_MCU_OP(0x12),
-@@ -1116,6 +1146,7 @@ static const struct rtpse_mcu_dialect rt
+@@ -1119,6 +1149,7 @@ static const struct rtpse_mcu_dialect rt
  	.opcode = {
  		[RTPSE_MCU_CMD_GET_SYSTEM_INFO]		= RTPSE_MCU_OP(0x20),
  		[RTPSE_MCU_CMD_GET_EXT_CONFIG]		= RTPSE_MCU_OP(0x2b),


### PR DESCRIPTION
The Realtek PSE MCU driver patches have been accepted upstream, being available in v7.3. Replace the current pending patches with the backported variants. This requires some additional DTS changes since the final version differs from what was merged as pending.

