### PR TITLE
wifi-scripts: mac80211: prepare and register monitor mode VIFs

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
@@ -230,6 +230,10 @@ function setup() {
 		}
 
 		switch (mode) {
+		case 'monitor':
+			validate('iface', v.config);
+			netifd.set_vif(k, v.config.ifname);
+			break;
 		case 'ap':
 			has_ap = true;
 			for (let _, sta in v.stas)


### PR DESCRIPTION
In mac80211.sh, the initial switch (mode) block prepares VIFs for AP, STA, adhoc, and mesh modes by validating interface options, calling iface.prepare() (allocating dynamic MAC addresses), and registering the interface name with netifd via netifd.set_vif().

However, 'monitor' mode was missing from this setup switch block. While a subsequent switch block handled monitor mode to fall back to wdev setup, the monitor VIF was never prepared or registered with netifd, causing interface configuration and lifecycle management to fail for monitor VIFs.

Add 'monitor' mode to the initial setup switch block to ensure interface validation, MAC preparation, noscan setting, and netifd VIF registration.