### PR TITLE
kernel: xhci: avoid xHC endpoint changes after disconnect or link error

### DIFF
--- a/target/linux/bcm27xx/patches-6.12/950-0125-xhci-implement-xhci_fixup_endpoint-for-interval-adju.patch
+++ b/target/linux/bcm27xx/patches-6.12/950-0125-xhci-implement-xhci_fixup_endpoint-for-interval-adju.patch
@@ -124,7 +124,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.org>
   * non-error returns are a promise to giveback() the urb later
   * we drop ownership so next owner (or urb unlink) can get it
   */
-@@ -5400,6 +5503,7 @@ static const struct hc_driver xhci_hc_dr
+@@ -5401,6 +5504,7 @@ static const struct hc_driver xhci_hc_dr
  	.endpoint_reset =	xhci_endpoint_reset,
  	.check_bandwidth =	xhci_check_bandwidth,
  	.reset_bandwidth =	xhci_reset_bandwidth,

--- a/target/linux/bcm27xx/patches-6.12/950-0333-xhci-quirks-add-link-TRB-quirk-for-VL805.patch
+++ b/target/linux/bcm27xx/patches-6.12/950-0333-xhci-quirks-add-link-TRB-quirk-for-VL805.patch
@@ -53,7 +53,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
  	if (addr == 0) {
 --- a/drivers/usb/host/xhci.h
 +++ b/drivers/usb/host/xhci.h
-@@ -1632,6 +1632,9 @@ struct xhci_hcd {
+@@ -1627,6 +1627,9 @@ struct xhci_hcd {
  #define XHCI_ETRON_HOST	BIT_ULL(49)
  #define XHCI_LIMIT_ENDPOINT_INTERVAL_9 BIT_ULL(50)
  

--- a/target/linux/bcm27xx/patches-6.12/950-0334-usb-xhci-add-VLI_SS_BULK_OUT_BUG-quirk.patch
+++ b/target/linux/bcm27xx/patches-6.12/950-0334-usb-xhci-add-VLI_SS_BULK_OUT_BUG-quirk.patch
@@ -100,7 +100,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
  
 --- a/drivers/usb/host/xhci.h
 +++ b/drivers/usb/host/xhci.h
-@@ -1634,6 +1634,7 @@ struct xhci_hcd {
+@@ -1629,6 +1629,7 @@ struct xhci_hcd {
  
  /* Downstream VLI fixes */
  #define XHCI_AVOID_DQ_ON_LINK	BIT_ULL(56)

--- a/target/linux/bcm27xx/patches-6.12/950-0335-usb-xhci-add-XHCI_VLI_HUB_TT_QUIRK.patch
+++ b/target/linux/bcm27xx/patches-6.12/950-0335-usb-xhci-add-XHCI_VLI_HUB_TT_QUIRK.patch
@@ -75,7 +75,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
  	if (pdev->vendor == PCI_VENDOR_ID_ASMEDIA &&
 --- a/drivers/usb/host/xhci-ring.c
 +++ b/drivers/usb/host/xhci-ring.c
-@@ -3667,6 +3667,48 @@ static int xhci_align_td(struct xhci_hcd
+@@ -3687,6 +3687,48 @@ static int xhci_align_td(struct xhci_hcd
  	return 1;
  }
  
@@ -124,7 +124,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
  /* This is very similar to what ehci-q.c qtd_fill() does */
  int xhci_queue_bulk_tx(struct xhci_hcd *xhci, gfp_t mem_flags,
  		struct urb *urb, int slot_id, unsigned int ep_index)
-@@ -3821,6 +3863,8 @@ int xhci_queue_bulk_tx(struct xhci_hcd *
+@@ -3841,6 +3883,8 @@ int xhci_queue_bulk_tx(struct xhci_hcd *
  	}
  
  	check_trb_math(urb, enqd_len);
@@ -133,7 +133,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
  	giveback_first_trb(xhci, slot_id, ep_index, urb->stream_id,
  			start_cycle, start_trb);
  	return 0;
-@@ -3969,6 +4013,8 @@ int xhci_queue_ctrl_tx(struct xhci_hcd *
+@@ -3989,6 +4033,8 @@ int xhci_queue_ctrl_tx(struct xhci_hcd *
  			/* Event on completion */
  			field | TRB_IOC | TRB_TYPE(TRB_STATUS) | ep_ring->cycle_state);
  
@@ -144,7 +144,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
  	return 0;
 --- a/drivers/usb/host/xhci.h
 +++ b/drivers/usb/host/xhci.h
-@@ -1635,6 +1635,7 @@ struct xhci_hcd {
+@@ -1630,6 +1630,7 @@ struct xhci_hcd {
  /* Downstream VLI fixes */
  #define XHCI_AVOID_DQ_ON_LINK	BIT_ULL(56)
  #define XHCI_VLI_SS_BULK_OUT_BUG	BIT_ULL(57)

--- a/target/linux/bcm27xx/patches-6.12/950-0401-xhci-Use-more-event-ring-segment-table-entries.patch
+++ b/target/linux/bcm27xx/patches-6.12/950-0401-xhci-Use-more-event-ring-segment-table-entries.patch
@@ -21,7 +21,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
 
 --- a/drivers/usb/host/xhci.h
 +++ b/drivers/usb/host/xhci.h
-@@ -1398,7 +1398,7 @@ struct urb_priv {
+@@ -1391,7 +1391,7 @@ struct urb_priv {
  };
  
  /* Number of Event Ring segments to allocate, when amount is not specified. (spec allows 32k) */

--- a/target/linux/bcm27xx/patches-6.12/950-0950-usb-xhci-default-to-Intel-scheme-for-calculating-U1-.patch
+++ b/target/linux/bcm27xx/patches-6.12/950-0950-usb-xhci-default-to-Intel-scheme-for-calculating-U1-.patch
@@ -40,7 +40,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
  static bool td_on_ring(struct xhci_td *td, struct xhci_ring *ring)
  {
  	struct xhci_segment *seg;
-@@ -4800,7 +4804,7 @@ static u16 xhci_calculate_u1_timeout(str
+@@ -4801,7 +4805,7 @@ static u16 xhci_calculate_u1_timeout(str
  		}
  	}
  
@@ -49,7 +49,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
  		timeout_ns = xhci_calculate_intel_u1_timeout(udev, desc);
  	else
  		timeout_ns = udev->u1_params.sel;
-@@ -4864,7 +4868,7 @@ static u16 xhci_calculate_u2_timeout(str
+@@ -4865,7 +4869,7 @@ static u16 xhci_calculate_u2_timeout(str
  		}
  	}
  

--- a/target/linux/bcm27xx/patches-6.18/0113-xhci-implement-xhci_fixup_endpoint-for-interval-adju.patch
+++ b/target/linux/bcm27xx/patches-6.18/0113-xhci-implement-xhci_fixup_endpoint-for-interval-adju.patch
@@ -124,7 +124,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.org>
   * non-error returns are a promise to giveback() the urb later
   * we drop ownership so next owner (or urb unlink) can get it
   */
-@@ -5605,6 +5708,7 @@ static const struct hc_driver xhci_hc_dr
+@@ -5606,6 +5709,7 @@ static const struct hc_driver xhci_hc_dr
  	.endpoint_reset =	xhci_endpoint_reset,
  	.check_bandwidth =	xhci_check_bandwidth,
  	.reset_bandwidth =	xhci_reset_bandwidth,

--- a/target/linux/bcm27xx/patches-6.18/0283-xhci-quirks-add-link-TRB-quirk-for-VL805.patch
+++ b/target/linux/bcm27xx/patches-6.18/0283-xhci-quirks-add-link-TRB-quirk-for-VL805.patch
@@ -53,7 +53,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
  	if (addr == 0) {
 --- a/drivers/usb/host/xhci.h
 +++ b/drivers/usb/host/xhci.h
-@@ -1647,6 +1647,9 @@ struct xhci_hcd {
+@@ -1642,6 +1642,9 @@ struct xhci_hcd {
  #define XHCI_ETRON_HOST	BIT_ULL(49)
  #define XHCI_LIMIT_ENDPOINT_INTERVAL_9 BIT_ULL(50)
  

--- a/target/linux/bcm27xx/patches-6.18/0284-usb-xhci-add-VLI_SS_BULK_OUT_BUG-quirk.patch
+++ b/target/linux/bcm27xx/patches-6.18/0284-usb-xhci-add-VLI_SS_BULK_OUT_BUG-quirk.patch
@@ -100,7 +100,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
  
 --- a/drivers/usb/host/xhci.h
 +++ b/drivers/usb/host/xhci.h
-@@ -1649,6 +1649,7 @@ struct xhci_hcd {
+@@ -1644,6 +1644,7 @@ struct xhci_hcd {
  
  /* Downstream VLI fixes */
  #define XHCI_AVOID_DQ_ON_LINK	BIT_ULL(56)

--- a/target/linux/bcm27xx/patches-6.18/0285-usb-xhci-add-XHCI_VLI_HUB_TT_QUIRK.patch
+++ b/target/linux/bcm27xx/patches-6.18/0285-usb-xhci-add-XHCI_VLI_HUB_TT_QUIRK.patch
@@ -75,7 +75,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
  	if (pdev->vendor == PCI_VENDOR_ID_ASMEDIA &&
 --- a/drivers/usb/host/xhci-ring.c
 +++ b/drivers/usb/host/xhci-ring.c
-@@ -3667,6 +3667,48 @@ static int xhci_align_td(struct xhci_hcd
+@@ -3687,6 +3687,48 @@ static int xhci_align_td(struct xhci_hcd
  	return 1;
  }
  
@@ -124,7 +124,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
  /* This is very similar to what ehci-q.c qtd_fill() does */
  int xhci_queue_bulk_tx(struct xhci_hcd *xhci, gfp_t mem_flags,
  		struct urb *urb, int slot_id, unsigned int ep_index)
-@@ -3821,6 +3863,8 @@ int xhci_queue_bulk_tx(struct xhci_hcd *
+@@ -3841,6 +3883,8 @@ int xhci_queue_bulk_tx(struct xhci_hcd *
  	}
  
  	check_trb_math(urb, enqd_len);
@@ -133,7 +133,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
  	giveback_first_trb(xhci, slot_id, ep_index, urb->stream_id,
  			start_cycle, start_trb);
  	return 0;
-@@ -3969,6 +4013,8 @@ int xhci_queue_ctrl_tx(struct xhci_hcd *
+@@ -3989,6 +4033,8 @@ int xhci_queue_ctrl_tx(struct xhci_hcd *
  			/* Event on completion */
  			field | TRB_IOC | TRB_TYPE(TRB_STATUS) | ep_ring->cycle_state);
  
@@ -144,7 +144,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
  	return 0;
 --- a/drivers/usb/host/xhci.h
 +++ b/drivers/usb/host/xhci.h
-@@ -1650,6 +1650,7 @@ struct xhci_hcd {
+@@ -1645,6 +1645,7 @@ struct xhci_hcd {
  /* Downstream VLI fixes */
  #define XHCI_AVOID_DQ_ON_LINK	BIT_ULL(56)
  #define XHCI_VLI_SS_BULK_OUT_BUG	BIT_ULL(57)

--- a/target/linux/bcm27xx/patches-6.18/0332-xhci-Use-more-event-ring-segment-table-entries.patch
+++ b/target/linux/bcm27xx/patches-6.18/0332-xhci-Use-more-event-ring-segment-table-entries.patch
@@ -21,7 +21,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
 
 --- a/drivers/usb/host/xhci.h
 +++ b/drivers/usb/host/xhci.h
-@@ -1412,7 +1412,7 @@ struct urb_priv {
+@@ -1405,7 +1405,7 @@ struct urb_priv {
  };
  
  /* Number of Event Ring segments to allocate, when amount is not specified. (spec allows 32k) */

--- a/target/linux/bcm27xx/patches-6.18/0542-usb-xhci-default-to-Intel-scheme-for-calculating-U1-.patch
+++ b/target/linux/bcm27xx/patches-6.18/0542-usb-xhci-default-to-Intel-scheme-for-calculating-U1-.patch
@@ -40,7 +40,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
  static bool td_on_ring(struct xhci_td *td, struct xhci_ring *ring)
  {
  	struct xhci_segment *seg;
-@@ -5000,7 +5004,7 @@ static u16 xhci_calculate_u1_timeout(str
+@@ -5001,7 +5005,7 @@ static u16 xhci_calculate_u1_timeout(str
  		}
  	}
  
@@ -49,7 +49,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
  		timeout_ns = xhci_calculate_intel_u1_timeout(udev, desc);
  	else
  		timeout_ns = udev->u1_params.sel;
-@@ -5064,7 +5068,7 @@ static u16 xhci_calculate_u2_timeout(str
+@@ -5065,7 +5069,7 @@ static u16 xhci_calculate_u2_timeout(str
  		}
  	}
  

--- a/target/linux/bcm53xx/patches-6.12/180-usb-xhci-add-support-for-performing-fake-doorbell.patch
+++ b/target/linux/bcm53xx/patches-6.12/180-usb-xhci-add-support-for-performing-fake-doorbell.patch
@@ -103,7 +103,7 @@ it on BCM4708 family.
  	if (xhci->quirks & XHCI_NEC_HOST)
 --- a/drivers/usb/host/xhci.h
 +++ b/drivers/usb/host/xhci.h
-@@ -1631,6 +1631,7 @@ struct xhci_hcd {
+@@ -1626,6 +1626,7 @@ struct xhci_hcd {
  #define XHCI_CDNS_SCTX_QUIRK	BIT_ULL(48)
  #define XHCI_ETRON_HOST	BIT_ULL(49)
  #define XHCI_LIMIT_ENDPOINT_INTERVAL_9 BIT_ULL(50)

--- a/target/linux/bcm53xx/patches-6.18/180-usb-xhci-add-support-for-performing-fake-doorbell.patch
+++ b/target/linux/bcm53xx/patches-6.18/180-usb-xhci-add-support-for-performing-fake-doorbell.patch
@@ -103,7 +103,7 @@ it on BCM4708 family.
  	if (xhci->quirks & XHCI_NEC_HOST)
 --- a/drivers/usb/host/xhci.h
 +++ b/drivers/usb/host/xhci.h
-@@ -1646,6 +1646,7 @@ struct xhci_hcd {
+@@ -1641,6 +1641,7 @@ struct xhci_hcd {
  #define XHCI_CDNS_SCTX_QUIRK	BIT_ULL(48)
  #define XHCI_ETRON_HOST	BIT_ULL(49)
  #define XHCI_LIMIT_ENDPOINT_INTERVAL_9 BIT_ULL(50)

--- a/target/linux/generic/backport-6.12/856-01-v7.3-xhci-include-all-root-port-children-in-recovery-prevention-on-link-error.patch
+++ b/target/linux/generic/backport-6.12/856-01-v7.3-xhci-include-all-root-port-children-in-recovery-prevention-on-link-error.patch
@@ -1,0 +1,145 @@
+From e3d757dc9257f2638ca61eda4faef26c2daeea10 Mon Sep 17 00:00:00 2001
+From: Mathias Nyman <mathias.nyman@linux.intel.com>
+Date: Thu, 6 Aug 2026 17:20:59 +0300
+Subject: [PATCH 1/3] xhci: include all root port children in recovery
+ prevention on link error
+
+Driver already prevents useless transfer retry and endpoint recovery
+for devices directly connected to a root port with link errors.
+
+These devices are either disconnecting or will be reset. Link is gone.
+
+Move the flag indicating link error from the xhci device structure to
+the root port strucure, allowing all child devices behind hubs to easily
+check for root port link errors, avoiding useless transfer retries and
+endpoint recovery.
+
+This extends the previous endpoint recovery prevention in
+commit b8c3b718087b ("usb: xhci: Don't try to recover an endpoint if port
+is in error state.")
+Only root port link errors can be detected early by xhci driver,
+not link errors between external hubs and their children.
+
+Tested-by: Xu Rao <raoxu@uniontech.com>
+Signed-off-by: Mathias Nyman <mathias.nyman@linux.intel.com>
+Link: https://patch.msgid.link/20260806142113.2436238-4-mathias.nyman@linux.intel.com
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+
+Backported to 6.12: context only. This tree predates the PORTSC
+accessor (xhci_portsc_readl) and the BIT() conversion of the endpoint
+state flags, and still carries max_ports in handle_port_status().
+No functional change from upstream.
+---
+--- a/drivers/usb/host/xhci.c
++++ b/drivers/usb/host/xhci.c
+@@ -1566,7 +1566,7 @@ static int xhci_urb_enqueue(struct usb_h
+ 		goto free_priv;
+ 	}
+ 
+-	if (xhci->devs[slot_id]->flags & VDEV_PORT_ERROR) {
++	if (xhci->devs[slot_id]->rhub_port->link_inactive) {
+ 		xhci_dbg(xhci, "Can't queue urb, port error, link inactive\n");
+ 		ret = -ENODEV;
+ 		goto free_priv;
+@@ -3826,7 +3826,6 @@ static int xhci_discover_or_reset_device
+ 				xhci_get_slot_state(xhci, virt_dev->out_ctx));
+ 		xhci_dbg(xhci, "Not freeing device rings.\n");
+ 		/* Don't treat this as an error.  May change my mind later. */
+-		virt_dev->flags = 0;
+ 		ret = 0;
+ 		goto command_cleanup;
+ 	case COMP_SUCCESS:
+@@ -3876,7 +3875,6 @@ static int xhci_discover_or_reset_device
+ 	}
+ 	/* If necessary, update the number of active TTs on this root port */
+ 	xhci_update_tt_active_eps(xhci, virt_dev, old_active_eps);
+-	virt_dev->flags = 0;
+ 	ret = 0;
+ 
+ command_cleanup:
+--- a/drivers/usb/host/xhci.h
++++ b/drivers/usb/host/xhci.h
+@@ -747,14 +747,6 @@ struct xhci_virt_device {
+ 	struct xhci_port		*rhub_port;
+ 	struct xhci_interval_bw_table	*bw_table;
+ 	struct xhci_tt_bw_info		*tt_info;
+-	/*
+-	 * flags for state tracking based on events and issued commands.
+-	 * Software can not rely on states from output contexts because of
+-	 * latency between events and xHC updating output context values.
+-	 * See xhci 1.1 section 4.8.3 for more details
+-	 */
+-	unsigned long			flags;
+-#define VDEV_PORT_ERROR			BIT(0) /* Port error, link inactive */
+ 
+ 	/* The current max exit latency for the enabled USB3 link states. */
+ 	u16				current_mel;
+@@ -1465,6 +1457,7 @@ struct xhci_port {
+ 	int			hcd_portnum;
+ 	struct xhci_hub		*rhub;
+ 	struct xhci_port_cap	*port_cap;
++	unsigned int		link_inactive:1;
+ 	unsigned int		lpm_incapable:1;
+ 	unsigned long		resume_timestamp;
+ 	bool			rexit_active;
+--- a/drivers/usb/host/xhci-ring.c
++++ b/drivers/usb/host/xhci-ring.c
+@@ -924,7 +924,7 @@ static int xhci_handle_halted_endpoint(s
+ 	 * Avoid resetting endpoint if link is inactive. Can cause host hang.
+ 	 * Device will be reset soon to recover the link so don't do anything
+ 	 */
+-	if (ep->vdev->flags & VDEV_PORT_ERROR)
++	if (ep->vdev->rhub_port->link_inactive)
+ 		return -ENODEV;
+ 
+ 	/* add td to cancelled list and let reset ep handler take care of it */
+@@ -1951,14 +1951,16 @@ static void xhci_cavium_reset_phy_quirk(
+ static void handle_port_status(struct xhci_hcd *xhci, union xhci_trb *event)
+ {
+ 	struct xhci_virt_device *vdev = NULL;
+-	struct usb_hcd *hcd;
+-	u32 port_id;
+-	u32 portsc, cmd_reg;
+-	int max_ports;
+-	unsigned int hcd_portnum;
+ 	struct xhci_bus_state *bus_state;
+-	bool bogus_port_status = false;
+ 	struct xhci_port *port;
++	struct usb_hcd *hcd;
++	bool bogus_port_status = false;
++	unsigned int hcd_portnum;
++	int max_ports;
++	u32 cmd_reg;
++	u32 port_id;
++	u32 portsc;
++	u32 pls;
+ 
+ 	/* Port status change events always have a successful completion code */
+ 	if (GET_COMP_CODE(le32_to_cpu(event->generic.field[2])) != COMP_SUCCESS)
+@@ -1996,6 +1998,7 @@ static void handle_port_status(struct xh
+ 	bus_state = &port->rhub->bus_state;
+ 	hcd_portnum = port->hcd_portnum;
+ 	portsc = readl(port->addr);
++	pls = portsc & PORT_PLS_MASK;
+ 
+ 	xhci_dbg(xhci, "Port change event, %d-%d, id %d, portsc: 0x%x\n",
+ 		 hcd->self.busnum, hcd_portnum + 1, port_id, portsc);
+@@ -2007,12 +2010,12 @@ static void handle_port_status(struct xh
+ 		usb_hcd_resume_root_hub(hcd);
+ 	}
+ 
+-	if (vdev && (portsc & PORT_PLS_MASK) == XDEV_INACTIVE) {
+-		if (!(portsc & PORT_RESET))
+-			vdev->flags |= VDEV_PORT_ERROR;
+-	} else if (vdev && portsc & PORT_RC) {
+-		vdev->flags &= ~VDEV_PORT_ERROR;
+-	}
++	/*
++	 * Tag broken links to avoid retries while hub driver sorts it out.
++	 * Link status is not relible while port is in reset.
++	 */
++	if (!(portsc & PORT_RESET))
++		port->link_inactive = (pls == XDEV_INACTIVE);
+ 
+ 	if ((portsc & PORT_PLC) && (portsc & PORT_PLS_MASK) == XDEV_RESUME) {
+ 		xhci_dbg(xhci, "port resume event for port %d\n", port_id);

--- a/target/linux/generic/backport-6.12/856-02-v7.3-xhci-prevent-endpoint-recovery-after-roothub-disconnect.patch
+++ b/target/linux/generic/backport-6.12/856-02-v7.3-xhci-prevent-endpoint-recovery-after-roothub-disconnect.patch
@@ -1,0 +1,75 @@
+From 042aad8d0db6607ac9789fc43b6221909bd6a3bc Mon Sep 17 00:00:00 2001
+From: Mathias Nyman <mathias.nyman@linux.intel.com>
+Date: Thu, 6 Aug 2026 17:21:00 +0300
+Subject: [PATCH 2/3] xhci: prevent endpoint recovery after roothub disconnect
+
+Prevent transfer retry and endpoint recovery if the device or its parent
+disconnected from the roothub. Just like link error case.
+
+There is a suspicion some xHC controllers may stop processing endpoint
+related commands after the last USB device disconnects from the host.
+
+Disconnect often causes transaction errors, xhci driver tries to (soft)
+reset and restart the endpoint to recover it.
+Hub driver again will cancel all pending URBs once disconnect is detected,
+stopping the endpoint right after (soft) reset restarted it.
+xHC controller sometimes fail to complete the stop endpoint command,
+leading to driver timing out, and tearing down xhci
+
+Prevent extra endpoint (soft) reset after xhci driver is aware of the
+parent roothub port disconnect.
+
+Tested-by: Xu Rao <raoxu@uniontech.com>
+Signed-off-by: Mathias Nyman <mathias.nyman@linux.intel.com>
+Link: https://patch.msgid.link/20260806142113.2436238-5-mathias.nyman@linux.intel.com
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+
+Backported to 6.12: context only. This tree predates the PORTSC
+accessor (xhci_portsc_readl) and the BIT() conversion of the endpoint
+state flags, and still carries max_ports in handle_port_status().
+No functional change from upstream.
+---
+--- a/drivers/usb/host/xhci.h
++++ b/drivers/usb/host/xhci.h
+@@ -1458,6 +1458,7 @@ struct xhci_port {
+ 	struct xhci_hub		*rhub;
+ 	struct xhci_port_cap	*port_cap;
+ 	unsigned int		link_inactive:1;
++	unsigned int		connected:1;
+ 	unsigned int		lpm_incapable:1;
+ 	unsigned long		resume_timestamp;
+ 	bool			rexit_active;
+--- a/drivers/usb/host/xhci-ring.c
++++ b/drivers/usb/host/xhci-ring.c
+@@ -917,14 +917,16 @@ static int xhci_handle_halted_endpoint(s
+ 				struct xhci_td *td,
+ 				enum xhci_ep_reset_type reset_type)
+ {
++	struct xhci_port *rhub_port = ep->vdev->rhub_port;
+ 	unsigned int slot_id = ep->vdev->slot_id;
+ 	int err;
+ 
+ 	/*
+-	 * Avoid resetting endpoint if link is inactive. Can cause host hang.
+-	 * Device will be reset soon to recover the link so don't do anything
++	 * Avoid resetting endpoint if link is inactive or device disonnected.
++	 * Can cause host hang.
++	 * Device will be reset to recover an inactive link, so don't do anything
+ 	 */
+-	if (ep->vdev->rhub_port->link_inactive)
++	if (rhub_port->link_inactive || !rhub_port->connected)
+ 		return -ENODEV;
+ 
+ 	/* add td to cancelled list and let reset ep handler take care of it */
+@@ -2014,8 +2016,10 @@ static void handle_port_status(struct xh
+ 	 * Tag broken links to avoid retries while hub driver sorts it out.
+ 	 * Link status is not relible while port is in reset.
+ 	 */
+-	if (!(portsc & PORT_RESET))
++	if (!(portsc & PORT_RESET)) {
+ 		port->link_inactive = (pls == XDEV_INACTIVE);
++		port->connected = !!(portsc & PORT_CONNECT);
++	}
+ 
+ 	if ((portsc & PORT_PLC) && (portsc & PORT_PLS_MASK) == XDEV_RESUME) {
+ 		xhci_dbg(xhci, "port resume event for port %d\n", port_id);

--- a/target/linux/generic/backport-6.12/856-03-v7.3-xhci-avoid-xhc-endpoint-changes-after-disconnect-or-link-error.patch
+++ b/target/linux/generic/backport-6.12/856-03-v7.3-xhci-avoid-xhc-endpoint-changes-after-disconnect-or-link-error.patch
@@ -1,0 +1,119 @@
+From 7e0ef4332ed9b70309fa1f22ec26a8c3c63686ea Mon Sep 17 00:00:00 2001
+From: Mathias Nyman <mathias.nyman@linux.intel.com>
+Date: Thu, 6 Aug 2026 17:21:01 +0300
+Subject: [PATCH 3/3] xhci: avoid xHC endpoint changes after disconnect or link
+ error.
+
+Avoid all extra endpoint state changes after the roothub link
+is lost due to disconnect or link error, and endpoint is known
+to be in a non-running state.
+
+Rapid endpoint state changes involving endpoint reset, restart, and
+stopping the endpoint have caused xHC failures to complete stop
+endpoint command. xhci driver sees this as a fatal flaw and tears
+down xhci.
+
+These endpoint state changes are normally part of recovery from
+transaction errors or URB cancel.
+In this case recovery is not needed.
+
+Add an endpoint state called EP_DROP_PENDING.
+Set ep->ep_state |= EP_DROP_PENDING when an endpoint is found in a
+halted or stopped non-running state, and the roothub link is
+lost. Prevent endpoint from restarting.
+
+URB cancel doesn't need to stop the endpoint if EP_DROP_PENDONG is set.
+URBs can be given back directly.
+Endpoint is, and will remain stopped until it's dropped.
+
+Tested-by: Xu Rao <raoxu@uniontech.com>
+Signed-off-by: Mathias Nyman <mathias.nyman@linux.intel.com>
+Link: https://patch.msgid.link/20260806142113.2436238-6-mathias.nyman@linux.intel.com
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+
+Backported to 6.12: context only. This tree predates the PORTSC
+accessor (xhci_portsc_readl) and the BIT() conversion of the endpoint
+state flags, and still carries max_ports in handle_port_status().
+No functional change from upstream.
+---
+--- a/drivers/usb/host/xhci.c
++++ b/drivers/usb/host/xhci.c
+@@ -1754,7 +1754,7 @@ static int xhci_urb_dequeue(struct usb_h
+ 	}
+ 
+ 	/* In this case no commands are pending but the endpoint is stopped */
+-	if (ep->ep_state & EP_CLEARING_TT) {
++	if (ep->ep_state & (EP_CLEARING_TT | EP_DROP_PENDING)) {
+ 		/* and cancelled TDs can be given back right away */
+ 		xhci_dbg(xhci, "Invalidating TDs instantly on slot %d ep %d in state 0x%x\n",
+ 				urb->dev->slot_id, ep_index, ep->ep_state);
+@@ -3878,6 +3878,9 @@ static int xhci_discover_or_reset_device
+ 	ret = 0;
+ 
+ command_cleanup:
++	for (i = 0; i < EP_CTX_PER_DEV; i++)
++		virt_dev->eps[i].ep_state &= ~EP_DROP_PENDING;
++
+ 	xhci_free_command(xhci, reset_device_cmd);
+ 	return ret;
+ }
+--- a/drivers/usb/host/xhci.h
++++ b/drivers/usb/host/xhci.h
+@@ -673,6 +673,7 @@ struct xhci_virt_ep {
+ #define EP_SOFT_CLEAR_TOGGLE	(1 << 7)
+ /* usb_hub_clear_tt_buffer is in progress */
+ #define EP_CLEARING_TT		(1 << 8)
++#define EP_DROP_PENDING		(1 << 9) /* port disconnect or link error, don't restart */
+ 	/* ----  Related to URB cancellation ---- */
+ 	struct list_head	cancelled_td_list;
+ 	struct xhci_hcd		*xhci;
+--- a/drivers/usb/host/xhci-ring.c
++++ b/drivers/usb/host/xhci-ring.c
+@@ -503,8 +503,8 @@ void xhci_ring_ep_doorbell(struct xhci_h
+ 	 * pointer command pending because the device can choose to start any
+ 	 * stream once the endpoint is on the HW schedule.
+ 	 */
+-	if ((ep_state & EP_STOP_CMD_PENDING) || (ep_state & SET_DEQ_PENDING) ||
+-	    (ep_state & EP_HALTED) || (ep_state & EP_CLEARING_TT))
++	if (ep_state & (EP_STOP_CMD_PENDING | SET_DEQ_PENDING | EP_HALTED |
++			EP_CLEARING_TT | EP_DROP_PENDING))
+ 		return;
+ 
+ 	trace_xhci_ring_ep_doorbell(slot_id, DB_VALUE(ep_index, stream_id));
+@@ -926,8 +926,10 @@ static int xhci_handle_halted_endpoint(s
+ 	 * Can cause host hang.
+ 	 * Device will be reset to recover an inactive link, so don't do anything
+ 	 */
+-	if (rhub_port->link_inactive || !rhub_port->connected)
++	if (rhub_port->link_inactive || !rhub_port->connected) {
++		ep->ep_state |= EP_DROP_PENDING;
+ 		return -ENODEV;
++	}
+ 
+ 	/* add td to cancelled list and let reset ep handler take care of it */
+ 	if (reset_type == EP_HARD_RESET) {
+@@ -997,6 +999,13 @@ static int xhci_invalidate_cancelled_tds
+ 				  td->urb, td->urb->stream_id);
+ 			continue;
+ 		}
++
++		/* device disconnected or link error, ep will be dropped */
++		if (ep->ep_state & EP_DROP_PENDING) {
++			td->cancel_status = TD_CLEARED;
++			continue;
++		}
++
+ 		/*
+ 		 * If a ring stopped on the TD we need to cancel then we have to
+ 		 * move the xHC endpoint ring dequeue pointer past this TD.
+@@ -1226,6 +1235,10 @@ reset_done:
+ 		}
+ 	}
+ 
++	/* link is inactive or disconnected, ep is not running and shouldn't be restarted */
++	if (ep->vdev->rhub_port->link_inactive || !ep->vdev->rhub_port->connected)
++		ep->ep_state |= EP_DROP_PENDING;
++
+ 	/* will queue a set TR deq if stopped on a cancelled, uncleared TD */
+ 	xhci_invalidate_cancelled_tds(ep);
+ 	ep->ep_state &= ~EP_STOP_CMD_PENDING;

--- a/target/linux/generic/backport-6.12/894-v7.3-usb-xhci-handle-port-events-when-there-is-one-roothub.patch
+++ b/target/linux/generic/backport-6.12/894-v7.3-usb-xhci-handle-port-events-when-there-is-one-roothub.patch
@@ -42,7 +42,7 @@ Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
 
 --- a/drivers/usb/host/xhci-ring.c
 +++ b/drivers/usb/host/xhci-ring.c
-@@ -1986,7 +1986,7 @@ static void handle_port_status(struct xh
+@@ -2003,7 +2003,7 @@ static void handle_port_status(struct xh
  		vdev = xhci->devs[port->slot_id];
  
  	/* We might get interrupts after shared_hcd is removed */

--- a/target/linux/generic/backport-6.18/856-01-v7.3-xhci-include-all-root-port-children-in-recovery-prevention-on-link-error.patch
+++ b/target/linux/generic/backport-6.18/856-01-v7.3-xhci-include-all-root-port-children-in-recovery-prevention-on-link-error.patch
@@ -1,0 +1,145 @@
+From e3d757dc9257f2638ca61eda4faef26c2daeea10 Mon Sep 17 00:00:00 2001
+From: Mathias Nyman <mathias.nyman@linux.intel.com>
+Date: Thu, 6 Aug 2026 17:20:59 +0300
+Subject: [PATCH 1/3] xhci: include all root port children in recovery
+ prevention on link error
+
+Driver already prevents useless transfer retry and endpoint recovery
+for devices directly connected to a root port with link errors.
+
+These devices are either disconnecting or will be reset. Link is gone.
+
+Move the flag indicating link error from the xhci device structure to
+the root port strucure, allowing all child devices behind hubs to easily
+check for root port link errors, avoiding useless transfer retries and
+endpoint recovery.
+
+This extends the previous endpoint recovery prevention in
+commit b8c3b718087b ("usb: xhci: Don't try to recover an endpoint if port
+is in error state.")
+Only root port link errors can be detected early by xhci driver,
+not link errors between external hubs and their children.
+
+Tested-by: Xu Rao <raoxu@uniontech.com>
+Signed-off-by: Mathias Nyman <mathias.nyman@linux.intel.com>
+Link: https://patch.msgid.link/20260806142113.2436238-4-mathias.nyman@linux.intel.com
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+
+Backported to 6.18: context only. This tree predates the PORTSC
+accessor (xhci_portsc_readl) and the BIT() conversion of the endpoint
+state flags, and still carries max_ports in handle_port_status().
+No functional change from upstream.
+---
+--- a/drivers/usb/host/xhci.c
++++ b/drivers/usb/host/xhci.c
+@@ -1660,7 +1660,7 @@ static int xhci_urb_enqueue(struct usb_h
+ 		goto free_priv;
+ 	}
+ 
+-	if (xhci->devs[slot_id]->flags & VDEV_PORT_ERROR) {
++	if (xhci->devs[slot_id]->rhub_port->link_inactive) {
+ 		xhci_dbg(xhci, "Can't queue urb, port error, link inactive\n");
+ 		ret = -ENODEV;
+ 		goto free_priv;
+@@ -4024,7 +4024,6 @@ static int xhci_discover_or_reset_device
+ 				xhci_get_slot_state(xhci, virt_dev->out_ctx));
+ 		xhci_dbg(xhci, "Not freeing device rings.\n");
+ 		/* Don't treat this as an error.  May change my mind later. */
+-		virt_dev->flags = 0;
+ 		ret = 0;
+ 		goto command_cleanup;
+ 	case COMP_SUCCESS:
+@@ -4076,7 +4075,6 @@ static int xhci_discover_or_reset_device
+ 	}
+ 	/* If necessary, update the number of active TTs on this root port */
+ 	xhci_update_tt_active_eps(xhci, virt_dev, old_active_eps);
+-	virt_dev->flags = 0;
+ 	ret = 0;
+ 
+ command_cleanup:
+--- a/drivers/usb/host/xhci.h
++++ b/drivers/usb/host/xhci.h
+@@ -750,14 +750,6 @@ struct xhci_virt_device {
+ 	struct xhci_port		*rhub_port;
+ 	struct xhci_interval_bw_table	*bw_table;
+ 	struct xhci_tt_bw_info		*tt_info;
+-	/*
+-	 * flags for state tracking based on events and issued commands.
+-	 * Software can not rely on states from output contexts because of
+-	 * latency between events and xHC updating output context values.
+-	 * See xhci 1.1 section 4.8.3 for more details
+-	 */
+-	unsigned long			flags;
+-#define VDEV_PORT_ERROR			BIT(0) /* Port error, link inactive */
+ 
+ 	/* The current max exit latency for the enabled USB3 link states. */
+ 	u16				current_mel;
+@@ -1479,6 +1471,7 @@ struct xhci_port {
+ 	int			hcd_portnum;
+ 	struct xhci_hub		*rhub;
+ 	struct xhci_port_cap	*port_cap;
++	unsigned int		link_inactive:1;
+ 	unsigned int		lpm_incapable:1;
+ 	unsigned long		resume_timestamp;
+ 	bool			rexit_active;
+--- a/drivers/usb/host/xhci-ring.c
++++ b/drivers/usb/host/xhci-ring.c
+@@ -992,7 +992,7 @@ static int xhci_handle_halted_endpoint(s
+ 	 * Avoid resetting endpoint if link is inactive. Can cause host hang.
+ 	 * Device will be reset soon to recover the link so don't do anything
+ 	 */
+-	if (ep->vdev->flags & VDEV_PORT_ERROR)
++	if (ep->vdev->rhub_port->link_inactive)
+ 		return -ENODEV;
+ 
+ 	/* add td to cancelled list and let reset ep handler take care of it */
+@@ -1991,14 +1991,16 @@ static void xhci_cavium_reset_phy_quirk(
+ static void handle_port_status(struct xhci_hcd *xhci, union xhci_trb *event)
+ {
+ 	struct xhci_virt_device *vdev = NULL;
+-	struct usb_hcd *hcd;
+-	u32 port_id;
+-	u32 portsc, cmd_reg;
+-	int max_ports;
+-	unsigned int hcd_portnum;
+ 	struct xhci_bus_state *bus_state;
+-	bool bogus_port_status = false;
+ 	struct xhci_port *port;
++	struct usb_hcd *hcd;
++	bool bogus_port_status = false;
++	unsigned int hcd_portnum;
++	int max_ports;
++	u32 cmd_reg;
++	u32 port_id;
++	u32 portsc;
++	u32 pls;
+ 
+ 	/* Port status change events always have a successful completion code */
+ 	if (GET_COMP_CODE(le32_to_cpu(event->generic.field[2])) != COMP_SUCCESS)
+@@ -2036,6 +2038,7 @@ static void handle_port_status(struct xh
+ 	bus_state = &port->rhub->bus_state;
+ 	hcd_portnum = port->hcd_portnum;
+ 	portsc = readl(port->addr);
++	pls = portsc & PORT_PLS_MASK;
+ 
+ 	xhci_dbg(xhci, "Port change event, %d-%d, id %d, portsc: 0x%x\n",
+ 		 hcd->self.busnum, hcd_portnum + 1, port_id, portsc);
+@@ -2047,12 +2050,12 @@ static void handle_port_status(struct xh
+ 		usb_hcd_resume_root_hub(hcd);
+ 	}
+ 
+-	if (vdev && (portsc & PORT_PLS_MASK) == XDEV_INACTIVE) {
+-		if (!(portsc & PORT_RESET))
+-			vdev->flags |= VDEV_PORT_ERROR;
+-	} else if (vdev && portsc & PORT_RC) {
+-		vdev->flags &= ~VDEV_PORT_ERROR;
+-	}
++	/*
++	 * Tag broken links to avoid retries while hub driver sorts it out.
++	 * Link status is not relible while port is in reset.
++	 */
++	if (!(portsc & PORT_RESET))
++		port->link_inactive = (pls == XDEV_INACTIVE);
+ 
+ 	if ((portsc & PORT_PLC) && (portsc & PORT_PLS_MASK) == XDEV_RESUME) {
+ 		xhci_dbg(xhci, "port resume event for port %d\n", port_id);

--- a/target/linux/generic/backport-6.18/856-02-v7.3-xhci-prevent-endpoint-recovery-after-roothub-disconnect.patch
+++ b/target/linux/generic/backport-6.18/856-02-v7.3-xhci-prevent-endpoint-recovery-after-roothub-disconnect.patch
@@ -1,0 +1,75 @@
+From 042aad8d0db6607ac9789fc43b6221909bd6a3bc Mon Sep 17 00:00:00 2001
+From: Mathias Nyman <mathias.nyman@linux.intel.com>
+Date: Thu, 6 Aug 2026 17:21:00 +0300
+Subject: [PATCH 2/3] xhci: prevent endpoint recovery after roothub disconnect
+
+Prevent transfer retry and endpoint recovery if the device or its parent
+disconnected from the roothub. Just like link error case.
+
+There is a suspicion some xHC controllers may stop processing endpoint
+related commands after the last USB device disconnects from the host.
+
+Disconnect often causes transaction errors, xhci driver tries to (soft)
+reset and restart the endpoint to recover it.
+Hub driver again will cancel all pending URBs once disconnect is detected,
+stopping the endpoint right after (soft) reset restarted it.
+xHC controller sometimes fail to complete the stop endpoint command,
+leading to driver timing out, and tearing down xhci
+
+Prevent extra endpoint (soft) reset after xhci driver is aware of the
+parent roothub port disconnect.
+
+Tested-by: Xu Rao <raoxu@uniontech.com>
+Signed-off-by: Mathias Nyman <mathias.nyman@linux.intel.com>
+Link: https://patch.msgid.link/20260806142113.2436238-5-mathias.nyman@linux.intel.com
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+
+Backported to 6.18: context only. This tree predates the PORTSC
+accessor (xhci_portsc_readl) and the BIT() conversion of the endpoint
+state flags, and still carries max_ports in handle_port_status().
+No functional change from upstream.
+---
+--- a/drivers/usb/host/xhci.h
++++ b/drivers/usb/host/xhci.h
+@@ -1472,6 +1472,7 @@ struct xhci_port {
+ 	struct xhci_hub		*rhub;
+ 	struct xhci_port_cap	*port_cap;
+ 	unsigned int		link_inactive:1;
++	unsigned int		connected:1;
+ 	unsigned int		lpm_incapable:1;
+ 	unsigned long		resume_timestamp;
+ 	bool			rexit_active;
+--- a/drivers/usb/host/xhci-ring.c
++++ b/drivers/usb/host/xhci-ring.c
+@@ -985,14 +985,16 @@ static int xhci_handle_halted_endpoint(s
+ 				struct xhci_td *td,
+ 				enum xhci_ep_reset_type reset_type)
+ {
++	struct xhci_port *rhub_port = ep->vdev->rhub_port;
+ 	unsigned int slot_id = ep->vdev->slot_id;
+ 	int err;
+ 
+ 	/*
+-	 * Avoid resetting endpoint if link is inactive. Can cause host hang.
+-	 * Device will be reset soon to recover the link so don't do anything
++	 * Avoid resetting endpoint if link is inactive or device disonnected.
++	 * Can cause host hang.
++	 * Device will be reset to recover an inactive link, so don't do anything
+ 	 */
+-	if (ep->vdev->rhub_port->link_inactive)
++	if (rhub_port->link_inactive || !rhub_port->connected)
+ 		return -ENODEV;
+ 
+ 	/* add td to cancelled list and let reset ep handler take care of it */
+@@ -2054,8 +2056,10 @@ static void handle_port_status(struct xh
+ 	 * Tag broken links to avoid retries while hub driver sorts it out.
+ 	 * Link status is not relible while port is in reset.
+ 	 */
+-	if (!(portsc & PORT_RESET))
++	if (!(portsc & PORT_RESET)) {
+ 		port->link_inactive = (pls == XDEV_INACTIVE);
++		port->connected = !!(portsc & PORT_CONNECT);
++	}
+ 
+ 	if ((portsc & PORT_PLC) && (portsc & PORT_PLS_MASK) == XDEV_RESUME) {
+ 		xhci_dbg(xhci, "port resume event for port %d\n", port_id);

--- a/target/linux/generic/backport-6.18/856-03-v7.3-xhci-avoid-xhc-endpoint-changes-after-disconnect-or-link-error.patch
+++ b/target/linux/generic/backport-6.18/856-03-v7.3-xhci-avoid-xhc-endpoint-changes-after-disconnect-or-link-error.patch
@@ -1,0 +1,119 @@
+From 7e0ef4332ed9b70309fa1f22ec26a8c3c63686ea Mon Sep 17 00:00:00 2001
+From: Mathias Nyman <mathias.nyman@linux.intel.com>
+Date: Thu, 6 Aug 2026 17:21:01 +0300
+Subject: [PATCH 3/3] xhci: avoid xHC endpoint changes after disconnect or link
+ error.
+
+Avoid all extra endpoint state changes after the roothub link
+is lost due to disconnect or link error, and endpoint is known
+to be in a non-running state.
+
+Rapid endpoint state changes involving endpoint reset, restart, and
+stopping the endpoint have caused xHC failures to complete stop
+endpoint command. xhci driver sees this as a fatal flaw and tears
+down xhci.
+
+These endpoint state changes are normally part of recovery from
+transaction errors or URB cancel.
+In this case recovery is not needed.
+
+Add an endpoint state called EP_DROP_PENDING.
+Set ep->ep_state |= EP_DROP_PENDING when an endpoint is found in a
+halted or stopped non-running state, and the roothub link is
+lost. Prevent endpoint from restarting.
+
+URB cancel doesn't need to stop the endpoint if EP_DROP_PENDONG is set.
+URBs can be given back directly.
+Endpoint is, and will remain stopped until it's dropped.
+
+Tested-by: Xu Rao <raoxu@uniontech.com>
+Signed-off-by: Mathias Nyman <mathias.nyman@linux.intel.com>
+Link: https://patch.msgid.link/20260806142113.2436238-6-mathias.nyman@linux.intel.com
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+
+Backported to 6.18: context only. This tree predates the PORTSC
+accessor (xhci_portsc_readl) and the BIT() conversion of the endpoint
+state flags, and still carries max_ports in handle_port_status().
+No functional change from upstream.
+---
+--- a/drivers/usb/host/xhci.c
++++ b/drivers/usb/host/xhci.c
+@@ -1848,7 +1848,7 @@ static int xhci_urb_dequeue(struct usb_h
+ 	}
+ 
+ 	/* In this case no commands are pending but the endpoint is stopped */
+-	if (ep->ep_state & EP_CLEARING_TT) {
++	if (ep->ep_state & (EP_CLEARING_TT | EP_DROP_PENDING)) {
+ 		/* and cancelled TDs can be given back right away */
+ 		xhci_dbg(xhci, "Invalidating TDs instantly on slot %d ep %d in state 0x%x\n",
+ 				urb->dev->slot_id, ep_index, ep->ep_state);
+@@ -4078,6 +4078,9 @@ static int xhci_discover_or_reset_device
+ 	ret = 0;
+ 
+ command_cleanup:
++	for (i = 0; i < EP_CTX_PER_DEV; i++)
++		virt_dev->eps[i].ep_state &= ~EP_DROP_PENDING;
++
+ 	xhci_free_command(xhci, reset_device_cmd);
+ 	return ret;
+ }
+--- a/drivers/usb/host/xhci.h
++++ b/drivers/usb/host/xhci.h
+@@ -674,6 +674,7 @@ struct xhci_virt_ep {
+ #define EP_SOFT_CLEAR_TOGGLE	(1 << 7)
+ /* usb_hub_clear_tt_buffer is in progress */
+ #define EP_CLEARING_TT		(1 << 8)
++#define EP_DROP_PENDING		(1 << 9) /* port disconnect or link error, don't restart */
+ 	/* ----  Related to URB cancellation ---- */
+ 	struct list_head	cancelled_td_list;
+ 	struct xhci_hcd		*xhci;
+--- a/drivers/usb/host/xhci-ring.c
++++ b/drivers/usb/host/xhci-ring.c
+@@ -560,8 +560,8 @@ void xhci_ring_ep_doorbell(struct xhci_h
+ 	 * pointer command pending because the device can choose to start any
+ 	 * stream once the endpoint is on the HW schedule.
+ 	 */
+-	if ((ep_state & EP_STOP_CMD_PENDING) || (ep_state & SET_DEQ_PENDING) ||
+-	    (ep_state & EP_HALTED) || (ep_state & EP_CLEARING_TT))
++	if (ep_state & (EP_STOP_CMD_PENDING | SET_DEQ_PENDING | EP_HALTED |
++			EP_CLEARING_TT | EP_DROP_PENDING))
+ 		return;
+ 
+ 	trace_xhci_ring_ep_doorbell(slot_id, DB_VALUE(ep_index, stream_id));
+@@ -994,8 +994,10 @@ static int xhci_handle_halted_endpoint(s
+ 	 * Can cause host hang.
+ 	 * Device will be reset to recover an inactive link, so don't do anything
+ 	 */
+-	if (rhub_port->link_inactive || !rhub_port->connected)
++	if (rhub_port->link_inactive || !rhub_port->connected) {
++		ep->ep_state |= EP_DROP_PENDING;
+ 		return -ENODEV;
++	}
+ 
+ 	/* add td to cancelled list and let reset ep handler take care of it */
+ 	if (reset_type == EP_HARD_RESET) {
+@@ -1065,6 +1067,13 @@ static int xhci_invalidate_cancelled_tds
+ 				  td->urb, td->urb->stream_id);
+ 			continue;
+ 		}
++
++		/* device disconnected or link error, ep will be dropped */
++		if (ep->ep_state & EP_DROP_PENDING) {
++			td->cancel_status = TD_CLEARED;
++			continue;
++		}
++
+ 		/*
+ 		 * If a ring stopped on the TD we need to cancel then we have to
+ 		 * move the xHC endpoint ring dequeue pointer past this TD.
+@@ -1295,6 +1304,10 @@ reset_done:
+ 		}
+ 	}
+ 
++	/* link is inactive or disconnected, ep is not running and shouldn't be restarted */
++	if (ep->vdev->rhub_port->link_inactive || !ep->vdev->rhub_port->connected)
++		ep->ep_state |= EP_DROP_PENDING;
++
+ 	/* will queue a set TR deq if stopped on a cancelled, uncleared TD */
+ 	xhci_invalidate_cancelled_tds(ep);
+ 	ep->ep_state &= ~EP_STOP_CMD_PENDING;

--- a/target/linux/generic/backport-6.18/894-v7.3-usb-xhci-handle-port-events-when-there-is-one-roothub.patch
+++ b/target/linux/generic/backport-6.18/894-v7.3-usb-xhci-handle-port-events-when-there-is-one-roothub.patch
@@ -42,7 +42,7 @@ Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
 
 --- a/drivers/usb/host/xhci-ring.c
 +++ b/drivers/usb/host/xhci-ring.c
-@@ -2026,7 +2026,7 @@ static void handle_port_status(struct xh
+@@ -2043,7 +2043,7 @@ static void handle_port_status(struct xh
  		vdev = xhci->devs[port->slot_id];
  
  	/* We might get interrupts after shared_hcd is removed */


### PR DESCRIPTION
The dwc3 instances on IPQ4019 mishandle xHCI Soft Retry. Unplugging a
device mid-transfer leaves a Stop Endpoint command on an endpoint carrying
TSP reset state; the command ring stops, and five seconds later the
watchdog declares the host dead:

```
xhci-hcd xhci-hcd.1.auto: xHCI host not responding to stop endpoint command
xhci-hcd xhci-hcd.1.auto: xHCI host controller not responding, assume dead
xhci-hcd xhci-hcd.1.auto: HC died; cleaning up
```
Reproducer: tether an iPhone over USB to a UniFi Travel Router and unplug
it while traffic is flowing.

Fixed by avoiding Soft Retry on known-disconnected root hub ports.

Backported from Linux kernel 7.3-rc1