### PR TITLE
hostapd: fix 802.11be MLO partner link association, security flags, and re-association

### DIFF
--- a/package/network/services/hostapd/patches/195-AP-MLD-skip-partner-link-SSID-and-WPA-IE-checks.patch
+++ b/package/network/services/hostapd/patches/195-AP-MLD-skip-partner-link-SSID-and-WPA-IE-checks.patch
@@ -1,0 +1,41 @@
+From: Alexander Astrovsky <astrouski@google.com>
+Date: Mon, 24 Aug 2026 10:40:00 +0000
+Subject: [PATCH] AP: MLD: skip partner link SSID and WPA IE checks
+
+In 802.11be MLO, association requests carry partner link Information
+Elements (IEs) in the Basic Multi-Link element. These partner link IEs
+contain per-link capabilities and parameters, but they typically omit the
+SSID element and WPA/RSN IEs (as security negotiation occurs at the MLD
+level on the primary association link).
+
+Previously, hostapd treated partner link IEs identically to primary
+association requests, checking for mandatory SSID and WPA IEs. When
+absent, hostapd rejected the partner link with WLAN_STATUS_UNSPECIFIED_FAILURE.
+
+Skip mandatory SSID and WPA IE checks when processing partner link IEs in
+MLO associations.
+
+Signed-off-by: Alexander Astrovsky <astrouski@google.com>
+---
+Index: hostapd-2026.08.07~831364bf/src/ap/ieee802_11.c
+===================================================================
+--- hostapd-2026.08.07~831364bf.orig/src/ap/ieee802_11.c
++++ hostapd-2026.08.07~831364bf/src/ap/ieee802_11.c
+@@ -5458,7 +5458,7 @@ static int __check_assoc_ies(struct host
+ #endif /* CONFIG_ENC_ASSOC */
+ #endif /* CONFIG_SAE */
+ 
+-	if (type != LINK_PARSE_RECONF) {
++	if (type != LINK_PARSE_RECONF && !sta->mld_assoc_sta) {
+ 		resp = check_ssid(hapd, sta, elems->ssid, elems->ssid_len);
+ 		if (resp != WLAN_STATUS_SUCCESS)
+ 			goto out;
+@@ -5704,7 +5704,7 @@ static int __check_assoc_ies(struct host
+ 		sta->flags |= WLAN_STA_MAYBE_WPS;
+ 	} else
+ #endif /* CONFIG_WPS */
+-	if (hapd->conf->wpa && wpa_ie == NULL) {
++	if (hapd->conf->wpa && wpa_ie == NULL && !assoc_wpa_sm) {
+ 		hostapd_logger(hapd, sta->addr, HOSTAPD_MODULE_IEEE80211,
+ 			       HOSTAPD_LEVEL_INFO,
+ 			       "No WPA/RSN IE in association request");

--- a/package/network/services/hostapd/patches/196-AP-MLD-sync-MFP-and-SPP-AMSDU-flags-for-partner-lin.patch
+++ b/package/network/services/hostapd/patches/196-AP-MLD-sync-MFP-and-SPP-AMSDU-flags-for-partner-lin.patch
@@ -1,0 +1,35 @@
+From: Alexander Astrovsky <astrouski@google.com>
+Date: Mon, 24 Aug 2026 10:41:00 +0000
+Subject: [PATCH] AP: MLD: sync MFP and SPP-AMSDU flags to partner links
+
+Partner link stations do not re-run full WPA IE validation because
+security handshakes operate at the MLD level. As a result, partner link
+sta_info entries lacked WLAN_STA_MFP and WLAN_STA_SPP_AMSDU flags.
+
+Propagate these flags from the primary association link's assoc_wpa_sm
+to all partner link station entries so that driver hardware encryption
+state is consistent across all affiliated radios.
+
+Signed-off-by: Alexander Astrovsky <astrouski@google.com>
+---
+Index: hostapd-2026.08.07~831364bf/src/ap/ieee802_11.c
+===================================================================
+--- hostapd-2026.08.07~831364bf.orig/src/ap/ieee802_11.c
++++ hostapd-2026.08.07~831364bf/src/ap/ieee802_11.c
+@@ -6008,6 +6008,16 @@ skip_pmkid_update:
+ 			ieee802_11_rsnx_capab_len(
+ 				elems->rsnxe, elems->rsnxe_len,
+ 				WLAN_RSNX_CAPAB_SSID_PROTECTION));
++	} else if (assoc_wpa_sm) {
++		if (wpa_auth_uses_mfp(assoc_wpa_sm))
++			sta->flags |= WLAN_STA_MFP;
++		else
++			sta->flags &= ~WLAN_STA_MFP;
++
++		if (wpa_auth_uses_spp_amsdu(assoc_wpa_sm))
++			sta->flags |= WLAN_STA_SPP_AMSDU;
++		else
++			sta->flags &= ~WLAN_STA_SPP_AMSDU;
+ 	} else
+ 		wpa_auth_sta_no_wpa(sta->wpa_sm);
+ 

--- a/package/network/services/hostapd/patches/197-AP-MLD-free-stale-partner-link-station-entries-on-r.patch
+++ b/package/network/services/hostapd/patches/197-AP-MLD-free-stale-partner-link-station-entries-on-r.patch
@@ -1,0 +1,35 @@
+From: Alexander Astrovsky <astrouski@google.com>
+Date: Mon, 24 Aug 2026 10:42:00 +0000
+Subject: [PATCH] AP: MLD: free stale partner link station entries on re-association
+
+When an MLO client re-associates or roams, existing partner link station
+entries from the prior session may still be present in hapd->sta_list.
+Previously, hostapd saw existing partner link entries and aborted with
+WLAN_STATUS_UNSPECIFIED_FAILURE.
+
+Free stale partner link station entries via ap_free_sta() before
+allocating a fresh partner link STA for the new association.
+
+Signed-off-by: Alexander Astrovsky <astrouski@google.com>
+---
+Index: hostapd-2026.08.07~831364bf/src/ap/ieee802_11.c
+===================================================================
+--- hostapd-2026.08.07~831364bf.orig/src/ap/ieee802_11.c
++++ hostapd-2026.08.07~831364bf/src/ap/ieee802_11.c
+@@ -6294,10 +6294,13 @@ int ieee80211_ml_process_link(struct hos
+ 	}
+ 
+ 	sta = ap_get_sta(hapd, origin_sta->addr);
+-	if (sta || TEST_FAIL()) {
+-		wpa_printf(MSG_INFO, "MLD: link: Station already exists");
+-		status = WLAN_STATUS_UNSPECIFIED_FAILURE;
++	if (sta) {
++		wpa_printf(MSG_DEBUG, "MLD: link: Station already exists, freeing stale entry");
++		ap_free_sta(hapd, sta);
+ 		sta = NULL;
++	}
++	if (TEST_FAIL()) {
++		status = WLAN_STATUS_UNSPECIFIED_FAILURE;
+ 		goto out;
+ 	}
+ 


### PR DESCRIPTION
 This series addresses three issues in `hostapd` Multi-Link Operation (IEEE 802.11be MLO) during station association, capability negotiation, and re-association/roaming:
  
    1. **`hostapd: skip partner link SSID and WPA IE checks in MLO`**
       - **Problem:** In 802.11be MLO, the SSID and RSN/WPA IEs are carried in the outer (Re)Association Request frame at the MLD level. Per-STA Profile subelements for partner links do  
  not duplicate outer SSID or WPA IEs. Currently, `__check_assoc_ies()` attempts to validate the SSID and WPA IE presence on partner links, rejecting the association.
       - **Fix:** Skip `check_ssid()` and WPA IE presence checks when parsing partner link profiles that have an established association link (`!sta->mld_assoc_sta` / `!assoc_wpa_sm`).   
  
    2. **`hostapd: sync MFP and SPP-AMSDU flags to partner links in MLO`**
       - **Problem:** Security handshakes (WPA3-SAE / 4-way handshake) occur at the MLD level on the primary association link (`assoc_wpa_sm`). Partner link `sta_info` entries were not   
  inheriting `WLAN_STA_MFP` and `WLAN_STA_SPP_AMSDU` flags. This caused driver/hardware encryption state mismatches on secondary radios (e.g. dropping protected management frames on      
  partner links).
       - **Fix:** Propagate `WLAN_STA_MFP` and `WLAN_STA_SPP_AMSDU` flags from `assoc_wpa_sm` to all partner link station entries.
  
    3. **`hostapd: free stale partner link stations on re-association`**
       - **Problem:** When an MLO station re-associates or roams, existing partner link station entries from the prior session may still be present in `hapd->sta_list`.
  `hostapd_mld_parse_link_sta()` saw `if (sta)` and aborted with `WLAN_STATUS_UNSPECIFIED_FAILURE`, preventing re-association.
       - **Fix:** Free stale partner link station entries via `ap_free_sta()` before allocating a fresh partner link station for the new association.
  
