### PR TITLE
mediatek: filogic: add Keenetic KN-3812 support

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3812.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3812.dts
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+
+/dts-v1/;
+
+#include "mt7981b.dtsi"
+
+/ {
+	model = "Keenetic KN-3812";
+	compatible = "keenetic,kn-3812", "mediatek,mt7981";
+
+	aliases {
+		label-mac-device = &gmac1;
+		led-boot = &status_led;
+		led-failsafe = &status_led;
+		led-running = &status_led;
+		led-upgrade = &status_led;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 24 GPIO_ACTIVE_LOW>;
+		};
+
+		button-wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 29 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		status_led: led-status-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 11 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-status-orange {
+			color = <LED_COLOR_ID_ORANGE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+	};
+
+	usb_vbus: regulator-usb-vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&pio 6 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-boot-on;
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&firmware1 &storage1 &firmware2 &storage2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x600000>;
+			};
+
+			partition@600000 {
+				label = "ubi";
+				reg = <0x600000 0x0>;
+			};
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4>;
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+		label = "wan";
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_a>;
+	};
+};
+
+&mdio_bus {
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <0x1f>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	/* Winbond W25N02KV (256M) */
+	spi_nand@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <256>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			/* bl2 */
+			partition@0 {
+				label = "preloader";
+				reg = <0x0 0x80000>;
+				read-only;
+			};
+
+			/* fip */
+			partition@80000 {
+				label = "u-boot";
+				reg = <0x80000 0x200000>;
+				read-only;
+			};
+
+			partition@280000 {
+				label = "u-config";
+				reg = <0x280000 0x80000>;
+				read-only;
+			};
+
+			partition@300000 {
+				label = "rf-eeprom";
+				reg = <0x300000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					/* lan mac */
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+
+					/* wan mac */
+					macaddr_factory_a: macaddr@a {
+						reg = <0xa 0x6>;
+					};
+				};
+			};
+
+			firmware1: partition@500000 {
+				label = "firmware_1";
+				reg = <0x500000 0x3a00000>;
+			};
+
+			partition@3f00000 {
+				label = "config_1";
+				reg = <0x3f00000 0x80000>;
+				read-only;
+			};
+
+			partition@3f80000 {
+				label = "dump";
+				reg = <0x3f80000 0x80000>;
+				read-only;
+			};
+
+			storage1: partition@4000000 {
+				label = "storage_a";
+				reg = <0x4000000 0x3800000>;
+			};
+
+			partition@7800000 {
+				label = "u-state";
+				reg = <0x7800000 0x80000>;
+				read-only;
+			};
+
+			partition@7a80000 {
+				label = "d-state";
+				reg = <0x7a80000 0x80000>;
+				read-only;
+			};
+
+			partition@7b00000 {
+				label = "rf-eeprom_res";
+				reg = <0x7b00000 0x200000>;
+				read-only;
+			};
+
+			firmware2: partition@7d00000 {
+				label = "firmware_2";
+				reg = <0x7d00000 0x3a00000>;
+			};
+
+			partition@b700000 {
+				label = "config_2";
+				reg = <0xb700000 0x80000>;
+				read-only;
+			};
+
+			storage2: partition@b780000 {
+				label = "storage_b";
+				reg = <0xb780000 0x3880000>;
+			};
+		};
+	};
+};
+
+&wifi {
+	nvmem-cell-names = "eeprom";
+	nvmem-cells = <&eeprom_factory_0>;
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
+	vbus-supply = <&usb_vbus>;
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -159,6 +159,10 @@ keenetic,kn-3711|\
 keenetic,kn-3811)
 	ucidef_set_led_netdev "internet" "internet" "green:wan" "wan" "link"
 	;;
