### PR TITLE
econet: en751221: add support for Nokia G-140W-F

### DIFF
--- a/target/linux/econet/dts/en751221_nokia_g140w-f.dts
+++ b/target/linux/econet/dts/en751221_nokia_g140w-f.dts
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/dts-v1/;
+
+#include "en751221.dtsi"
+
+/ {
+	model = "Nokia G-140W-F";
+	compatible = "nokia,g140w-f", "econet,en751221";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>;
+	};
+
+	chosen {
+		stdout-path = "/serial@1fbf0000:115200";
+		linux,usable-memory-range = <0x00020000 0x0ffe0000>;
+	};
+};
+
+&nand {
+	status = "okay";
+	econet,bmt;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "bootloader";
+			reg = <0x0 0x40000>;
+			read-only;
+		};
+
+		partition@40000 {
+			label = "romfile";
+			reg = <0x40000 0x40000>;
+		};
+
+		partition@80000 {
+			label = "tclinux";
+			reg = <0x80000 0x2200000>;
+			econet,enable-remap;
+		};
+
+		partition@480000 {
+			label = "rootfs";
+			reg = <0x480000 0x1e00000>;
+			linux,rootfs;
+		};
+
+		partition@2280000 {
+			label = "kernel_slave";
+			reg = <0x2280000 0x300000>;
+		};
+
+		partition@2580000 {
+			label = "rootfs_slave";
+			reg = <0x2580000 0x1f00000>;
+		};
+
+		partition@4480000 {
+			label = "kernel_oflt";
+			reg = <0x4480000 0x300000>;
+		};
+
+		partition@4780000 {
+			label = "rootfs_oflt";
+			reg = <0x4780000 0xc00000>;
+		};
+
+		partition@5380000 {
+			label = "config";
+			reg = <0x5380000 0x800000>;
+		};
+
+		partition@5b80000 {
+			label = "log";
+			reg = <0x5b80000 0xc00000>;
+		};
+
+		partition@6780000 {
+			label = "extfs";
+			reg = <0x6780000 0x600000>;
+		};
+
+		partition@6d80000 {
+			label = "bosa";
+			reg = <0x6d80000 0x40000>;
+		};
+
+		partition@6dc0000 {
+			label = "flag";
+			reg = <0x6dc0000 0x40000>;
+		};
+
+		partition@6e00000 {
+			label = "flagback";
+			reg = <0x6e00000 0x40000>;
+		};
+
+		partition@6e40000 {
+			label = "ri";
+			reg = <0x6e40000 0x40000>;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_ri_3e: macaddr@3e {
+					compatible = "mac-base";
+					reg = <0x3e 0x6>;
+					#nvmem-cell-cells = <1>;
+				};
+			};
+		};
+
+		partition@6e80000 {
+			label = "riback";
+			reg = <0x6e80000 0x40000>;
+		};
+	};
+};
+
+&gmac0 {
+	status = "okay";
+	nvmem-cells = <&macaddr_ri_3e 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+/*
+ * WiFi: MT7603E (2.4 GHz) on PCIe port 0 and MT7662 (5 GHz) on PCIe port 1.
+ * This board has no on-flash WiFi EEPROM partition (unlike the SmartFiber
+ * XP8421-B); both radios calibrate from their on-chip eFuse, so only a
+ * per-radio MAC is supplied via nvmem, derived from the "ri" MAC base.
+ */
+&pcie0 {
+	status = "okay";
+};
+
+&slot0 {
+	wifi@0,0 {
+		reg = <0x0 0 0 0 0>;
+		compatible = "mediatek,mt76";
+		nvmem-cells = <&macaddr_ri_3e 1>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&pcie1 {
+	status = "okay";
+};
+
+&slot1 {
+	wifi@0,0 {
+		reg = <0x0 0 0 0 0>;
+		compatible = "mediatek,mt76";
+		nvmem-cells = <&macaddr_ri_3e 2>;
+		nvmem-cell-names = "mac-address";
+	};
+};

--- a/target/linux/econet/image/en751221.mk
+++ b/target/linux/econet/image/en751221.mk
@@ -54,6 +54,16 @@ define Device/nokia_g240g-e
 endef
 TARGET_DEVICES += nokia_g240g-e
 
+define Device/nokia_g140w-f
+  DEVICE_VENDOR := Nokia
+  DEVICE_MODEL := G-140W-F
+  DEVICE_DTS := en751221_nokia_g140w-f
+  IMAGES := tclinux.trx
+  IMAGE/tclinux.trx := append-kernel | lzma | tclinux-trx
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7603 kmod-mt76x2
+endef
+TARGET_DEVICES += nokia_g140w-f
+
 define Device/smartfiber_xp8421-b
   DEVICE_VENDOR := SmartFiber
   DEVICE_MODEL := XP8421-B


### PR DESCRIPTION
## Description

Add support for the **Nokia G-140W-F**, an ISP-provided GPON ONT / home
router based on the EcoNet EN751221 (EN7526G).

It is the same OEM platform as the already-supported **Nokia G-240G-E** —
the SPI-NAND partition layout is identical (verified byte-for-byte against
a full per-partition dump of a unit) — so the board support closely mirrors
that device, with WiFi wired up the same way as the SmartFiber XP8421-B
(which carries the same two radios).

### What works
- Boot from NAND, `tclinux` slot
- Ethernet LAN — the four RJ45 jacks are aggregated behind the on-die
  switch and come up as a single bridged `eth0`, the same way the other
  EN751221 boards present their ports (this subtarget has no DSA switch
  driver yet)
- 2.4 GHz WiFi (MT7603E) and 5 GHz WiFi (MT7662), calibrated from on-chip
  eFuse; per-radio MAC from the `ri` MAC base
- USB (xHCI)

### Not included
- **GPON WAN** — the EN7528/EN751221 xPON driver is not in tree yet, so the
  device is contributed as a LAN/WiFi board. WAN can be enabled later once
  that driver lands, without changing this board file.

## Hardware
| | |
|---|---|
| SoC | EcoNet EN751221 (EN7526G) |
| RAM | 256 MiB DDR3 |
| Flash | 256 MiB SPI NAND (Micron MT29F2G01) |
| WiFi | MT7603E (2.4 GHz) + MT7662 (5 GHz) |
| Ethernet | 4x 10/100/1000 |
| USB | 1x USB port |
| Telephony | 1x FXS (RJ11) phone jack |

## Installation
Serial console (115200 8n1); interrupt the bootloader and use its built-in
TFTP server to load an OpenWrt initramfs image into RAM (any file name
other than the vendor's `tcboot.bin` / `tclinux.bin`), boot it, then write
the sysupgrade image to the `tclinux` partition and reboot.

## Testing
- Full image build from a clean tree against `main` (`make -j12`,
  kernel 6.18.44) — builds cleanly, produces
  `openwrt-econet-en751221-nokia_g140w-f-squashfs-tclinux.trx`.
- DTB compiles with no new warnings.
- Board brings up LAN + both WiFi radios on real hardware.

<!--
OpenWrt PR checklist:
- [x] The commit message is of the form "target: subsystem: description"
- [x] The commit has a Signed-off-by matching the author
- [x] Tested on real hardware
- [x] Full image build tested (make -j …)
- [x] No unrelated changes
-->
