### PR TITLE
mpc85xx: image: drop unused pad-dtb

### DIFF
--- a/target/linux/mpc85xx/image/Makefile
+++ b/target/linux/mpc85xx/image/Makefile
@@ -3,12 +3,6 @@
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/image.mk
 
-DEVICE_VARS += DTB_SIZE
-
-define Build/pad-dtb
-	$(call Image/BuildDTB,$(DTS_DIR)/$(DEVICE_DTS).dts,$(dir $@)/image-$(DEVICE_DTS).dtb,,--space $(DTB_SIZE))
-endef
-
 define Device/Default
   PROFILES := Default
   DEVICE_DTS := $(lastword $(subst _, ,$(1)))


### PR DESCRIPTION
`Build/pad-dtb` and the `DTB_SIZE` device variable in the mpc85xx image Makefile have no users. The last one was ws-ap3825i, which stopped padding its device tree in ed82189339 ("mpc85xx: use bootwrapper for ws-ap3825i") in March 2023.

Verified with a tree-wide `git grep` for `pad-dtb` and `DTB_SIZE`. After this change nothing under `target/linux/mpc85xx/` references either of them, and no target defines `Build/pad-dtb` any more. The only remaining hits in the tree are in `target/linux/at91/image/Makefile`, which sets its own `DTB_SIZE` inside a `Device/` template and consumes it with its own `pad-to` recipe, so at91 is unaffected.

Build system only, no device definition changes.
