### PR TITLE
generic: 6.18: mxl862xx enable assisted learning on CPU port

### DIFF
--- a/target/linux/generic/backport-6.18/945-v7.2-net-dsa-mxl862xx-enable-assisted-learning-on-cpu-port.patch
+++ b/target/linux/generic/backport-6.18/945-v7.2-net-dsa-mxl862xx-enable-assisted-learning-on-cpu-port.patch
@@ -1,0 +1,52 @@
+From 88c71cc0ad9800d8814bd3627b21a0da9028e057 Mon Sep 17 00:00:00 2001
+From: Edoardo Pinci <epinci@outlook.com>
+Date: Mon, 24 Aug 2026 15:11:43 +0200
+Subject: [PATCH] net: dsa: mxl862xx: enable assisted learning on CPU port
+
+The MxL862xx driver enables FDB isolation but does not enable assisted
+learning on the CPU port. Consequently, MAC addresses learned through a
+physical switch port are not updated in hardware when the corresponding
+station moves to a foreign bridge port, such as a Wi-Fi interface.
+
+The stale hardware FDB entry continues directing return traffic toward
+the original physical port. Traffic entering that same port is then
+filtered instead of being forwarded to the CPU and software bridge. This
+causes downstream unicast traffic, including DHCP OFFER and ACK packets,
+to disappear after a client roams to a local wireless interface. The
+client eventually considers the connection unusable and disconnects.
+
+Enable assisted CPU-port learning so DSA installs foreign bridge FDB
+entries on the CPU port. This keeps the hardware FDB synchronized with
+the software bridge and allows return traffic to reach locally attached
+Wi-Fi clients after roaming.
+
+Tested on a BPI R4 PRO with a MxL862xx switch and a BE14000 WiFi interface.
+- Without patch, wired uplink on lan6 port (mxl path)
+  Wifi clients connect but roam away not getting DHCP offers
+- Without patch, wired uplink on wan port (no mxl path)
+  Wifi clients connect and roam successfully
+- With this patch, uplink on lan6 (mxl path)
+  Wifi clients connect and roam successfully
+
+Fixes: 340bdf984613 ("net: dsa: mxl862xx: implement bridge offloading")
+Signed-off-by: Edoardo Pinci <epinci@outlook.com>
+Link: https://patch.msgid.link/DU0P251MB069949C6DEB4D1D51F31FE87C4A02@DU0P251MB0699.EURP251.PROD.OUTLOOK.COM
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/mxl862xx/mxl862xx.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/net/dsa/mxl862xx/mxl862xx.c b/drivers/net/dsa/mxl862xx/mxl862xx.c
+index 45d237b3a..cfa7e3e26 100644
+--- a/drivers/net/dsa/mxl862xx/mxl862xx.c
++++ b/drivers/net/dsa/mxl862xx/mxl862xx.c
+@@ -2111,6 +2111,7 @@ static int mxl862xx_probe(struct mdio_device *mdiodev)
+ 	ds->ops = &mxl862xx_switch_ops;
+ 	ds->phylink_mac_ops = &mxl862xx_phylink_mac_ops;
+ 	ds->num_ports = MXL862XX_MAX_PORTS;
++	ds->assisted_learning_on_cpu_port = true;
+ 	ds->fdb_isolation = true;
+ 	ds->max_num_bridges = MXL862XX_MAX_BRIDGES;
+ 
+-- 
+2.47.3


### PR DESCRIPTION
Backport of [netdev patch](https://patchwork.kernel.org/project/netdevbpf/patch/DU0P251MB069949C6DEB4D1D51F31FE87C4A02@DU0P251MB0699.EURP251.PROD.OUTLOOK.COM/) to be accepted.

---

The MxL862xx driver enables FDB isolation but does not enable assisted
learning on the CPU port. Consequently, MAC addresses learned through a
physical switch port are not updated in hardware when the corresponding
station moves to a foreign bridge port, such as a Wi-Fi interface.

The stale hardware FDB entry continues directing return traffic toward
the original physical port. Traffic entering that same port is then
filtered instead of being forwarded to the CPU and software bridge. This
causes downstream unicast traffic, including DHCP OFFER and ACK packets,
to disappear after a client roams to a local wireless interface. The
client eventually considers the connection unusable and disconnects.

Enable assisted CPU-port learning so DSA installs foreign bridge FDB
entries on the CPU port. This keeps the hardware FDB synchronized with
the software bridge and allows return traffic to reach locally attached
Wi-Fi clients after roaming.

Tested on a BPI R4 PRO with a MxL862xx switch and a BE14000 WiFi interface.
- Without patch, wired uplink on lan6 port (mxl path)
  Wifi clients connect but roam away not getting DHCP offers
- Without patch, wired uplink on wan port (no mxl path)
  Wifi clients connect and roam successfully
- With this patch, uplink on lan6 (mxl path)
  Wifi clients connect and roam successfully