### PR TITLE
mediatek: filogic: light the WAN LED on Cudy WR3000P v1

### DIFF
--- a/target/linux/generic/backport-6.12/799-v7.2-net-phy-realtek-Add-support-for-PHY-LEDs-on-RTL8221B.patch
+++ b/target/linux/generic/backport-6.12/799-v7.2-net-phy-realtek-Add-support-for-PHY-LEDs-on-RTL8221B.patch
@@ -1,0 +1,211 @@
+From d3aae4d954f92a273388439ab015763e0cdea1e0 Mon Sep 17 00:00:00 2001
+From: Chukun Pan <amadeus@jmu.edu.cn>
+Date: Fri, 1 May 2026 18:00:02 +0800
+Subject: [PATCH] net: phy: realtek: Add support for PHY LEDs on RTL8221B
+
+Realtek RTL8221B Ethernet PHY supports three LED pins which are used to
+indicate link status and activity. Add netdev trigger support for them.
+
+Signed-off-by: Chukun Pan <amadeus@jmu.edu.cn>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Link: https://patch.msgid.link/20260501100002.755672-1-amadeus@jmu.edu.cn
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/phy/realtek/realtek_main.c | 165 +++++++++++++++++++++++++
+ 1 file changed, 165 insertions(+)
+
+--- a/drivers/net/phy/realtek/realtek_main.c
++++ b/drivers/net/phy/realtek/realtek_main.c
+@@ -149,6 +149,18 @@
+ 
+ #define RTL8221B_VND2_INSR			0xa4d4
+ 
++#define RTL822X_VND2_LED(x)			(0xd032 + ((x) * 2))
++#define RTL822X_VND2_LCR_LINK_10		BIT(0)
++#define RTL822X_VND2_LCR_LINK_100		BIT(1)
++#define RTL822X_VND2_LCR_LINK_1000		BIT(2)
++#define RTL822X_VND2_LCR_LINK_2500		BIT(5)
++
++#define RTL822X_VND2_LCR6			0xd040
++#define RTL822X_VND2_LED_ACT(x)			BIT(x)
++
++#define RTL822X_VND2_LCR7			0xd044
++#define RTL822X_VND2_LED_POLAR(x)		BIT(x)
++
+ #define RTL8224_MII_RTCT			0x11
+ #define RTL8224_MII_RTCT_ENABLE			BIT(0)
+ #define RTL8224_MII_RTCT_PAIR_A			BIT(4)
+@@ -1657,6 +1669,151 @@ static int rtl822xb_c45_read_status(stru
+ 	return 0;
+ }
+ 
++static int rtl822xb_led_brightness_set(struct phy_device *phydev, u8 index,
++				       enum led_brightness value)
++{
++	int ret;
++
++	if (index >= RTL8211x_LED_COUNT)
++		return -EINVAL;
++
++	/* clear HW LED setup */
++	ret = phy_write_mmd(phydev, MDIO_MMD_VEND2,
++			    RTL822X_VND2_LED(index), 0);
++	if (ret < 0)
++		return ret;
++
++	/* clear HW LED blink */
++	ret = phy_clear_bits_mmd(phydev, MDIO_MMD_VEND2, RTL822X_VND2_LCR6,
++				 RTL822X_VND2_LED_ACT(index));
++	if (ret < 0)
++		return ret;
++
++	if (value != LED_OFF)
++		return phy_set_bits_mmd(phydev, MDIO_MMD_VEND2,
++					RTL822X_VND2_LCR7,
++					RTL822X_VND2_LED_POLAR(index));
++	else
++		return phy_clear_bits_mmd(phydev, MDIO_MMD_VEND2,
++					  RTL822X_VND2_LCR7,
++					  RTL822X_VND2_LED_POLAR(index));
++}
++
++static int rtl822xb_led_hw_is_supported(struct phy_device *phydev, u8 index,
++					unsigned long rules)
++{
++	const unsigned long  act_mask = BIT(TRIGGER_NETDEV_RX) |
++					BIT(TRIGGER_NETDEV_TX);
++
++	const unsigned long link_mask = BIT(TRIGGER_NETDEV_LINK) |
++					BIT(TRIGGER_NETDEV_LINK_10) |
++					BIT(TRIGGER_NETDEV_LINK_100) |
++					BIT(TRIGGER_NETDEV_LINK_1000) |
++					BIT(TRIGGER_NETDEV_LINK_2500);
++
++	if (index >= RTL8211x_LED_COUNT)
++		return -EINVAL;
++
++	/* Filter out any other unsupported triggers. */
++	if (rules & ~(link_mask | act_mask))
++		return -EOPNOTSUPP;
++
++	/* RX and TX are not differentiated, they are not possible
++	 * without combination with a link trigger.
++	 */
++	if ((rules & act_mask) && !(rules & link_mask))
++		return -EOPNOTSUPP;
++
++	return 0;
++}
++
++static int rtl822xb_led_hw_control_get(struct phy_device *phydev, u8 index,
++				       unsigned long *rules)
++{
++	int val;
++
++	if (index >= RTL8211x_LED_COUNT)
++		return -EINVAL;
++
++	val = phy_read_mmd(phydev, MDIO_MMD_VEND2, RTL822X_VND2_LED(index));
++	if (val < 0)
++		return val;
++
++	if (val & RTL822X_VND2_LCR_LINK_10)
++		__set_bit(TRIGGER_NETDEV_LINK_10, rules);
++
++	if (val & RTL822X_VND2_LCR_LINK_100)
++		__set_bit(TRIGGER_NETDEV_LINK_100, rules);
++
++	if (val & RTL822X_VND2_LCR_LINK_1000)
++		__set_bit(TRIGGER_NETDEV_LINK_1000, rules);
++
++	if (val & RTL822X_VND2_LCR_LINK_2500)
++		__set_bit(TRIGGER_NETDEV_LINK_2500, rules);
++
++	if ((val & RTL822X_VND2_LCR_LINK_10) &&
++	    (val & RTL822X_VND2_LCR_LINK_100) &&
++	    (val & RTL822X_VND2_LCR_LINK_1000) &&
++	    (val & RTL822X_VND2_LCR_LINK_2500))
++		__set_bit(TRIGGER_NETDEV_LINK, rules);
++
++	val = phy_read_mmd(phydev, MDIO_MMD_VEND2, RTL822X_VND2_LCR6);
++	if (val < 0)
++		return val;
++
++	if (val & RTL822X_VND2_LED_ACT(index)) {
++		__set_bit(TRIGGER_NETDEV_RX, rules);
++		__set_bit(TRIGGER_NETDEV_TX, rules);
++	}
++
++	return 0;
++}
++
++static int rtl822xb_led_hw_control_set(struct phy_device *phydev, u8 index,
++				       unsigned long rules)
++{
++	u16 val = 0;
++	bool act;
++	int ret;
++
++	if (index >= RTL8211x_LED_COUNT)
++		return -EINVAL;
++
++	if (test_bit(TRIGGER_NETDEV_LINK, &rules) ||
++	    test_bit(TRIGGER_NETDEV_LINK_10, &rules))
++		val |= RTL822X_VND2_LCR_LINK_10;
++
++	if (test_bit(TRIGGER_NETDEV_LINK, &rules) ||
++	    test_bit(TRIGGER_NETDEV_LINK_100, &rules))
++		val |= RTL822X_VND2_LCR_LINK_100;
++
++	if (test_bit(TRIGGER_NETDEV_LINK, &rules) ||
++	    test_bit(TRIGGER_NETDEV_LINK_1000, &rules))
++		val |= RTL822X_VND2_LCR_LINK_1000;
++
++	if (test_bit(TRIGGER_NETDEV_LINK, &rules) ||
++	    test_bit(TRIGGER_NETDEV_LINK_2500, &rules))
++		val |= RTL822X_VND2_LCR_LINK_2500;
++
++	ret = phy_write_mmd(phydev, MDIO_MMD_VEND2,
++			    RTL822X_VND2_LED(index), val);
++	if (ret < 0)
++		return ret;
++
++	act = test_bit(TRIGGER_NETDEV_RX, &rules) ||
++	      test_bit(TRIGGER_NETDEV_TX, &rules);
++
++	ret = phy_modify_mmd(phydev, MDIO_MMD_VEND2, RTL822X_VND2_LCR6,
++			     RTL822X_VND2_LED_ACT(index), act ?
++			     RTL822X_VND2_LED_ACT(index) : 0);
++	if (ret < 0)
++		return ret;
++
++	/* Reset polarity to default */
++	return phy_clear_bits_mmd(phydev, MDIO_MMD_VEND2, RTL822X_VND2_LCR7,
++				  RTL822X_VND2_LED_POLAR(index));
++}
++
+ static int rtl8224_cable_test_start(struct phy_device *phydev)
+ {
+ 	u32 val;
+@@ -2329,6 +2486,10 @@ static struct phy_driver realtek_drvs[]
+ 		.write_page	= rtl821x_write_page,
+ 		.read_mmd	= rtl822xb_read_mmd,
+ 		.write_mmd	= rtl822xb_write_mmd,
++		.led_brightness_set = rtl822xb_led_brightness_set,
++		.led_hw_is_supported = rtl822xb_led_hw_is_supported,
++		.led_hw_control_get = rtl822xb_led_hw_control_get,
++		.led_hw_control_set = rtl822xb_led_hw_control_set,
+ 	}, {
+ 		.match_phy_device = rtl8221b_vm_cg_match_phy_device,
+ 		.name		= "RTL8221B-VM-CG 2.5Gbps PHY",
+@@ -2348,6 +2509,10 @@ static struct phy_driver realtek_drvs[]
+ 		.write_page	= rtl821x_write_page,
+ 		.read_mmd	= rtl822xb_read_mmd,
+ 		.write_mmd	= rtl822xb_write_mmd,
++		.led_brightness_set = rtl822xb_led_brightness_set,
++		.led_hw_is_supported = rtl822xb_led_hw_is_supported,
++		.led_hw_control_get = rtl822xb_led_hw_control_get,
++		.led_hw_control_set = rtl822xb_led_hw_control_set,
+ 	}, {
+ 		.match_phy_device = rtl8251b_c45_match_phy_device,
+ 		.name		= "RTL8251B 5Gbps PHY",

--- a/target/linux/generic/backport-6.18/799-v7.2-net-phy-realtek-Add-support-for-PHY-LEDs-on-RTL8221B.patch
+++ b/target/linux/generic/backport-6.18/799-v7.2-net-phy-realtek-Add-support-for-PHY-LEDs-on-RTL8221B.patch
@@ -1,0 +1,211 @@
+From d3aae4d954f92a273388439ab015763e0cdea1e0 Mon Sep 17 00:00:00 2001
+From: Chukun Pan <amadeus@jmu.edu.cn>
+Date: Fri, 1 May 2026 18:00:02 +0800
+Subject: [PATCH] net: phy: realtek: Add support for PHY LEDs on RTL8221B
+
+Realtek RTL8221B Ethernet PHY supports three LED pins which are used to
+indicate link status and activity. Add netdev trigger support for them.
+
+Signed-off-by: Chukun Pan <amadeus@jmu.edu.cn>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Link: https://patch.msgid.link/20260501100002.755672-1-amadeus@jmu.edu.cn
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/phy/realtek/realtek_main.c | 165 +++++++++++++++++++++++++
+ 1 file changed, 165 insertions(+)
+
+--- a/drivers/net/phy/realtek/realtek_main.c
++++ b/drivers/net/phy/realtek/realtek_main.c
+@@ -149,6 +149,18 @@
+ 
+ #define RTL8221B_VND2_INSR			0xa4d4
+ 
++#define RTL822X_VND2_LED(x)			(0xd032 + ((x) * 2))
++#define RTL822X_VND2_LCR_LINK_10		BIT(0)
++#define RTL822X_VND2_LCR_LINK_100		BIT(1)
++#define RTL822X_VND2_LCR_LINK_1000		BIT(2)
++#define RTL822X_VND2_LCR_LINK_2500		BIT(5)
++
++#define RTL822X_VND2_LCR6			0xd040
++#define RTL822X_VND2_LED_ACT(x)			BIT(x)
++
++#define RTL822X_VND2_LCR7			0xd044
++#define RTL822X_VND2_LED_POLAR(x)		BIT(x)
++
+ #define RTL8224_MII_RTCT			0x11
+ #define RTL8224_MII_RTCT_ENABLE			BIT(0)
+ #define RTL8224_MII_RTCT_PAIR_A			BIT(4)
+@@ -1658,6 +1670,151 @@ static int rtl822xb_c45_read_status(stru
+ 	return 0;
+ }
+ 
++static int rtl822xb_led_brightness_set(struct phy_device *phydev, u8 index,
++				       enum led_brightness value)
++{
++	int ret;
++
++	if (index >= RTL8211x_LED_COUNT)
++		return -EINVAL;
++
++	/* clear HW LED setup */
++	ret = phy_write_mmd(phydev, MDIO_MMD_VEND2,
++			    RTL822X_VND2_LED(index), 0);
++	if (ret < 0)
++		return ret;
++
++	/* clear HW LED blink */
++	ret = phy_clear_bits_mmd(phydev, MDIO_MMD_VEND2, RTL822X_VND2_LCR6,
++				 RTL822X_VND2_LED_ACT(index));
++	if (ret < 0)
++		return ret;
++
++	if (value != LED_OFF)
++		return phy_set_bits_mmd(phydev, MDIO_MMD_VEND2,
++					RTL822X_VND2_LCR7,
++					RTL822X_VND2_LED_POLAR(index));
++	else
++		return phy_clear_bits_mmd(phydev, MDIO_MMD_VEND2,
++					  RTL822X_VND2_LCR7,
++					  RTL822X_VND2_LED_POLAR(index));
++}
++
++static int rtl822xb_led_hw_is_supported(struct phy_device *phydev, u8 index,
++					unsigned long rules)
++{
++	const unsigned long  act_mask = BIT(TRIGGER_NETDEV_RX) |
++					BIT(TRIGGER_NETDEV_TX);
++
++	const unsigned long link_mask = BIT(TRIGGER_NETDEV_LINK) |
++					BIT(TRIGGER_NETDEV_LINK_10) |
++					BIT(TRIGGER_NETDEV_LINK_100) |
++					BIT(TRIGGER_NETDEV_LINK_1000) |
++					BIT(TRIGGER_NETDEV_LINK_2500);
++
++	if (index >= RTL8211x_LED_COUNT)
++		return -EINVAL;
++
++	/* Filter out any other unsupported triggers. */
++	if (rules & ~(link_mask | act_mask))
++		return -EOPNOTSUPP;
++
++	/* RX and TX are not differentiated, they are not possible
++	 * without combination with a link trigger.
++	 */
++	if ((rules & act_mask) && !(rules & link_mask))
++		return -EOPNOTSUPP;
++
++	return 0;
++}
++
++static int rtl822xb_led_hw_control_get(struct phy_device *phydev, u8 index,
++				       unsigned long *rules)
++{
++	int val;
++
++	if (index >= RTL8211x_LED_COUNT)
++		return -EINVAL;
++
++	val = phy_read_mmd(phydev, MDIO_MMD_VEND2, RTL822X_VND2_LED(index));
++	if (val < 0)
++		return val;
++
++	if (val & RTL822X_VND2_LCR_LINK_10)
++		__set_bit(TRIGGER_NETDEV_LINK_10, rules);
++
++	if (val & RTL822X_VND2_LCR_LINK_100)
++		__set_bit(TRIGGER_NETDEV_LINK_100, rules);
++
++	if (val & RTL822X_VND2_LCR_LINK_1000)
++		__set_bit(TRIGGER_NETDEV_LINK_1000, rules);
++
++	if (val & RTL822X_VND2_LCR_LINK_2500)
++		__set_bit(TRIGGER_NETDEV_LINK_2500, rules);
++
++	if ((val & RTL822X_VND2_LCR_LINK_10) &&
++	    (val & RTL822X_VND2_LCR_LINK_100) &&
++	    (val & RTL822X_VND2_LCR_LINK_1000) &&
++	    (val & RTL822X_VND2_LCR_LINK_2500))
++		__set_bit(TRIGGER_NETDEV_LINK, rules);
++
++	val = phy_read_mmd(phydev, MDIO_MMD_VEND2, RTL822X_VND2_LCR6);
++	if (val < 0)
++		return val;
++
++	if (val & RTL822X_VND2_LED_ACT(index)) {
++		__set_bit(TRIGGER_NETDEV_RX, rules);
++		__set_bit(TRIGGER_NETDEV_TX, rules);
++	}
++
++	return 0;
++}
++
++static int rtl822xb_led_hw_control_set(struct phy_device *phydev, u8 index,
++				       unsigned long rules)
++{
++	u16 val = 0;
++	bool act;
++	int ret;
++
++	if (index >= RTL8211x_LED_COUNT)
++		return -EINVAL;
++
++	if (test_bit(TRIGGER_NETDEV_LINK, &rules) ||
++	    test_bit(TRIGGER_NETDEV_LINK_10, &rules))
++		val |= RTL822X_VND2_LCR_LINK_10;
++
++	if (test_bit(TRIGGER_NETDEV_LINK, &rules) ||
++	    test_bit(TRIGGER_NETDEV_LINK_100, &rules))
++		val |= RTL822X_VND2_LCR_LINK_100;
++
++	if (test_bit(TRIGGER_NETDEV_LINK, &rules) ||
++	    test_bit(TRIGGER_NETDEV_LINK_1000, &rules))
++		val |= RTL822X_VND2_LCR_LINK_1000;
++
++	if (test_bit(TRIGGER_NETDEV_LINK, &rules) ||
++	    test_bit(TRIGGER_NETDEV_LINK_2500, &rules))
++		val |= RTL822X_VND2_LCR_LINK_2500;
++
++	ret = phy_write_mmd(phydev, MDIO_MMD_VEND2,
++			    RTL822X_VND2_LED(index), val);
++	if (ret < 0)
++		return ret;
++
++	act = test_bit(TRIGGER_NETDEV_RX, &rules) ||
++	      test_bit(TRIGGER_NETDEV_TX, &rules);
++
++	ret = phy_modify_mmd(phydev, MDIO_MMD_VEND2, RTL822X_VND2_LCR6,
++			     RTL822X_VND2_LED_ACT(index), act ?
++			     RTL822X_VND2_LED_ACT(index) : 0);
++	if (ret < 0)
++		return ret;
++
++	/* Reset polarity to default */
++	return phy_clear_bits_mmd(phydev, MDIO_MMD_VEND2, RTL822X_VND2_LCR7,
++				  RTL822X_VND2_LED_POLAR(index));
++}
++
+ static int rtl8224_cable_test_start(struct phy_device *phydev)
+ {
+ 	u32 val;
+@@ -2330,6 +2487,10 @@ static struct phy_driver realtek_drvs[]
+ 		.write_page	= rtl821x_write_page,
+ 		.read_mmd	= rtl822xb_read_mmd,
+ 		.write_mmd	= rtl822xb_write_mmd,
++		.led_brightness_set = rtl822xb_led_brightness_set,
++		.led_hw_is_supported = rtl822xb_led_hw_is_supported,
++		.led_hw_control_get = rtl822xb_led_hw_control_get,
++		.led_hw_control_set = rtl822xb_led_hw_control_set,
+ 	}, {
+ 		.match_phy_device = rtl8221b_vm_cg_match_phy_device,
+ 		.name		= "RTL8221B-VM-CG 2.5Gbps PHY",
+@@ -2349,6 +2510,10 @@ static struct phy_driver realtek_drvs[]
+ 		.write_page	= rtl821x_write_page,
+ 		.read_mmd	= rtl822xb_read_mmd,
+ 		.write_mmd	= rtl822xb_write_mmd,
++		.led_brightness_set = rtl822xb_led_brightness_set,
++		.led_hw_is_supported = rtl822xb_led_hw_is_supported,
++		.led_hw_control_get = rtl822xb_led_hw_control_get,
++		.led_hw_control_set = rtl822xb_led_hw_control_set,
+ 	}, {
+ 		.match_phy_device = rtl8251b_c45_match_phy_device,
+ 		.name		= "RTL8251B 5Gbps PHY",

--- a/target/linux/generic/pending-6.12/720-01-net-phy-realtek-use-genphy_soft_reset-for-2.5G-PHYs.patch
+++ b/target/linux/generic/pending-6.12/720-01-net-phy-realtek-use-genphy_soft_reset-for-2.5G-PHYs.patch
@@ -15,7 +15,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -2255,6 +2255,7 @@ static struct phy_driver realtek_drvs[]
+@@ -2412,6 +2412,7 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.name		= "RTL8226 2.5Gbps PHY",
  		.match_phy_device = rtl8226_match_phy_device,
@@ -23,7 +23,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.get_features	= rtl822x_get_features,
  		.config_aneg	= rtl822x_config_aneg,
  		.read_status	= rtl822x_read_status,
-@@ -2267,6 +2268,7 @@ static struct phy_driver realtek_drvs[]
+@@ -2424,6 +2425,7 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.match_phy_device = rtl8221b_match_phy_device,
  		.name		= "RTL8226B_RTL8221B 2.5Gbps PHY",
@@ -31,7 +31,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.get_features	= rtl822x_get_features,
  		.config_aneg	= rtl822x_config_aneg,
  		.config_init	= rtl822xb_config_init,
-@@ -2297,6 +2299,7 @@ static struct phy_driver realtek_drvs[]
+@@ -2454,6 +2456,7 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		PHY_ID_MATCH_EXACT(0x001cc848),
  		.name		= "RTL8226B-CG_RTL8221B-CG 2.5Gbps PHY",
@@ -39,7 +39,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.get_features	= rtl822x_get_features,
  		.config_aneg	= rtl822x_config_aneg,
  		.config_init	= rtl822xb_config_init,
-@@ -2315,6 +2318,7 @@ static struct phy_driver realtek_drvs[]
+@@ -2472,6 +2475,7 @@ static struct phy_driver realtek_drvs[]
  		.name		= "RTL8221B-VB-CG 2.5Gbps PHY",
  		.config_intr	= rtl8221b_config_intr,
  		.handle_interrupt = rtl8221b_handle_interrupt,
@@ -47,7 +47,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.probe		= rtl822x_probe,
  		.config_init	= rtl822xb_config_init,
  		.inband_caps	= rtl822x_inband_caps,
-@@ -2334,6 +2338,7 @@ static struct phy_driver realtek_drvs[]
+@@ -2495,6 +2499,7 @@ static struct phy_driver realtek_drvs[]
  		.name		= "RTL8221B-VM-CG 2.5Gbps PHY",
  		.config_intr	= rtl8221b_config_intr,
  		.handle_interrupt = rtl8221b_handle_interrupt,

--- a/target/linux/generic/pending-6.12/720-03-net-phy-realtek-make-sure-paged-read-is-protected-by.patch
+++ b/target/linux/generic/pending-6.12/720-03-net-phy-realtek-make-sure-paged-read-is-protected-by.patch
@@ -18,7 +18,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -1823,9 +1823,11 @@ static bool rtlgen_supports_2_5gbps(stru
+@@ -1980,9 +1980,11 @@ static bool rtlgen_supports_2_5gbps(stru
  {
  	int val;
  

--- a/target/linux/generic/pending-6.12/720-04-net-phy-realtek-setup-aldps.patch
+++ b/target/linux/generic/pending-6.12/720-04-net-phy-realtek-setup-aldps.patch
@@ -13,7 +13,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -170,6 +170,10 @@
+@@ -182,6 +182,10 @@
  
  #define RTL8224_SRAM_RTCT_LEN(pair)		(0x8028 + (pair) * 4)
  
@@ -24,7 +24,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  #define RTL8366RB_POWER_SAVE			0x15
  #define RTL8366RB_POWER_SAVE_ON			BIT(12)
  
-@@ -216,6 +220,10 @@ struct rtl821x_priv {
+@@ -228,6 +232,10 @@ struct rtl821x_priv {
  	u16 iner;
  };
  
@@ -35,7 +35,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  static int rtl821x_read_page(struct phy_device *phydev)
  {
  	return __phy_read(phydev, RTL821x_PAGE_SELECT);
-@@ -1238,6 +1246,18 @@ static int rtl822x_write_mmd(struct phy_
+@@ -1250,6 +1258,18 @@ static int rtl822x_write_mmd(struct phy_
  
  static int rtl822x_probe(struct phy_device *phydev)
  {
@@ -54,7 +54,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	if (IS_ENABLED(CONFIG_REALTEK_PHY_HWMON) &&
  	    phydev->phy_id != RTL_GENERIC_PHYID)
  		return rtl822x_hwmon_init(phydev);
-@@ -1328,6 +1348,19 @@ static int rtl822xb_write_mmd(struct phy
+@@ -1340,6 +1360,19 @@ static int rtl822xb_write_mmd(struct phy
  	return write_ret;
  }
  
@@ -74,7 +74,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  static int rtl822x_set_serdes_option_mode(struct phy_device *phydev, bool gen1)
  {
  	bool has_2500, has_sgmii;
-@@ -1385,7 +1418,15 @@ static int rtl822x_set_serdes_option_mod
+@@ -1397,7 +1430,15 @@ static int rtl822x_set_serdes_option_mod
  	if (ret < 0)
  		return ret;
  

--- a/target/linux/generic/pending-6.12/720-05-net-phy-realtek-detect-early-version-of-RTL8221B.patch
+++ b/target/linux/generic/pending-6.12/720-05-net-phy-realtek-detect-early-version-of-RTL8221B.patch
@@ -14,7 +14,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 Signed-off-by: Mieczyslaw Nalewaj <namiltd@yahoo.com>
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -1908,10 +1908,32 @@ static int rtl8226_match_phy_device(stru
+@@ -2065,10 +2065,32 @@ static int rtl8226_match_phy_device(stru
  static int rtlgen_is_c45_match(struct phy_device *phydev, unsigned int id,
  			       bool is_c45)
  {

--- a/target/linux/generic/pending-6.12/720-06-net-phy-realtek-mark-existing-MMDs-as-present.patch
+++ b/target/linux/generic/pending-6.12/720-06-net-phy-realtek-mark-existing-MMDs-as-present.patch
@@ -15,7 +15,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -1604,6 +1604,9 @@ static int rtl822x_c45_get_features(stru
+@@ -1616,6 +1616,9 @@ static int rtl822x_c45_get_features(stru
  	linkmode_set_bit(ETHTOOL_LINK_MODE_TP_BIT,
  			 phydev->supported);
  

--- a/target/linux/generic/pending-6.12/720-07-net-phy-realtek-disable-MDIO-broadcast.patch
+++ b/target/linux/generic/pending-6.12/720-07-net-phy-realtek-disable-MDIO-broadcast.patch
@@ -13,7 +13,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 ---
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -173,6 +173,7 @@
+@@ -185,6 +185,7 @@
  #define RTL8221B_PHYCR1				0xa430
  #define RTL8221B_PHYCR1_ALDPS_EN		BIT(2)
  #define RTL8221B_PHYCR1_ALDPS_XTAL_OFF_EN	BIT(12)
@@ -21,7 +21,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  
  #define RTL8366RB_POWER_SAVE			0x15
  #define RTL8366RB_POWER_SAVE_ON			BIT(12)
-@@ -1351,14 +1352,21 @@ static int rtl822xb_write_mmd(struct phy
+@@ -1363,14 +1364,21 @@ static int rtl822xb_write_mmd(struct phy
  static int rtl822x_init_phycr1(struct phy_device *phydev, bool no_aldps)
  {
  	struct rtl822x_priv *priv = phydev->priv;

--- a/target/linux/generic/pending-6.12/720-08-net-phy-realtek-rate-adapter-in-C22-mode.patch
+++ b/target/linux/generic/pending-6.12/720-08-net-phy-realtek-rate-adapter-in-C22-mode.patch
@@ -11,7 +11,7 @@ interface mode if the PHY is connected using Clause-45 MDIO.
 Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -1393,7 +1393,7 @@ static int rtl822x_set_serdes_option_mod
+@@ -1405,7 +1405,7 @@ static int rtl822x_set_serdes_option_mod
  		return 0;
  
  	/* determine SerDes option mode */

--- a/target/linux/generic/pending-6.18/720-01-net-phy-realtek-use-genphy_soft_reset-for-2.5G-PHYs.patch
+++ b/target/linux/generic/pending-6.18/720-01-net-phy-realtek-use-genphy_soft_reset-for-2.5G-PHYs.patch
@@ -15,7 +15,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -2256,6 +2256,7 @@ static struct phy_driver realtek_drvs[]
+@@ -2413,6 +2413,7 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.name		= "RTL8226 2.5Gbps PHY",
  		.match_phy_device = rtl8226_match_phy_device,
@@ -23,7 +23,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.get_features	= rtl822x_get_features,
  		.config_aneg	= rtl822x_config_aneg,
  		.read_status	= rtl822x_read_status,
-@@ -2268,6 +2269,7 @@ static struct phy_driver realtek_drvs[]
+@@ -2425,6 +2426,7 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.match_phy_device = rtl8221b_match_phy_device,
  		.name		= "RTL8226B_RTL8221B 2.5Gbps PHY",
@@ -31,7 +31,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.get_features	= rtl822x_get_features,
  		.config_aneg	= rtl822x_config_aneg,
  		.config_init	= rtl822xb_config_init,
-@@ -2298,6 +2300,7 @@ static struct phy_driver realtek_drvs[]
+@@ -2455,6 +2457,7 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		PHY_ID_MATCH_EXACT(0x001cc848),
  		.name		= "RTL8226B-CG_RTL8221B-CG 2.5Gbps PHY",
@@ -39,7 +39,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.get_features	= rtl822x_get_features,
  		.config_aneg	= rtl822x_config_aneg,
  		.config_init	= rtl822xb_config_init,
-@@ -2316,6 +2319,7 @@ static struct phy_driver realtek_drvs[]
+@@ -2473,6 +2476,7 @@ static struct phy_driver realtek_drvs[]
  		.name		= "RTL8221B-VB-CG 2.5Gbps PHY",
  		.config_intr	= rtl8221b_config_intr,
  		.handle_interrupt = rtl8221b_handle_interrupt,
@@ -47,7 +47,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.probe		= rtl822x_probe,
  		.config_init	= rtl822xb_config_init,
  		.inband_caps	= rtl822x_inband_caps,
-@@ -2335,6 +2339,7 @@ static struct phy_driver realtek_drvs[]
+@@ -2496,6 +2500,7 @@ static struct phy_driver realtek_drvs[]
  		.name		= "RTL8221B-VM-CG 2.5Gbps PHY",
  		.config_intr	= rtl8221b_config_intr,
  		.handle_interrupt = rtl8221b_handle_interrupt,

--- a/target/linux/generic/pending-6.18/720-03-net-phy-realtek-make-sure-paged-read-is-protected-by.patch
+++ b/target/linux/generic/pending-6.18/720-03-net-phy-realtek-make-sure-paged-read-is-protected-by.patch
@@ -18,7 +18,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -1824,9 +1824,11 @@ static bool rtlgen_supports_2_5gbps(stru
+@@ -1981,9 +1981,11 @@ static bool rtlgen_supports_2_5gbps(stru
  {
  	int val;
  

--- a/target/linux/generic/pending-6.18/720-04-net-phy-realtek-setup-aldps.patch
+++ b/target/linux/generic/pending-6.18/720-04-net-phy-realtek-setup-aldps.patch
@@ -13,7 +13,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -170,6 +170,10 @@
+@@ -182,6 +182,10 @@
  
  #define RTL8224_SRAM_RTCT_LEN(pair)		(0x8028 + (pair) * 4)
  
@@ -24,7 +24,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  #define RTL8366RB_POWER_SAVE			0x15
  #define RTL8366RB_POWER_SAVE_ON			BIT(12)
  
-@@ -216,6 +220,10 @@ struct rtl821x_priv {
+@@ -228,6 +232,10 @@ struct rtl821x_priv {
  	u16 iner;
  };
  
@@ -35,7 +35,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  static int rtl821x_read_page(struct phy_device *phydev)
  {
  	return __phy_read(phydev, RTL821x_PAGE_SELECT);
-@@ -1238,6 +1246,18 @@ static int rtl822x_write_mmd(struct phy_
+@@ -1250,6 +1258,18 @@ static int rtl822x_write_mmd(struct phy_
  
  static int rtl822x_probe(struct phy_device *phydev)
  {
@@ -54,7 +54,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	if (IS_ENABLED(CONFIG_REALTEK_PHY_HWMON) &&
  	    phydev->phy_id != RTL_GENERIC_PHYID)
  		return rtl822x_hwmon_init(phydev);
-@@ -1328,6 +1348,19 @@ static int rtl822xb_write_mmd(struct phy
+@@ -1340,6 +1360,19 @@ static int rtl822xb_write_mmd(struct phy
  	return write_ret;
  }
  
@@ -74,7 +74,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  static int rtl822x_set_serdes_option_mode(struct phy_device *phydev, bool gen1)
  {
  	bool has_2500, has_sgmii;
-@@ -1385,7 +1418,15 @@ static int rtl822x_set_serdes_option_mod
+@@ -1397,7 +1430,15 @@ static int rtl822x_set_serdes_option_mod
  	if (ret < 0)
  		return ret;
  

--- a/target/linux/generic/pending-6.18/720-05-net-phy-realtek-detect-early-version-of-RTL8221B.patch
+++ b/target/linux/generic/pending-6.18/720-05-net-phy-realtek-detect-early-version-of-RTL8221B.patch
@@ -14,7 +14,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 Signed-off-by: Mieczyslaw Nalewaj <namiltd@yahoo.com>
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -1909,10 +1909,32 @@ static int rtl8226_match_phy_device(stru
+@@ -2066,10 +2066,32 @@ static int rtl8226_match_phy_device(stru
  static int rtlgen_is_c45_match(struct phy_device *phydev, unsigned int id,
  			       bool is_c45)
  {

--- a/target/linux/generic/pending-6.18/720-06-net-phy-realtek-mark-existing-MMDs-as-present.patch
+++ b/target/linux/generic/pending-6.18/720-06-net-phy-realtek-mark-existing-MMDs-as-present.patch
@@ -15,7 +15,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -1605,6 +1605,9 @@ static int rtl822x_c45_get_features(stru
+@@ -1617,6 +1617,9 @@ static int rtl822x_c45_get_features(stru
  	linkmode_set_bit(ETHTOOL_LINK_MODE_TP_BIT,
  			 phydev->supported);
  

--- a/target/linux/generic/pending-6.18/720-07-net-phy-realtek-disable-MDIO-broadcast.patch
+++ b/target/linux/generic/pending-6.18/720-07-net-phy-realtek-disable-MDIO-broadcast.patch
@@ -13,7 +13,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 ---
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -173,6 +173,7 @@
+@@ -185,6 +185,7 @@
  #define RTL8221B_PHYCR1				0xa430
  #define RTL8221B_PHYCR1_ALDPS_EN		BIT(2)
  #define RTL8221B_PHYCR1_ALDPS_XTAL_OFF_EN	BIT(12)
@@ -21,7 +21,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  
  #define RTL8366RB_POWER_SAVE			0x15
  #define RTL8366RB_POWER_SAVE_ON			BIT(12)
-@@ -1351,14 +1352,21 @@ static int rtl822xb_write_mmd(struct phy
+@@ -1363,14 +1364,21 @@ static int rtl822xb_write_mmd(struct phy
  static int rtl822x_init_phycr1(struct phy_device *phydev, bool no_aldps)
  {
  	struct rtl822x_priv *priv = phydev->priv;

--- a/target/linux/generic/pending-6.18/720-08-net-phy-realtek-rate-adapter-in-C22-mode.patch
+++ b/target/linux/generic/pending-6.18/720-08-net-phy-realtek-rate-adapter-in-C22-mode.patch
@@ -11,7 +11,7 @@ interface mode if the PHY is connected using Clause-45 MDIO.
 Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -1393,7 +1393,7 @@ static int rtl822x_set_serdes_option_mod
+@@ -1405,7 +1405,7 @@ static int rtl822x_set_serdes_option_mod
  		return 0;
  
  	/* determine SerDes option mode */

--- a/target/linux/generic/pending-6.18/742-net-phy-realtek-add-5G-and-10G-PHY-support.patch
+++ b/target/linux/generic/pending-6.18/742-net-phy-realtek-add-5G-and-10G-PHY-support.patch
@@ -64,7 +64,7 @@ Signed-off-by: Balázs Triszka <info@balika011.hu>
  #include <linux/string_choices.h>
  #include <net/phy/realtek_phy.h>
  
-@@ -205,10 +207,27 @@
+@@ -217,10 +219,27 @@
  #define RTL_8221B_VM_CG				0x001cc84a
  #define RTL_8251B				0x001cc862
  #define RTL_8261C				0x001cc890
@@ -92,7 +92,7 @@ Signed-off-by: Balázs Triszka <info@balika011.hu>
  MODULE_DESCRIPTION("Realtek PHY driver");
  MODULE_AUTHOR("Johnson Leung");
  MODULE_LICENSE("GPL");
-@@ -1994,6 +2013,125 @@ static int rtl8251b_c45_match_phy_device
+@@ -2151,6 +2170,125 @@ static int rtl8251b_c45_match_phy_device
  	return rtlgen_is_c45_match(phydev, RTL_8251B, true);
  }
  
@@ -218,7 +218,7 @@ Signed-off-by: Balázs Triszka <info@balika011.hu>
  static int rtlgen_resume(struct phy_device *phydev)
  {
  	int ret = genphy_resume(phydev);
-@@ -2215,6 +2353,482 @@ static int rtlgen_sfp_config_aneg(struct
+@@ -2372,6 +2510,482 @@ static int rtlgen_sfp_config_aneg(struct
  	return 0;
  }
  
@@ -701,7 +701,7 @@ Signed-off-by: Balázs Triszka <info@balika011.hu>
  static struct phy_driver realtek_drvs[] = {
  	{
  		PHY_ID_MATCH_EXACT(0x00008201),
-@@ -2521,6 +3135,108 @@ static struct phy_driver realtek_drvs[]
+@@ -2686,6 +3300,108 @@ static struct phy_driver realtek_drvs[]
  		.resume		= genphy_resume,
  		.read_mmd	= genphy_read_mmd_unsupported,
  		.write_mmd	= genphy_write_mmd_unsupported,

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000p-v1.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000p-v1.dtsi
@@ -43,12 +43,6 @@
 			linux,default-trigger = "phy1tpt";
 		};
 
-		led-wan {
-			function = LED_FUNCTION_WAN;
-			color = <LED_COLOR_ID_WHITE>;
-			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
-		};
-
 		led-usb {
 			function = LED_FUNCTION_USB;
 			color = <LED_COLOR_ID_WHITE>;

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000p-v1.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000p-v1.dtsi
@@ -79,6 +79,17 @@
 		reset-assert-us = <100000>;
 		reset-deassert-us = <100000>;
 		reset-gpios = <&pio 3 GPIO_ACTIVE_LOW>;
+
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led@1 {
+				reg = <1>;
+				color = <LED_COLOR_ID_WHITE>;
+				function = LED_FUNCTION_WAN;
+			};
+		};
 	};
 };
 

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -96,14 +96,16 @@ cudy,wr3000e-v1-ubootmod)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan"
 	;;
 cudy,wr3000h-v1|\
-cudy,wr3000h-v1-ubootmod|\
-cudy,wr3000p-v1|\
-cudy,wr3000p-v1-ubootmod)
+cudy,wr3000h-v1-ubootmod)
 	ucidef_set_led_netdev "lan1" "lan1" "white:lan-1" "lan1" "link tx rx"
 	ucidef_set_led_netdev "lan2" "lan2" "white:lan-2" "lan2" "link tx rx"
 	ucidef_set_led_netdev "lan3" "lan3" "white:lan-3" "lan3" "link tx rx"
 	ucidef_set_led_netdev "lan4" "lan4" "white:lan-4" "lan4" "link tx rx"
 	ucidef_set_led_netdev "wan" "wan" "white:wan" "wan" "link tx rx"
+	ucidef_set_led_netdev "internet" "internet" "white:wan-online" "wan" "link"
+	;;
+cudy,wr3000p-v1|\
+cudy,wr3000p-v1-ubootmod)
 	ucidef_set_led_netdev "internet" "internet" "white:wan-online" "wan" "link"
 	;;
 cudy,wr3000u-v1|\

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -106,6 +106,7 @@ cudy,wr3000h-v1-ubootmod)
 	;;
 cudy,wr3000p-v1|\
 cudy,wr3000p-v1-ubootmod)
+	ucidef_set_led_netdev "wan" "wan" "mdio-bus:06:white:wan" "wan" "link tx rx"
 	ucidef_set_led_netdev "internet" "internet" "white:wan-online" "wan" "link"
 	;;
 cudy,wr3000u-v1|\

--- a/target/linux/realtek/patches-6.18/024-02-v7.1-net-phy-realtek-add-RTL8224-pair-order-support.patch
+++ b/target/linux/realtek/patches-6.18/024-02-v7.1-net-phy-realtek-add-RTL8224-pair-order-support.patch
@@ -45,7 +45,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  #include "realtek.h"
  
  #define RTL8201F_IER				0x13
-@@ -177,6 +178,8 @@
+@@ -189,6 +190,8 @@
  #define RTL8221B_PHYCR1_ALDPS_XTAL_OFF_EN	BIT(12)
  #define RTL8221B_PHYCR1_PHYAD_0_EN		BIT(13)
  
@@ -54,7 +54,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  #define RTL8366RB_POWER_SAVE			0x15
  #define RTL8366RB_POWER_SAVE_ON			BIT(12)
  
-@@ -1891,6 +1894,66 @@ static int rtl8224_cable_test_get_status
+@@ -2048,6 +2051,66 @@ static int rtl8224_cable_test_get_status
  	return rtl8224_cable_test_report(phydev, finished);
  }
  
@@ -121,7 +121,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  static bool rtlgen_supports_2_5gbps(struct phy_device *phydev)
  {
  	int val;
-@@ -3087,6 +3150,8 @@ static struct phy_driver realtek_drvs[]
+@@ -3252,6 +3315,8 @@ static struct phy_driver realtek_drvs[]
  		PHY_ID_MATCH_EXACT(0x001ccad0),
  		.name		= "RTL8224 2.5Gbps PHY",
  		.flags		= PHY_POLL_CABLE_TEST,

--- a/target/linux/realtek/patches-6.18/024-04-v7.1-net-phy-realtek-add-RTL8224-polarity-support.patch
+++ b/target/linux/realtek/patches-6.18/024-04-v7.1-net-phy-realtek-add-RTL8224-polarity-support.patch
@@ -24,7 +24,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -179,6 +179,7 @@
+@@ -191,6 +191,7 @@
  #define RTL8221B_PHYCR1_PHYAD_0_EN		BIT(13)
  
  #define RTL8224_VND1_MDI_PAIR_SWAP		0xa90
@@ -32,7 +32,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  
  #define RTL8366RB_POWER_SAVE			0x15
  #define RTL8366RB_POWER_SAVE_ON			BIT(12)
-@@ -1942,9 +1943,40 @@ static int rtl8224_mdi_config_order(stru
+@@ -2099,9 +2100,40 @@ static int rtl8224_mdi_config_order(stru
  					  order ? BIT(port_offset) : 0);
  }
  

--- a/target/linux/realtek/patches-6.18/030-v7.2-net-phy-realtek-support-MDI-swapping-for-RTL8226-CG.patch
+++ b/target/linux/realtek/patches-6.18/030-v7.2-net-phy-realtek-support-MDI-swapping-for-RTL8226-CG.patch
@@ -38,7 +38,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -181,6 +181,21 @@
+@@ -193,6 +193,21 @@
  #define RTL8224_VND1_MDI_PAIR_SWAP		0xa90
  #define RTL8224_VND1_MDI_POLARITY_SWAP		0xa94
  
@@ -60,7 +60,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  #define RTL8366RB_POWER_SAVE			0x15
  #define RTL8366RB_POWER_SAVE_ON			BIT(12)
  
-@@ -1392,6 +1407,144 @@ static int rtl822x_init_phycr1(struct ph
+@@ -1404,6 +1419,144 @@ static int rtl822x_init_phycr1(struct ph
  				      mask, val);
  }
  
@@ -205,7 +205,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  static int rtl822x_set_serdes_option_mode(struct phy_device *phydev, bool gen1)
  {
  	bool has_2500, has_sgmii;
-@@ -3074,6 +3227,7 @@ static struct phy_driver realtek_drvs[]
+@@ -3231,6 +3384,7 @@ static struct phy_driver realtek_drvs[]
  		.soft_reset	= rtl822x_c45_soft_reset,
  		.get_features	= rtl822x_c45_get_features,
  		.config_aneg	= rtl822x_c45_config_aneg,

--- a/target/linux/realtek/patches-6.18/743-net-realtek-serdes-configuration.patch
+++ b/target/linux/realtek/patches-6.18/743-net-realtek-serdes-configuration.patch
@@ -1,6 +1,6 @@
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -173,6 +173,41 @@
+@@ -185,6 +185,41 @@
  
  #define RTL8224_SRAM_RTCT_LEN(pair)		(0x8028 + (pair) * 4)
  
@@ -42,7 +42,7 @@
  #define RTL8221B_PHYCR1				0xa430
  #define RTL8221B_PHYCR1_ALDPS_EN		BIT(2)
  #define RTL8221B_PHYCR1_ALDPS_XTAL_OFF_EN	BIT(12)
-@@ -2071,6 +2106,147 @@ exit:
+@@ -2228,6 +2263,147 @@ exit:
  	return ret;
  }
  
@@ -190,7 +190,7 @@
  static int rtl8224_mdi_config_order(struct phy_device *phydev)
  {
  	struct device_node *np = phydev->mdio.dev.of_node;
-@@ -2125,6 +2301,10 @@ static int rtl8224_config_init(struct ph
+@@ -2282,6 +2458,10 @@ static int rtl8224_config_init(struct ph
  {
  	int ret;
  


### PR DESCRIPTION
This series makes the front-panel **WAN LED** on the Cudy WR3000P v1 work. It has never lit under
OpenWrt — the known issue from the original port (#19636, "WAN LED does not light up").

### Root cause

The WAN lamp is wired to the **LED1 pin of the RTL8221B 2.5G WAN PHY** (MDIO addr 6), not to a SoC
GPIO. Two problems on current main:

1. The port inherited a `led-wan` GPIO node (pio 5) from the 1G WR3000 v1, where pin 5 is a real
   LED; on the WR3000P it drives nothing (verified on hardware: neither polarity lights a lamp, and
   the device's own stock DTB defines no WAN GPIO LED). The P also shares the WR3000H `01_leds`
   block, whose `lan1..4`/`wan` netdev entries reference `white:lan-*`/`white:wan` sysfs LEDs that
   don't exist on this board (its LAN LEDs are MT7531-switch-driven, #18338).
2. Even with a framework that could drive it, the PHY's LED1 speed-select register (`0xd034`)
   power-on default is 1000BASE-T-link only, so at this board's 2.5G WAN link the lamp is dark.

### The change (3 commits)

1. **`mediatek: filogic: drop bogus WAN LED on Cudy WR3000P v1`** — remove the phantom `led-wan`
   GPIO node and split the P out of the WR3000H `01_leds` group (dropping the netdev entries that
   point at non-existent sysfs LEDs). Independently correct on any kernel.
2. **`generic: 6.18: backport RTL8221B PHY LED support`** — cherry-pick of Linux v7.2
   `d3aae4d954f9`, exposing the RTL8221B LED pins as `/sys/class/leds` with netdev triggers and
   programming the speed-select register in-kernel. Applies cleanly on the mediatek 6.18 kernel.
3. **`mediatek: filogic: light the WAN LED on Cudy WR3000P v1`** — add a `leds` node under the WAN
   PHY (`phy6`) plus a board.d netdev entry so the lamp is triggered on `wan` at boot with no
   userspace and no raw register writes. Uses the generic `link` mode: the per-speed `link_<speed>`
   netdev attributes are created dynamically from the PHY's reported supported modes, so at early
   boot (PHY still probing, link down) they don't all exist yet and only 2.5G would light; the
   generic `link` attribute always exists and the offload driver maps it to all speed bits. This
   matches the stock firmware, which programs `0xd034 = 0xa7` to light at every speed.

### Testing

- **Compile-tested** on current `main`: full `cudy_wr3000p-v1` image builds (kernel 6.18.44).
- **Run-tested** on a WR3000P v1 (RTL8221B-VB-CG, `phy_id 0x001cc849`): flashed with config wiped
  (`sysupgrade -n`) and cold-booted — `/sys/class/leds/mdio-bus:06:white:wan` appears, the
  `netdev`/`wan` trigger is applied from board.d, the kernel programs `0xd034 = 0x0027` (all speeds)
  + `0xd040 = 0x391f` (blink), and there is no mdio hook or userspace involved.
- **All-speeds sweep, eyes-on**: forced the WAN link to 10 / 100 / 1000 / 2500 Mb (`ethtool -s wan
  advertise …`); `0xd034` held `0x0027` at each and the panel WAN lamp was **lit + flashing at every
  speed**.

### Note on the backport

Commit 2 backports a driver from Linux v7.2 onto OpenWrt's 6.18 kernel. If you'd prefer to wait
until the mediatek target naturally reaches ≥7.2, commits 1 and 3 still stand — commit 3's DT node
just works once the driver is present, and commit 1 (the cleanup) is independently mergeable today.
The backport patch is numbered `800-`; happy to renumber it into the existing `784-` realtek
cluster if you'd rather keep the PHY backports together.
