### PR TITLE
ramips: mt76x8: add support for Keenetic 4G (KN-1211)

### DIFF
--- a/target/linux/ramips/dts/mt7628an_keenetic_kn-1211.dts
+++ b/target/linux/ramips/dts/mt7628an_keenetic_kn-1211.dts
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "keenetic,kn-1211", "mediatek,mt7628an-soc";
+	model = "Keenetic KN-1211";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	regulator-usb {
+		compatible = "regulator-fixed";
+		regulator-name = "USB-power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio 37 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-always-on;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+		};
+
+		internet {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		mode {
+			label = "mode";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&firmware_1 &firmware_2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x0 0x1ec0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2s", "i2c", "gpio", "refclk", "wdt", "wled_an";
+		function = "gpio";
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>; /* Higher frequencies are unstable on this PCB */
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "rf-eeprom";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+				};
+			};
+
+			firmware_1: partition@50000 {
+				label = "firmware_1";
+				reg = <0x50000 0xf60000>;
+			};
+
+			partition@fb0000 {
+				label = "config_1";
+				reg = <0xfb0000 0x40000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "dump";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+
+			partition@1000000 {
+				label = "u-state";
+				reg = <0x1000000 0x30000>;
+				read-only;
+			};
+
+			partition@1030000 {
+				label = "u-config_res";
+				reg = <0x1030000 0x10000>;
+				read-only;
+			};
+
+			partition@1040000 {
+				label = "rf-eeprom_res";
+				reg = <0x1040000 0x10000>;
+				read-only;
+			};
+
+			firmware_2: partition@1050000 {
+				label = "firmware_2";
+				reg = <0x1050000 0xf60000>;
+			};
+
+			partition@1fb0000 {
+				label = "config_2";
+				reg = <0x1fb0000 0x40000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -481,6 +481,19 @@ define Device/keenetic_kn-1112
 endef
 TARGET_DEVICES += keenetic_kn-1112
 
+define Device/keenetic_kn-1211
+  BLOCKSIZE := 64k
+  IMAGE_SIZE := 31488k
+  DEVICE_VENDOR := Keenetic
+  DEVICE_MODEL := KN-1211
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | pad-to $$$$(BLOCKSIZE) | \
+	check-size 15744k | zyimage -d 0x801211 -v "KN-1211"
+endef
+TARGET_DEVICES += keenetic_kn-1211
+
+
 define Device/keenetic_kn-1212
   BLOCKSIZE := 64k
   IMAGE_SIZE := 15073280

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -77,6 +77,7 @@ hiwifi,hc5761a)
 	ucidef_set_led_switch "wan" "WAN" "blue:wan" "switch0" "0x10"
 	;;
 keenetic,kn-1112|\
+keenetic,kn-1211|\
 keenetic,kn-1212|\
 keenetic,kn-1221|\
 keenetic,kn-1510|\

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -137,6 +137,7 @@ ramips_setup_interfaces()
 	cudy,wr300-v1|\
 	hongdian,h8850-v20|\
 	keenetic,kn-1112|\
+	keenetic,kn-1211|\
 	keenetic,kn-1212|\
 	keenetic,kn-1510|\
 	keenetic,kn-1613|\


### PR DESCRIPTION
Adds support for the Keenetic 4G (KN-1211), a MediaTek MT7628AN router
close to the Keenetic 4G (KN-1212) added in #19157.

Differences from KN-1212:
- both firmware slots are 0xf60000 (concat ~30 MB usable)
- ethernet MAC is taken from factory offset 0x04 (single-MAC design,
  shared by LAN/WAN/2.4G, matching OEM behaviour)
- OEM recovery device id: 0x801211

Tested on real hardware: Ethernet WAN/LAN, 2.4 GHz WiFi, LEDs,
OEM recovery flashing (factory image renamed to KN-1211_recovery.bin)
and sysupgrade from a community 19.07 build.
