### PR TITLE
qualcommax: ipq50xx: mr5500: switch qca8k to external MDIO bus

### DIFF
--- a/target/linux/qualcommax/dts/ipq5018-mr5500.dts
+++ b/target/linux/qualcommax/dts/ipq5018-mr5500.dts
@@ -82,6 +82,31 @@
 	pinctrl-names = "default";
 	reset-gpios = <&tlmm 39 GPIO_ACTIVE_LOW>;
 
+	// QCA8337 Phy0 -> LAN1
+	qca8337_0: ethernet-phy@0 {
+		reg = <0>;
+	};
+
+	// QCA8337 Phy1 -> LAN2
+	qca8337_1: ethernet-phy@1 {
+		reg = <1>;
+	};
+
+	// QCA8337 Phy2 -> LAN3
+	qca8337_2: ethernet-phy@2 {
+		reg = <2>;
+	};
+
+	// QCA8337 Phy3 -> LAN4
+	qca8337_3: ethernet-phy@3 {
+		reg = <3>;
+	};
+
+	// QCA8337 Phy4 -> WAN
+	qca8337_4: ethernet-phy@4 {
+		reg = <4>;
+	};
+
 	switch1: ethernet-switch@17 {
 		compatible = "qca,qca8337";
 		reg = <17>;
@@ -96,7 +121,6 @@
 				reg = <1>;
 				label = "lan1";
 				phy-handle = <&qca8337_0>;
-				phy-mode = "internal";
 
 				leds {
 					#address-cells = <1>;
@@ -122,7 +146,6 @@
 				reg = <2>;
 				label = "lan2";
 				phy-handle = <&qca8337_1>;
-				phy-mode = "internal";
 
 				leds {
 					#address-cells = <1>;
@@ -148,7 +171,6 @@
 				reg = <3>;
 				label = "lan3";
 				phy-handle = <&qca8337_2>;
-				phy-mode = "internal";
 
 				leds {
 					#address-cells = <1>;
@@ -174,7 +196,6 @@
 				reg = <4>;
 				label = "lan4";
 				phy-handle = <&qca8337_3>;
-				phy-mode = "internal";
 
 				leds {
 					#address-cells = <1>;
@@ -200,7 +221,6 @@
 				reg = <5>;
 				label = "wan";
 				phy-handle = <&qca8337_4>;
-				phy-mode = "internal";
 
 				leds {
 					#address-cells = <1>;
@@ -233,36 +253,6 @@
 					speed = <1000>;
 					full-duplex;
 				};
-			};
-		};
-
-		mdio {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			// QCA8337 Phy0 -> LAN1
-			qca8337_0: ethernet-phy@0 {
-				reg = <0>;
-			};
-
-			// QCA8337 Phy1 -> LAN2
-			qca8337_1: ethernet-phy@1 {
-				reg = <1>;
-			};
-
-			// QCA8337 Phy2 -> LAN3
-			qca8337_2: ethernet-phy@2 {
-				reg = <2>;
-			};
-
-			// QCA8337 Phy3 -> LAN4
-			qca8337_3: ethernet-phy@3 {
-				reg = <3>;
-			};
-
-			// QCA8337 Phy4 -> WAN
-			qca8337_4: ethernet-phy@4 {
-				reg = <4>;
 			};
 		};
 	};

--- a/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/01_leds
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/01_leds
@@ -16,16 +16,16 @@ iodata,wn-dax3000gr)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan" "tx rx link_10 link_100 link_1000"
 	;;
 linksys,mr5500)
