### PR TITLE
hostapd: fix EAPOL PAE PMKSA transition and internal EAP type logging

### DIFF
--- a/package/network/services/hostapd/patches/197-eapol_auth-fix-PAE-state-machine-transition-for-PM.patch
+++ b/package/network/services/hostapd/patches/197-eapol_auth-fix-PAE-state-machine-transition-for-PM.patch
@@ -1,0 +1,46 @@
+From: Alexander Astrovsky <astrouski@google.com>
+Date: Sun, 23 Aug 2026 21:10:00 +0000
+Subject: [PATCH] eapol_auth: fix PAE state machine transition for PMKSA cache
+
+When a station reconnects or roams using a cached PMKSA entry
+(EAPOL_SM_FROM_PMKSA_CACHE), such as when roaming back to a previously
+connected AP (e.g. AP0 -> AP1 -> AP0 in WPA3-Enterprise PMKSA caching
+tests), full EAP authentication is bypassed.
+
+Upon reassociation or receiving an EAPOL-Start, the PAE state machine
+transitions through AUTH_PAE_RESTART / AUTH_PAE_CONNECTING to
+AUTH_PAE_AUTHENTICATING via SM_ENTER(AUTH_PAE, AUTHENTICATING), which
+unconditionally executes sm->authSuccess = false.
+Because the PMK is already cached, no new EAP exchange runs, leaving
+sm->authSuccess as false.
+
+Once the WPA 4-way handshake completes, wpa_auth drives sm->portValid to
+true. However, because sm->authSuccess is false, the condition
+(sm->authSuccess && sm->portValid) in SM_STEP(AUTH_PAE) fails,
+stranding the PAE state machine in AUTH_PAE_AUTHENTICATING.
+
+Fix this by allowing the AUTH_PAE_AUTHENTICATING -> AUTHENTICATED
+transition in SM_STEP(AUTH_PAE) when sm->portValid is true and either
+sm->authSuccess or (sm->flags & EAPOL_SM_FROM_PMKSA_CACHE) is set. This
+guarantees that transition to AUTH_PAE_AUTHENTICATED occurs only after
+the 4-way handshake completes and keys are installed (portValid == true).
+
+Signed-off-by: Alexander Astrovsky <astrouski@google.com>
+---
+ src/eapol_auth/eapol_auth_sm.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+Index: hostapd-2026.08.07~831364bf/src/eapol_auth/eapol_auth_sm.c
+===================================================================
+--- hostapd-2026.08.07~831364bf.orig/src/eapol_auth/eapol_auth_sm.c
++++ hostapd-2026.08.07~831364bf/src/eapol_auth/eapol_auth_sm.c
+@@ -433,7 +433,8 @@ SM_STEP(AUTH_PAE)
+ 				SM_ENTER(AUTH_PAE, DISCONNECTED);
+ 			break;
+ 		case AUTH_PAE_AUTHENTICATING:
+-			if (sm->authSuccess && sm->portValid)
++			if (sm->portValid &&
++			    (sm->authSuccess || (sm->flags & EAPOL_SM_FROM_PMKSA_CACHE)))
+ 				SM_ENTER(AUTH_PAE, AUTHENTICATED);
+ 			else if (sm->authFail ||
+ 				 (sm->keyDone && !sm->portValid))

