### PR TITLE
base-files: stop sending ICMP redirects

### DIFF
--- a/package/base-files/files/etc/sysctl.d/10-default.conf
+++ b/package/base-files/files/etc/sysctl.d/10-default.conf
@@ -13,6 +13,8 @@ net.core.bpf_jit_kallsyms=1
 
 net.ipv4.conf.default.arp_ignore=1
 net.ipv4.conf.all.arp_ignore=1
+net.ipv4.conf.default.send_redirects=0
+net.ipv4.conf.all.send_redirects=0
 net.ipv4.ip_forward=1
 net.ipv4.icmp_echo_ignore_broadcasts=1
 net.ipv4.icmp_ignore_bogus_error_responses=1


### PR DESCRIPTION
A router with two IPv4 subnets on one L3 device routes a pair of local hosts
back out the interface they arrived on, so it redirects each to reach the other
directly. A Linux peer accepts that redirect even though the new next hop is
outside its own subnet, because `shared_media` defaults to 1, and answers over
L2 from then on, never through the router again.

Conntrack then sees one packet of that connection, ever: the entry sits at
`SYN_SENT [UNREPLIED]` with `packets=1` while the transfer runs, and every later
packet is invalid on it and is left untracked, so the stateful part of the
ruleset does not see those connections either. Nothing is offered to a
flowtable, software or hardware, because the offload rule never gets a conntrack
entry:

```
net/netfilter/nft_flow_offload.c, nft_flow_offload_eval():
	ct = nf_ct_get(pkt->skb, &ctinfo);
	if (!ct)
		goto out;
```

I measured this on an IPQ8074 (Xiaomi AX3600) with `192.168.1.0/24` and
`192.168.2.0/24` on one bridge, `iperf3 -P2` between two wired hosts, counting
packets on the DSA conduit, every run at 936-937 Mbit/s:

| | packets forwarded by the CPU |
|---|---|
| redirects on, peer's redirect cache just flushed (one run) | 82 |
| redirects on, redirect cached (two runs) | 860973 / 858906 |
| `send_redirects=0` (three runs) | 84 / 131 / 80 |

The change sets both `conf/all` and `conf/default` because the kernel ORs
`conf/all` with `conf/<dev>`. It does not un-poison a peer that already holds a
redirect; the peer keeps the exception for up to 300 s after the router stops
redirecting, or until `ip route flush cache`. The cost is one extra switch hop
for traffic that had a direct L2 path, which any switch-based device forwards in
hardware.

I found no send-side IPv6 key to mirror. `ip6_forward()` sends the v6 redirect
from the forwarding path with no sysctl in it, and `accept_redirects` on the
receiver is the only redirect control the v6 devconf carries:

```
net/ipv6/ip6_output.c, ip6_forward():
	if (IP6CB(skb)->iif == dev->ifindex &&
	    opt->srcrt == 0 && !skb_sec_path(skb)) {
		...
		if (inet_peer_xrlim_allow(peer, 1*HZ))
			ndisc_send_redirect(skb, target);
```

Found while debugging hardware flow offload in openwrt/openwrt#24806, where no
driver-side counter moves because the driver is never called.

I used AI to help me write the change. LuCI already exposes `send_redirects` as
a per-device toggle, so is a global default the right place for this?