-	ucidef_set_led_netdev "lan1-port-link" "LAN1-PORT-LINK" "qca8k-0.0:00:green:lan" "lan1" "link_10 link_100 link_1000"
-	ucidef_set_led_netdev "lan1-port-activity" "LAN1-PORT-ACTIVITY" "qca8k-0.0:00:amber:lan" "lan1" "tx rx"
-	ucidef_set_led_netdev "lan2-port-link" "LAN2-PORT-LINK" "qca8k-0.0:01:green:lan" "lan2" "link_10 link_100 link_1000"
-	ucidef_set_led_netdev "lan2-port-activity" "LAN2-PORT-ACTIVITY" "qca8k-0.0:01:amber:lan" "lan2" "tx rx"
-	ucidef_set_led_netdev "lan3-port-link" "LAN3-PORT-LINK" "qca8k-0.0:02:green:lan" "lan3" "link_10 link_100 link_1000"
-	ucidef_set_led_netdev "lan3-port-activity" "LAN3-PORT-ACTIVITY" "qca8k-0.0:02:amber:lan" "lan3" "tx rx"
-	ucidef_set_led_netdev "lan4-port-link" "LAN4-PORT-LINK" "qca8k-0.0:03:green:lan" "lan4" "link_10 link_100 link_1000"
-	ucidef_set_led_netdev "lan4-port-activity" "LAN4-PORT-ACTIVITY" "qca8k-0.0:03:amber:lan" "lan4" "tx rx"
-	ucidef_set_led_netdev "wan-port-link" "WAN-PORT-LINK" "qca8k-0.0:04:green:wan" "wan" "link_10 link_100 link_1000"
-	ucidef_set_led_netdev "wan-port-activity" "WAN-PORT-ACTIVITY" "qca8k-0.0:04:amber:wan" "wan" "tx rx"
+	ucidef_set_led_netdev "lan1-port-link" "LAN1-PORT-LINK" "90000.mdio-1:00:green:lan" "lan1" "link_10 link_100 link_1000"
+	ucidef_set_led_netdev "lan1-port-activity" "LAN1-PORT-ACTIVITY" "90000.mdio-1:00:amber:lan" "lan1" "tx rx"
+	ucidef_set_led_netdev "lan2-port-link" "LAN2-PORT-LINK" "90000.mdio-1:01:green:lan" "lan2" "link_10 link_100 link_1000"
+	ucidef_set_led_netdev "lan2-port-activity" "LAN2-PORT-ACTIVITY" "90000.mdio-1:01:amber:lan" "lan2" "tx rx"
+	ucidef_set_led_netdev "lan3-port-link" "LAN3-PORT-LINK" "90000.mdio-1:02:green:lan" "lan3" "link_10 link_100 link_1000"
+	ucidef_set_led_netdev "lan3-port-activity" "LAN3-PORT-ACTIVITY" "90000.mdio-1:02:amber:lan" "lan3" "tx rx"
+	ucidef_set_led_netdev "lan4-port-link" "LAN4-PORT-LINK" "90000.mdio-1:03:green:lan" "lan4" "link_10 link_100 link_1000"
+	ucidef_set_led_netdev "lan4-port-activity" "LAN4-PORT-ACTIVITY" "90000.mdio-1:03:amber:lan" "lan4" "tx rx"
+	ucidef_set_led_netdev "wan-port-link" "WAN-PORT-LINK" "90000.mdio-1:04:green:wan" "wan" "link_10 link_100 link_1000"
+	ucidef_set_led_netdev "wan-port-activity" "WAN-PORT-ACTIVITY" "90000.mdio-1:04:amber:wan" "wan" "tx rx"
 	;;
 xiaomi,redmi-ax5400)
 	ucidef_set_led_netdev "wan-port-link-top-blue" "WAN-PORT-LINK-TOP-BLUE" "blue:wan" "wan" "link_1000"


### PR DESCRIPTION
With below patch merged upstream, the qca8k driver can use the external MDIO bus instead of its internal one. This fixes the issue of the LED names when an external MDIO bus is used.

LED names were prefixed with "(efault)" because the driver was hardcoded to use the internal MDIO bus when naming the LEDs as the internal bus was NULL. This forced the LEDs to be populated under the internal bus.

In addition, the internal MDIO will likely be removed from the driver in the future.

So let's move the PHYs from the internal MDIO bus to the external bus, the one from the SoC, in line with all other boards, and rename the LED names.

link: https://github.com/torvalds/linux/commit/0b7b378ce6cafbb948786cb6f17f406d94016c8c.patch
