### PR TITLE
mediatek: mt7622: remove bogus dsa-migration from Netgear WAX206

### DIFF
--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -333,7 +333,6 @@ endef
 TARGET_DEVICES += mediatek_mt7622-rfb1-ubi
 
 define Device/netgear_wax206
-  $(Device/dsa-migration)
   DEVICE_VENDOR := NETGEAR
   DEVICE_MODEL := WAX206
   DEVICE_DTS := mt7622-netgear-wax206


### PR DESCRIPTION
The Netgear WAX206 was added to OpenWrt long after the mt7622 target had already been converted to DSA. Consequently, this device never shipped with a swconfig-based network setup and there is no DSA migration to perform.

Remove the spurious $(Device/dsa-migration) reference. Device/dsa-migration is not defined for the mediatek target, so the reference expands to nothing and no DEVICE_COMPAT_VERSION was ever set for this device; removing it has no effect on sysupgrade compatibility.