### PR TITLE
mediatek: drop unused kmod-mt7916-firmware for JioRouter AX6000 JIDU6101

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2216,7 +2216,7 @@ define Device/jiorouter_ax6000-jidu6101
   DEVICE_VARIANT := JIDU6101
   DEVICE_DTS := mt7986a-jiorouter-ax6000-jidu6101
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7916-firmware kmod-mt7986-firmware mt7986-wo-firmware
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
   UBINIZE_OPTS := -E 5
   UBOOTENV_IN_UBI := 1
   BLOCKSIZE := 128k


### PR DESCRIPTION
Drop the unused kmod-mt7916-firmware package from DEVICE_PACKAGES.

The JioRouter AX6000 (JIDU6101) does not have a PCIe radio and relies
solely on the MT7986 SoC integrated Wi-Fi, which is covered by
kmod-mt7986-firmware.