### PR TITLE
build, qualcommbe: add Cortex-A73 CPU type and apply to IPQ95xx

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -256,6 +256,7 @@ ifeq ($(DUMP),1)
     CPU_TYPE ?= generic
     CPU_CFLAGS_generic = -mcpu=generic
     CPU_CFLAGS_cortex-a53 = -mcpu=cortex-a53
+    CPU_CFLAGS_cortex-a73 = -mcpu=cortex-a73
   endif
   ifeq ($(ARCH),riscv64)
     CPU_TYPE ?= generic

--- a/target/linux/qualcommbe/ipq95xx/target.mk
+++ b/target/linux/qualcommbe/ipq95xx/target.mk
@@ -1,6 +1,7 @@
 SUBTARGET:=ipq95xx
 BOARDNAME:=Qualcomm Atheros IPQ95xx
-DEFAULT_PACKAGES += 
+CPU_TYPE:=cortex-a73
+DEFAULT_PACKAGES +=
 
 define Target/Description
 	Build firmware images for Qualcomm Atheros IPQ95XX based boards.


### PR DESCRIPTION
This PR introduces proper compiler optimizations for the Qualcomm IPQ95xx SoC family (IPQ9574, IPQ9570, IPQ9554), which physically utilizes a quad-core ARM Cortex-A73 architecture.

Currently, the parent `qualcommbe` target defaults to `cortex-a53`. Because of this, the `ipq95xx` subtarget was silently compiling with A53-specific (or generic) instruction sets, missing out on proper A73 pipeline optimizations.

### Changes in this PR:
1. **build:** Adds `CPU_CFLAGS_cortex-a73 = -mcpu=cortex-a73` to `include/target.mk` so the OpenWrt build system knows how to handle the `cortex-a73` CPU type.
2. **qualcommbe (ipq95xx):** Overrides `CPU_TYPE` to `cortex-a73` specifically for the `ipq95xx` subtarget.

### Impact & Safety:
* **IPQ95xx boards** (e.g., 8devices Kiwi, AP-AL02) will now correctly compile with `-mcpu=cortex-a73`, resulting in better CPU performance and instruction scheduling.
* **Other qualcommbe SoCs** (like the IPQ53xx family) share the same parent directory but are completely unaffected by this change. They will safely remain on their native `cortex-a53` default.

Compiled and tested on: 8devices Kiwi-DVK (IPQ9570).