### PR TITLE
realtek: eth: raise the scatter RX fragment size to 1568

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/ethernet/realtek/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.18/drivers/net/ethernet/realtek/rtl838x_eth.c
@@ -52,8 +52,7 @@
 #define RTETH_839X_MAX_FRAME		12288
 #define RTETH_930X_MAX_FRAME		12288
 #define RTETH_931X_MAX_FRAME		12288
-/* TODO: change this to 1568 after fragment handling has been tested in the wild */
-#define SKB_FRAG_SIZE			400
+#define SKB_FRAG_SIZE			1568
 #define SKB_PAD				MAX(32, L1_CACHE_BYTES)
 #define SKB_HEADROOM_FAST		(SKB_PAD + NET_IP_ALIGN)
 #define SKB_HEADROOM_SLOW		SKB_PAD


### PR DESCRIPTION
Raises `SKB_FRAG_SIZE` from 400 to 1568, the value the in-tree TODO names. 400 was the deliberate
proof-of-concept value of the scatter RX groundwork in #24245, chosen to force multi-fragment
reception at a standard MTU; the one defect reported since, #24492, was closed as completed by its
reporter after #24538 was merged. Separate PR as asked in
https://github.com/openwrt/openwrt/pull/24400#issuecomment-5440757352.

## Hardware

Hasivo S1100W-8XGT-SE: RTL9303 SoC, 8x RTL8264 10G PHY, SerDes in USXGMII mode, kernel 6.18.44,
RAM-booted. Baseline is `main` at 1ad2e78e6a with nothing else applied. The arms are told apart on
the device itself: only the patched one accepts an `eth0` MTU of 7175.

## Numbers

One iperf3 TCP stream from a host into the switch, which is the direction this constant governs,
conduit at its default MTU of 1504. The `eth0` interrupt and the receiving process are pinned to one
VPE, because the two VPEs of the 34Kc share a pipeline and an unpinned run is bimodal. Both arms
RAM-booted in one session in the order A B B A; 12 receive runs of 20 s per arm over two boots,
medians, nothing excluded. Transmit is a control, six runs per arm. Deviation from the usual recipe:
the two directions were measured in separate unidirectional runs, not bidirectionally.

| | `main` 1ad2e78e6a | this commit |
|---|---|---|
| RX iperf3, median of 12 | 231.8 Mbit/s | **426.1 Mbit/s** (+83.9%) |
| RX spread | 231.2 - 232.1 | 424.8 - 427.2 |
| TCP retransmissions per 20 s run | 1550 (1460 - 1600) | 0 |
| single 300 s run | 231.9 Mbit/s, 23147 retr | 427.8 Mbit/s, 0 retr |
| RX non-idle ticks per run | 1993 | 2022 |
| TX iperf3, median of 6 (control) | 201.4 Mbit/s | 202.3 Mbit/s |
| largest `eth0` MTU probed and accepted | 7174, 7175 gives `EINVAL` | 9000 |

All 144 RX pairwise comparisons favour the patch and the two distributions are disjoint. The patched
arm spends 1.5% more CPU per run for 84% more throughput. The likely mechanism is skb truesize
rather than copy cost: every fragment carries a full 2048-byte page-pool fragment of truesize
(`napi_build_skb(..., PPOOL_FRAG_SIZE)`, `skb_add_rx_frag(..., PPOOL_FRAG_SIZE)`), so a 1518-byte
frame accounted for four of them at 400 bytes and accounts for one now. Consistent with that, the
losses driving the retransmissions on `main` happen with `rx_errors` and `rx_dropped` at zero, i.e.
above the driver.

For context, not as a comparison of absolute numbers across boards: on #24245 jonasjelonek measured
~450 Mbit/s before the scatter change and ~140 after on an RTL9302B, and the prediction was that
1600-byte fragments would recover ~250. On this RTL9303 the recovery is more complete than that.

## Not tested, and what this opens

- RTL838x, RTL839x and RTL931x hardware. The descriptor buffer size grows on all four families; only
  the head-of-line budget is RTL93xx-specific, since `rteth_83xx_set_hol()` writes 0 for free
  floating rings and never reads the constant.
- **The RTL838x reproducer of #24492 was not re-run.** The 300 s soak above was on an RTL9303, and
  #24538 states the "buffer full" situation cannot arise on RTL93xx at all, so it cannot stand in
  for that test.
- The MTU ceiling this lifts. Above 7174 nothing has ever run on any family: the conduit maximum
  becomes 9974 on RTL838x and 12262 on the others. On RTL930x I only probed that `eth0` accepts 9000,
  without driving traffic at that MTU. User ports are unaffected either way, as the DSA driver has no
  `port_change_mtu` on `main` — that is #24400.
- On RTL838x the `NET_IP_ALIGN` trade-off of #24245, which cost ~30% there to allow multiple
  fragments, now buys nothing at the default MTU, where a frame fits one fragment again. Revisiting
  it is a possible follow-up, not attempted here.

Happy to run anything asked for on the RTL9303.

*Bench testing and analysis assisted by Claude Opus 5 (Anthropic AI).*
