### PR TITLE
qualcommax: ipq807x: nbg7815: add LED, bluetooth, fan and temp sensor support

### DIFF
--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -390,6 +390,7 @@ generate_rssimon() {
 generate_led() {
 	local key="$1"
 	local cfg="led_$key"
+	local led_keys led_key led_value
 
 	json_select led
 	json_select "$key"
@@ -403,6 +404,19 @@ generate_led() {
 		set system.$cfg.trigger='$trigger'
 		set system.$cfg.default='$default'
 	EOF
+
+	# A multicolor LED carries one intensity per entry of its multi_index,
+	# which the led init script applies through multi_intensity.
+	json_get_keys led_keys
+	for led_key in $led_keys; do
+		case "$led_key" in
+			color_*) ;;
+			*) continue ;;
+		esac
+
+		json_get_var led_value "$led_key"
+		uci -q set "system.$cfg.$led_key=$led_value"
+	done
 
 	case "$type" in
 		gpio)

--- a/package/base-files/files/lib/functions/uci-defaults.sh
+++ b/package/base-files/files/lib/functions/uci-defaults.sh
@@ -428,6 +428,23 @@ _ucidef_set_led_common() {
 	json_add_string sysfs "$sysfs"
 }
 
+ucidef_set_led_colors() {
+	local cfg="$1"
+
+	shift
+
+	json_select_object led
+	json_select_object "$cfg"
+
+	while [ "$#" -gt 1 ]; do
+		json_add_string "color_$1" "$2"
+		shift 2
+	done
+
+	json_select ..
+	json_select ..
+}
+
 ucidef_set_led_default() {
 	local default="$4"
 

--- a/package/kernel/linux/modules/leds.mk
+++ b/package/kernel/linux/modules/leds.mk
@@ -366,3 +366,20 @@ define KernelPackage/leds-lp5562/description
 endef
 
 $(eval $(call KernelPackage,leds-lp5562))
+
+
+define KernelPackage/leds-lp5569
+  SUBMENU:=$(LEDS_MENU)
+  TITLE:=LED driver for LP5569 controllers
+  DEPENDS:=+kmod-i2c-core +kmod-leds-lp55xx-common
+  KCONFIG:=CONFIG_LEDS_LP5569
+  FILES:=$(LINUX_DIR)/drivers/leds/leds-lp5569.ko
+  AUTOLOAD:=$(call AutoLoad,60,leds-lp5569,1)
+endef
+
+define KernelPackage/leds-lp5569/description
+ This option enables support for Texas Instruments LP5569
+ LED controllers.
+endef
+
+$(eval $(call KernelPackage,leds-lp5569))

--- a/target/linux/qualcommax/dts/ipq8074-nbg7815.dts
+++ b/target/linux/qualcommax/dts/ipq8074-nbg7815.dts
@@ -43,6 +43,24 @@
 			gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 		};
 	};
+
+	fan: fan {
+		compatible = "gpio-fan";
+		gpios = <&tlmm 21 GPIO_ACTIVE_HIGH>;
+		/* nominal rpm of the stock fan */
+		gpio-fan,speed-map = <0 0>,
+				     <3000 1>;
+		#cooling-cells = <2>;
+	};
+
+	usb_vbus: regulator-usb-vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&tlmm 32 GPIO_ACTIVE_HIGH>;
+		regulator-boot-on;
+	};
 };
 
 &tlmm {
@@ -62,7 +80,27 @@
 		};
 	};
 
-	/* the stock firmware keeps gpio60 high to enable the LED board */
+	i2c_1_pins: i2c1-pins {
+		mux {
+			pins = "gpio50", "gpio51";
+			function = "blsp3_i2c";
+			drive-strength = <8>;
+			bias-disable;
+		};
+	};
+
+	/*
+	 * The stock firmware keeps these outputs high:
+	 * gpio22: second fan enable
+	 * gpio60: LED board enable
+	 */
+	fan2-en {
+		gpio-hog;
+		gpios = <22 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "fan2-enable";
+	};
+
 	led-en {
 		gpio-hog;
 		gpios = <60 GPIO_ACTIVE_HIGH>;
@@ -728,6 +766,33 @@
 };
 
 
+/* use the second I2C bus for the second temperature sensor */
+/delete-node/ &blsp1_spi4;
+
+&soc {
+	i2c@78b8000 {
+		compatible = "qcom,i2c-qup-v2.2.1";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x078b8000 0x600>;
+		interrupts = <GIC_SPI 98 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&gcc GCC_BLSP1_QUP4_I2C_APPS_CLK>,
+			 <&gcc GCC_BLSP1_AHB_CLK>;
+		clock-names = "core", "iface";
+		clock-frequency = <400000>;
+		dmas = <&blsp_dma 18>, <&blsp_dma 19>;
+		dma-names = "tx", "rx";
+		pinctrl-0 = <&i2c_1_pins>;
+		pinctrl-names = "default";
+		status = "okay";
+
+		tmp103@70 {
+			compatible = "ti,tmp103";
+			reg = <0x70>;
+		};
+	};
+};
+
 &sdhc_1 {
 	status = "okay";
 	/* unstable, problem with the hs400 > h200 speed switch */
@@ -750,6 +815,7 @@
 };
 
 &qusb_phy_1 {
+	vdd-supply = <&usb_vbus>;
 	status = "okay";
 };
 
