### PR TITLE
kernel: handle EPROBE_DEFER when reading the MAC address 

### DIFF
--- a/target/linux/generic/backport-6.18/781-v7.1-net-mvneta-support-EPROBE_DEFER-when-reading-MAC-add.patch
+++ b/target/linux/generic/backport-6.18/781-v7.1-net-mvneta-support-EPROBE_DEFER-when-reading-MAC-add.patch
@@ -1,0 +1,39 @@
+From 73a864352570fd30d942652f05bfe9340d7a2055 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Fri, 6 Mar 2026 19:17:09 -0800
+Subject: [PATCH] net: mvneta: support EPROBE_DEFER when reading MAC address
+
+If nvmem loads after the ethernet driver, mac address assignments will
+not take effect. of_get_ethdev_address returns EPROBE_DEFER in such a
+case so we need to handle that to avoid eth_hw_addr_random.
+
+Add extra goto section to just free stats as they are allocated right
+above.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Link: https://patch.msgid.link/20260307031709.640141-1-rosenp@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/marvell/mvneta.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/drivers/net/ethernet/marvell/mvneta.c
++++ b/drivers/net/ethernet/marvell/mvneta.c
+@@ -5628,6 +5628,8 @@ static int mvneta_probe(struct platform_
+ 	}
+ 
+ 	err = of_get_ethdev_address(dn, dev);
++	if (err == -EPROBE_DEFER)
++		goto err_free_stats;
+ 	if (!err) {
+ 		mac_from = "device tree";
+ 	} else {
+@@ -5763,6 +5765,7 @@ err_netdev:
+ 				       1 << pp->id);
+ 		mvneta_bm_put(pp->bm_priv);
+ 	}
++err_free_stats:
+ 	free_percpu(pp->stats);
+ err_free_ports:
+ 	free_percpu(pp->ports);

