### PR TITLE
realtek: add support for MokerLink 10GT080M

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -107,6 +107,7 @@ realtek_setup_macs()
 	hasivo,f5800w-12s-plus|\
 	hasivo,s1300wp-8xgt-4s-plus|\
 	hasivo,s600wp-5gt-2s-plus|\
+	mokerlink,10gt080m|\
 	tplink,tl-st1008f-v2|\
 	zyxel,xgs1010-12-a1|\
 	zyxel,xgs1010-12-b1)

--- a/target/linux/realtek/dts/rtl9313_mokerlink_10gt080m.dts
+++ b/target/linux/realtek/dts/rtl9313_mokerlink_10gt080m.dts
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl931x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/phy/phy.h>
+
+/ {
+	compatible = "mokerlink,10gt080m", "realtek,rtl9313-soc";
+	model = "MokerLink 10GT080M";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>,
+		      <0x90000000 0x10000000>;
+	};
+
+	aliases {
+		label-mac-device = &ethernet0;
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200 earlycon";
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio0 27 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_sys: led-0 {
+			gpios = <&gpio0 31 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+
+	sfp9: sfp-p9 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sda3>;
+		maximum-power-milliwatt = <2000>;
+		tx-disable-gpios = <&gpio0 26 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
+		los-gpios = <&gpio0 24 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp10: sfp-p10 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sda2>;
+		maximum-power-milliwatt = <2000>;
+		tx-disable-gpios = <&gpio0 23 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
+		los-gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp11: sfp-p11 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sda1>;
+		maximum-power-milliwatt = <2000>;
+		tx-disable-gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		los-gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp12: sfp-p12 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sda0>;
+		maximum-power-milliwatt = <2000>;
+		tx-disable-gpios = <&gpio0 10 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+		los-gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	led_set {
+		compatible = "realtek,rtl9300-leds";
+		active-low;
+
+		led_set1 = <(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_LINK |
+			     RTL93XX_LED_SET_ACT)
+			    (RTL93XX_LED_SET_5G | RTL93XX_LED_SET_LINK |
+			     RTL93XX_LED_SET_ACT)
+			    (RTL93XX_LED_SET_2P5G | RTL93XX_LED_SET_LINK |
+			     RTL93XX_LED_SET_ACT)
+			    (RTL93XX_LED_SET_1G | RTL93XX_LED_SET_100M |
+			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)>;
+
+		led_set3 = <RTL93XX_LED_SET_NONE
+			    RTL93XX_LED_SET_NONE
+			    (RTL93XX_LED_SET_10G | RTL93XX_LED_SET_2P5G |
+			     RTL93XX_LED_SET_1G | RTL93XX_LED_SET_LINK |
+			     RTL93XX_LED_SET_ACT)
+			    RTL93XX_LED_SET_NONE>;
+	};
+};
+
+&i2c_mst1 {
+	status = "okay";
+
+	i2c1_sda0: i2c@0 { reg = <0>; };
+	i2c1_sda1: i2c@1 { reg = <1>; };
+	i2c1_sda2: i2c@2 { reg = <2>; };
+	i2c1_sda3: i2c@3 { reg = <3>; };
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0000000 0x00e0000>;
+				read-only;
+			};
+
+			/* stock layout calls this BDINFO */
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0x00e0000 0x0010000>;
+				read-only;
+			};
+
+			partition@f0000 {
+				label = "sysinfo";
+				reg = <0x00f0000 0x0010000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "cfg";
+				reg = <0x0100000 0x0100000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "log";
+				reg = <0x0200000 0x0100000>;
+				read-only;
+			};
+
+			/* stock layout calls this RUNTIME1 */
+			partition@300000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				reg = <0x0300000 0x0e00000>;
+				openwrt,ih-magic = <0x83800000>;
+			};
+
+			/* stock layout calls this RUNTIME2 */
+			partition@1100000 {
+				label = "runtime2";
+				reg = <0x1100000 0x0e00000>;
+				read-only;
+			};
+
+			partition@1f00000 {
+				label = "oeminfo";
+				reg = <0x1f00000 0x0100000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio_ctrl {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinmux_enable_mdc_mdio_0>,
+		    <&pinmux_enable_mdc_mdio_1>;
+};
+
+&mdio_bus0 {
+	/* Four discrete RTL8261BE PHYs */
+	PHY_C45(0, 0)
+	PHY_C45(8, 1)
+	PHY_C45(16, 2)
+	PHY_C45(24, 3)
+};
+
+&mdio_bus1 {
+	/* Four discrete RTL8261BE PHYs */
+	PHY_C45(32, 4)
+	PHY_C45(40, 5)
+	PHY_C45(48, 6)
+	PHY_C45(50, 7)
+};
+
+&switch0 {
+	ethernet-ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT_LED(0,  1, 2, 0, 1, usxgmii)
+		SWITCH_PORT_LED(8,  2, 3, 0, 1, usxgmii)
+		SWITCH_PORT_LED(16, 3, 4, 0, 1, usxgmii)
+		SWITCH_PORT_LED(24, 4, 5, 0, 1, usxgmii)
+		SWITCH_PORT_LED(32, 5, 6, 0, 1, usxgmii)
+		SWITCH_PORT_LED(40, 6, 7, 0, 1, usxgmii)
+		SWITCH_PORT_LED(48, 7, 8, 0, 1, usxgmii)
+		SWITCH_PORT_LED(50, 8, 9, 0, 1, usxgmii)
+
+		SWITCH_PORT_SFP(52, 10, 10, 3, 10)
+		SWITCH_PORT_SFP(53, 9,  11, 3, 9)
+		SWITCH_PORT_SFP(54, 12, 12, 3, 12)
+		SWITCH_PORT_SFP(55, 11, 13, 3, 11)
+
+		/* Internal CPU port. */
+		port@56 {
+			reg = <56>;
+			ethernet = <&ethernet0>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&serdes2 { rx-polarity = <PHY_POL_INVERT>; };
+&serdes3 { rx-polarity = <PHY_POL_INVERT>; };
+&serdes4 { rx-polarity = <PHY_POL_INVERT>; };
+&serdes5 { rx-polarity = <PHY_POL_INVERT>; };
+&serdes6 { rx-polarity = <PHY_POL_INVERT>; };
+&serdes7 { rx-polarity = <PHY_POL_INVERT>; };
+&serdes8 { rx-polarity = <PHY_POL_INVERT>; };
+&serdes9 { rx-polarity = <PHY_POL_INVERT>; };
+&serdes10 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes11 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes12 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes13 { tx-polarity = <PHY_POL_INVERT>; };

--- a/target/linux/realtek/image/rtl931x.mk
+++ b/target/linux/realtek/image/rtl931x.mk
@@ -24,6 +24,17 @@ define Device/hasivo_s1300wp-8xgt-4s-plus
 endef
 TARGET_DEVICES += hasivo_s1300wp-8xgt-4s-plus
 
+define Device/mokerlink_10gt080m
+  SOC := rtl9313
+  DEVICE_VENDOR := MokerLink
+  DEVICE_MODEL := 10GT080M
+  IMAGE_SIZE := 14336k
+  DEVICE_PACKAGES := kmod-phy-realtek rtl826x-firmware
+  UIMAGE_MAGIC := 0x83800000
+  $(Device/kernel-lzma)
+endef
+TARGET_DEVICES += mokerlink_10gt080m
+
 define Device/plasmacloud-common
   SOC := rtl9312
   UIMAGE_MAGIC := 0x93100000


### PR DESCRIPTION
The MokerLink 10GT080M is a 12-port managed switch based on the
Realtek RTL9313 SoC.

Specifications:
- SoC: Realtek RTL9313
- RAM: 512 MB
- Flash: 32 MB SPI NOR
- Ethernet: 8x 10GBASE-T (RTL8261BE), 4x SFP+ (10G)
- LEDs: per-port link/activity via the SoC LED engine
- UART: 115200 8N1 on the front-panel RJ45 console port

Working: switching on the copper and SFP+ ports, SFP hotplug and
EEPROM access, copper and SFP+ port LEDs, system status LED, reset
button, PHY temperature monitoring, sysupgrade, and the persistent
JFFS2 overlay.

Installation:
Netboot the initramfs image over TFTP, then run sysupgrade from OpenWrt.
Connect to the serial console and press Escape during the one-second
U-Boot countdown. Configure the network parameters for the local TFTP
server, then initialize the switch and boot the image:

  RTL9310# setenv ipaddr 192.168.1.250
  RTL9310# setenv serverip 192.168.1.156
  RTL9310# setenv netmask 255.255.255.0
  RTL9310# rtk network on
  RTL9310# rtk 10g 54 dac300cm
  RTL9310# tftpboot 0x84f00000 openwrt-...-initramfs-kernel.bin
  RTL9310# bootm 0x84f00000

Port 54 is front-panel SFP+ port 12. Select the matching U-Boot media
mode when using a transceiver or a different DAC length. Once OpenWrt
has booted, copy the sysupgrade image to the device and install it with
sysupgrade.

The OpenWrt firmware partition replaces the stock RUNTIME1 partition.
The stock RUNTIME2 partition remains read-only and can be booted with
"boota 1" from U-Boot for recovery.

MAC addresses:
The base MAC comes from the U-Boot environment variable "ethaddr" in
the u-boot-env partition. Per-port LAN MACs are derived sequentially.

Signed-off-by: Tanner Lane <tannerln7@gmail.com>