@@ -765,4 +831,28 @@
 	status = "okay";
 
 	qcom,ath11k-calibration-variant = "Zyxel-NBG7815";
+};
+
+&cluster_thermal {
+	trips {
+		cluster_fan: cluster-fan {
+			/*
+			 * The stock firmware only switches the fan at 108/85
+			 * degC, which the SoC hardly ever reaches, so the case
+			 * gets uncomfortably hot under load first. Start it at
+			 * 85 degC instead, as discussed for this device in
+			 * https://github.com/openwrt/openwrt/pull/14210
+			 */
+			temperature = <85000>;
+			hysteresis = <5000>;
+			type = "active";
+		};
+	};
+
+	cooling-maps {
+		map2 {
+			trip = <&cluster_fan>;
+			cooling-device = <&fan THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+		};
+	};
 };

--- a/target/linux/qualcommax/dts/ipq8074-nbg7815.dts
+++ b/target/linux/qualcommax/dts/ipq8074-nbg7815.dts
@@ -18,6 +18,13 @@
 	compatible = "zyxel,nbg7815", "qcom,ipq8074";
 
 	aliases {
+		/*
+		 * No led-boot or led-failsafe: both states are set from
+		 * preinit, before the i2c driver for the controller is
+		 * loaded, so the LED does not exist yet at that point.
+		 */
+		led-running = &led_status;
+		led-upgrade = &led_status;
 		serial0 = &blsp1_uart5;
 		serial1 = &blsp1_uart3;
 		label-mac-device = &swport1;
@@ -54,9 +61,18 @@
 			bias-pull-up;
 		};
 	};
+
+	/* the stock firmware keeps gpio60 high to enable the LED board */
+	led-en {
+		gpio-hog;
+		gpios = <60 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "led-enable";
+	};
 };
 
 &blsp1_uart3 {
+	/* CSR8811 bluetooth, 4-wire HSUART on the hsuart_pins */
 	status = "okay";
 };
 
@@ -392,11 +408,325 @@
 	pinctrl-names = "default";
 	status = "okay";
 
