### PR TITLE
mt76: install default MT7915 EEPROM bins

### DIFF
--- a/package/kernel/mt76/Makefile
+++ b/package/kernel/mt76/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mt76
-PKG_RELEASE=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=BSD-3-Clause-Clear
 PKG_LICENSE_FILES:=
@@ -612,6 +612,8 @@ define KernelPackage/mt7915-firmware/install
 		$(PKG_BUILD_DIR)/firmware/mt7915_wa.bin \
 		$(PKG_BUILD_DIR)/firmware/mt7915_wm.bin \
 		$(PKG_BUILD_DIR)/firmware/mt7915_rom_patch.bin \
+		$(PKG_BUILD_DIR)/firmware/mt7915_eeprom.bin \
+		$(PKG_BUILD_DIR)/firmware/mt7915_eeprom_dbdc.bin \
 		$(1)/lib/firmware/mediatek
 endef
 


### PR DESCRIPTION
The MT7915 default EEPROM bins are part of the mt76 sources and are installed for the MT7996 family, but not for MT7915.

Devices that carry no calibration data in flash, and whose efuse does not hold a complete EEPROM either, depend on them: mt7915_eeprom_load() fails with -EINVAL and the driver falls back to request_firmware() for mediatek/mt7915_eeprom_dbdc.bin. Without the file the probe never finishes and no PHY is registered at all - the radio is simply missing.

Installing the two bins adds 7 KiB to kmod-mt7915-firmware.

Tested on a TP-Link EX220 v1 (NAND), whose support I am submitting separately: with this change both bands come up and a client associates at HE rates over 80 MHz, a local transfer peaking at 541 Mbit/s.