### PR TITLE
uqmi: avoid SIM reset on unavailable UIM state

### DIFF
--- a/package/network/utils/uqmi/Makefile
+++ b/package/network/utils/uqmi/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uqmi
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/uqmi.git

--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -130,14 +130,45 @@ proto_qmi_setup() {
 	done
 
 	# Check if UIM application is stuck in illegal state
-	local uim_state_timeout=0
+	local uim_unavailable_timeout=0
+	local uim_recovery_timeout=0
+	local uim_state_json card_application_state
 	while true; do
-		json_load "$(uqmi -s -d "$device" -t 2000 --uim-get-sim-state)"
-		json_get_var card_application_state card_application_state
+		[ -e "$device" ] || return 1
+		card_application_state=""
+		uim_state_json="$(uqmi -s -d "$device" -t 2000 \
+			--uim-get-sim-state 2>/dev/null)"
+		[ -e "$device" ] || return 1
 
-		# SIM card is either completely absent or state is labeled as illegal
-		# Try to power-cycle the SIM card to recover from this state
-		if [ -z "$card_application_state" -o "$card_application_state" = "illegal" ]; then
+		# Let the existing PIN fallback handle modems without UIM support.
+		case "$uim_state_json" in
+			'"Not supported"'|'"Invalid QMI command"') break ;;
+		esac
+
+		if json_load "$uim_state_json" 2>/dev/null; then
+			json_get_var card_application_state card_application_state
+			json_cleanup
+		fi
+
+		# An empty or malformed response means that the UIM service is not
+		# ready.  It is not evidence of the explicit illegal state.  In
+		# particular, some modems return an empty object when no SIM is
+		# installed and reset the whole device when the SIM is powered off.
+		if [ -z "$card_application_state" ]; then
+			if [ "$uim_unavailable_timeout" -lt "$timeout" ] || [ "$timeout" = "0" ]; then
+				let uim_unavailable_timeout++
+				sleep 1
+				continue
+			fi
+
+			echo "Unable to obtain SIM state"
+			proto_notify_error "$interface" SIM_NOT_INITIALIZED
+			proto_block_restart "$interface"
+			return 1
+		fi
+
+		# Only an explicit illegal state warrants power-cycling the SIM.
+		if [ "$card_application_state" = "illegal" ]; then
 			echo "SIM in illegal state - Power-cycling SIM"
 
 			# Try to reset SIM application
@@ -145,8 +176,8 @@ proto_qmi_setup() {
 			sleep 3
 			uqmi -d "$device" -t 1000 --uim-power-on --uim-slot 1
 
-			if [ "$uim_state_timeout" -lt "$timeout" ] || [ "$timeout" = "0" ]; then
-				let uim_state_timeout++
+			if [ "$uim_recovery_timeout" -lt "$timeout" ] || [ "$timeout" = "0" ]; then
+				let uim_recovery_timeout++
 				sleep 5
 				continue
 			fi


### PR DESCRIPTION
The illegal-state recovery currently treats a missing `card_application_state` as an explicit `illegal` state. UIM may return malformed or empty data while the service is initializing. As reported in #14462, the ZTE MF287 also returns `{}` when no SIM is installed; the resulting `--uim-power-off` resets the complete router and causes an endless boot loop.

Retry unavailable UIM responses within the configured interface timeout, then report `SIM_NOT_INITIALIZED` without changing SIM power. Preserve the existing PIN fallback for modems which report UIM commands as unsupported. SIM power-cycling remains unchanged for an explicitly reported `illegal` state.

This also addresses the `Failed to parse message data` followed by repeated SIM power cycles reported after `--uim-power-on` in #18772.

Fixes #14462.

## Validation

- `sh -n` passes for the patched protocol handler.
- `scripts/checkpatch.pl --no-tree --strict`: 0 errors, 0 warnings.
- A shell regression harness executes the exact changed block with mocked UQMI responses. Eight scenarios pass: `ready`, unsupported command, malformed JSON, `{}`, unavailable then `illegal` then `ready`, persistent `illegal`, device absent before the query, and device disappearing during the query. The unavailable and illegal paths have independent retry budgets; device loss returns to netifd without a power command or `proto_block_restart`.
- The package release was rebuilt as `uqmi ...-r3` in a complete ramips/mt7620 image and the installed `qmi.sh` was verified from the final SquashFS.
- Hardware validation:
  - MeiG SLM828 in a ZBTlink ZBT-Z8102AX V2: the same unavailable-UIM retry path was previously deployed and the modem registered without a false SIM power cycle. The SLM828 also needs separate attach-profile ordering for reliable registration; that independent change is not part of this PR.
  - BroadMobi BM806C in a D-Link DWR-921 C3: on a cold boot, one transient unavailable SIM state was retried without a power command; the SIM became ready four seconds later, LTE was up 12 seconds after QMI setup began, and DHCP completed after 15 seconds. Before this change, the same boot produced two false SIM power cycles, with LTE up after 24 seconds and DHCP after 27 seconds.
  - Quectel RM520N-GL in a Banana Pi BPI-R3 Mini: an independent cold-boot A/B test with only this PR applied reduced QMI setup from 43 seconds to 20 seconds. False SIM power cycles dropped from three to zero, request timeouts from two to one, and parse failures from four to one. The remaining parse warning comes from the unchanged legacy `--get-pin-status` fallback and does not cause a SIM reset. See [the full test report](https://github.com/openwrt/openwrt/pull/24868#issuecomment-5411133408).