### PR TITLE
openssl: update to 3.5.8

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
-PKG_VERSION:=3.5.7
+PKG_VERSION:=3.5.8
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
@@ -21,7 +21,7 @@ PKG_SOURCE_URL:= \
 	https://www.openssl.org/source/old/$(PKG_BASE)/ \
 	https://github.com/openssl/openssl/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
 
-PKG_HASH:=a8c0d28a529ca480f9f36cf5792e2cd21984552a3c8e4aa11a24aa31aeac98e8
+PKG_HASH:=a8f84a39918ec6415ce765d9b429d313ba97b8143169c172e734b9514464f5b2
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE.txt


### PR DESCRIPTION
OpenSSL 3.5.8 is a security patch release. The most severe CVE fixed in this release is Moderate.

This release incorporates the following bug fixes and mitigations:

Fixed QUIC server being able to trigger double free when processing INITIAL packet.
(CVE-2026-18798)

Fixed heap buffer overflow in CMS key unwrapping.
(CVE-2026-63072)

Fixed invalid pointer dereference in CMP server via crafted protectionAlg. (CVE-2026-63076)

Fixed unbounded memory growth in QUIC server incoming channel queue. (CVE-2026-14456)

Fixed RPK server signature algorithm selection being able to dereference a missing certificate.
(CVE-2026-14457)

Fixed excessive memory use buffering DTLS records for a future epoch. (CVE-2026-54874)

Fixed untrusted Sender DN being used as a format string in CMP response validation.
(CVE-2026-63073)

Fixed CMP indefinite cache growth of extraCerts.
(CVE-2026-63074)

Fixed QUIC ACK-only packet retention being able to cause memory exhaustion. (CVE-2026-63075)

Fixed possibility of AEAD forgeries with empty ciphertext when using EVP_Cipher().
(CVE-2026-75803)

Fixed checking of authentication tags for empty ciphertexts for AEAD ciphers in CCM cipher mode.