### PR TITLE
openssl: update to 3.5.8

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
-PKG_VERSION:=3.5.7
+PKG_VERSION:=3.5.8
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
@@ -21,7 +21,7 @@ PKG_SOURCE_URL:= \
 	https://www.openssl.org/source/old/$(PKG_BASE)/ \
 	https://github.com/openssl/openssl/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
 
-PKG_HASH:=a8c0d28a529ca480f9f36cf5792e2cd21984552a3c8e4aa11a24aa31aeac98e8
+PKG_HASH:=a8f84a39918ec6415ce765d9b429d313ba97b8143169c172e734b9514464f5b2
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE.txt


### PR DESCRIPTION
Update OpenSSL to 3.5.8, a security patch release.

This fixes:
- CVE-2026-18798
- CVE-2026-63072
- CVE-2026-63076
- CVE-2026-14456
- CVE-2026-14457
- CVE-2026-54874
- CVE-2026-63073
- CVE-2026-63074
- CVE-2026-63075
- CVE-2026-75803

Link: https://openssl-library.org/news/secadv/20260825.txt