### PR TITLE
mediatek: fix wh3000-pro image check

### DIFF
--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -441,6 +441,8 @@ platform_check_image() {
 	creatlentem,clt-r30b1|\
 	creatlentem,clt-r30b1-112m|\
 	hiveton,h5000m|\
+	huasifei,wh3000|\
+	huasifei,wh3000-pro-emmc|\
 	nradio,c8-668gl)
 		# tar magic `ustar`
 		magic="$(dd if="$1" bs=1 skip=257 count=5 2>/dev/null)"


### PR DESCRIPTION
The huasifei,wh3000-pro-emmc sysupgrade image is delivered as a tar, but a missing case in the platform_check_image function causes it to fall through to nand_do_platform_check, which then fails with 'invalid sysupgrade file'.

We add a case label to correct this, so the file is validated by the 'ustar' magic string check.

Links: https://forum.openwrt.org/t/unable-to-upgrade-huasifei-wh3000pro/252360

---
This needs backporting to 24.10 and 25.12, too (I didn't check if it would merge clean, so let me know if I need to do manual backports).