### PR TITLE
ramips: mt7621: add support for WeVO Hi1200AC

### DIFF
--- a/target/linux/ramips/dts/mt7621_wevo_hi1200ac.dts
+++ b/target/linux/ramips/dts/mt7621_wevo_hi1200ac.dts
@@ -1,0 +1,6 @@
+#include "mt7621_wevo_w2914ns-v2.dtsi"
+
+/ {
+	compatible = "wevo,hi1200ac", "mediatek,mt7621-soc";
+	model = "WeVO Hi1200AC";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -3461,6 +3461,18 @@ define Device/wevo_11acnas
 endef
 TARGET_DEVICES += wevo_11acnas
 
+define Device/wevo_hi1200ac
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 16064k
+  UIMAGE_NAME := Hi1200AC(0.0.0)
+  DEVICE_VENDOR := WeVO
+  DEVICE_MODEL := Hi1200AC
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
+	kmod-usb-ledtrig-usbport -uboot-envtools
+endef
+TARGET_DEVICES += wevo_hi1200ac
+
 define Device/wevo_w2914ns-v2
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)


### PR DESCRIPTION
ramips: mt7621: add support for WeVO Hi1200AC

This adds support for the WeVO Hi1200AC wireless router.
this device  has the exact same hardware as WeVO_W2914NS_v2.

Hardware specifications:
- SoC: MediaTek MT7621AT (880 MHz, 2C/4T)
- RAM: 128 MB DDR3
- Flash: 16 MB SPI NOR (Winbond W25Q128)
- Wi-Fi 2.4 GHz: MediaTek MT7603E (2x2)
- Wi-Fi 5 GHz: MediaTek MT7612E (2x2)
- Ethernet: 5x 10/100/1000 Mbps (MT7621AT Built-in Switch: 1 WAN, 4 LAN)
- USB: 1x USB 2.0, 1x USB 3.0
- Buttons: Reset, WPS
- LEDs: Power, WAN, LAN1-4, 2.4G, 5G, USB
- UART: 115200 8N1 (VCC, RX, TX, GND marked on PCB)

Installation via OEM Web Interface:
1. Navigate to Management -> Firmware Upgrade in the OEM UI.
2. Upload 'openwrt-ramips-mt7621-wevo_hi1200ac-initramfs-kernel.bin'
or Upload 'openwrt-ramips-mt7621-wevo_hi1200ac-squashfs-sysupgrade.bin'.
3. Wait for the router to flash and reboot.

Signed-off-by: park jongwoung <xxfree86@gmail.com>
