### PR TITLE
ramips: add support for GL.iNet GL-MG1300

### DIFF
--- a/target/linux/generic/pending-6.18/478-mtd-spi-nor-add-eon-en25qe16a.patch
+++ b/target/linux/generic/pending-6.18/478-mtd-spi-nor-add-eon-en25qe16a.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: GLiNet Tech <glrouter@gl-inet.com>
+Date: Mon, 24 Aug 2026 10:42:14 +0800
+Subject: [PATCH] mtd: spi-nor: add support for EON EN25QE16A
+
+The GL-MG1300 uses a 2MB EON EN25QE16A (JEDEC ID 0x1c4115) SPI-NOR
+flash for bootloader and factory data.
+
+Signed-off-by: GLiNet Tech <glrouter@gl-inet.com>
+---
+ drivers/mtd/spi-nor/eon.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+--- a/drivers/mtd/spi-nor/eon.c
++++ b/drivers/mtd/spi-nor/eon.c
+@@ -18,6 +18,11 @@ static const struct flash_info eon_nor_p
+ 		.name = "en25p64",
+ 		.size = SZ_8M,
+ 	}, {
++		.id = SNOR_ID(0x1c, 0x41, 0x15),
++		.name = "en25qe16a",
++		.size = SZ_2M,
++		.no_sfdp_flags = SECT_4K,
++	}, {
+ 		.id = SNOR_ID(0x1c, 0x30, 0x18),
+ 		.name = "en25q128",
+ 		.size = SZ_16M,

--- a/target/linux/ramips/dts/mt7621_glinet_gl-mg1300.dts
+++ b/target/linux/ramips/dts/mt7621_glinet_gl-mg1300.dts
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "glinet,gl-mg1300", "mediatek,mt7621-soc";
+	model = "GL.iNet GL-MG1300";
+
+	aliases {
+		led-boot = &led_run;
+		led-failsafe = &led_run;
+		led-running = &led_run;
+		led-upgrade = &led_run;
+		label-mac-device = &gmac1;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		switch {
+			label = "switch";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_run: run {
+			color = <LED_COLOR_ID_BLUE>;
+			function = "run";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		system {
+			color = <LED_COLOR_ID_WHITE>;
+			function = "system";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		usb_power {
+			gpio-export,name = "usb_power";
+			gpio-export,output = <1>;
+			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		broken-flash-reset;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x80000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "u-boot-env";
+				reg = <0x80000 0x10000>;
+				read-only;
+			};
+
+			partition@90000 {
+				label = "factory";
+				reg = <0x90000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x4da8>;
+					};
+
+					macaddr_factory_4000: macaddr@4000 {
+						compatible = "mac-base";
+						reg = <0x4000 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@a0000 {
+				label = "log";
+				reg = <0xa0000 0x40000>;
+			};
+
+			partition@e0000 {
+				label = "CFG";
+				reg = <0xe0000 0x20000>;
+			};
+		};
+	};
+
+	flash@1 {
+		compatible = "spi-nand";
+		reg = <1>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ubi";
+				reg = <0x0 0x0>;
+				compatible = "linux,ubi";
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		band@0 {
+			reg = <0>;
+			nvmem-cells = <&macaddr_factory_4000 2>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		band@1 {
+			reg = <1>;
+			nvmem-cells = <&macaddr_factory_4000 3>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_4000 1>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_factory_4000 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethphy4 {
+	/delete-property/ interrupts;
+};
+
+&switch0 {
+	ports {
+		port@2 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "uart2", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1597,6 +1597,16 @@ define Device/genexis_pulse-ex400
 endef
 TARGET_DEVICES += genexis_pulse-ex400
 
+define Device/glinet_gl-mg1300
+  $(Device/nand)
+  DEVICE_VENDOR := GL.iNet
+  DEVICE_MODEL := GL-MG1300
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 -uboot-envtools
+  IMAGE_SIZE := 129024k
+  KERNEL_IN_UBI := 1
+endef
+TARGET_DEVICES += glinet_gl-mg1300
+
 define Device/glinet_gl-mt1300
   $(Device/dsa-migration)
   IMAGE_SIZE := 32448k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -83,6 +83,7 @@ ramips_setup_interfaces()
 	cudy,m1800|\
 	dna,valokuitu-plus-ex400|\
 	genexis,pulse-ex400|\
+	glinet,gl-mg1300|\
 	humax,e10|\
 	keenetic,kn-3510|\
 	maginon,mc-1200ac|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -108,6 +108,7 @@ platform_do_upgrade() {
 	hiwifi,hc5962|\
 	gemtek,wvrtm-127acn|\
 	gemtek,wvrtm-130acn|\
+	glinet,gl-mg1300|\
 	iptime,a3004t|\
 	iptime,ax2002m|\
 	iptime,ax2004m|\


### PR DESCRIPTION
This patch adds support for GL.iNet GL-MG1300 (Mango 2). The GL.iNet GL-MG1300 is a dual-band mini travel router with Wi-Fi 5, featuring one gigabit WAN port, one gigabit LAN port and one USB 3.0 port.

Product page: https://www.gl-inet.com/products/gl-mg1300

Hardware Specification:
 - SoC: MediaTek MT7621A (Dual-core MIPS 1004Kc 880 MHz)
 - RAM: 128 MiB DDR3
 - Flash: 2 MiB SPI-NOR (EON EN25QE16A) + 128 MiB SPI-NAND
 - WiFi: MediaTek MT7615D (DBDC, WiFi 5)
 - 2.4GHz: b/g/n (2x2 MIMO)
 - 5GHz: a/n/ac (2x2 MIMO)
 - Ethernet:
 - 1x 10/100/1000 Mbps WAN
 - 1x 10/100/1000 Mbps LAN
 - USB: 1x USB 3.0 (power controlled by GPIO 12, exported as usb_power)
 - Buttons: Reset, Switch (slide switch)
 - LEDs: 1x dual-color status LED (blue + white) (two GPIO-driven dies, one visible indicator on the enclosure)
 - UART: 115200 8n1 (RX, TX, GND)

Flash Layout (SPI-NOR):
 - 0x0~0x80000 : u-boot
 - 0x80000~0x90000 : u-boot-env
 - 0x90000~0xa0000 : factory
 - 0xa0000~0xe0000 : log
 - 0xe0000~0x100000 : CFG

Flash Layout (SPI-NAND):
 - 0x0~0x8000000 : ubi

MAC Addresses:
 - Base MAC located at factory partition offset 0x4000
 - gmac1 (WAN) : Base + 0 (Label MAC)
 - gmac0 (LAN) : Base + 1
 - 2.4GHz WiFi : Base + 2
 - 5GHz WiFi : Base + 3

Installation:
 1. You can directly upgrade using the openwrt-ramips-mt7621-glinet_gl-mg1300-squashfs-sysupgrade.bin image on the official GL firmware upgrade page.
 2. Access the device and use the sysupgrade command to upgrade. Note: When upgrading from official firmware, use the -n parameter to preserve no configuration.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
