### PR TITLE
wifi-scripts: mac80211: fix 6 GHz 40 MHz channel configuration for non-AP modes

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
@@ -782,6 +782,14 @@ mac80211_prepare_iw_htmode() {
 						;;
 					esac
 				;;
+				6g)
+					if [ "$auto_channel" -eq 0 ] && [ "$channel" -gt 0 ]; then
+						local c_base=$(( (($channel - 1) / 8) * 8 + 1 ))
+						iw_htmode="40 $(( 5950 + ($c_base + 2) * 5 ))"
+					else
+						iw_htmode=""
+					fi
+				;;
 				*)
 					case "$(( ($channel / 4) % 2 ))" in
 						1) iw_htmode="HT40+" ;;
@@ -789,7 +797,7 @@ mac80211_prepare_iw_htmode() {
 					esac
 				;;
 			esac
-			[ "$auto_channel" -gt 0 ] && iw_htmode="HT40+"
+			[ "$auto_channel" -gt 0 ] && [ "$band" != "6g" ] && iw_htmode="HT40+"
 		;;
 		VHT80|HE80|EHT80)
 			iw_htmode="80MHz"


### PR DESCRIPTION
In `iw_htmode()`, 40 MHz modes (HE40/EHT40) on the 6 GHz band fell through to the 5 GHz HT40+/HT40- calculation. Since 802.11n HT modes do not exist in 6 GHz, `iw` commands like `iw dev <ifname> set freq <freq> HT40+` fail in cfg80211 with `-EINVAL` (`invalid channel definition`). Fix this by adding 6 GHz band handling in `iw_htmode()` to calculate and return the 40 MHz center frequency (`40 <center_freq>`).
