### PR TITLE
kernel: split framebuffer console out of kmod-fb

### DIFF
--- a/package/kernel/linux/modules/video.mk
+++ b/package/kernel/linux/modules/video.mk
@@ -112,13 +112,35 @@ $(eval $(call KernelPackage,backlight-pwm))
 
 define KernelPackage/fb
   SUBMENU:=$(VIDEO_MENU)
-  TITLE:=Framebuffer and framebuffer console support
+  TITLE:=Framebuffer support
   DEPENDS:=@DISPLAY_SUPPORT +PACKAGE_kmod-backlight:kmod-backlight
   KCONFIG:= \
 	CONFIG_FB \
 	CONFIG_FB_DEVICE=y \
 	CONFIG_FB_MXS=n \
-	CONFIG_FB_SM750=n \
+	CONFIG_FB_SM750=n
+  FILES:=$(LINUX_DIR)/drivers/video/fbdev/core/fb.ko \
+	$(if $(CONFIG_PACKAGE_kmod-fb-console),$(LINUX_DIR)/lib/fonts/font.ko)
+  AUTOLOAD:=$(call AutoLoad,06,fb$(if $(CONFIG_PACKAGE_kmod-fb-console), font))
+endef
+
+define KernelPackage/fb/description
+ Kernel support for framebuffers.
+endef
+
+define KernelPackage/fb/x86
+  FILES+=$(LINUX_DIR)/arch/x86/video/video-common.ko
+  AUTOLOAD:=$(call AutoLoad,06,video-common fb$(if $(CONFIG_PACKAGE_kmod-fb-console), font))
+endef
+
+$(eval $(call KernelPackage,fb))
+
+
+define KernelPackage/fb-console
+  SUBMENU:=$(VIDEO_MENU)
+  TITLE:=Framebuffer console support
+  DEPENDS:=+kmod-fb
+  KCONFIG:= \
 	CONFIG_FRAMEBUFFER_CONSOLE=y \
 	CONFIG_FRAMEBUFFER_CONSOLE_DETECT_PRIMARY=y \
 	CONFIG_FRAMEBUFFER_CONSOLE_ROTATION=y \
@@ -138,21 +160,13 @@ define KernelPackage/fb
 	CONFIG_CONSOLE_TRANSLATIONS=y \
 	CONFIG_VT_CONSOLE=y \
 	CONFIG_VT_HW_CONSOLE_BINDING=y
-  FILES:=$(LINUX_DIR)/drivers/video/fbdev/core/fb.ko \
-	$(LINUX_DIR)/lib/fonts/font.ko
-  AUTOLOAD:=$(call AutoLoad,06,fb font)
 endef
 
-define KernelPackage/fb/description
- Kernel support for framebuffers and framebuffer console.
+define KernelPackage/fb-console/description
+ Kernel support for framebuffer console.
 endef
 
-define KernelPackage/fb/x86
-  FILES+=$(LINUX_DIR)/arch/x86/video/video-common.ko
-  AUTOLOAD:=$(call AutoLoad,06,video-common fb font)
-endef
-
-$(eval $(call KernelPackage,fb))
+$(eval $(call KernelPackage,fb-console))
 
 
 define KernelPackage/fb-cfb-fillrect


### PR DESCRIPTION
Splits the framebuffer console out of `kmod-fb` into a new `kmod-fb-console`
package.

`kmod-fb` currently carries both the framebuffer and the text console on top of
it — `CONFIG_FRAMEBUFFER_CONSOLE`, `CONFIG_FONTS`, `CONFIG_VT` and friends, all
`=y`. Since `config VT` does `select INPUT`, that means the virtual terminal
layer, console translation tables, bitmap fonts and the input core all land in
vmlinux.

There is no way to opt out. `kmod-drm-kms-helper` depends on `kmod-fb`, so a
device with a DRM panel — e.g. `panel-mipi-dbi` on a 136x240 SPI display —
pulls in the whole console stack on hardware with no keyboard. On targets where
the kernel lives in a fixed partition, that can push images past their size
limit.

`fbcon` is not its own module: `drivers/video/fbdev/core/Makefile` links
`fbcon.o` into `fb.ko`, and that code needs `find_font()`/`get_default_font()`
from `font.ko`. So `kmod-fb-console` is KCONFIG-only, and `kmod-fb` ships
`font.ko` alongside `fb.ko` exactly when the console is selected — the two files
ship together or not at all, as before.

No target config or default package set changes. Nothing in the tree selects
`kmod-fb` in `DEFAULT_PACKAGES`, so no default image gains or loses anything.
For users who select `kmod-fb` by hand today and want the console, it is now a
second checkbox.