### PR TITLE
qualcommax: ipq60xx: add stock-web-UI factory image for Netgear WAX214

### DIFF
--- a/target/linux/qualcommax/image/ipq60xx.mk
+++ b/target/linux/qualcommax/image/ipq60xx.mk
@@ -1,5 +1,5 @@
 DTS_DIR := $(DTS_DIR)/qcom
-DEVICE_VARS += TPLINK_SUPPORT_STRING
+DEVICE_VARS += SENAO_PRODUCT SENAO_ROOTFS_OFFSET SENAO_ROOTFS_SIZE SENAO_VENDOR TPLINK_SUPPORT_STRING
 
 define Build/wax610-netgear-tar
 	mkdir $@.tmp
@@ -20,6 +20,23 @@ define Build/netgear-rbx350-qsdk-ipq-factory
 	$(TOPDIR)/scripts/mkits-qsdk-ipq-image.sh $@.its $(FLASH_SCRIPT) txt $@.metadata ubi $@
 	PATH=$(LINUX_DIR)/scripts/dtc:$(PATH) mkimage -f $@.its $@.new
 	@mv $@.new $@
+endef
+
+define Build/senao-factory-nand
+	{ \
+		echo 'imxtract $$imgaddr ubi || exit 1'; \
+		printf 'nand device 0 && nand erase %s %s || exit 1\n' \
+			'$(SENAO_ROOTFS_OFFSET)' '$(SENAO_ROOTFS_SIZE)'; \
+		printf 'nand write $$fileaddr %s 0x%x || exit 1\n' \
+			'$(SENAO_ROOTFS_OFFSET)' "$$(stat -c%s $@)"; \
+		echo 'exit 0'; \
+	} > $@.bootscript
+	$(TOPDIR)/scripts/mkits-qsdk-ipq-image.sh $@.its $@.bootscript ubi $@
+	PATH=$(LINUX_DIR)/scripts/dtc:$(PATH) mkimage -f $@.its $@.fit
+	$(STAGING_DIR_HOST)/bin/mksenaofw -r $(SENAO_VENDOR) -p $(SENAO_PRODUCT) \
+		-t 0 -v 9.9.9.9 -e $@.fit -o $@.new
+	mv $@.new $@
+	rm -f $@.its $@.fit $@.bootscript
 endef
 
 define Device/8devices_mango-dvk
@@ -210,6 +227,13 @@ define Device/netgear_wax214
 	PAGESIZE := 2048
 	DEVICE_DTS_CONFIG := config@cp03-c1
 	SOC := ipq6010
+	SENAO_VENDOR := 0x231
+	SENAO_PRODUCT := 0x11d
+	# rootfs partition bounds from the SMEM layout (mtd11), as used by the stock flash.scr
+	SENAO_ROOTFS_OFFSET := 0x01180000
+	SENAO_ROOTFS_SIZE := 0x03740000
+	IMAGES += ui-factory.bin
+	IMAGE/ui-factory.bin := append-ubi | check-size $$$$(SENAO_ROOTFS_SIZE) | senao-factory-nand
 	DEVICE_PACKAGES := ipq-wifi-netgear_wax214
 endef
 TARGET_DEVICES += netgear_wax214


### PR DESCRIPTION
The WAX214 was installable only via serial + U-Boot + tftp + ubiformat. Its stock OTA firmware is the Senao img_header container that the in-tree `mksenaofw` builds (0x60 header + payload XOR'd with `magic >> (i % 8) & 0xff`, magic 0x12345678). Header values recovered from stock images: vendor 0x231, product 0x11d, plain type-0.

The stock updater runs the FIT flash script but does not erase the rootfs partition itself, so the factory image embeds a bootscript that erases rootfs before writing the UBI (mirroring the stock flash.scr); without it a stale overlay survives and first boot hangs. SENAO_ROOTFS_OFFSET/SIZE are the rootfs partition bounds (mtd11 in the SMEM layout).

Adds `IMAGE/ui-factory.bin := append-ubi | senao-factory-nand`. Install: upload the `*-ui-factory.bin` via the stock web-UI Firmware Upgrade page.

**Depends on** the firmware-utils change allowing plain type-0 (openwrt/firmware-utils#76). CI will need a tools/firmware-utils bump after that merges.

Testing: flashed on real WAX214 v1 hardware. Stock 2.1.1.3 → OpenWrt 25.12.5 via the stock web UI, no serial, running as an AP. (First build without the erase-script hung on a stale overlay; recovered with failsafe + `firstboot`, which is what led to the flash-script fix.) Recipe build-verified in the 25.12.5 ipq60xx ImageBuilder: it produces a valid Senao image whose FIT carries the flash bootscript + ubi, with correct erase/write offsets.

Return to stock: re-upload the Netgear stock `WAX214_V1.0.x.x_firmware.bin` the same way.

https://forum.openwrt.org/t/wax214-v1-no-serial-openwrt-install-via-the-stock-web-ui-working/252965
