### PR TITLE
wifi-scripts: mac80211: fix 6 GHz 40 MHz configuration for non-AP modes

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
@@ -125,6 +125,20 @@ function iw_htmode(config) {
 	case "HE20":
 	case "EHT20":
 		return "HT20";
+	case "HT40":
+	case "VHT40":
+	case "HE40":
+	case "EHT40":
+		switch (config.band) {
+		case "2g":
+			return (+config.channel < 7) ? "HT40+" : "HT40-";
+		case "6g":
+			let ch = +config.channel;
+			let c_base = int((ch - 1) / 8) * 8 + 1;
+			return "40 " + (5950 + (c_base + 2) * 5);
+		default:
+			return ((+config.channel / 4) % 2) ? "HT40+" : "HT40-";
+		}
 	case "VHT80":
 	case "HE80":
 	case "EHT80":
@@ -135,18 +149,6 @@ function iw_htmode(config) {
 	case "NONE":
 	case "NOHT":
 		return "NOHT";
-	}
-
-	if (substr(config.htmode, 2) == "40") {
-		switch (config.band) {
-		case "2g":
-			if (+config.channel < 7)
-				return "HT40+";
-			else
-				return "HT40-";
-		default:
-			return ((+config.channel / 4) % 2) ? "HT40+" : "HT40-";
-		}
 	}
 
 	return null;


### PR DESCRIPTION
In `iw_htmode()`, 40 MHz modes (HE40/EHT40) on the 6 GHz band fell through to the 5 GHz HT40+/HT40- calculation. Since 802.11n HT modes do not exist in 6 GHz, `iw` commands like `iw dev <ifname> set freq <freq> HT40+` fail in cfg80211 with `-EINVAL` (`invalid channel definition`). Fix this by adding 6 GHz band handling in `iw_htmode()` to calculate and return the 40 MHz center frequency (`40 <center_freq>`).