+keenetic,kn-3812)
+	ucidef_set_led_netdev "internet" "internet" "green:status" "wan" "link"
+	ucidef_set_led_default "wps" "WPS" "orange:status" "0"
+	;;
 livinet,li320)
 	ucidef_set_led_netdev "wlan2g" "WLAN2G" "green:wlan-2ghz" "phy0-ap0"
 	ucidef_set_led_netdev "wlan5g" "WLAN5G" "green:wlan-5ghz" "phy1-ap0"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -66,6 +66,7 @@ mediatek_setup_interfaces()
 	jcg,q30-pro|\
 	keenetic,kn-3711|\
 	keenetic,kn-3811|\
+	keenetic,kn-3812|\
 	livinet,li320|\
 	mercusys,mr85x|\
 	mercusys,mr85x-ubi|\

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -179,6 +179,7 @@ case "$board" in
 	keenetic,kap-630|\
 	keenetic,kn-3711|\
 	keenetic,kn-3811|\
+	keenetic,kn-3812|\
 	keenetic,kn-3911|\
 	netcraze,nap-630)
 		[ "$PHYNBR" = "1" ] && \

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2331,6 +2331,26 @@ define Device/keenetic_kn-3811
 endef
 TARGET_DEVICES += keenetic_kn-3811
 
+define Device/keenetic_kn-3812
+  DEVICE_VENDOR := Keenetic
+  DEVICE_MODEL := KN-3812
+  DEVICE_DTS := mt7981b-keenetic-kn-3812
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 6144k
+  IMAGE_SIZE := 233984k
+  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
+	append-squashfs4-fakeroot
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
+	append-ubi | check-size | zyimage -d 0x803812 -v "KN-3812"
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += keenetic_kn-3812
+
 define Device/keenetic_kn-3911
   DEVICE_VENDOR := Keenetic
   DEVICE_MODEL := KN-3911


### PR DESCRIPTION
Add support for the Keenetic KN-3812 (Hopper SE), based on the
MediaTek MT7981 platform.

Hardware:
 * SoC: MediaTek MT7981BA, dual-core 1.3 GHz
 * RAM: 512 MB DDR4
 * Flash: 256 MB SPI-NAND, Winbond W25N02KV
 * Wi-Fi: MediaTek MT7976CN, 802.11ax
   * 2.4 GHz: 2T2R, 2SS, up to 40 MHz
   * 5 GHz: 3T3R, 2SS, up to 160 MHz
 * Ethernet: 3x 1 GbE LAN via MediaTek MT7531AE switch
 * Ethernet: 1x 1 GbE WAN via MT7981 internal PHY
 * LED: dual-color green/orange status LED
 * Buttons: WPS/Wi-Fi and reset
 * USB: 1x USB 3.0
 * UART: internal 3-pin GND/RX/TX header, 115200 8N1
 * Power: 12 V, 1.5 A

MAC address layout:
 * LAN: xx:xx:xx:xx:xx:xx, rf-eeprom + 0x4
 * WAN: xx:xx:xx:xx:xx:xx, rf-eeprom + 0xa
 * 2.4 GHz: xx:xx:xx:xx:xx:xx, from the Wi-Fi EEPROM in rf-eeprom
 * 5 GHz: xx:xx:xx:xx:xx:xx, derived from the LAN MAC with the
   locally administered bit set

Installation:
 1. Configure the host with the static address 192.168.1.2/24 and
    start a TFTP server.
 2. Rename
    openwrt-mediatek-filogic-keenetic_kn-3812-squashfs-factory.bin
    to KN-3812_recovery.bin and place it in the TFTP root.
 3. Connect the host to the router via Ethernet.
 4. Hold the reset button while powering on the router and keep it
    held until the status LED starts blinking.
 5. Release the reset button. The bootloader downloads the image,
    writes it to flash and reboots into OpenWrt.

To return to stock firmware, use the KeeneticOS recovery utility for
KN-3812.

The device uses the vendor dual-image flash layout. The OpenWrt
factory image is generated using Keenetic device ID 0x803812.