### PR TITLE
[25.12] kernel: add support for HeYangTek HYF1GQ4UDACAE SPI-NAND

### DIFF
--- a/target/linux/airoha/patches-6.12/901-snand-mtk-bmt-support.patch
+++ b/target/linux/airoha/patches-6.12/901-snand-mtk-bmt-support.patch
@@ -8,7 +8,7 @@
  
  static int spinand_read_reg_op(struct spinand_device *spinand, u8 reg, u8 *val)
  {
-@@ -1585,6 +1586,7 @@ static int spinand_probe(struct spi_mem
+@@ -1586,6 +1587,7 @@ static int spinand_probe(struct spi_mem
  	if (ret)
  		return ret;
  
@@ -16,7 +16,7 @@
  	ret = mtd_device_register(mtd, NULL, 0);
  	if (ret)
  		goto err_spinand_cleanup;
-@@ -1592,6 +1594,7 @@ static int spinand_probe(struct spi_mem
+@@ -1593,6 +1595,7 @@ static int spinand_probe(struct spi_mem
  	return 0;
  
  err_spinand_cleanup:
@@ -24,7 +24,7 @@
  	spinand_cleanup(spinand);
  
  	return ret;
-@@ -1610,6 +1613,7 @@ static int spinand_remove(struct spi_mem
+@@ -1611,6 +1614,7 @@ static int spinand_remove(struct spi_mem
  	if (ret)
  		return ret;
  

--- a/target/linux/econet/patches-6.12/902-snand-mtk-bmt-support.patch
+++ b/target/linux/econet/patches-6.12/902-snand-mtk-bmt-support.patch
@@ -8,7 +8,7 @@
  
  static int spinand_read_reg_op(struct spinand_device *spinand, u8 reg, u8 *val)
  {
-@@ -1585,6 +1586,7 @@ static int spinand_probe(struct spi_mem
+@@ -1586,6 +1587,7 @@ static int spinand_probe(struct spi_mem
  	if (ret)
  		return ret;
  
@@ -16,7 +16,7 @@
  	ret = mtd_device_register(mtd, NULL, 0);
  	if (ret)
  		goto err_spinand_cleanup;
-@@ -1592,6 +1594,7 @@ static int spinand_probe(struct spi_mem
+@@ -1593,6 +1595,7 @@ static int spinand_probe(struct spi_mem
  	return 0;
  
  err_spinand_cleanup:
@@ -24,7 +24,7 @@
  	spinand_cleanup(spinand);
  
  	return ret;
-@@ -1610,6 +1613,7 @@ static int spinand_remove(struct spi_mem
+@@ -1611,6 +1614,7 @@ static int spinand_remove(struct spi_mem
  	if (ret)
  		return ret;
  

--- a/target/linux/generic/backport-6.12/438-v7.3-mtd-spinand-add-support-for-HeYangTek-HYF1GQ4UDACAE.patch
+++ b/target/linux/generic/backport-6.12/438-v7.3-mtd-spinand-add-support-for-HeYangTek-HYF1GQ4UDACAE.patch
@@ -1,0 +1,190 @@
+From a8374683868634012ac873d628fa581fcc452e9c Mon Sep 17 00:00:00 2001
+From: Aleksei Sviridkin <f@lex.la>
+Date: Tue, 16 Jun 2026 16:28:44 +0300
+Subject: mtd: spinand: add support for HeYangTek HYF1GQ4UDACAE
+
+The HeYangTek HYF1GQ4UDACAE is a 1 Gbit (128 MiB) SLC SPI-NAND with
+2048 + 64 byte pages and on-die 4-bit / 512-byte ECC; its JEDEC
+manufacturer ID is 0xc9. The die is GD5F1GQ4-compatible, so the OOB
+layout is taken from the in-tree gd5fxgq4xa. The die exposes only a
+coarse 2-bit ECC status with no fine-grained bitflip-count register, so
+the status is decoded into a representative number of corrected bitflips.
+
+It is found, among others, on some Keenetic KN-3411 (Buddy 6) units.
+
+Datasheet:
+https://www.heyangtek.cn/previewfile.jsp?file=ABUIABA9GAAgwsvRnwYo-eDpsgc
+
+Signed-off-by: Aleksei Sviridkin <f@lex.la>
+Signed-off-by: Miquel Raynal <miquel.raynal@bootlin.com>
+---
+ drivers/mtd/nand/spi/Makefile    |   2 +-
+ drivers/mtd/nand/spi/core.c      |   1 +
+ drivers/mtd/nand/spi/heyangtek.c | 132 +++++++++++++++++++++++++++++++++++++++
+ include/linux/mtd/spinand.h      |   1 +
+ 4 files changed, 135 insertions(+), 1 deletion(-)
+ create mode 100644 drivers/mtd/nand/spi/heyangtek.c
+
+--- a/drivers/mtd/nand/spi/Makefile
++++ b/drivers/mtd/nand/spi/Makefile
+@@ -1,4 +1,4 @@
+ # SPDX-License-Identifier: GPL-2.0
+-spinand-objs := core.o alliancememory.o ato.o esmt.o fmsh.o foresee.o gigadevice.o macronix.o
++spinand-objs := core.o alliancememory.o ato.o esmt.o fmsh.o foresee.o gigadevice.o heyangtek.o macronix.o
+ spinand-objs += micron.o paragon.o toshiba.o winbond.o xtx.o
+ obj-$(CONFIG_MTD_SPI_NAND) += spinand.o
+--- a/drivers/mtd/nand/spi/core.c
++++ b/drivers/mtd/nand/spi/core.c
+@@ -1171,6 +1171,7 @@ static const struct spinand_manufacturer
+ 	&fmsh_spinand_manufacturer,
+ 	&foresee_spinand_manufacturer,
+ 	&gigadevice_spinand_manufacturer,
++	&heyangtek_spinand_manufacturer,
+ 	&macronix_spinand_manufacturer,
+ 	&micron_spinand_manufacturer,
+ 	&paragon_spinand_manufacturer,
+--- /dev/null
++++ b/drivers/mtd/nand/spi/heyangtek.c
+@@ -0,0 +1,132 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Authors:
++ *	Andrey Zolotarev <andrey.zolotarev@keenetic.com> - the main driver logic
++ *	Aleksei Sviridkin <f@lex.la> - adaptation to the mainline Linux kernel
++ *
++ * Based on:
++ *	https://github.com/keenetic/kernel-49/commit/bacade569fb12bc0ad31ba09bca9b890118fbca7
++ */
++
++#include <linux/device.h>
++#include <linux/kernel.h>
++#include <linux/mtd/spinand.h>
++
++#define SPINAND_MFR_HEYANGTEK			0xc9
++
++#define HYF1GQ4_STATUS_ECC_LIMIT_BITFLIPS	(3 << 4)
++
++static SPINAND_OP_VARIANTS(read_cache_variants,
++		SPINAND_PAGE_READ_FROM_CACHE_QUADIO_OP(0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_X4_OP(0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_DUALIO_OP(0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_X2_OP(0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_OP(true, 0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_OP(false, 0, 1, NULL, 0));
++
++static SPINAND_OP_VARIANTS(write_cache_variants,
++		SPINAND_PROG_LOAD_X4(true, 0, NULL, 0),
++		SPINAND_PROG_LOAD(true, 0, NULL, 0));
++
++static SPINAND_OP_VARIANTS(update_cache_variants,
++		SPINAND_PROG_LOAD_X4(false, 0, NULL, 0),
++		SPINAND_PROG_LOAD(false, 0, NULL, 0));
++
++/*
++ * HYF1GQ4UDACAE is a GD5F1GQ4-compatible die, so the OOB layout is taken
++ * from gd5fxgq4xa: the on-die ECC parity occupies bytes 8..15 of each
++ * 16-byte section, the bad block marker sits in byte 0 and the remaining
++ * bytes are exposed as free.
++ */
++static int hyf1gq4_ooblayout_ecc(struct mtd_info *mtd, int section,
++				 struct mtd_oob_region *region)
++{
++	if (section > 3)
++		return -ERANGE;
++
++	region->offset = (16 * section) + 8;
++	region->length = 8;
++
++	return 0;
++}
++
++static int hyf1gq4_ooblayout_free(struct mtd_info *mtd, int section,
++				  struct mtd_oob_region *region)
++{
++	if (section > 3)
++		return -ERANGE;
++
++	if (section) {
++		region->offset = 16 * section;
++		region->length = 8;
++	} else {
++		/* section 0 has one byte reserved for the bad block marker */
++		region->offset = 1;
++		region->length = 7;
++	}
++
++	return 0;
++}
++
++static const struct mtd_ooblayout_ops hyf1gq4_ooblayout = {
++	.ecc = hyf1gq4_ooblayout_ecc,
++	.free = hyf1gq4_ooblayout_free,
++};
++
++static int hyf1gq4_ecc_get_status(struct spinand_device *spinand, u8 status)
++{
++	struct nand_device *nand = spinand_to_nand(spinand);
++
++	switch (status & STATUS_ECC_MASK) {
++	case STATUS_ECC_NO_BITFLIPS:
++		return 0;
++
++	case STATUS_ECC_UNCOR_ERROR:
++		return -EBADMSG;
++
++	case STATUS_ECC_HAS_BITFLIPS:
++		/*
++		 * The die exposes only a coarse 2-bit ECC status and has no
++		 * register for the exact bitflip count. This code means
++		 * "corrected, below the refresh threshold", so report half of
++		 * the ECC strength as a representative value.
++		 */
++		return nanddev_get_ecc_conf(nand)->strength / 2;
++
++	case HYF1GQ4_STATUS_ECC_LIMIT_BITFLIPS:
++		/*
++		 * "Corrected, refresh recommended": report the full ECC
++		 * strength so the upper layers relocate the data.
++		 */
++		return nanddev_get_ecc_conf(nand)->strength;
++
++	default:
++		break;
++	}
++
++	return -EINVAL;
++}
++
++static const struct spinand_info heyangtek_spinand_table[] = {
++	SPINAND_INFO("HYF1GQ4UDACAE",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_ADDR, 0x21),
++		     NAND_MEMORG(1, 2048, 64, 64, 1024, 20, 1, 1, 1),
++		     NAND_ECCREQ(4, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&hyf1gq4_ooblayout,
++				     hyf1gq4_ecc_get_status)),
++};
++
++static const struct spinand_manufacturer_ops heyangtek_spinand_manuf_ops = {
++};
++
++const struct spinand_manufacturer heyangtek_spinand_manufacturer = {
++	.id = SPINAND_MFR_HEYANGTEK,
++	.name = "HeYangTek",
++	.chips = heyangtek_spinand_table,
++	.nchips = ARRAY_SIZE(heyangtek_spinand_table),
++	.ops = &heyangtek_spinand_manuf_ops,
++};
+--- a/include/linux/mtd/spinand.h
++++ b/include/linux/mtd/spinand.h
+@@ -267,6 +267,7 @@ extern const struct spinand_manufacturer
+ extern const struct spinand_manufacturer fmsh_spinand_manufacturer;
+ extern const struct spinand_manufacturer foresee_spinand_manufacturer;
+ extern const struct spinand_manufacturer gigadevice_spinand_manufacturer;
++extern const struct spinand_manufacturer heyangtek_spinand_manufacturer;
+ extern const struct spinand_manufacturer macronix_spinand_manufacturer;
+ extern const struct spinand_manufacturer micron_spinand_manufacturer;
+ extern const struct spinand_manufacturer paragon_spinand_manufacturer;

--- a/target/linux/generic/pending-6.12/487-mtd-spinand-Add-support-for-Etron-EM73D044VCx.patch
+++ b/target/linux/generic/pending-6.12/487-mtd-spinand-Add-support-for-Etron-EM73D044VCx.patch
@@ -42,9 +42,9 @@ Submitted-by: Daniel Danzberger <daniel@dd-wrt.com>
 +++ b/drivers/mtd/nand/spi/Makefile
 @@ -1,4 +1,4 @@
  # SPDX-License-Identifier: GPL-2.0
--spinand-objs := core.o alliancememory.o ato.o esmt.o fmsh.o foresee.o gigadevice.o macronix.o
+-spinand-objs := core.o alliancememory.o ato.o esmt.o fmsh.o foresee.o gigadevice.o heyangtek.o macronix.o
 -spinand-objs += micron.o paragon.o toshiba.o winbond.o xtx.o
-+spinand-objs := core.o alliancememory.o ato.o esmt.o etron.o fmsh.o foresee.o gigadevice.o
++spinand-objs := core.o alliancememory.o ato.o esmt.o etron.o fmsh.o foresee.o gigadevice.o heyangtek.o
 +spinand-objs += macronix.o micron.o paragon.o toshiba.o winbond.o xtx.o
  obj-$(CONFIG_MTD_SPI_NAND) += spinand.o
 --- a/drivers/mtd/nand/spi/core.c

--- a/target/linux/mediatek/patches-6.12/330-snand-mtk-bmt-support.patch
+++ b/target/linux/mediatek/patches-6.12/330-snand-mtk-bmt-support.patch
@@ -8,7 +8,7 @@
  
  static int spinand_read_reg_op(struct spinand_device *spinand, u8 reg, u8 *val)
  {
-@@ -1585,6 +1586,7 @@ static int spinand_probe(struct spi_mem
+@@ -1586,6 +1587,7 @@ static int spinand_probe(struct spi_mem
  	if (ret)
  		return ret;
  
@@ -16,7 +16,7 @@
  	ret = mtd_device_register(mtd, NULL, 0);
  	if (ret)
  		goto err_spinand_cleanup;
-@@ -1592,6 +1594,7 @@ static int spinand_probe(struct spi_mem
+@@ -1593,6 +1595,7 @@ static int spinand_probe(struct spi_mem
  	return 0;
  
  err_spinand_cleanup:
@@ -24,7 +24,7 @@
  	spinand_cleanup(spinand);
  
  	return ret;
-@@ -1610,6 +1613,7 @@ static int spinand_remove(struct spi_mem
+@@ -1611,6 +1614,7 @@ static int spinand_remove(struct spi_mem
  	if (ret)
  		return ret;
  

--- a/target/linux/mediatek/patches-6.12/340-mtd-spinand-Add-support-for-the-Fidelix-FM35X1GA.patch
+++ b/target/linux/mediatek/patches-6.12/340-mtd-spinand-Add-support-for-the-Fidelix-FM35X1GA.patch
@@ -18,8 +18,8 @@ Signed-off-by: Davide Fioravanti <pantanastyle@gmail.com>
 +++ b/drivers/mtd/nand/spi/Makefile
 @@ -1,4 +1,4 @@
  # SPDX-License-Identifier: GPL-2.0
--spinand-objs := core.o alliancememory.o ato.o esmt.o etron.o fmsh.o foresee.o gigadevice.o
-+spinand-objs := core.o alliancememory.o ato.o esmt.o etron.o fidelix.o fmsh.o foresee.o gigadevice.o
+-spinand-objs := core.o alliancememory.o ato.o esmt.o etron.o fmsh.o foresee.o gigadevice.o heyangtek.o
++spinand-objs := core.o alliancememory.o ato.o esmt.o etron.o fidelix.o fmsh.o foresee.o gigadevice.o heyangtek.o
  spinand-objs += macronix.o micron.o paragon.o toshiba.o winbond.o xtx.o
  obj-$(CONFIG_MTD_SPI_NAND) += spinand.o
 --- a/drivers/mtd/nand/spi/core.c
@@ -31,7 +31,7 @@ Signed-off-by: Davide Fioravanti <pantanastyle@gmail.com>
 +	&fidelix_spinand_manufacturer,
  	&foresee_spinand_manufacturer,
  	&gigadevice_spinand_manufacturer,
- 	&macronix_spinand_manufacturer,
+ 	&heyangtek_spinand_manufacturer,
 --- /dev/null
 +++ b/drivers/mtd/nand/spi/fidelix.c
 @@ -0,0 +1,76 @@
@@ -120,4 +120,4 @@ Signed-off-by: Davide Fioravanti <pantanastyle@gmail.com>
 +extern const struct spinand_manufacturer fidelix_spinand_manufacturer;
  extern const struct spinand_manufacturer foresee_spinand_manufacturer;
  extern const struct spinand_manufacturer gigadevice_spinand_manufacturer;
- extern const struct spinand_manufacturer macronix_spinand_manufacturer;
+ extern const struct spinand_manufacturer heyangtek_spinand_manufacturer;

--- a/target/linux/mediatek/patches-6.12/435-drivers-mtd-spinand-Add-calibration-support-for-spin.patch
+++ b/target/linux/mediatek/patches-6.12/435-drivers-mtd-spinand-Add-calibration-support-for-spin.patch
@@ -11,7 +11,7 @@ Signed-off-by: SkyLake.Huang <skylake.huang@mediatek.com>
 
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -1209,6 +1209,56 @@ static int spinand_manufacturer_match(st
+@@ -1210,6 +1210,56 @@ static int spinand_manufacturer_match(st
  	return -EOPNOTSUPP;
  }
  
@@ -68,7 +68,7 @@ Signed-off-by: SkyLake.Huang <skylake.huang@mediatek.com>
  static int spinand_id_detect(struct spinand_device *spinand)
  {
  	u8 *id = spinand->id.data;
-@@ -1462,6 +1512,10 @@ static int spinand_init(struct spinand_d
+@@ -1463,6 +1513,10 @@ static int spinand_init(struct spinand_d
  	if (!spinand->scratchbuf)
  		return -ENOMEM;
  

--- a/target/linux/mediatek/patches-6.12/436-drivers-mtd-spi-nor-Add-calibration-support-for-spi-.patch
+++ b/target/linux/mediatek/patches-6.12/436-drivers-mtd-spi-nor-Add-calibration-support-for-spi-.patch
@@ -12,7 +12,7 @@ Signed-off-by: SkyLake.Huang <skylake.huang@mediatek.com>
 
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -1250,7 +1250,10 @@ static int spinand_cal_read(void *priv,
+@@ -1251,7 +1251,10 @@ static int spinand_cal_read(void *priv,
  	if (ret)
  		return ret;
  

--- a/target/linux/mediatek/patches-6.12/960-asus-hack-u-boot-ignore-mtdparts.patch
+++ b/target/linux/mediatek/patches-6.12/960-asus-hack-u-boot-ignore-mtdparts.patch
@@ -29,7 +29,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -1679,6 +1679,7 @@ static int spinand_remove(struct spi_mem
+@@ -1680,6 +1680,7 @@ static int spinand_remove(struct spi_mem
  
  static const struct spi_device_id spinand_ids[] = {
  	{ .name = "spi-nand" },
@@ -37,7 +37,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	{ /* sentinel */ },
  };
  MODULE_DEVICE_TABLE(spi, spinand_ids);
-@@ -1686,6 +1687,7 @@ MODULE_DEVICE_TABLE(spi, spinand_ids);
+@@ -1687,6 +1688,7 @@ MODULE_DEVICE_TABLE(spi, spinand_ids);
  #ifdef CONFIG_OF
  static const struct of_device_id spinand_of_ids[] = {
  	{ .compatible = "spi-nand" },


### PR DESCRIPTION
Backport support for the HeYangTek HYF1GQ4UDACAE SPI-NAND from openwrt/openwrt#23742 to OpenWrt 25.12, and fix boot for the already-supported Keenetic KN-3711 (see [PR#24001 comment](https://github.com/openwrt/openwrt/pull/24001#issuecomment-4869498638)).