### PR TITLE
mediatek: filogic: add support for Cudy AP3000D v1

### DIFF
--- a/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
+++ b/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
@@ -15,6 +15,7 @@ set_preinit_iface() {
 		ifname=eth1
 		;;
 	cudy,ap3000-v1|\
+	cudy,ap3000d-v1|\
 	cudy,ap3000outdoor-v1|\
 	cudy,re3000-v1|\
 	ubnt,unifi-6-lr|\

--- a/target/linux/mediatek/dts/mt7981b-cudy-ap3000d-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-ap3000d-v1.dts
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+
+#include "mt7981b.dtsi"
+
+/ {
+	model = "Cudy AP3000D v1";
+	compatible = "cudy,ap3000d-v1", "mediatek,mt7981";
+
+	aliases {
+		label-mac-device = &gmac1;
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status: led-0 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led-2 {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led-4 {
+			function = LED_FUNCTION_WPS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led-5 {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+	status = "okay";
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_bdinfo_de00 0>;
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "disabled";
+};
+
+&spi2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi2_flash_pins>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+
+		spi-max-frequency = <25000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x00000 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "Factory";
+				reg = <0x50000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+				};
+			};
+
+			bdinfo: partition@60000 {
+				label = "bdinfo";
+				reg = <0x60000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_bdinfo_de00: macaddr@de00 {
+						compatible = "mac-base";
+						reg = <0xde00 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@70000 {
+				label = "FIP";
+				reg = <0x70000 0x80000>;
+				read-only;
+			};
+
+			partition@f0000 {
+				compatible = "denx,fit";
+				label = "firmware";
+				reg = <0xf0000 0xf10000>;
+			};
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+	};
+
+	spi2_flash_pins: spi2-pins {
+		mux {
+			function = "spi";
+			groups = "spi2", "spi2_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&wifi {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -85,6 +85,11 @@ comfast,cf-xr186)
 	ucidef_set_led_netdev "wlan2g" "WLAN2G" "green:wlan" "phy0-ap0" "link tx rx"
 	ucidef_set_led_netdev "wlan5g" "WLAN5G" "blue:wlan" "phy1-ap0" "link tx rx"
 	;;
+cudy,ap3000d-v1)
+	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "eth0" "link tx rx"
+	ucidef_set_led_netdev "wlan2g" "WLAN2G" "blue:wlan-2ghz" "phy0-ap0" "link tx rx"
+	ucidef_set_led_netdev "wlan5g" "WLAN5G" "blue:wlan-5ghz" "phy1-ap0" "link tx rx"
+	;;
 cudy,re3000-v1|\
 kebidumei,ax3000-u22|\
 wavlink,wl-wn573hx3)

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -135,6 +135,7 @@ mediatek_setup_interfaces()
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4 lan5"
 		;;
 	comfast,cf-xr186|\
+	cudy,ap3000d-v1|\
 	cudy,ap3000outdoor-v1|\
 	cudy,ap3000-v1|\
 	cudy,re3000-v1|\

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -90,6 +90,7 @@ case "$board" in
 		;;
 	cudy,ap3000outdoor-v1|\
 	cudy,ap3000wall-v1|\
+	cudy,ap3000d-v1|\
 	cudy,ap3000-v1|\
 	cudy,m3000-v1|\
 	cudy,m3000-v1-ubootmod|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -277,6 +277,7 @@ platform_do_upgrade() {
 		CI_UBIPART="ubi"
 		nand_do_upgrade "$1"
 		;;
+	cudy,ap3000d-v1|\
 	cudy,re3000-v1|\
 	cudy,wr3000-v1|\
 	kebidumei,ax3000-u22|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1294,6 +1294,22 @@ define Device/cudy_ap3000-v1
 endef
 TARGET_DEVICES += cudy_ap3000-v1
 
+define Device/cudy_ap3000d-v1
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := AP3000D
+  DEVICE_VARIANT := v1
+  DEVICE_DTS := mt7981b-cudy-ap3000d-v1
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTS_LOADADDR := 0x47000000
+  IMAGES := sysupgrade.bin
+  IMAGE_SIZE := 15424k
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/sysupgrade.bin := append-kernel | pad-to 128k | append-rootfs | pad-rootfs | check-size | append-metadata
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+endef
+TARGET_DEVICES += cudy_ap3000d-v1
+
 define Device/cudy_m3000-v1
   DEVICE_VENDOR := Cudy
   DEVICE_MODEL := M3000


### PR DESCRIPTION
The Cudy AP3000D is a desktop Wi-Fi 6 access point based on MediaTek
MT7981B. Despite the name it is a distinct board from the AP3000 v1: it
uses 16 MB SPI-NOR instead of SPI-NAND, and its single Ethernet port is
driven by the SoC-internal gigabit PHY rather than an external 2.5G PHY.

The OEM firmware identifies this board as "R81" (seen in the stock
boot log: "Machine model: MediaTek MT7981 RFB/R81")

Specifications:
- SoC:   MediaTek MT7981B (Filogic 820)
- RAM:   256 MB DDR3
- Flash: 16 MB SPI-NOR (XMC XM25QH128C)
- WLAN:  MT7981 2x2 DBDC 802.11ax (2.4 + 5 GHz)
- ETH:   1x 10/100/1000 Mbps (SoC internal GbE PHY)
- LEDs:  6x (blue), all GPIO-controlled
- Btns:  Reset, WPS
- UART:  115200 8N1, 3.3V, on-board header (3V3/GND/RX/TX)

MAC addresses as verified from OEM firmware:
- LAN/label   *:09        bdinfo 0xde00
- 2.4 GHz     *:09        (= LAN/label)
- 5 GHz       *:0a        (= LAN + 1, LA bit set)

Buttons (active low):
- Reset: GPIO 1
- WPS:   GPIO 0

LEDs (blue, active low):
- Status:     GPIO 10
- Internet:   GPIO 11
- WLAN 2.4G:  GPIO 6
- WLAN 5G:    GPIO 7
- WPS:        GPIO 4
- LAN:        GPIO 8

Installation:

Cudy provides no OpenWrt migration image for this model and the OEM web 
UI rejects unsigned images, so installation requires the serial console
and U-Boot TFTP recovery:

1. Connect to the UART header (115200 8N1, 3.3V).
2. Power on and interrupt U-Boot autoboot. Hold the reset button while powering on. It will attempt to download recovery.bin via TFTP. If unsuccessful, it will drop to the shell.
3. Serve the OpenWrt initramfs image over TFTP (U-Boot expects the server at 192.168.1.88) and boot it: tftpboot 0x46000000 <initramfs>; bootm 0x46000000
4. From the RAM-booted system, transfer the sysupgrade image and run sysupgrade.

The stock bootloader (BL2/FIP) and its TFTP recovery are left intact, so the device can be returned to OEM firmware.

The build was tested on the real hardware.

Signed-off-by: Dimitri Panchenko <dima@panchenko.net>