### PR TITLE
qualcommax: ipq807x: fix Linksys HomeWRK boot integration

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq807x
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq807x
@@ -56,15 +56,13 @@ tplink,eap660hd-v1)
 edimax,cax1800)
 	ubootenv_add_mtd "0:appsblenv" "0x0" "0x10000" "0x20000"
 	;;
-linksys,homewrk)
-	ubootenv_add_mtd "0:appsblenv" "0x0" "0x40000" "0x40000"
-	;;
 linksys,mx4200v1|\
 linksys,mx4200v2|\
 linksys,mx5300|\
 linksys,mx8500)
 	ubootenv_add_mtd "u_env" "0x0" "0x40000" "0x20000"
 	;;
+linksys,homewrk|\
 linksys,mx4300)
 	ubootenv_add_mtd "u_env" "0x0" "0x40000" "0x40000"
 	;;

--- a/target/linux/qualcommax/dts/ipq8174-homewrk.dts
+++ b/target/linux/qualcommax/dts/ipq8174-homewrk.dts
@@ -9,7 +9,11 @@
 	compatible = "linksys,homewrk", "qcom,ipq8074";
 
 	chosen {
-		bootargs-append = " root=/dev/ubiblock0_1";
+		bootargs-find-1 = "ubi.mtd=22,2048";
+		bootargs-replace-1 = "ubi.mtd=22,4096";
+		bootargs-find-2 = "ubi.mtd=24,2048";
+		bootargs-replace-2 = "ubi.mtd=24,4096";
+		bootargs-append = " root=/dev/ubiblock0_0";
 	};
 };
 

--- a/target/linux/qualcommax/ipq807x/base-files/etc/init.d/bootcount
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/init.d/bootcount
@@ -10,6 +10,7 @@ boot() {
 		# Unset changed flag after sysupgrade complete
 		fw_setenv changed
 	;;
+	linksys,homewrk|\
 	linksys,mx4200v1|\
 	linksys,mx4200v2|\
 	linksys,mx4300|\

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -128,8 +128,8 @@ linksys_mx_pre_upgrade() {
 		fi
 	fi
 
-	boot_part_ready="$(fw_printenv -n boot_part_ready)"
-	if [ "$boot_part_ready" -ne "3" ]; then
+	boot_part_ready="$(fw_printenv -n boot_part_ready 2>/dev/null)"
+	if [ "$boot_part_ready" != "3" ]; then
 		echo "boot_part_ready 3" >> $setenv_script
 	fi
 
@@ -218,11 +218,7 @@ platform_do_upgrade() {
 		fw_setenv upgrade_available 1
 		nand_do_upgrade "$1"
 		;;
-	linksys,homewrk)
-		CI_UBIPART="rootfs"
-		remove_oem_ubi_volume ubi_rootfs
-		nand_do_upgrade "$1"
-		;;
+	linksys,homewrk|\
 	linksys,mx4200v1|\
 	linksys,mx4200v2|\
 	linksys,mx4300)


### PR DESCRIPTION
## Summary

Complete the Linksys HomeWRK boot, A/B upgrade, and automatic-recovery integration.

HomeWRK currently differs from the related Linksys MX devices in several places even though physical hardware shows that it actively uses the same dual-slot recovery model:

- `uboot-envtools` points at `0:appsblenv`, while U-Boot reads its live environment from `u_env`.
- Stock U-Boot supplies `ubi.mtd=22,2048` / `ubi.mtd=24,2048`, while the NAND reports a 4096-byte minimum I/O size and OpenWrt formats UBI with VID offset 4096.
- The DTS selects `/dev/ubiblock0_1`, while `nand_do_upgrade` creates `rootfs` as volume 0.
- HomeWRK is omitted from the successful-boot `mtd resetbc s_env` handling.
- Sysupgrade treats HomeWRK as a single-slot device rather than using the existing Linksys MX inactive-slot upgrade path.

This changes HomeWRK to:

- use `u_env`;
- rewrite both stock U-Boot UBI offsets from 2048 to 4096;
- boot `rootfs` from volume 0;
- reset the Linksys boot counter after successful boot;
- use `linksys_mx_pre_upgrade()` and the inactive kernel/rootfs pair;
- remove the OEM `squashfs` volume like MX4200/MX4300;
- correctly initialize `boot_part_ready=3` when that variable is absent on an OEM installation.

## Hardware findings

Two physical HomeWRK units were directly inspected. Both have:

- U-Boot `2016.01-v0.20.256.210611_11.3csu2`
- Micron `MT29F8G08ABBCAH4`
- 4096-byte NAND page/minimum I/O size
- primary kernel/rootfs at mtd21/mtd22
- alternate kernel/rootfs at mtd23/mtd24
- `u_env` at the U-Boot-reported environment offset
- active `auto_recovery=yes`, `boot_part`, and `maxpartialboots=3`

The factory images in the primary and alternate kernel partitions are byte-for-byte identical, as are the two factory rootfs partitions.

The Linksys recovery mechanism was directly observed switching between the slots after failed boots.

HomeWRK support also lists the AMD/Spansion S34MS08G2 NAND variant. Its documented geometry is consistent with a 4096-byte page size, but I have not directly tested a HomeWRK containing that NAND.

## Testing

Tested against current `main` at:

`3d1645ee26d6a2e20be71d7fa1716721bac78e53`

Hardware testing included:

- boot from primary slot;
- boot from alternate slot;
- sysupgrade primary -> alternate;
- sysupgrade alternate -> primary;
- configuration-preserving A/B sysupgrade;
- successful-boot `s_env` counter reset;
- deliberate failed boots followed by automatic U-Boot rollback;
- `fw_printenv` / `fw_setenv` through `u_env`;
- migration from an official OpenWrt 25.12.5 installation to the patched image;
- restore and normal boot of the factory OEM firmware;
- fresh OEM -> patched OpenWrt installation from initramfs.

For the fresh OEM test, slot 1 contained the restored factory firmware and was active. The patched initramfs:

1. detected `boot_part=1` with `boot_part_ready` unset;
2. selected the inactive `alt_kernel` / `alt_rootfs` pair;
3. encountered the expected OEM VID offset 2048 on mtd24;
4. reformatted mtd24 using native VID offset 4096;
5. created `rootfs` as volume 0 and `rootfs_data` as volume 1;
6. set `boot_part=2`, `boot_part_ready=3`, and retained `auto_recovery=yes`;
7. rebooted successfully into the newly installed OpenWrt slot.

After installation, SHA256 hashes of the factory mtd21/mtd22 pair were unchanged, confirming that the active OEM slot had not been modified.

Fixes #24836
Fixes #24837
Fixes #24857