+	/* front panel RGB LEDs, 6 pcs. */
+	lp5569@32 {
+		compatible = "ti,lp5569";
+		reg = <0x32>;
+		clock-mode = /bits/8 <1>; /* internal */
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		multi-led@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+			color = <LED_COLOR_ID_RGB>;
+
+			led@0 {
+				reg = <0>;
+				chan-name = "nbg7815:led1";
+				color = <LED_COLOR_ID_RED>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+
+			led@1 {
+				reg = <1>;
+				chan-name = "nbg7815:led1";
+				color = <LED_COLOR_ID_GREEN>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+
+			led@2 {
+				reg = <2>;
+				chan-name = "nbg7815:led1";
+				color = <LED_COLOR_ID_BLUE>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+		};
+
+		multi-led@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+			color = <LED_COLOR_ID_RGB>;
+
+			led@3 {
+				reg = <3>;
+				chan-name = "nbg7815:led2";
+				color = <LED_COLOR_ID_RED>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+
+			led@4 {
+				reg = <4>;
+				chan-name = "nbg7815:led2";
+				color = <LED_COLOR_ID_GREEN>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+
+			led@5 {
+				reg = <5>;
+				chan-name = "nbg7815:led2";
+				color = <LED_COLOR_ID_BLUE>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+		};
+
+		multi-led@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+			color = <LED_COLOR_ID_RGB>;
+
+			led@6 {
+				reg = <6>;
+				chan-name = "nbg7815:led3";
+				color = <LED_COLOR_ID_RED>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+
+			led@7 {
+				reg = <7>;
+				chan-name = "nbg7815:led3";
+				color = <LED_COLOR_ID_GREEN>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+
+			led@8 {
+				reg = <8>;
+				chan-name = "nbg7815:led3";
+				color = <LED_COLOR_ID_BLUE>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+		};
+	};
+
+	lp5569@35 {
+		compatible = "ti,lp5569";
+		reg = <0x35>;
+		clock-mode = /bits/8 <2>; /* external */
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		multi-led@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+			color = <LED_COLOR_ID_RGB>;
+
+			led@6 {
+				reg = <6>;
+				chan-name = "nbg7815:led4";
+				color = <LED_COLOR_ID_RED>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+
+			led@7 {
+				reg = <7>;
+				chan-name = "nbg7815:led4";
+				color = <LED_COLOR_ID_GREEN>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+
+			led@8 {
+				reg = <8>;
+				chan-name = "nbg7815:led4";
+				color = <LED_COLOR_ID_BLUE>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+		};
+
+		multi-led@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+			color = <LED_COLOR_ID_RGB>;
+
+			led@3 {
+				reg = <3>;
+				chan-name = "nbg7815:led5";
+				color = <LED_COLOR_ID_RED>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+
+			led@4 {
+				reg = <4>;
+				chan-name = "nbg7815:led5";
+				color = <LED_COLOR_ID_GREEN>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+
+			led@5 {
+				reg = <5>;
+				chan-name = "nbg7815:led5";
+				color = <LED_COLOR_ID_BLUE>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+		};
+
+		multi-led@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+			color = <LED_COLOR_ID_RGB>;
+
+			led@0 {
+				reg = <0>;
+				chan-name = "nbg7815:led6";
+				color = <LED_COLOR_ID_RED>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+
+			led@1 {
+				reg = <1>;
+				chan-name = "nbg7815:led6";
+				color = <LED_COLOR_ID_GREEN>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+
+			led@2 {
+				reg = <2>;
+				chan-name = "nbg7815:led6";
+				color = <LED_COLOR_ID_BLUE>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+		};
+	};
+
 	tmp103@70 {
 		compatible = "ti,tmp103";
 		reg = <0x70>;
 	};
+	/* third front panel RGB LED group (LED7-LED9); the chip answers to the
+	 * lp5569 register layout - a write to the pwm registers at 0x16 lights
+	 * the LEDs, while the lp50xx driver only got -EIO
+	 */
+	lp5569@40 {
+		compatible = "ti,lp5569";
+		reg = <0x40>;
+		clock-mode = /bits/8 <1>; /* internal */
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		led_status: multi-led@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+			color = <LED_COLOR_ID_RGB>;
+			/*
+			 * Read by get_dt_led() for the aliases above.
+			 * The driver only looks at "label" on the chip
+			 * node, so this does not rename the classdev.
+			 */
+			label = "nbg7815:led7";
+
+			led@0 {
+				reg = <0>;
+				chan-name = "nbg7815:led7";
+				color = <LED_COLOR_ID_RED>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+
+			led@1 {
+				reg = <1>;
+				chan-name = "nbg7815:led7";
+				color = <LED_COLOR_ID_GREEN>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+
+			led@2 {
+				reg = <2>;
+				chan-name = "nbg7815:led7";
+				color = <LED_COLOR_ID_BLUE>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+		};
+
+		multi-led@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+			color = <LED_COLOR_ID_RGB>;
+
+			led@3 {
+				reg = <3>;
+				chan-name = "nbg7815:led8";
+				color = <LED_COLOR_ID_RED>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+
+			led@4 {
+				reg = <4>;
+				chan-name = "nbg7815:led8";
+				color = <LED_COLOR_ID_GREEN>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+
+			led@5 {
+				reg = <5>;
+				chan-name = "nbg7815:led8";
+				color = <LED_COLOR_ID_BLUE>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+		};
+
+		multi-led@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+			color = <LED_COLOR_ID_RGB>;
+
+			led@6 {
+				reg = <6>;
+				chan-name = "nbg7815:led9";
+				color = <LED_COLOR_ID_RED>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+
+			led@7 {
+				reg = <7>;
+				chan-name = "nbg7815:led9";
+				color = <LED_COLOR_ID_GREEN>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+
+			led@8 {
+				reg = <8>;
+				chan-name = "nbg7815:led9";
+				color = <LED_COLOR_ID_BLUE>;
+				led-cur = /bits/8 <0xdf>;
+				max-cur = /bits/8 <0xff>;
+			};
+		};
+	};
 };
+
 
 &sdhc_1 {
 	status = "okay";

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -603,7 +603,8 @@ define Device/zyxel_nbg7815
 	SOC := ipq8074
 	DEVICE_PACKAGES := kmod-fs-f2fs f2fs-tools ipq-wifi-zyxel_nbg7815 kmod-ath11k-pci \
 		kmod-hci-uart kmod-hwmon-tmp103 \
-		kmod-leds-lp5569
+		kmod-leds-lp5569 \
+		bluez-daemon bluez-utils
 endef
 TARGET_DEVICES += zyxel_nbg7815
 

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -602,7 +602,7 @@ define Device/zyxel_nbg7815
 	DEVICE_DTS_CONFIG := config@nbg7815
 	SOC := ipq8074
 	DEVICE_PACKAGES := kmod-fs-f2fs f2fs-tools ipq-wifi-zyxel_nbg7815 kmod-ath11k-pci \
-		kmod-hci-uart kmod-hwmon-tmp103 \
+		kmod-hci-uart kmod-hwmon-tmp103 kmod-hwmon-gpiofan \
 		kmod-leds-lp5569 \
 		bluez-daemon bluez-utils
 endef

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -602,7 +602,8 @@ define Device/zyxel_nbg7815
 	DEVICE_DTS_CONFIG := config@nbg7815
 	SOC := ipq8074
 	DEVICE_PACKAGES := kmod-fs-f2fs f2fs-tools ipq-wifi-zyxel_nbg7815 kmod-ath11k-pci \
-		kmod-hci-uart kmod-hwmon-tmp103
+		kmod-hci-uart kmod-hwmon-tmp103 \
+		kmod-leds-lp5569
 endef
 TARGET_DEVICES += zyxel_nbg7815
 

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
@@ -74,6 +74,10 @@ yuncore,ax880)
 zbtlink,zbt-z800ax)
 	ucidef_set_led_netdev "internet" "Internet" "green:wan-online" "wan"
 	;;
+zyxel,nbg7815)
+	ucidef_set_led_default "led7" "LED7" "nbg7815:led7" "1"
+	ucidef_set_led_colors "led7" red 255 green 255 blue 255
+	;;
 esac
 
 board_config_flush

--- a/target/linux/qualcommax/ipq807x/base-files/etc/init.d/nbg7815-bluetooth
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/init.d/nbg7815-bluetooth
@@ -1,0 +1,70 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=96
+
+EXTRA_COMMANDS="attach"
+
+BLE_SERIAL=/dev/ttyMSM1
+
+gen_mac_psr() {
+	local lan_mac ble_mac
+
+	lan_mac=$(cat /sys/class/net/lan1/address 2>/dev/null) || return 0
+	ble_mac=$(macaddr_add "$lan_mac" 5) || return 0
+
+	mkdir -p /etc/bluetooth
+	echo "&0001 = 00${ble_mac:9:2} ${ble_mac:12:2}${ble_mac:15:2} 00${ble_mac:6:2} ${ble_mac:0:2}${ble_mac:3:2}" \
+		> /etc/bluetooth/csr8x11-mac.psr
+}
+
+load_psr() {
+	local file
+
+	for file in csr8x11-a12-bt4.2-patch.psr csr8x11-coex.psr csr8x11-mac.psr; do
+		[ -r /etc/bluetooth/$file ] || continue
+		# through logger, so that it is visible whether the keys made it
+		nbg7815-bt-pskey $BLE_SERIAL /etc/bluetooth/$file 2>&1 |
+			logger -t nbg7815-bluetooth
+	done
+}
+
+# procd runs this on every (re)start of the instance. The PSKEYs have to be
+# loaded again each time: a fresh attach resets the controller, and without
+# them it comes back with the CSR default address 00:02:5b:00:a5:a5 instead
+# of the one derived from the LAN MAC.
+attach() {
+	. /lib/functions/system.sh
+
+	gen_mac_psr
+
+	# PSKEYs before attach, following the stock order: the chip answers
+	# cleanly to the BCSP load and the attach follows, while loading over
+	# HCI after attach proved unreliable - the chip acks and keeps its
+	# defaults.
+	load_psr
+
+	# rc.common holds a lock on fd 1000 for as long as this script runs.
+	# hciattach must not inherit it, or every later call of the init script
+	# would block in procd_lock while the attach is up.
+	exec 1000>&-
+
+	# Powering the controller on is left to the bluetooth stack; bluetoothd
+	# enables what it finds. -n keeps hciattach in the foreground so that
+	# procd supervises it.
+	exec /usr/bin/hciattach -n -s 115200 $BLE_SERIAL bcsp 115200
+}
+
+start_service() {
+	[ "$(board_name)" = "zyxel,nbg7815" ] || return 0
+
+	[ -c $BLE_SERIAL ] || {
+		echo "nbg7815-bluetooth: $BLE_SERIAL not found" >&2
+		return 1
+	}
+
+	procd_open_instance
+	procd_set_param command "$initscript" attach
+	procd_set_param respawn
+	procd_close_instance
+}

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/keep.d/zyxel-nbg7815
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/keep.d/zyxel-nbg7815
@@ -1,0 +1,1 @@
+/etc/bluetooth/

--- a/target/linux/qualcommax/ipq807x/base-files/sbin/ath11k-160mhz
+++ b/target/linux/qualcommax/ipq807x/base-files/sbin/ath11k-160mhz
@@ -1,0 +1,208 @@
+#!/bin/sh
+# Switch the ath11k board file between the two radio layouts of the IPQ8074:
+#
+#   3 radios: 2x 5 GHz 4x4, max 80 MHz   (default, as shipped)
+#   2 radios: 1x 5 GHz 4x4, up to 160 MHz
+#
+# Byte 0x40 of the raw BDF carries the radio topology; bit 4 (0x10) enables
+# 160 MHz and drops the second 5 GHz radio - the chip cannot do both.
+# The u16 at 0x0a is a header checksum (~XOR over all u16 words); the
+# firmware rejects the board file without it. XOR is incremental, so
+# flipping bit 4 at 0x40 flips the same bit in the checksum - exactly two
+# bytes change.
+#
+# The uci sections of the second 5 GHz radio (path *wifi+2) are moved out of
+# the way and restored when switching back - marking them disabled is not
+# enough, netifd maps the phy first and retries ("PHY is undefined for
+# device", retry_setup_failed).
+#
+# Flipping the topology bit is not quite enough: the data blocks of the third
+# radio stay in the board file, the firmware keeps announcing a third phy and
+# the driver rejects its regulatory event, because the phy id is then >= the
+# number of radios it knows ("failed to process regulatory info -22", a
+# WARN_ON in ath11k_reg_handle_chan_list()). Board files of devices that are
+# built as two radio designs have zeroes in those blocks, so zero them too.
+# The offsets below were derived by comparing 29 such board files against 8
+# three radio ones and taking the positions where the two groups differ
+# consistently, aligned to the u16 grid the checksum works on.
+#
+# The board file comes from the ipq-wifi package, so the untouched original
+# is always readable below the overlay in /rom and no copy has to be kept.
+# Only the calibration data is built at runtime, by 11-ath11k-caldata out of
+# the 0:art partition, and that file is not touched here.
+#
+# A sysupgrade drops the modified board file and the device is back to three
+# radios, which is deliberate: keeping it would carry a stale board file past
+# an ipq-wifi update. Run this again after upgrading.
+
+BOARD=/lib/firmware/ath11k/IPQ8074/hw2.0/board-2.bin
+ORIG=/rom$BOARD
+SAVE=/etc/nbg7815-160mhz.radio.save
+DEVICE=zyxel,nbg7815
+VARIANT=Zyxel-NBG7815
+BIT=16					# 0x10
+
+# data blocks of the third radio, "offset length" into the raw BDF
+RADIO3="0x22c 2 0xac1a 36 0xaca8 2 0xb406 2 0x16800 6 0x16806 2 0x1680c 8
+	0x16816 2 0x1681c 4 0x16830 2 0x1683e 2 0x16844 4 0x16852 2 0x16858 4
+	0x16864 8 0x16870 8 0x16880 4 0x16894 4 0x168a8 4 0x168bc 4
+	0x1b8cc 128 0x1b95a 300"
+RADIO3_END=113286			# 0x1b95a + 300, highest offset used above
+
+rd() { hexdump -v -s "$1" -n "$2" -e "1/$2 \"%u\"" "$BOARD"; }
+wr() { printf "$(printf '\\%03o' "$2")" | dd of="$BOARD" bs=1 seek="$1" \
+	count=1 conv=notrunc 2>/dev/null; }
+wr16() {
+	wr "$1" $(($2 & 255))
+	wr $(($1 + 1)) $((($2 >> 8) & 255))
+}
+
+. /lib/functions.sh
+
+board=$(board_name)
+[ "$board" = "$DEVICE" ] || {
+	echo "refusing to run: this is for $DEVICE, board is '${board:-unknown}'" >&2
+	exit 1; }
+[ -f "$BOARD" ] || { echo "no board file: $BOARD" >&2; exit 1; }
+
+# board-2.bin: 20 byte signature, then {u32 id, u32 len} TLVs; the board
+# entry holds a name TLV followed by the raw BDF as data TLV. Only a
+# single-entry board file with our variant is touched - offsets would be
+# wrong for anything else.
+NAMELEN=$(rd 32 4)
+BDF=$((36 + NAMELEN + (4 - NAMELEN % 4) % 4 + 8))
+NAME=$(dd if="$BOARD" bs=1 skip=36 count="$NAMELEN" 2>/dev/null)
+case "$NAME" in
+*variant=$VARIANT) ;;
+*)	echo "refusing to run: unexpected board file entry '$NAME'" >&2; exit 1 ;;
+esac
+[ "$(rd $((BDF - 8)) 4)" = "1" ] || { echo "unexpected board file layout" >&2; exit 1; }
+
+# The offsets below are only valid for a board file of the known layout, and
+# dd would happily write past the end and leave a longer file behind whose
+# checksum is consistent over the wrong bytes. The data TLV length sits right
+# in front of the board data.
+BDFLEN=$(rd $((BDF - 4)) 4)
+[ "$BDFLEN" -ge "$RADIO3_END" ] && \
+[ "$(wc -c < "$BOARD")" -ge $((BDF + RADIO3_END)) ] || {
+	echo "refusing to run: the third radio blocks end at $RADIO3_END, but" \
+		"the board data declares $BDFLEN bytes and the file holds" \
+		"$(($(wc -c < "$BOARD") - BDF))" >&2
+	exit 1; }
+
+TOPO=$(rd $((BDF + 64)) 1)
+[ $((TOPO / BIT % 2)) = 1 ] && MODE=160 || MODE=80
+
+show() {
+	if [ "$1" = 160 ]; then
+		echo "2 radios: 1x 5 GHz (160 MHz) + 2.4 GHz"
+	else
+		echo "3 radios: 2x 5 GHz (max 80 MHz) + 2.4 GHz"
+	fi
+}
+
+# uci section of the second 5 GHz radio, gone in 160 MHz mode
+radio2() {
+	uci show wireless 2>/dev/null |
+		sed -n "s/^wireless\.\([^.]*\)\.path='.*wifi+2'$/\1/p"
+}
+
+config() {				# $1 = new mode
+	if [ "$1" = 160 ]; then
+		for r in $(radio2); do
+			ifaces=$(uci show wireless |
+				sed -n "s/^wireless\.\([^.]*\)\.device='$r'$/\1/p")
+			for s in $r $ifaces; do
+				uci show "wireless.$s" | sed 's/^/uci -q set /'
+			done >> "$SAVE"
+			for s in $ifaces $r; do uci -q delete "wireless.$s"; done
+			echo "removed $r $ifaces (no second 5 GHz radio in this mode,"
+			echo "  saved in $SAVE and restored when switching back)"
+		done
+	elif [ -f "$SAVE" ]; then
+		. "$SAVE" && rm -f "$SAVE"
+		echo "restored the second 5 GHz radio config"
+	fi
+	uci commit wireless
+}
+
+reload() {
+	wifi down 2>/dev/null
+	rmmod ath11k_ahb 2>/dev/null
+	sleep 2
+	modprobe ath11k_ahb
+	sleep 15
+	wifi up 2>/dev/null
+	echo "radios now: $(ls /sys/class/ieee80211/ | tr '\n' ' ')"
+}
+
+# Set the topology bit and drop the third radio blocks. Every touched u16 ends
+# up zero, so the checksum delta is just the xor of the original words.
+patch160() {
+	local topo csum off len w
+
+	topo=$(rd $((BDF + 64)) 1)
+	csum=$(($(rd $((BDF + 10)) 2) ^ BIT))
+	wr $((BDF + 64)) $((topo | BIT))
+
+	set -- $RADIO3
+	while [ $# -ge 2 ]; do
+		off=$(($1))
+		len=$2
+		shift 2
+
+		for w in $(hexdump -v -s $((BDF + off)) -n "$len" \
+				-e '1/2 "%u "' "$ORIG"); do
+			csum=$((csum ^ w))
+		done
+
+		dd if=/dev/zero of="$BOARD" bs=1 seek=$((BDF + off)) \
+			count="$len" conv=notrunc 2>/dev/null
+	done
+
+	wr16 $((BDF + 10)) $csum
+}
+
+switch() {
+	[ -f "$ORIG" ] || {
+		echo "no pristine board file below the overlay: $ORIG" >&2
+		exit 1; }
+
+	# Going to 160 MHz starts from an unmodified board file, so the two have
+	# to be identical here. If they are not, something else replaced it - an
+	# ipq-wifi update writes a new one into the overlay while /rom keeps the
+	# one from the image - and patching the wrong data is worse than doing
+	# nothing.
+	if [ "$MODE" = 80 ] && ! cmp -s "$ORIG" "$BOARD"; then
+		echo "refusing to run: $BOARD differs from $ORIG, so it is not the" \
+			"board file this script knows" >&2
+		exit 1
+	fi
+
+	[ "$MODE" = 160 ] && MODE=80 || MODE=160
+
+	cp "$ORIG" "$BOARD" || exit 1
+	[ "$MODE" = 160 ] && patch160
+
+	config "$MODE"
+	echo "switched to: $(show $MODE)"
+
+	if [ "$MODE" = 160 ]; then
+		echo "note: a sysupgrade restores the board file from the image," \
+			"run '${0##*/} 160' again afterwards"
+	fi
+}
+
+case "$1" in
+160)	[ "$MODE" = 160 ] && { echo "already $(show $MODE)"; exit 0; }; switch ;;
+80|3)	[ "$MODE" = 80 ] && { echo "already $(show $MODE)"; exit 0; }; switch ;;
+toggle)	switch ;;
+status|"")
+	show "$MODE"; exit 0 ;;
+*)	echo "usage: ${0##*/} [status|160|80|toggle] [reload]" >&2; exit 1 ;;
+esac
+
+case "$2" in
+reload)	reload; echo "a reboot is still recommended to start from a clean state" ;;
+*)	echo "reboot to apply (recommended), or run '${0##*/} $1 reload'" ;;
+esac

--- a/target/linux/qualcommax/ipq807x/base-files/usr/bin/nbg7815-bt-pskey
+++ b/target/linux/qualcommax/ipq807x/base-files/usr/bin/nbg7815-bt-pskey
@@ -1,0 +1,155 @@
+#!/usr/bin/ucode
+// Load CSR PSKEYs over BCSP, the subset of bccmd this board needs.
+//
+//   nbg7815-bt-pskey /dev/ttyMSM1 FILE...
+//
+// Must run while the tty is free, i.e. before hciattach. PSKEYs only take
+// effect this way: sent over HCI after the attach the chip acknowledges
+// them but keeps its defaults.
+import { open, lsdir, basename, IOC_DIR_WRITE } from 'fs';
+
+const SYNC = '\xda\xdc\xed\xed', SYNC_R = '\xac\xaf\xef\xee';
+const CONF = '\xad\xef\xac\xed', CONF_R = '\xde\xad\xd0\xd0';
+
+let tty = ARGV[0], files = slice(ARGV, 1);
+if (!tty || !length(files)) { warn('usage: nbg7815-bt-pskey TTY FILE...\n'); exit(2); }
+
+// hciattach owns the port once the line discipline is attached, and talking
+// BCSP into it from here just hangs. The HCI device shows up below the tty.
+if (length(lsdir(`/sys/class/tty/${basename(tty)}`, /^hci[0-9]+$/))) {
+	warn(`${tty}: already attached, stop the bluetooth service first\n`);
+	exit(1);
+}
+
+let fd = open(tty, 'r+');
+if (!fd) { warn(`${tty}: cannot open\n`); exit(1); }
+
+// 115200 8E1, raw, no flow control: B115200|CS8|CREAD|CLOCAL|PARENB in
+// c_cflag, everything else cleared. BCSP needs even parity - bccmd sets it
+// the same way. VMIN=0/VTIME=1 makes read() return after 0.1s even when
+// nothing arrives, so the loops below cannot block. Built rather than left
+// to stty, which busybox does not have. fs.ioctl() passes a raw request
+// number through when the num argument is null, so TCSETS is reachable.
+let le32 = (v) => chr(v & 0xff) + chr((v >> 8) & 0xff) + chr((v >> 16) & 0xff) + chr(v >> 24);
+let tio = le32(0) + le32(0) + le32(0x19b2) + le32(0) + '\x00';
+for (let i = 0; i < 19; i++) tio += chr(i == 5 ? 1 : 0);   // c_cc, VTIME = 1
+if (fd.ioctl(IOC_DIR_WRITE, 0x5402, null, tio) == null) {
+	warn(`${tty}: cannot set line settings\n`);
+	exit(1);
+}
+
+let send = (p) => { fd.write(p); fd.flush(); };
+
+// BCSP header (reliable/ack/seq, protocol id + length, checksum) in a SLIP
+// frame. No CRC: the chip accepts packets with the crc bit clear.
+let pkt = (proto, rel, seq, ack, pl) => {
+	let n = length(pl);
+	let a = (rel << 7) | (ack << 3) | seq, b = ((n & 0x0f) << 4) | proto, c = n >> 4;
+	let s = chr(a) + chr(b) + chr(c) + chr(~(a + b + c) & 0xff) + pl, o = '\xc0';
+	for (let i = 0; i < length(s); i++) {
+		let ch = substr(s, i, 1);
+		o += (ch == '\xc0') ? '\xdb\xdc' : (ch == '\xdb') ? '\xdb\xdd' : ch;
+	}
+	return o + '\xc0';
+};
+
+// Read what arrived and split it into frames at the 0xc0 delimiters, undoing
+// the escaping. Scanning the raw buffer for byte patterns is not enough - a
+// frame can straddle two reads and escapes would hide the payload.
+let frames = () => {
+	let buf = fd.read(2048) ?? '';
+	// A VTIME timeout surfaces as a zero byte read, which the buffered handle
+	// latches as EOF: every later read would return nothing. Reopening clears
+	// that, and the buffer is drained at this point, so nothing is lost.
+	if (length(buf) < 2048) { fd.close(); fd = open(tty, 'r+'); }
+	let out = [], cur = null;
+	for (let i = 0; i < length(buf); i++) {
+		let b = ord(buf, i);
+		if (b == 0xc0) {
+			if (length(cur) >= 4) push(out, cur);
+			cur = '';
+		} else if (cur != null) {
+			if (b == 0xdb && i + 1 < length(buf)) b = (ord(buf, ++i) == 0xdc) ? 0xc0 : 0xdb;
+			cur += chr(b);
+		}
+	}
+	return out;
+};
+
+let payload = (f) => substr(f, 4, (ord(f, 1) >> 4) | (ord(f, 2) << 4));
+let proto = (f) => ord(f, 1) & 0x0f;
+let ackof = (f) => (ord(f, 0) >> 3) & 7;
+
+// Link establishment. Both sides run the same state machine, so the peer's
+// sync/conf have to be answered - otherwise it never leaves its sync phase.
+// One read can hold dozens of repeats, hence answer per round, not per frame.
+let establish = () => {
+	let synced = false;
+	for (let i = 0; i < 300; i++) {
+		let got = '';
+		for (let f in frames())
+			if (proto(f) == 1) got += payload(f);
+		if (index(got, SYNC_R) >= 0) synced = true;
+		if (index(got, SYNC) >= 0) send(pkt(1, 0, 0, 0, SYNC_R));
+		if (index(got, CONF) >= 0) send(pkt(1, 0, 0, 0, CONF_R));
+		if (synced && index(got, CONF_R) >= 0) return true;
+		send(pkt(1, 0, 0, 0, synced ? CONF : SYNC));
+	}
+	return false;
+};
+
+let seq = 0, sn = 0;
+
+// One BCCMD, then wait for the vendor event that carries its status. The
+// transport ack says nothing about acceptance - a rejected key is acked too.
+// Reset varids get no answer, the chip is already restarting.
+let bccmd = (varid, args) => {
+	// Short commands are rounded up to nine words and zero padded, exactly as
+	// bccmd does - the chip drops anything shorter, warm reset included.
+	let sz = (length(args) < 4) ? 9 : length(args) + 5;
+	let d = '\xc2';
+	for (let v in [ 0x0002, sz, sn++, varid, 0, ...args ]) d += chr(v & 0xff) + chr(v >> 8);
+	while (length(d) < sz * 2 + 1) d += '\x00';
+	let pl = '\x00\xfc' + chr(length(d)) + d, acked = false;
+	for (let i = 0; i < 40; i++) {
+		if (!acked) send(pkt(5, 1, seq, 0, pl));
+		for (let f in frames()) {
+			if (proto(f) == 1 && payload(f) == SYNC) send(pkt(1, 0, 0, 0, SYNC_R));
+			if (!acked && ackof(f) == (seq + 1) % 8) {
+				seq = (seq + 1) % 8;
+				if (varid == 0x4002) return true;
+				acked = true;
+			}
+			if (proto(f) != 5) continue;
+			if (ord(f, 0) & 0x80)          // reliable, so ack it or it repeats
+				send(pkt(0, 0, 0, ((ord(f, 0) & 7) + 1) % 8, ''));
+			let r = payload(f);
+			if (ord(r, 0) == 0xff && ord(r, 2) == 0xc2)
+				return (ord(r, 11) | (ord(r, 12) << 8)) == 0;
+		}
+	}
+	return false;
+};
+
+if (!establish()) { warn('BCSP link establishment failed\n'); exit(1); }
+
+let n = 0;
+for (let f in files) {
+	let src = open(f, 'r');
+	if (!src) { warn(`${f}: cannot read\n`); continue; }
+	for (let l = src.read('line'); length(l); l = src.read('line')) {
+		let m = match(l, /^&([0-9a-fA-F]+)[ \t]*=[ \t]*([0-9a-fA-F ]+)/);
+		if (!m) continue;
+		let val = [];
+		for (let x in split(trim(m[2]), /[ \t]+/)) push(val, hex(x));
+		if (bccmd(0x7003, [ hex(m[1]), length(val), 0x0008, ...val ]))
+			n++;
+		else
+			warn(sprintf('pskey 0x%04x rejected\n', hex(m[1])));
+	}
+	src.close();
+}
+
+bccmd(0x4002, []);                 // warm reset
+fd.close();
+warn(`${n} keys loaded\n`);


### PR DESCRIPTION
This completes the hardware support for the Zyxel NBG7815 (Armor G5), which
has been in the tree since #11818 but so far covers neither the front panel
LEDs nor the fan, the second temperature sensor or Bluetooth.

Everything was tested on the device, on a clean `sysupgrade -n` install.

### The commits

1. **`base-files: support per-color intensities for multicolor LEDs`**
   The led init script has been able to drive a multicolor LED for a while
   (`led_color_set()` reads `multi_index` and writes `multi_intensity` from
   `color_<name>` options), but `generate_led()` never passed those options
   on, so no board could reach the feature - a multicolor LED stayed dark
   whatever trigger was configured. This passes `color_*` through and adds
   `ucidef_set_led_colors()`. No board in the tree sets `color_*` today, so
   nothing changes for existing devices.

2. **`linux/modules: add kmod-leds-lp5569`**
   The driver is in mainline, the package was missing. Modelled after
   `kmod-leds-lp5562` (#14290).

3. **`add RGB LED support`** - three LP5569 on the first I2C bus, nine RGB
   LEDs. The third one is at 0x40, where the schematics say LP5009 and where
   the lp50xx driver only ever got -EIO; it answers to the lp5569 register
   layout instead. Channel mapping and LED currents taken from the stock
   firmware; LED7 is set to white through `board.d`. A camera measurement in
   the thread shows why: LED1-6 are the bar, LED7-9 feed one brighter element
   in its middle, and that is the one the stock firmware keeps driving in
   every state. It is also the target of the `led-running` and `led-upgrade`
   aliases. `led-boot` and `led-failsafe` are left out on purpose: both are
   set from preinit, before the i2c driver is loaded, so the LED does not
   exist yet - verified by recording a boot.

4. **`add bluetooth support`** - CSR8811 on a 4-wire HSUART. A procd service
   loads the PSKEYs and supervises `hciattach`. The PSKEY loader is ucode
   rather than `bccmd`: that tool was dropped from bluez after 5.55 and is
   not packaged, and packaging it was rejected in openwrt/packages#20383.
   The two stock PSKEY files are not part of this PR; without them the
   controller works, it just reports 4.1 and misses the coexistence tuning.

5. **`add fan and second temp sensor support`** - `gpio-fan` as a cooling
   device with an active trip on the CPU cluster, plus the second tmp103 and
   the USB VBUS regulator. The trip is at 85 degC with 5 degC hysteresis;
   the commit message quotes the stock `fanctld` config, whose 108/85 degC
   points are the context for deviating from them.

6. **`add a 160 MHz switch for the board file`** - the IPQ8074 can drive
   either two 5 GHz radios at 80 MHz or one at 160 MHz. The board file
   selects the two radio layout, so 160 MHz is unreachable at runtime; the
   script flips the bit and fixes the board file checksum.

### Relation to existing PRs

The LED and fan areas overlap with two PRs that are still open:

* #15504 (LEDs) - the lp5569 driver has since landed in mainline, so the
  backports there are no longer needed. The `kmod-leds-lp5569` definition in
  commit 2 is identical to the one in that PR.
* #14210 (fan) - the `gpio-fan` node here matches that PR (TLMM 21, active
  high). It deliberately does **not** bind the AQR PHY as a thermal zone:
  its driver rejects the low trip the thermal core installs by default, the
  problem reported in #16625 and #14210.

@Ansuel - this picks up work you started in #15504 and #14210. If you would
rather rebase those yourself, say so and I will drop the corresponding
commits here.

Also related: #11835 (why there is no userspace fan script and no downstream
LED driver), #12010 (`kmod-hci-uart`), #16625.

### One question for the maintainers

Commit 4 lists `bluez-daemon bluez-utils` in `DEVICE_PACKAGES`. @robimarko,
you noted in #14883 that bluez is not in the core repository and cannot be
included by default, so this needs a decision.

I would like to keep both, because only together do they make the hardware
usable: `hciattach` lives in `bluez-utils`, and `bluetoothd` is what powers
the controller on - without it `hci0` stays down after the attach. Shipping
only the kmod is what this device had so far, and it left the controller
described but dead, which is why it kept coming up as an open question
(#11818, #12010, #21712).

If feed packages in `DEVICE_PACKAGES` are not acceptable here at all, the
fallback is to drop both and document the installation in the commit
message, as was done in #11818 - but that trades a working feature for a
formality.

### Testing

Cold boot after `sysupgrade -n`, so with a freshly generated config:

* LEDs: all nine appear with the expected names, LED7 comes up white through
  `board.d` -> `board.json` -> `config_generate` -> `multi_intensity`.
  Placement and colours were measured with a camera, see the thread. The
  same camera confirmed the two LED states: the LED comes on once the system
  is up, and blinks 200 ms on / 200 ms off through a real `sysupgrade`
* Bluetooth: `hci0` up, address derived from the LAN MAC, `HCI Version: 4.2`
  with the stock PSKEY files, 4.1 without them
* Both tmp103 sensors present, `gpio-fan` registered as a cooling device.
  The fan itself was driven through its hwmon `pwm1` and audibly spins up
  and stops again
* `dtc` reports no new warnings for this DTS