### PR TITLE
ramips: add support for Cudy LT500 v2

### DIFF
--- a/target/linux/ramips/dts/mt7628an_cudy_lt500-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_cudy_lt500-v2.dts
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "cudy,lt500-v2", "mediatek,mt7628an-soc";
+	model = "Cudy LT500 v2";
+
+	aliases {
+		led-boot = &led_status;
+		led-running = &led_status;
+		led-failsafe = &led_status;
+		led-upgrade = &led_status;
+		label-mac-device = &ethernet;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status: led-0 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan1 {
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan2 {
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan3 {
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan4 {
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <4>;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		pwr {
+			gpio-export,name = "pwr";
+			gpio-export,output = <0>;
+			gpios = <&gpio 38 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb4g {
+			gpio-export,name = "4g";
+			gpio-export,output = <0>;
+			gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xf80000>;
+			};
+
+			partition@fd0000 {
+				label = "debug";
+				reg = <0xfd0000 0x10000>;
+				read-only;
+			};
+
+			partition@fe0000 {
+				label = "backup";
+				reg = <0xfe0000 0x10000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "bdinfo";
+				reg = <0xff0000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_bdinfo_de00: macaddr@de00 {
+						compatible = "mac-base";
+						reg = <0xde00 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "gpio", "i2s", "i2c", "wdt", "p0led_an", "p1led_an",
+			 "p2led_an", "p4led_an";
+		function = "gpio";
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_bdinfo_de00 2>;
+		nvmem-cell-names = "eeprom", "mac-address";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_bdinfo_de00 0>;
+	nvmem-cell-names = "eeprom", "mac-address";
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_bdinfo_de00 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x37>;
+	mediatek,portdisable = <0x30>;
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -233,6 +233,19 @@ define Device/cudy_lt500-outdoor-v1
 endef
 TARGET_DEVICES += cudy_lt500-outdoor-v1
 
+define Device/cudy_lt500-v2
+  IMAGE_SIZE := 15872k
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := LT500
+  DEVICE_VARIANT := v2
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-net-qmi-wwan \
+	kmod-usb-serial-option modemmanager \
+	kmod-mt7615e kmod-mt7663-firmware-ap
+  UIMAGE_NAME := R25
+  SUPPORTED_DEVICES += R25
+endef
+TARGET_DEVICES += cudy_lt500-v2
+
 define Device/cudy_m1200-v1
   IMAGE_SIZE := 15872k
   DEVICE_VENDOR := Cudy

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -137,6 +137,12 @@ cudy,lt500-outdoor-v1)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x01"
 	ucidef_set_led_netdev "internet" "internet" "green:wan-online" "usb0"
 	;;
+cudy,lt500-v2)
+	ucidef_set_led_switch "lan1" "lan1" "green:lan-1" "switch0" "0x01"
+	ucidef_set_led_switch "lan2" "lan2" "green:lan-2" "switch0" "0x02"
+	ucidef_set_led_switch "lan3" "lan3" "green:lan-3" "switch0" "0x04"
+	ucidef_set_led_switch "lan4" "lan4" "green:lan-4" "switch0" "0x08"
+	;;
 cudy,re1200-outdoor-v1|\
 mercusys,mb130-4g-v1|\
 tplink,re200-v2|\

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -113,6 +113,12 @@ ramips_setup_interfaces()
 		uci add_list firewall.@zone[1].network='wwan'
 		uci add_list firewall.@zone[1].network='wwan6'
 		;;
+	cudy,lt500-v2)
+		ucidef_add_switch "switch0" \
+			"0:lan" "1:lan" "2:lan" "3:wan" "6@eth0"
+		uci add_list firewall.@zone[1].network='wwan'
+		uci add_list firewall.@zone[1].network='wwan6'
+		;;
 	cudy,m1200-v1|\
 	cudy,tr1200-v1)
 		ucidef_add_switch "switch0" \


### PR DESCRIPTION
Cudy LT500 v2 is a MediaTek MT7628AN-based 4G LTE router.

Specifications:
- SoC: MediaTek MT7628AN
- RAM: 128 MB DDR2
- Flash: 16 MB SPI-NOR
- WLAN: 2.4GHz onboard (mt76_wmac) + 5GHz via PCIe (MediaTek 7663-family,
  kmod-mt7615e/kmod-mt7663-firmware-ap)
- WWAN: Quectel EC25 (USB, QMI, via ModemManager)
- Ethernet: switch, 3x LAN + 1x combo LAN/WAN
- UART: not accessible without significant hardware modification
- Power: 12V / 1A, DC barrel jack

GPIO:
- LED: 1x status (blue GPIO 0, red GPIO 4), 4x port link (GPIO 43/42/41/39)
- Button: reset (GPIO 11), WPS (GPIO 5)
- WWAN power/reset ("pwr" GPIO 38, "4g" GPIO 3): exported active-high,
  default LOW (powered/out-of-reset), matching the vendor's own
  GPL-released R25.dts

MAC Addresses:
- Ethernet (LAN/WAN): from the "bdinfo" partition (mac-base cell, offset
  0xDE00). LAN and WAN are VLANs on the same physical eth0/switch, so
  both share this address.
- WLAN 2.4GHz: same as Ethernet, since this interface is bridged with
  LAN on this device.
- WLAN 5GHz: from the "bdinfo" partition (mac-base cell, index 2).

Switch port mapping (0/1/2 = LAN, 3 = combo LAN/WAN) is derived from the
vendor DTS's `mediatek,port-map = "lllwl"`. Port 4 has no physical connector on this board and is left out of the port list. 

Installation:

To install OpenWrt, you need the intermediate firmware from Cudy (U-boot
is locked). It is available from Cudy's intermediate/interim OpenWrt
firmware folder:

  https://drive.google.com/drive/folders/1BKVarlwlNxf7uJUtRhuMGUqeCa5KpMnj

After installing the intermediate firmware via the stock web UI, you can
install OpenWrt via sysupgrade.

Recovery:

TFTP available. See also Cudy's own instructions:
https://docs.cudy.com/faq/10002_How_to_recover_Cudy_devices'_firmware_via_TFTP/

1. Place recovery.bin in your TFTP server's serving directory and set
   your IP to 192.168.1.88/24.
2. Hold the reset button, then power on the router while continuing to
   hold it.
3. Release the reset button once TFTP starts downloading the firmware.