### PR TITLE
kernel: workaround premature ready bit on SkyHigh SPI-NAND chips

### DIFF
--- a/target/linux/airoha/patches-6.18/901-snand-mtk-bmt-support.patch
+++ b/target/linux/airoha/patches-6.18/901-snand-mtk-bmt-support.patch
@@ -8,7 +8,7 @@
  
  int spinand_read_reg_op(struct spinand_device *spinand, u8 reg, u8 *val)
  {
-@@ -1719,6 +1720,7 @@ static int spinand_probe(struct spi_mem
+@@ -1768,6 +1769,7 @@ static int spinand_probe(struct spi_mem
  	if (ret)
  		return ret;
  
@@ -16,7 +16,7 @@
  	ret = mtd_device_register(mtd, NULL, 0);
  	if (ret)
  		goto err_spinand_cleanup;
-@@ -1726,6 +1728,7 @@ static int spinand_probe(struct spi_mem
+@@ -1775,6 +1777,7 @@ static int spinand_probe(struct spi_mem
  	return 0;
  
  err_spinand_cleanup:
@@ -24,7 +24,7 @@
  	spinand_cleanup(spinand);
  
  	return ret;
-@@ -1744,6 +1747,7 @@ static int spinand_remove(struct spi_mem
+@@ -1793,6 +1796,7 @@ static int spinand_remove(struct spi_mem
  	if (ret)
  		return ret;
  

--- a/target/linux/econet/patches-6.18/902-snand-mtk-bmt-support.patch
+++ b/target/linux/econet/patches-6.18/902-snand-mtk-bmt-support.patch
@@ -8,7 +8,7 @@
  
  int spinand_read_reg_op(struct spinand_device *spinand, u8 reg, u8 *val)
  {
-@@ -1719,6 +1720,7 @@ static int spinand_probe(struct spi_mem
+@@ -1768,6 +1769,7 @@ static int spinand_probe(struct spi_mem
  	if (ret)
  		return ret;
  
@@ -16,7 +16,7 @@
  	ret = mtd_device_register(mtd, NULL, 0);
  	if (ret)
  		goto err_spinand_cleanup;
-@@ -1726,6 +1728,7 @@ static int spinand_probe(struct spi_mem
+@@ -1775,6 +1777,7 @@ static int spinand_probe(struct spi_mem
  	return 0;
  
  err_spinand_cleanup:
@@ -24,7 +24,7 @@
  	spinand_cleanup(spinand);
  
  	return ret;
-@@ -1744,6 +1747,7 @@ static int spinand_remove(struct spi_mem
+@@ -1793,6 +1796,7 @@ static int spinand_remove(struct spi_mem
  	if (ret)
  		return ret;
  

--- a/target/linux/generic/pending-6.18/489-mtd-spinand-skyhigh-workaround-premature-ready-bit.patch
+++ b/target/linux/generic/pending-6.18/489-mtd-spinand-skyhigh-workaround-premature-ready-bit.patch
@@ -1,0 +1,168 @@
+From f5e0d7642e7239aa5e014f821756405cf29b8293 Mon Sep 17 00:00:00 2001
+From: Vitaliy Sochnev <sochnev.v.74@gmail.com>
+Date: Tue, 18 Aug 2026 23:04:36 +0100
+Subject: [PATCH] mtd: spinand: workaround premature ready bit on SkyHigh chips
+
+Nokia XG-040G-MD units built with SkyHigh SPI-NAND occasionally log UBI
+"fixable bit-flip" events in production, weeks apart:
+
+  ubi0: fixable bit-flip detected at PEB 1316
+  ubi0: scrubbed PEB 1316 (LEB 5:195), data moved to PEB 399
+  ubi0: fixable bit-flip detected at PEB 511
+  ubi0: schedule PEB 511 for scrubbing
+
+spinand_wait() never re-verifies that the chip is still ready once it
+has first observed a non-busy sample: it polls REG_STATUS via
+spi_mem_poll_status() until STATUS_READY clears (or times out) and
+trusts that single result. The extra spinand_read_status() call further
+down only runs as a fallback for controllers whose hardware
+->poll_status() offload didn't already leave a non-busy sample in
+spinand->scratchbuf - it is not a second confirmation of readiness.
+
+On SkyHigh chips the ready bit has been observed to flip back to busy
+shortly after first going ready, so a caller can act on stale/settling
+state - reading the cache register before page data has settled, or
+issuing the next command before a program/erase has actually completed.
+
+Add a SPINAND_HAS_PREMATURE_READY_BIT quirk flag and a SkyHigh-specific
+wait that wraps spinand_wait() and only trusts readiness once a
+follow-up status read still shows non-busy, retrying otherwise (bounded
+by the existing SPINAND_WAITRDY_TIMEOUT_MS). SkyHigh's ->init() sets the
+flag; the read, write and erase paths use the wait for any manufacturer
+that sets it, everyone else keeps using spinand_wait() unchanged.
+
+Not yet confirmed to eliminate the bit-flips over a long soak on
+hardware - posted as a workaround for the observed behavior.
+
+Suggested-by: Mikhail Zhilkin <csharper2005@gmail.com>
+Signed-off-by: Vitaliy Sochnev <sochnev.v.74@gmail.com>
+---
+ drivers/mtd/nand/spi/core.c    | 49 ++++++++++++++++++++++++++++++++++-------
+ drivers/mtd/nand/spi/skyhigh.c |  2 ++
+ include/linux/mtd/spinand.h    |  1 +
+ 3 files changed, 45 insertions(+), 7 deletions(-)
+
+--- a/drivers/mtd/nand/spi/core.c
++++ b/drivers/mtd/nand/spi/core.c
+@@ -613,6 +613,37 @@ static int spinand_lock_block(struct spi
+ 	return spinand_write_reg_op(spinand, REG_BLOCK_LOCK, lock);
+ }
+ 
++/*
++ * SkyHigh SPI-NAND chips have been observed to flip the ready bit back
++ * to busy shortly after first reporting ready. Wrap spinand_wait() -
++ * which still does the normal delay/poll and any hardware
++ * ->poll_status() offload - and only trust its result once a follow-up
++ * status read confirms the chip is still non-busy, retrying otherwise.
++ */
++static int spinand_skyhigh_wait_ready(struct spinand_device *spinand,
++				      unsigned long initial_delay_us,
++				      unsigned long poll_delay_us, u8 *s)
++{
++	unsigned long timeo = jiffies + msecs_to_jiffies(SPINAND_WAITRDY_TIMEOUT_MS);
++	u8 status;
++	int ret;
++
++	do {
++		ret = spinand_wait(spinand, initial_delay_us, poll_delay_us,
++				   &status);
++		if (ret < 0)
++			return ret;
++
++		ret = spinand_read_status(spinand, &status);
++		if (ret)
++			return ret;
++	} while ((status & STATUS_BUSY) && time_before(jiffies, timeo));
++
++	*s = status;
++
++	return status & STATUS_BUSY ? -ETIMEDOUT : 0;
++}
++
+ /**
+  * spinand_read_page() - Read a page
+  * @spinand: the spinand device
+@@ -636,10 +667,16 @@ int spinand_read_page(struct spinand_dev
+ 	if (ret)
+ 		return ret;
+ 
+-	ret = spinand_wait(spinand,
+-			   SPINAND_READ_INITIAL_DELAY_US,
+-			   SPINAND_READ_POLL_DELAY_US,
+-			   &status);
++	if (spinand->flags & SPINAND_HAS_PREMATURE_READY_BIT)
++		ret = spinand_skyhigh_wait_ready(spinand,
++						  SPINAND_READ_INITIAL_DELAY_US,
++						  SPINAND_READ_POLL_DELAY_US,
++						  &status);
++	else
++		ret = spinand_wait(spinand,
++				   SPINAND_READ_INITIAL_DELAY_US,
++				   SPINAND_READ_POLL_DELAY_US,
++				   &status);
+ 	if (ret < 0)
+ 		return ret;
+ 
+@@ -683,10 +720,16 @@ int spinand_write_page(struct spinand_de
+ 	if (ret)
+ 		return ret;
+ 
+-	ret = spinand_wait(spinand,
+-			   SPINAND_WRITE_INITIAL_DELAY_US,
+-			   SPINAND_WRITE_POLL_DELAY_US,
+-			   &status);
++	if (spinand->flags & SPINAND_HAS_PREMATURE_READY_BIT)
++		ret = spinand_skyhigh_wait_ready(spinand,
++						  SPINAND_WRITE_INITIAL_DELAY_US,
++						  SPINAND_WRITE_POLL_DELAY_US,
++						  &status);
++	else
++		ret = spinand_wait(spinand,
++				   SPINAND_WRITE_INITIAL_DELAY_US,
++				   SPINAND_WRITE_POLL_DELAY_US,
++				   &status);
+ 	if (ret)
+ 		return ret;
+ 
+@@ -1070,10 +1113,16 @@ static int spinand_erase(struct nand_dev
+ 	if (ret)
+ 		return ret;
+ 
+-	ret = spinand_wait(spinand,
+-			   SPINAND_ERASE_INITIAL_DELAY_US,
+-			   SPINAND_ERASE_POLL_DELAY_US,
+-			   &status);
++	if (spinand->flags & SPINAND_HAS_PREMATURE_READY_BIT)
++		ret = spinand_skyhigh_wait_ready(spinand,
++						  SPINAND_ERASE_INITIAL_DELAY_US,
++						  SPINAND_ERASE_POLL_DELAY_US,
++						  &status);
++	else
++		ret = spinand_wait(spinand,
++				   SPINAND_ERASE_INITIAL_DELAY_US,
++				   SPINAND_ERASE_POLL_DELAY_US,
++				   &status);
+ 
+ 	if (!ret && (status & STATUS_ERASE_FAILED))
+ 		ret = -EIO;
+--- a/drivers/mtd/nand/spi/skyhigh.c
++++ b/drivers/mtd/nand/spi/skyhigh.c
+@@ -125,6 +125,8 @@ static const struct spinand_info skyhigh
+ 
+ static int skyhigh_spinand_init(struct spinand_device *spinand)
+ {
++	spinand->flags |= SPINAND_HAS_PREMATURE_READY_BIT;
++
+ 	/*
+ 	 * Config_Protect_En (bit 1 in Block Lock register) must be set to 1
+ 	 * before writing other bits. Do it here before core unlocks all blocks
+--- a/include/linux/mtd/spinand.h
++++ b/include/linux/mtd/spinand.h
+@@ -418,6 +418,7 @@ struct spinand_ecc_info {
+ #define SPINAND_HAS_PROG_PLANE_SELECT_BIT		BIT(2)
+ #define SPINAND_HAS_READ_PLANE_SELECT_BIT		BIT(3)
+ #define SPINAND_NO_RAW_ACCESS				BIT(4)
++#define SPINAND_HAS_PREMATURE_READY_BIT		BIT(5)
+ 
+ /**
+  * struct spinand_ondie_ecc_conf - private SPI-NAND on-die ECC engine structure

--- a/target/linux/mediatek/patches-6.18/010-v7.0-mtd-spinand-add-support-for-Dosilicon-DS35Q1GA-DS35M.patch
+++ b/target/linux/mediatek/patches-6.18/010-v7.0-mtd-spinand-add-support-for-Dosilicon-DS35Q1GA-DS35M.patch
@@ -42,7 +42,7 @@ Signed-off-by: Miquel Raynal <miquel.raynal@bootlin.com>
  obj-$(CONFIG_MTD_SPI_NAND) += spinand.o
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -1226,6 +1226,7 @@ static const struct nand_ops spinand_ops
+@@ -1275,6 +1275,7 @@ static const struct nand_ops spinand_ops
  static const struct spinand_manufacturer *spinand_manufacturers[] = {
  	&alliancememory_spinand_manufacturer,
  	&ato_spinand_manufacturer,

--- a/target/linux/mediatek/patches-6.18/121-hack-spi-nand-1b-bbm.patch
+++ b/target/linux/mediatek/patches-6.18/121-hack-spi-nand-1b-bbm.patch
@@ -11,7 +11,7 @@ Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
 ---
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -970,7 +970,7 @@ static int spinand_mtd_write(struct mtd_
+@@ -1013,7 +1013,7 @@ static int spinand_mtd_write(struct mtd_
  static bool spinand_isbad(struct nand_device *nand, const struct nand_pos *pos)
  {
  	struct spinand_device *spinand = nand_to_spinand(nand);
@@ -20,7 +20,7 @@ Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
  	struct nand_page_io_req req = {
  		.pos = *pos,
  		.ooblen = sizeof(marker),
-@@ -989,7 +989,7 @@ static bool spinand_isbad(struct nand_de
+@@ -1032,7 +1032,7 @@ static bool spinand_isbad(struct nand_de
  		spinand_read_page(spinand, &req);
  	}
  

--- a/target/linux/mediatek/patches-6.18/330-snand-mtk-bmt-support.patch
+++ b/target/linux/mediatek/patches-6.18/330-snand-mtk-bmt-support.patch
@@ -20,7 +20,7 @@ Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
  
  int spinand_read_reg_op(struct spinand_device *spinand, u8 reg, u8 *val)
  {
-@@ -1720,6 +1721,7 @@ static int spinand_probe(struct spi_mem
+@@ -1769,6 +1770,7 @@ static int spinand_probe(struct spi_mem
  	if (ret)
  		return ret;
  
@@ -28,7 +28,7 @@ Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
  	ret = mtd_device_register(mtd, NULL, 0);
  	if (ret)
  		goto err_spinand_cleanup;
-@@ -1727,6 +1729,7 @@ static int spinand_probe(struct spi_mem
+@@ -1776,6 +1778,7 @@ static int spinand_probe(struct spi_mem
  	return 0;
  
  err_spinand_cleanup:
@@ -36,7 +36,7 @@ Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
  	spinand_cleanup(spinand);
  
  	return ret;
-@@ -1745,6 +1748,7 @@ static int spinand_remove(struct spi_mem
+@@ -1794,6 +1797,7 @@ static int spinand_remove(struct spi_mem
  	if (ret)
  		return ret;
  

--- a/target/linux/mediatek/patches-6.18/435-drivers-mtd-spinand-Add-calibration-support-for-spin.patch
+++ b/target/linux/mediatek/patches-6.18/435-drivers-mtd-spinand-Add-calibration-support-for-spin.patch
@@ -11,7 +11,7 @@ Signed-off-by: SkyLake.Huang <skylake.huang@mediatek.com>
 
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -1271,6 +1271,56 @@ static int spinand_manufacturer_match(st
+@@ -1320,6 +1320,56 @@ static int spinand_manufacturer_match(st
  	return -EOPNOTSUPP;
  }
  
@@ -68,7 +68,7 @@ Signed-off-by: SkyLake.Huang <skylake.huang@mediatek.com>
  static int spinand_id_detect(struct spinand_device *spinand)
  {
  	u8 *id = spinand->id.data;
-@@ -1590,6 +1640,10 @@ static int spinand_init(struct spinand_d
+@@ -1639,6 +1689,10 @@ static int spinand_init(struct spinand_d
  
  	spinand_init_ssdr_templates(spinand);
  

--- a/target/linux/mediatek/patches-6.18/436-drivers-mtd-spi-nor-Add-calibration-support-for-spi-.patch
+++ b/target/linux/mediatek/patches-6.18/436-drivers-mtd-spi-nor-Add-calibration-support-for-spi-.patch
@@ -12,7 +12,7 @@ Signed-off-by: SkyLake.Huang <skylake.huang@mediatek.com>
 
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -1312,7 +1312,10 @@ static int spinand_cal_read(void *priv,
+@@ -1361,7 +1361,10 @@ static int spinand_cal_read(void *priv,
  	if (ret)
  		return ret;
  

--- a/target/linux/mediatek/patches-6.18/960-asus-hack-u-boot-ignore-mtdparts.patch
+++ b/target/linux/mediatek/patches-6.18/960-asus-hack-u-boot-ignore-mtdparts.patch
@@ -29,7 +29,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -1813,6 +1813,7 @@ static int spinand_remove(struct spi_mem
+@@ -1862,6 +1862,7 @@ static int spinand_remove(struct spi_mem
  
  static const struct spi_device_id spinand_ids[] = {
  	{ .name = "spi-nand" },
@@ -37,7 +37,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	{ /* sentinel */ },
  };
  MODULE_DEVICE_TABLE(spi, spinand_ids);
-@@ -1820,6 +1821,7 @@ MODULE_DEVICE_TABLE(spi, spinand_ids);
+@@ -1869,6 +1870,7 @@ MODULE_DEVICE_TABLE(spi, spinand_ids);
  #ifdef CONFIG_OF
  static const struct of_device_id spinand_of_ids[] = {
  	{ .compatible = "spi-nand" },

--- a/target/linux/qualcommax/patches-6.18/0412-mtd-spinand-qpic-only-support-max-4-bytes-ID.patch
+++ b/target/linux/qualcommax/patches-6.18/0412-mtd-spinand-qpic-only-support-max-4-bytes-ID.patch
@@ -14,7 +14,7 @@ Signed-off-by: Ziyang Huang <hzyitc@outlook.com>
 
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -1409,7 +1409,7 @@ int spinand_match_and_init(struct spinan
+@@ -1458,7 +1458,7 @@ int spinand_match_and_init(struct spinan
  		if (rdid_method != info->devid.method)
  			continue;
  


### PR DESCRIPTION
Nokia XG-040G-MD units built with SkyHigh SPI-NAND occasionally log UBI "fixable bit-flip" events in production, here after about a month of uptime:

```
[2503209.483768] ubi0: schedule PEB 399 for scrubbing
[2503209.542280] ubi0: scrubbed PEB 399 (LEB 5:272), data moved to PEB 366
[2562754.294549] ubi0: fixable bit-flip detected at PEB 1316
[2562754.360134] ubi0: scrubbed PEB 1316 (LEB 5:195), data moved to PEB 399
[2589193.123216] ubi0: fixable bit-flip detected at PEB 511
[2589193.128571] ubi0: schedule PEB 511 for scrubbing
[2589193.197174] ubi0: scrubbed PEB 511 (LEB 5:116), data moved to PEB 364
[2689227.173721] ubi0: fixable bit-flip detected at PEB 1194
[2689227.179237] ubi0: schedule PEB 1194 for scrubbing
[2689227.221495] ubi0: fixable bit-flip detected at PEB 1194
[2689227.295181] ubi0: scrubbed PEB 1194 (LEB 5:76),
```

`spinand_wait()` never re-verifies that the chip is still ready once it has first observed a non-busy sample: it polls `REG_STATUS` via `spi_mem_poll_status()` until `STATUS_READY` clears and trusts that single result. The extra `spinand_read_status()` further down is only a fallback for controllers whose hardware `->poll_status()` offload didn't leave a non-busy sample in `spinand->scratchbuf`, not a second confirmation. On SkyHigh chips the ready bit has been observed to flip back to busy shortly after first going ready, so the cache can be read before page data has settled, or the next command issued before a program/erase has actually completed.

This adds a `SPINAND_PREMATURE_READY_QUIRK` flag, set in the chip table for the SkyHigh S35ML01G301, S35ML01G300, S35ML02G300 and S35ML04G300 entries. The reset, page load (regular and continuous read), program and erase waits go through a new `spinand_wait_ready_confirmed()` helper: for flagged parts it only trusts a ready result from `spinand_wait()` once a follow-up status read still shows the device ready, and calls `spinand_wait()` again otherwise, so the normal delay/poll and any hardware `->poll_status()` offload are kept. Each `spinand_wait()` gets its own `SPINAND_WAITRDY_TIMEOUT_MS` budget and no new one is started once that span has elapsed, so a flagged part can spend up to roughly twice that time waiting. The reset issued from `spinand_detect()` runs before `spinand->flags` is assigned and so keeps the unflagged behavior; the resume path is covered. Parts without the flag get plain `spinand_wait()`, unchanged.

The patch lives in `target/linux/generic/pending-6.18/` since it changes generic `drivers/mtd/nand/spi/core.c`, not airoha-specific code. The other changed files are hunk offset refreshes of target patches that touch the same `core.c` (airoha 901, econet 902, mediatek 010/121/330/435/436/960, qualcommax 0412).

**Not yet confirmed to eliminate the bit-flips over a long soak on hardware** — this is a workaround for the observed behavior, not a proven fix.

Testing: `make target/linux/refresh` is clean on airoha/an7581, mediatek/filogic, qualcommax/ipq50xx and econet/en751221; `checkpatch.pl --strict` reports no issues; the airoha kernel builds with `CONFIG_KERNEL_WERROR=y` and all kmods without a single diagnostic. This revision was flashed with sysupgrade to a Nokia XG-040G-MD with a SkyHigh chip: the upgrade (real erase and program cycles through the new path) completed and the board booted cleanly, with no UBI or SPI-NAND errors. The reset on the resume path isn't exercised by a plain boot, so that one call site is compile-tested only.