### PR TITLE
ramips: add support for Qihoo 360 T5

### DIFF
--- a/target/linux/ramips/dts/mt7621_qihoo_360-t5.dts
+++ b/target/linux/ramips/dts/mt7621_qihoo_360-t5.dts
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "qihoo,360-t5", "mediatek,mt7621-soc";
+	model = "Qihoo 360 T5";
+
+	aliases {
+		label-mac-device = &gmac0;
+
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_green;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		key-0 {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_green: led-5 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+		};
+		partition@80000 {
+			label = "u-boot-env";
+			reg = <0x80000 0x80000>;
+		};
+		factory: partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x40000>;
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
+
+				macaddr_factory_a: macaddr@a {
+					reg = <0xa 0x6>;
+				};
+			};
+
+		};
+
+		partition@140000 {
+			label = "firmware";
+			reg = <0x140000 0x7ec0000>;
+
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x7ac0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+
+		mediatek,disable-radar-background;
+
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan0";
+		};
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "wan";
+		};
+	};
+};

--- a/target/linux/ramips/dts/mt7621_qihoo_360t5.dts
+++ b/target/linux/ramips/dts/mt7621_qihoo_360t5.dts
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "qihoo,360t5", "mediatek,mt7621-soc";
+	model = "Qihoo 360T5";
+
+	aliases {
+		led-boot = &led_power_red;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_red;
+		led-upgrade = &led_power_red;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_red: led-1 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+		};
+		partition@80000 {
+			label = "u-boot-env";
+			reg = <0x80000 0x80000>;
+		};
+		factory: partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x40000>;
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0xe00>;
+				};
+			};
+
+		};
+
+		partition@140000 {
+			label = "firmware";
+			reg = <0x140000 0x7ec0000>;
+
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x7ac0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+
+		ieee80211-freq-limit = <2400000 2500000>;
+
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&gmac1 {
+	status = "okay";
+	phy-handle = <&ethphy4>;
+};
+
+&ethphy4 {
+	/delete-property/ interrupts;
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag", "uart3", "wdt";
+		function = "gpio";
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "wan";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2716,6 +2716,22 @@ define Device/plasmacloud_pax1800-lite
 endef
 TARGET_DEVICES += plasmacloud_pax1800-lite
 
+define Device/qihoo_360t5
+  $(Device/nand)
+  DEVICE_VENDOR := Qihoo
+  DEVICE_MODEL := 360T5
+  DEVICE_DTS := mt7621_qihoo_360t5
+  IMAGE_SIZE := 129792k
+  KERNEL_LOADADDR := 0x82000000
+  KERNEL := kernel-bin | relocate-kernel $(loadaddr-y) | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware -uboot-envtools
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
+	append-ubi | check-size
+endef
+TARGET_DEVICES += qihoo_360t5
+
 define Device/raisecom_msg1500-x-00
   $(Device/nand)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2716,6 +2716,26 @@ define Device/plasmacloud_pax1800-lite
 endef
 TARGET_DEVICES += plasmacloud_pax1800-lite
 
+define Device/qihoo_360-t5
+  $(Device/dsa-migration)
+  $(Device/nand)
+  DEVICE_VENDOR := Qihoo
+  DEVICE_MODEL := 360 T5
+  DEVICE_ALT0_VENDOR := Qihoo
+  DEVICE_ALT0_MODEL := AC1200
+  DEVICE_DTS := mt7621_qihoo_360-t5
+  IMAGE_SIZE := 129024k
+  KERNEL_LOADADDR := 0x82000000
+  KERNEL := kernel-bin | relocate-kernel $(loadaddr-y) | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  DEVICE_PACKAGES += kmod-mt7603 kmod-mt7615e kmod-mt7615-firmware \
+	-uboot-envtools
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
+	append-ubi | check-size
+endef
+TARGET_DEVICES += qihoo_360-t5
+
 define Device/raisecom_msg1500-x-00
   $(Device/nand)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -209,6 +209,9 @@ oraybox,x3a)
 	ucidef_set_led_netdev "wan" "wan link" "red:status" "wan"
 	ucidef_set_led_netdev "lan" "lan link" "green:status" "br-lan"
 	;;
+qihoo,360t5)
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
+	;;
 snr,snr-cpe-me1)
 	ucidef_set_led_usbport "usb" "USB" "green:usb" "usb1-port1" "usb2-port1"
 	;;

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -158,6 +158,9 @@ ramips_setup_interfaces()
 	mqmaker,witi)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan1 wan2"
 		;;
+	qihoo,360t5)
+		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
+		;;
 	tozed,zlt-s12-pro)
 		ucidef_set_interface_lan "lan1 lan2 lan3 wan"
 		ucidef_set_interface "wwan" device "/dev/ttyUSB0" protocol "ncm"
@@ -312,6 +315,11 @@ ramips_setup_macs()
 	netgear,wax214v2)
 		lan_mac=$(mtd_get_mac_ascii Config ethaddr)
 		label_mac=$lan_mac