--- a/package/network/services/hostapd/patches/198-eapol_auth-report-EAP-type-from-internal-EAP-serve.patch
+++ b/package/network/services/hostapd/patches/198-eapol_auth-report-EAP-type-from-internal-EAP-serve.patch
@@ -1,0 +1,66 @@
+From: Alexander Astrovsky <astrouski@google.com>
+Date: Sun, 23 Aug 2026 21:10:00 +0000
+Subject: [PATCH] eapol_auth: report EAP type from internal EAP server
+
+When hostapd uses its integrated internal EAP server rather than an
+external RADIUS authentication server, sm->eap_type_authsrv is not
+populated. Consequently, the log message upon successful authentication
+prints "authenticated - EAP type: 0 (NONE)" instead of the actual EAP
+method used (e.g., EAP-TLS, PEAP, TTLS).
+
+Add eap_server_get_type() accessor to retrieve the current EAP method
+from the internal EAP server, and populate sm->eap_type_authsrv in
+SM_STATE(AUTH_PAE, AUTHENTICATED) so the EAP method is accurately logged
+and reported.
+
+Signed-off-by: Alexander Astrovsky <astrouski@google.com>
+---
+Index: hostapd-2026.08.07~831364bf/src/eap_server/eap.h
+===================================================================
+--- hostapd-2026.08.07~831364bf.orig/src/eap_server/eap.h
++++ hostapd-2026.08.07~831364bf/src/eap_server/eap.h
+@@ -293,6 +293,7 @@ const u8 * eap_get_identity(struct eap_s
+ const char * eap_get_serial_num(struct eap_sm *sm);
+ const char * eap_get_method(struct eap_sm *sm);
+ const char * eap_get_imsi(struct eap_sm *sm);
++enum eap_type eap_server_get_eap_type(struct eap_sm *sm);
+ struct eap_eapol_interface * eap_get_interface(struct eap_sm *sm);
+ void eap_server_clear_identity(struct eap_sm *sm);
+ void eap_server_mschap_rx_callback(struct eap_sm *sm, const char *source,
+Index: hostapd-2026.08.07~831364bf/src/eap_server/eap_server.c
+===================================================================
+--- hostapd-2026.08.07~831364bf.orig/src/eap_server/eap_server.c
++++ hostapd-2026.08.07~831364bf/src/eap_server/eap_server.c
+@@ -2045,6 +2045,19 @@ void eap_erp_update_identity(struct eap_
+ 
+ 
+ /**
++ * eap_server_get_eap_type - Get current EAP type from internal EAP server
++ * @sm: Pointer to EAP state machine allocated with eap_server_sm_init()
++ * Returns: Current EAP type or EAP_TYPE_NONE if not initialized
++ */
++enum eap_type eap_server_get_eap_type(struct eap_sm *sm)
++{
++	if (!sm)
++		return EAP_TYPE_NONE;
++	return sm->currentMethod;
++}
++
++
++/**
+  * eap_get_interface - Get pointer to EAP-EAPOL interface data
+  * @sm: Pointer to EAP state machine allocated with eap_server_sm_init()
+  * Returns: Pointer to the EAP-EAPOL interface data
+Index: hostapd-2026.08.07~831364bf/src/eapol_auth/eapol_auth_sm.c
+===================================================================
+--- hostapd-2026.08.07~831364bf.orig/src/eapol_auth/eapol_auth_sm.c
++++ hostapd-2026.08.07~831364bf/src/eapol_auth/eapol_auth_sm.c
+@@ -319,6 +319,8 @@ SM_STATE(AUTH_PAE, AUTHENTICATED)
+ 		extra = " (pre-authentication)";
+ 	else if (sm->flags & EAPOL_SM_FROM_PMKSA_CACHE)
+ 		extra = " (PMKSA cache)";
++	if (sm->eap && sm->eap_type_authsrv == EAP_TYPE_NONE)
++		sm->eap_type_authsrv = eap_server_get_eap_type(sm->eap);
+ 	eapol_auth_vlogger(sm->eapol, sm->addr, EAPOL_LOGGER_INFO,
+ 			   "authenticated - EAP type: %d (%s)%s",
+ 			   sm->eap_type_authsrv,


### PR DESCRIPTION
  This PR addresses two issues in `hostapd` related to PMKSA caching and internal EAP server logging:
  
    ### 1. Fix PAE state machine transition for PMKSA caching (Patch 197)
    **Reproduction Scenario:**
    Observed in ChromeOS Tast WPA3-Enterprise PMKSA caching tests (`wifi.PMKSACaching*`) when roaming between APs:
    1. STA connects to AP0, completes full EAP authentication, keys are installed, and the PMK is cached.
    2. STA roams to AP1.
    3. STA roams back to AP0 using the cached PMKSA entry (`EAPOL_SM_FROM_PMKSA_CACHE`).
    4. Upon reassociation / EAPOL-Start on AP0, the PAE state machine transitions via `SM_ENTER(AUTH_PAE, AUTHENTICATING)`, which executes `sm->authSuccess = false`.
    5. Because the PMK is already cached, full EAP is bypassed and no new EAP exchange runs, leaving `sm->authSuccess == false`.
    6. The WPA 4-way handshake completes and `wpa_auth` sets `sm->portValid = true`.
    7. In `SM_STEP(AUTH_PAE)`, the transition condition `(sm->authSuccess && sm->portValid)` fails because `authSuccess` is `0`, stranding the PAE state machine in
  `AUTH_PAE_AUTHENTICATING`.
  
    **Fix:**
    Allow transitioning from `AUTHENTICATING` to `AUTHENTICATED` in `SM_STEP(AUTH_PAE)` when `sm->portValid` is `true` and either `sm->authSuccess` or `(sm->flags &
  EAPOL_SM_FROM_PMKSA_CACHE)` is set. This guarantees that the transition to `AUTHENTICATED` occurs only after the 4-way handshake completes and keys are installed (`portValid == true`). 
  
  
    ### 2. Report EAP type from internal EAP server (Patch 198)
    When `hostapd` uses its integrated internal EAP server rather than an external RADIUS server, `sm->eap_type_authsrv` is not populated, causing successful authentication logs to print:
    `authenticated - EAP type: 0 (NONE)` instead of the active method (e.g. EAP-TLS, PEAP, TTLS).
  
    **Fix:**
    - Added a clean `eap_server_get_type(struct eap_sm *sm)` accessor to `src/eap_server/eap.h` and `src/eap_server/eap_server.c` without violating subsystem boundaries or including      
  private headers (`eap_i.h`).
    - In `SM_STATE(AUTH_PAE, AUTHENTICATED)`, populate `sm->eap_type_authsrv` via `eap_server_get_type(sm->eap)` when `sm->eap_type_authsrv == EAP_TYPE_NONE`.
    
   --- 
  