### PR TITLE
ath79: add support for Lite-On WP8722-BT

### DIFF
--- a/target/linux/ath79/dts/qca9563_liteon_wp8722-bt.dts
+++ b/target/linux/ath79/dts/qca9563_liteon_wp8722-bt.dts
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "liteon,wp8722-bt", "qca,qca9563";
+	model = "Lite-On WP8722-BT";
+
+	aliases {
+		serial0 = &uart;
+		label-mac-device = &eth0;
+
+		led-boot = &led_green;
+		led-failsafe = &led_red;
+		led-running = &led_green;
+		led-upgrade = &led_blue;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_red: status_red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_green: status_green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_blue: status_blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0 0 0 0 0>;
+		nvmem-cells = <&macaddr_art_0 1>, <&precal_art_5000>;
+		nvmem-cell-names = "mac-address", "pre-calibration";
+	};
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb1 {
+	status = "okay";
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				label = "firmware";
+				reg = <0x050000 0xd20000>;
+				compatible = "denx,uimage";
+			};
+
+			partition@d70000 {
+				label = "data";
+				reg = <0x00d70000 0x1e0000>;
+			};
+
+			partition@f50000 {
+				label = "nvram";
+				reg = <0x00f50000 0x0a0000>;
+			};
+
+			partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						compatible = "mac-base";
+						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+
+					precal_art_5000: pre-calibration@5000 {
+						reg = <0x5000 0x2f20>;
+					};
+				};
+			};
+
+			/*
+			 * Unused flash area
+			 *
+			 * Physical flash: 64 MiB
+			 * OEM layout ends: 16 MiB
+			 *
+			 * 0x01000000 - 0x04000000
+			 */
+
+			partition@1000000 {
+				label = "unused";
+				reg = <0x1000000 0x3000000>;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+		phy-mode = "sgmii";
+		reset-gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+	phy-mode = "sgmii";
+	phy-handle = <&phy4>;
+	pll-data = <0x03000000 0x00000101 0x00001313>;
+
+	nvmem-cells = <&macaddr_art_6>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wmac {
+	status = "okay";
+	nvmem-cells = <&macaddr_art_0 0>, <&cal_art_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -418,6 +418,9 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0u@eth0" "5:wan" "6u@eth1" "4:lan"
 		;;
+	liteon,wp8722-bt)
+		ucidef_set_interface_lan "eth0"
+		;;
 	longdata,aps256)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2049,6 +2049,15 @@ define Device/librerouter_librerouter-v1
 endef
 TARGET_DEVICES += librerouter_librerouter-v1
 
+define Device/liteon_wp8722-bt
+  SOC := qca9563
+  DEVICE_VENDOR := Lite-On
+  DEVICE_MODEL := WP8722-BT
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct -swconfig kmod-usb2 kmod-usb-storage
+  IMAGE_SIZE := 13440k
+endef
+TARGET_DEVICES += liteon_wp8722-bt
+
 define Device/longdata_aps256
   SOC := ar9344
   DEVICE_VENDOR := LONGDATA


### PR DESCRIPTION
Hardware specifications:
- SoC: Qualcomm Atheros QCA9563
- RAM: 128 MB DDR2 (Winbond W971GG6SB-25)
- Flash: 64 MB SPI NOR (Macronix MX25L51245GM)
  (only 16MB of flash used by vendor)
- WLAN 2.4GHz: Integrated QCA9563 802.11b/g/n
- WLAN 5GHz: Qualcomm QCA9886 802.11a/n/ac
- Ethernet: 1x 10/100/1000 Mbps (AR8033-AL1A PHY)
- UART1: SIPEX SP3232EEE (Console RJ45 form factor)
- UART2: 115200 8N1 3.3v on PCB (J5 Label)
  (RX TX VCC GND) GND is next to TP7
  Don't connect VCC pin!
- 1x RGB LED status (GPIO0, GPIO2, GPIO3) active high.
- 1x USB 2.0 port.
- 1x Reset button (GPIO1) active low.
- 1x 12V 1A 5.5x2.5 barrel jack (not  5.5x2.1)

Installation instructions:
- Connect via serial console.
- Interrupt U-Boot boot sequence by pressing enter or esc.
- Load the OpenWrt initramfs image into RAM via TFTP.
- set computer ip to : 192.168.1.200, Gateway :192.168.1.1
- from computer
    tftp 192.168.1.100
    tftp> bin
    tftp> put <image name.bin>
- from router tftpboot 0x81000000 <image name.bin>
    bootm
- Boot the initramfs image and browse to 192.168.1.1.
- Backup all partitions using the initramfs image
  by login to luci>system>backup/flash firmware
- Flash the sysupgrade image using the sysupgrade CLI or LuCI.

MAC addresses:
- QCA9563 2.4GHz from art@0x0 index 0
- QCA9886 5GHz from art@0x0 index 1
- AR8033 ethernet from art@0x6

Back to stock from openwrt:
-send oem_firmware.bin from backup via scp to /tmp/
-flash oem_firmware.bin using command:
 mtd -r write oem_firmware.bin firmware
-device will restart automaticaly.

FCC : https://fccid.io/PPQ-WP8722