### PR TITLE
mediatek: filogic: fix Teltonika RUTC50 pcie reset GPIO export

### DIFF
--- a/target/linux/mediatek/dts/mt7981a-teltonika-rutc50.dts
+++ b/target/linux/mediatek/dts/mt7981a-teltonika-rutc50.dts
@@ -45,7 +45,7 @@
 
 		gpio_pcie_reset {
 			gpio-export,name = "pcie_reset";
-			gpio-export,output = <1>;
+			gpio-export,output = <0>;
 			gpios = <&pio 3 GPIO_ACTIVE_LOW>;
 		};
 


### PR DESCRIPTION
DTS GPIOs export properties handling changed in commit 0ca78951739a1e6e2f569438764381bd5fdb5190. This prevents USB hub startup by holding pcie reset. Update the device-tree accordingly. This commit has been tested on the device.