--- a/target/linux/generic/pending-6.12/704-net-dsa-support-EPROBE_DEFER-when-reading-the-port-M.patch
+++ b/target/linux/generic/pending-6.12/704-net-dsa-support-EPROBE_DEFER-when-reading-the-port-M.patch
@@ -1,0 +1,47 @@
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Thu, 27 Aug 2026 20:00:00 +0200
+Subject: [PATCH] net: dsa: support EPROBE_DEFER when reading the port MAC
+ address
+
+The MAC address of a user port can be stored in an NVMEM provider which
+is not available yet when the switch probes, for example an MTD
+partition or an EEPROM. of_get_mac_address() returns -EPROBE_DEFER in
+that case, but the return value is thrown away and the port silently
+inherits the MAC address of its conduit interface instead.
+
+Propagate the deferral instead so the switch is probed again later.
+Ports without any MAC address in the device tree are unaffected,
+of_get_mac_address() returns -ENODEV for those and that is still
+ignored.
+
+dsa_tree_setup_ports() has to pass -EPROBE_DEFER on as well, otherwise
+it converts the port into an unused one and the retry never happens.
+
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+---
+ net/dsa/dsa.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+--- a/net/dsa/dsa.c
++++ b/net/dsa/dsa.c
+@@ -509,7 +509,10 @@ static int dsa_port_setup(struct dsa_por
+ 
+ 		break;
+ 	case DSA_PORT_TYPE_USER:
+-		of_get_mac_address(dp->dn, dp->mac);
++		err = of_get_mac_address(dp->dn, dp->mac);
++		if (err == -EPROBE_DEFER)
++			break;
++
+ 		err = dsa_user_create(dp);
+ 		break;
+ 	}
+@@ -750,6 +753,8 @@ static int dsa_tree_setup_ports(struct d
+ 	list_for_each_entry(dp, &dst->ports, list) {
+ 		if (dsa_port_is_user(dp) || dsa_port_is_unused(dp)) {
+ 			err = dsa_port_setup(dp);
++			if (err == -EPROBE_DEFER)
++				goto teardown;
+ 			if (err) {
+ 				err = dsa_port_setup_as_unused(dp);
+ 				if (err)

--- a/target/linux/generic/pending-6.18/704-net-dsa-support-EPROBE_DEFER-when-reading-the-port-M.patch
+++ b/target/linux/generic/pending-6.18/704-net-dsa-support-EPROBE_DEFER-when-reading-the-port-M.patch
@@ -1,0 +1,47 @@
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Thu, 27 Aug 2026 20:00:00 +0200
+Subject: [PATCH] net: dsa: support EPROBE_DEFER when reading the port MAC
+ address
+
+The MAC address of a user port can be stored in an NVMEM provider which
+is not available yet when the switch probes, for example an MTD
+partition or an EEPROM. of_get_mac_address() returns -EPROBE_DEFER in
+that case, but the return value is thrown away and the port silently
+inherits the MAC address of its conduit interface instead.
+
+Propagate the deferral instead so the switch is probed again later.
+Ports without any MAC address in the device tree are unaffected,
+of_get_mac_address() returns -ENODEV for those and that is still
+ignored.
+
+dsa_tree_setup_ports() has to pass -EPROBE_DEFER on as well, otherwise
+it converts the port into an unused one and the retry never happens.
+
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+---
+ net/dsa/dsa.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+--- a/net/dsa/dsa.c
++++ b/net/dsa/dsa.c
+@@ -509,7 +509,10 @@ static int dsa_port_setup(struct dsa_por
+ 
+ 		break;
+ 	case DSA_PORT_TYPE_USER:
+-		of_get_mac_address(dp->dn, dp->mac);
++		err = of_get_mac_address(dp->dn, dp->mac);
++		if (err == -EPROBE_DEFER)
++			break;
++
+ 		err = dsa_user_create(dp);
+ 		break;
+ 	}
+@@ -750,6 +753,8 @@ static int dsa_tree_setup_ports(struct d
+ 	list_for_each_entry(dp, &dst->ports, list) {
+ 		if (dsa_port_is_user(dp) || dsa_port_is_unused(dp)) {
+ 			err = dsa_port_setup(dp);
++			if (err == -EPROBE_DEFER)
++				goto teardown;
+ 			if (err) {
+ 				err = dsa_port_setup_as_unused(dp);
+ 				if (err)

--- a/target/linux/octeon/patches-6.18/105-staging-octeon-support-EPROBE_DEFER-when-reading-MAC.patch
+++ b/target/linux/octeon/patches-6.18/105-staging-octeon-support-EPROBE_DEFER-when-reading-MAC.patch
@@ -1,0 +1,66 @@
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Thu, 27 Aug 2026 20:00:00 +0200
+Subject: [PATCH] staging: octeon: support EPROBE_DEFER when reading MAC
+ addresses
+
+The per port MAC addresses are read in cvm_oct_common_init(), which runs
+as ndo_init() from register_netdev(). When the NVMEM provider holding
+them is not available yet - on the Ubiquiti EdgeRouter it is an MTD
+partition on the SPI flash - of_get_ethdev_address() returns
+-EPROBE_DEFER and every port ends up with a random MAC address that
+changes on every boot.
+
+Returning the error from ndo_init() does not help: it only makes
+register_netdev() fail and the interface disappear. cvm_oct_probe() has
+no unwind path either once it started to bring up the packet I/O
+hardware.
+
+Look at all port nodes at the very beginning of cvm_oct_probe() instead,
+where returning an error is still free, and ask to be probed again later
+when one of them is not readable yet.
+
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+---
+ drivers/staging/octeon/ethernet.c | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+--- a/drivers/staging/octeon/ethernet.c
++++ b/drivers/staging/octeon/ethernet.c
+@@ -670,6 +670,27 @@ static void cvm_set_rgmii_delay(struct o
+ 		priv->phy_mode = PHY_INTERFACE_MODE_RGMII;
+ }
+ 
++/*
++ * The per-port MAC addresses may live in an NVMEM provider that is not there
++ * yet, for example an MTD partition on a SPI flash. The netdevs read them from
++ * ndo_init(), which is far too late to ask for a retry: once cvm_oct_probe()
++ * has begun to bring up the packet I/O hardware there is no way back. Look at
++ * all of them here instead, while returning an error is still free.
++ */
++static bool cvm_oct_mac_addresses_deferred(struct device_node *pip)
++{
++	u8 mac[ETH_ALEN];
++
++	for_each_available_child_of_node_scoped(pip, interface) {
++		for_each_available_child_of_node_scoped(interface, port) {
++			if (of_get_mac_address(port, mac) == -EPROBE_DEFER)
++				return true;
++		}
++	}
++
++	return false;
++}
++
+ static int cvm_oct_probe(struct platform_device *pdev)
+ {
+ 	int num_interfaces;
+@@ -689,6 +710,9 @@ static int cvm_oct_probe(struct platform
+ 		return -EINVAL;
+ 	}
+ 
++	if (cvm_oct_mac_addresses_deferred(pip))
++		return -EPROBE_DEFER;
++
+ 	cvm_oct_configure_common_hw();
+ 
+ 	cvmx_helper_initialize_packet_io_global();

--- a/target/linux/octeon/patches-6.18/110-er200-ethernet_probe_order.patch
+++ b/target/linux/octeon/patches-6.18/110-er200-ethernet_probe_order.patch
@@ -1,6 +1,6 @@
 --- a/drivers/staging/octeon/ethernet.c
 +++ b/drivers/staging/octeon/ethernet.c
-@@ -676,6 +676,7 @@ static int cvm_oct_probe(struct platform
+@@ -697,6 +697,7 @@ static int cvm_oct_probe(struct platform
  	int interface;
  	int fau = FAU_NUM_PACKET_BUFFERS_TO_FREE;
  	int qos;
@@ -8,7 +8,7 @@
  	struct device_node *pip;
  	int mtu_overhead = ETH_HLEN + ETH_FCS_LEN;
  
-@@ -797,13 +798,19 @@ static int cvm_oct_probe(struct platform
+@@ -821,13 +822,19 @@ static int cvm_oct_probe(struct platform
  	}
  
  	num_interfaces = cvmx_helper_get_number_of_interfaces();

--- a/target/linux/octeon/patches-6.18/701-honor_sgmii_node_device_tree_status.patch
+++ b/target/linux/octeon/patches-6.18/701-honor_sgmii_node_device_tree_status.patch
@@ -12,7 +12,7 @@ Tested-by: Johannes Kimmel <fff@bareminimum.eu>
 Signed-off-by: Roman Kuzmitskii <damex.pp@icloud.com>
 --- a/drivers/staging/octeon/ethernet.c
 +++ b/drivers/staging/octeon/ethernet.c
-@@ -877,8 +877,10 @@ static int cvm_oct_probe(struct platform
+@@ -901,8 +901,10 @@ static int cvm_oct_probe(struct platform
  
  			case CVMX_HELPER_INTERFACE_MODE_SGMII:
  				priv->phy_mode = PHY_INTERFACE_MODE_SGMII;


### PR DESCRIPTION
Handle deferred mac address loading in driver missing it. 