+		;;
+	qihoo,360t5)
+		wan_mac=$(mtd_get_mac_binary factory 0x1ffe8)
+		lan_mac=$(macaddr_add "$wan_mac" 1)
+		label_mac=$wan_mac
 		;;
 	esac
 

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -158,6 +158,9 @@ ramips_setup_interfaces()
 	mqmaker,witi)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan1 wan2"
 		;;
+	qihoo,360-t5)
+		ucidef_set_interfaces_lan_wan "lan0 lan1 wan"
+		;;
 	tozed,zlt-s12-pro)
 		ucidef_set_interface_lan "lan1 lan2 lan3 wan"
 		ucidef_set_interface "wwan" device "/dev/ttyUSB0" protocol "ncm"
@@ -312,6 +315,11 @@ ramips_setup_macs()
 	netgear,wax214v2)
 		lan_mac=$(mtd_get_mac_ascii Config ethaddr)
 		label_mac=$lan_mac
+		;;
+	qihoo,360-t5)
+		lan_mac=$(mtd_get_mac_binary factory 0x4)
+		wan_mac=$(macaddr_add "$lan_mac" 1)
+		label_mac=$wan_mac
 		;;
 	esac
 

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -156,6 +156,11 @@ case "$board" in
 			macaddr_setbit_la "$(macaddr_add $hw_mac_addr 0x100000)" > /sys${DEVPATH}/macaddress
 		fi
 		;;
+	qihoo,360t5)
+		hw_mac_addr="$(mtd_get_mac_binary factory 0x1ffe8)"
+		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 3 > /sys${DEVPATH}/macaddress
+		;;
 	raisecom,msg1500-x-00)
 		[ "$PHYNBR" = "0" ] && \
 			macaddr_setbit_la "$(get_mac_label)" > /sys${DEVPATH}/macaddress

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -156,6 +156,11 @@ case "$board" in
 			macaddr_setbit_la "$(macaddr_add $hw_mac_addr 0x100000)" > /sys${DEVPATH}/macaddress
 		fi
 		;;
+	qihoo,360-t5)
+		addr=$(mtd_get_mac_binary factory 0x4)
+		[ "$PHYNBR" = "0" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $addr 4 > /sys${DEVPATH}/macaddress
+		;;
 	raisecom,msg1500-x-00)
 		[ "$PHYNBR" = "0" ] && \
 			macaddr_setbit_la "$(get_mac_label)" > /sys${DEVPATH}/macaddress

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -140,6 +140,7 @@ platform_do_upgrade() {
 	netgear,wax214v2|\
 	netis,n6|\
 	netis,wf2881|\
+	qihoo,360t5|\
 	raisecom,msg1500-x-00|\
 	rostelecom,rt-fe-1a|\
 	rostelecom,rt-sf-1|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -140,6 +140,7 @@ platform_do_upgrade() {
 	netgear,wax214v2|\
 	netis,n6|\
 	netis,wf2881|\
+	qihoo,360-t5|\
 	raisecom,msg1500-x-00|\
 	rostelecom,rt-fe-1a|\
 	rostelecom,rt-sf-1|\


### PR DESCRIPTION
Hardware Specifications:
- SoC: MediaTek MT7621
- RAM: 128MB DDR3
- Flash: 128MB SPI NAND (F59L1G81MB)
- Ethernet: 2 x LAN, 1 x WAN (MT7530 switch)
- Wireless: MT7603 (2.4GHz) + MT7615 (5GHz) on PCIe
- Buttons: Reset, WPS
- LEDs: Power green, WAN green
- UART: 3.3V TTL, baud rate 115200 8N1

MAC address layout (factory partition):
- 2.4GHz Wi-Fi: factory@0x4
- 5GHz Wi-Fi: 2.4GHz Wi-Fi MAC address plus 3
- LAN: factory@0x4
- WAN: LAN MAC address plus 1

Flash layout:
u-boot(0x80000), u-boot-env(0x80000), factory(0x40000),
firmware(0x7ec0000): kernel(0x400000), ubi(0x7ac0000)

Installation:

- sysupgrade image is used for in-place upgrade from a running
  OpenWrt system. Use LuCI firmware page or run 'sysupgrade -n'
  via SSH.

- Initial installation from stock vendor firmware:
  Upload the generated factory.bin via the stock firmware's web
  recovery page.

- U-Boot TFTP recovery:
  1. Set a static IP 192.168.1.x on your computer
  2. Serve openwrt-ramips-mt7621-qihoo_360-t5-initramfs-kernel.bin
     via TFTP at 192.168.1.100
  3. Power on the device while pressing the reset button
  4. After OpenWrt is running in memory, sysupgrade to flash
     sysupgrade.bin to NAND

Signed-off-by: Han Deyang [galy.hanfuwei@gmail.com](mailto:galy.hanfuwei@gmail.com)