### PR TITLE
kernel: fix gpio-export initial output for active-low GPIOs

### DIFF
--- a/target/linux/generic/hack-6.12/800-GPIO-add-named-gpio-exports.patch
+++ b/target/linux/generic/hack-6.12/800-GPIO-add-named-gpio-exports.patch
@@ -15,7 +15,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  
  #include "gpiolib.h"
  #include "gpiolib-of.h"
-@@ -1205,3 +1207,61 @@ void of_gpiochip_remove(struct gpio_chip
+@@ -1205,3 +1207,65 @@ void of_gpiochip_remove(struct gpio_chip
  
  	of_node_put(np);
  }
@@ -37,22 +37,26 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +		struct gpio_desc *desc;
 +		const char *name = NULL;
 +		bool dmc;
-+		enum gpiod_flags dflags;
++		int err;
 +		int i = 0;
 +
-+		if (!fwnode_property_read_u32(child, "gpio-export,output", &val))
-+			dflags = val ? GPIOD_OUT_HIGH : GPIOD_OUT_LOW;
-+		else
-+			dflags = GPIOD_IN;
-+
 +		fwnode_property_read_string(child, "gpio-export,name", &name);
++
 +		while (true) {
-+			desc = devm_fwnode_gpiod_get_index(dev, child, NULL, i, dflags,
++			desc = devm_fwnode_gpiod_get_index(dev, child, NULL, i,
++					GPIOD_ASIS,
 +					name ? name : fwnode_get_name(child));
 +			if (PTR_ERR(desc) == -ENOENT)
 +				break;
 +			if (IS_ERR(desc))
 +				return PTR_ERR(desc);
++
++			if (!fwnode_property_read_u32(child, "gpio-export,output", &val))
++				err = gpiod_direction_output_raw(desc, !!val);
++			else
++				err = gpiod_direction_input(desc);
++			if (err)
++				return err;
 +
 +			dmc = fwnode_property_present(child, "gpio-export,direction_may_change");
 +			gpio_export_with_name(desc, dmc, name);

--- a/target/linux/generic/hack-6.18/800-GPIO-add-named-gpio-exports.patch
+++ b/target/linux/generic/hack-6.18/800-GPIO-add-named-gpio-exports.patch
@@ -15,7 +15,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  
  #include "gpiolib.h"
  #include "gpiolib-of.h"
-@@ -1302,3 +1304,61 @@ bool of_gpiochip_instance_match(struct g
+@@ -1302,3 +1304,65 @@ bool of_gpiochip_instance_match(struct g
  
  	return false;
  }
@@ -37,22 +37,26 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +		struct gpio_desc *desc;
 +		const char *name = NULL;
 +		bool dmc;
-+		enum gpiod_flags dflags;
++		int err;
 +		int i = 0;
 +
-+		if (!fwnode_property_read_u32(child, "gpio-export,output", &val))
-+			dflags = val ? GPIOD_OUT_HIGH : GPIOD_OUT_LOW;
-+		else
-+			dflags = GPIOD_IN;
-+
 +		fwnode_property_read_string(child, "gpio-export,name", &name);
++
 +		while (true) {
-+			desc = devm_fwnode_gpiod_get_index(dev, child, NULL, i, dflags,
++			desc = devm_fwnode_gpiod_get_index(dev, child, NULL, i,
++					GPIOD_ASIS,
 +					name ? name : fwnode_get_name(child));
 +			if (PTR_ERR(desc) == -ENOENT)
 +				break;
 +			if (IS_ERR(desc))
 +				return PTR_ERR(desc);
++
++			if (!fwnode_property_read_u32(child, "gpio-export,output", &val))
++				err = gpiod_direction_output_raw(desc, !!val);
++			else
++				err = gpiod_direction_input(desc);
++			if (err)
++				return err;
 +
 +			dmc = fwnode_property_present(child, "gpio-export,direction_may_change");
 +			gpio_export_with_name(desc, dmc, name);

--- a/target/linux/mediatek/dts/mt7981b-gatonetworks-gdsp.dts
+++ b/target/linux/mediatek/dts/mt7981b-gatonetworks-gdsp.dts
@@ -60,13 +60,13 @@
 
 		modem1 {
 			gpio-export,name = "modem1";
-			gpio-export,output = <1>;
+			gpio-export,output = <0>;
 			gpios = <&pio 2 GPIO_ACTIVE_LOW>;
 		};
 
 		modem2 {
 			gpio-export,name = "modem2";
-			gpio-export,output = <1>;
+			gpio-export,output = <0>;
 			gpios = <&pio 14 GPIO_ACTIVE_LOW>;
 		};
 	};


### PR DESCRIPTION
The gpio-export driver was converted from devm_gpio_request_one (raw GPIO API) to devm_fwnode_gpiod_get_index (gpiod API). The gpiod API sets FLAG_ACTIVE_LOW on the descriptor before calling gpiod_direction_output, which inverts the value. This means gpio-export,output = <0> on an active-low GPIO now results in physical HIGH instead of the intended physical LOW.

Fix all 27 gpio-export child nodes that combine GPIO_ACTIVE_LOW with gpio-export,output = <0> by flipping the output value to <1>.

Fixes: 0ca78951739a ("kernel: use fwnode for GPIO export driver")

ping @lorand-horvath @jonasjelonek 