### PR TITLE
wifi-scripts: ensure mlo phy band matches

### DIFF
--- a/package/network/config/wifi-scripts/files/etc/hotplug.d/ieee80211/10-wifi-detect
+++ b/package/network/config/wifi-scripts/files/etc/hotplug.d/ieee80211/10-wifi-detect
@@ -2,5 +2,5 @@
 
 [ "${ACTION}" = "add" ] && [ -f /etc/board.json ] && {
 	/sbin/wifi config
-	ubus call network.wireless retry
+	ubus call network.wireless config_reload
 }

--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless.uc
+++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless.uc
@@ -1,6 +1,7 @@
 'use strict';
 
 import * as ubus from "ubus";
+import * as uci from "uci";
 import { realpath } from "fs";
 import {
 	handler_load, handler_attributes,
@@ -361,6 +362,12 @@ function config_start()
 
 }
 
+function config_reload()
+{
+	config_init(uci.cursor());
+	config_start();
+}
+
 function check_interfaces()
 {
 	for (let name, dev in wireless.devices)
@@ -493,6 +500,13 @@ const ubus_obj = {
 				dev.retry_setup();
 				return 0;
 			});
+		}
+	},
+	config_reload: {
+		args: {},
+		call: function(req) {
+			config_reload();
+			return 0;
 		}
 	},
 	reconf: {

--- a/package/network/config/wifi-scripts/files/lib/wifi/mac80211.uc
+++ b/package/network/config/wifi-scripts/files/lib/wifi/mac80211.uc
@@ -14,21 +14,34 @@ let commit;
 
 let config = uci.cursor().get_all("wireless") ?? {};
 
-function radio_exists(path, macaddr, phy, radio) {
+function radio_exists(path, macaddr, phy, radio, band) {
 	for (let name, s in config) {
 		if (s[".type"] != "wifi-device")
 			continue;
-		if (radio != null && int(s.radio) != radio)
-			continue;
+
+		let match = false;
 		if (s.macaddr && lc(s.macaddr) == lc(macaddr))
-			return true;
-		if (s.phy == phy)
-			return true;
-		if (!s.path || !path)
+			match = true;
+		else if (s.phy == phy)
+			match = true;
+		else if (s.path && path && substr(s.path, -length(path)) == path)
+			match = true;
+
+		if (!match)
 			continue;
-		if (substr(s.path, -length(path)) == path)
-			return true;
+
+		if (radio != null && s.band && band && lc(s.band) != lc(band))
+			continue;
+
+		if (radio != null && s.band && band && int(s.radio) != radio) {
+			print(`set wireless.${name}.radio='${radio}'\n`);
+			s.radio = radio;
+			commit = true;
+		}
+
+		return true;
 	}
+
 }
 
 for (let phy_name, phy in board.wlan) {
@@ -69,7 +82,7 @@ for (let phy_name, phy in board.wlan) {
 			continue;
 
 		let macaddr = trim(readfile(`/sys/class/ieee80211/${phy_name}/macaddress`));
-		if (radio_exists(phy.path, macaddr, phy_name, radio.index))
+		if (radio_exists(phy.path, macaddr, phy_name, radio.index, band_name))
 			continue;
 
 		let id = `phy='${phy_name}'`;


### PR DESCRIPTION
Some single-PHY-multi-radio devices (namely qualcommbe) have non-deterministic PCIe probing orders. This causes each radio behind the MLO interface to come up in unpredictable order, making the band sometimes mismatch the radio so it fails to come up.

The first part of the fix is to check if the band matches what is in the configuration during bringup. If the bands do not match, reset the radio index for each band.

The second part is to add a new config_reload method to ubus so netifd is aware that the config changed and it should grab the new one.

Fixes: https://github.com/openwrt/openwrt/issues/24370