### PR TITLE
kernel: backport ksmbd TCP connection fixes

### DIFF
--- a/target/linux/generic/backport-6.12/503-01-v7.3-ksmbd-enable-tcp-keepalive-for-accepted-connections.patch
+++ b/target/linux/generic/backport-6.12/503-01-v7.3-ksmbd-enable-tcp-keepalive-for-accepted-connections.patch
@@ -1,0 +1,35 @@
+From 56549c18a4f75309161ca780feaa4d17904e3ee9 Mon Sep 17 00:00:00 2001
+From: Namjae Jeon <linkinjeon@kernel.org>
+Date: Wed, 19 Aug 2026 10:01:11 +0900
+Subject: [PATCH] ksmbd: enable TCP keepalive for accepted connections
+
+A client that disappears without sending a FIN or RST can leave its
+ksmbd connection in ESTABLISHED indefinitely. ksmbd sets a socket
+receive timeout, but the connection receive loop retries timeout errors
+without a limit, so the connection remains in conn_list and consumes the
+per-IP connection quota.
+
+Enable SO_KEEPALIVE on accepted TCP sockets so the TCP stack can detect a
+silent peer failure. The keepalive idle time, interval, and probe count
+remain controlled by the existing TCP sysctl settings.
+
+Signed-off-by: Namjae Jeon <linkinjeon@kernel.org>
+---
+ fs/smb/server/transport_tcp.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+--- a/fs/smb/server/transport_tcp.c
++++ b/fs/smb/server/transport_tcp.c
+@@ -325,6 +325,12 @@ skip_max_ip_conns_limit:
+ 		ksmbd_debug(CONN, "connect success: accepted new connection\n");
+ 		client_sk->sk->sk_rcvtimeo = KSMBD_TCP_RECV_TIMEOUT;
+ 		client_sk->sk->sk_sndtimeo = KSMBD_TCP_SEND_TIMEOUT;
++		/*
++		 * Detect peers that disappear without sending a FIN or RST.
++		 * Otherwise the connection handler can retry receive timeouts
++		 * indefinitely and keep the connection in conn_list.
++		 */
++		sock_set_keepalive(client_sk->sk);
+ 
+ 		ksmbd_tcp_new_connection(client_sk);
+ 	}

--- a/target/linux/generic/backport-6.12/503-02-v7.3-ksmbd-keep-tcp-timers-alive-for-kernel-sockets.patch
+++ b/target/linux/generic/backport-6.12/503-02-v7.3-ksmbd-keep-tcp-timers-alive-for-kernel-sockets.patch
@@ -1,0 +1,42 @@
+From 80b6367ec37faf61fbd11aae6fae64c51faa5bba Mon Sep 17 00:00:00 2001
+From: Namjae Jeon <linkinjeon@kernel.org>
+Date: Thu, 20 Aug 2026 08:26:03 +0900
+Subject: [PATCH] ksmbd: keep TCP timers alive for kernel sockets
+
+ksmbd creates its listening socket with sock_create_kern(). Kernel
+sockets do not hold a network namespace reference by default. Accepted
+sockets inherit this state.
+
+When an accepted socket is released, tcp_close() clears its pending TCP
+timers for a kernel socket after the socket enters an orphaned state. If
+the peer is unreachable while ksmbd sends a FIN, this can leave a
+FIN-WAIT-1 orphan without a retransmission timer.
+
+Upgrade the listening socket's network namespace reference before
+kernel_listen(). Accepted sockets inherit the reference, so the TCP
+stack can keep the retransmission timer active and apply its normal
+orphan retry policy.
+
+Preserve the existing graceful shutdown behavior.
+
+Link: https://github.com/openwrt/openwrt/issues/24744
+Signed-off-by: Namjae Jeon <linkinjeon@kernel.org>
+---
+ fs/smb/server/transport_tcp.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+--- a/fs/smb/server/transport_tcp.c
++++ b/fs/smb/server/transport_tcp.c
+@@ -557,6 +557,12 @@ static int create_socket(struct interfac
+ 	ksmbd_socket->sk->sk_rcvtimeo = KSMBD_TCP_RECV_TIMEOUT;
+ 	ksmbd_socket->sk->sk_sndtimeo = KSMBD_TCP_SEND_TIMEOUT;
+ 
++	/*
++	 * Accepted sockets inherit the listener's net reference. Keep TCP
++	 * timers alive after a kernel socket is released.
++	 */
++	sk_net_refcnt_upgrade(ksmbd_socket->sk);
++
+ 	ret = kernel_listen(ksmbd_socket, KSMBD_SOCKET_BACKLOG);
+ 	if (ret) {
+ 		pr_err("Port listen() error: %d\n", ret);

--- a/target/linux/generic/backport-6.18/503-01-v7.3-ksmbd-enable-tcp-keepalive-for-accepted-connections.patch
+++ b/target/linux/generic/backport-6.18/503-01-v7.3-ksmbd-enable-tcp-keepalive-for-accepted-connections.patch
@@ -1,0 +1,35 @@
+From 56549c18a4f75309161ca780feaa4d17904e3ee9 Mon Sep 17 00:00:00 2001
+From: Namjae Jeon <linkinjeon@kernel.org>
+Date: Wed, 19 Aug 2026 10:01:11 +0900
+Subject: [PATCH] ksmbd: enable TCP keepalive for accepted connections
+
+A client that disappears without sending a FIN or RST can leave its
+ksmbd connection in ESTABLISHED indefinitely. ksmbd sets a socket
+receive timeout, but the connection receive loop retries timeout errors
+without a limit, so the connection remains in conn_list and consumes the
+per-IP connection quota.
+
+Enable SO_KEEPALIVE on accepted TCP sockets so the TCP stack can detect a
+silent peer failure. The keepalive idle time, interval, and probe count
+remain controlled by the existing TCP sysctl settings.
+
+Signed-off-by: Namjae Jeon <linkinjeon@kernel.org>
+---
+ fs/smb/server/transport_tcp.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+--- a/fs/smb/server/transport_tcp.c
++++ b/fs/smb/server/transport_tcp.c
+@@ -312,6 +312,12 @@ skip_max_ip_conns_limit:
+ 		ksmbd_debug(CONN, "connect success: accepted new connection\n");
+ 		client_sk->sk->sk_rcvtimeo = KSMBD_TCP_RECV_TIMEOUT;
+ 		client_sk->sk->sk_sndtimeo = KSMBD_TCP_SEND_TIMEOUT;
++		/*
++		 * Detect peers that disappear without sending a FIN or RST.
++		 * Otherwise the connection handler can retry receive timeouts
++		 * indefinitely and keep the connection in conn_list.
++		 */
++		sock_set_keepalive(client_sk->sk);
+ 
+ 		ksmbd_tcp_new_connection(client_sk);
+ 	}

--- a/target/linux/generic/backport-6.18/503-02-v7.3-ksmbd-keep-tcp-timers-alive-for-kernel-sockets.patch
+++ b/target/linux/generic/backport-6.18/503-02-v7.3-ksmbd-keep-tcp-timers-alive-for-kernel-sockets.patch
@@ -1,0 +1,42 @@
+From 80b6367ec37faf61fbd11aae6fae64c51faa5bba Mon Sep 17 00:00:00 2001
+From: Namjae Jeon <linkinjeon@kernel.org>
+Date: Thu, 20 Aug 2026 08:26:03 +0900
+Subject: [PATCH] ksmbd: keep TCP timers alive for kernel sockets
+
+ksmbd creates its listening socket with sock_create_kern(). Kernel
+sockets do not hold a network namespace reference by default. Accepted
+sockets inherit this state.
+
+When an accepted socket is released, tcp_close() clears its pending TCP
+timers for a kernel socket after the socket enters an orphaned state. If
+the peer is unreachable while ksmbd sends a FIN, this can leave a
+FIN-WAIT-1 orphan without a retransmission timer.
+
+Upgrade the listening socket's network namespace reference before
+kernel_listen(). Accepted sockets inherit the reference, so the TCP
+stack can keep the retransmission timer active and apply its normal
+orphan retry policy.
+
+Preserve the existing graceful shutdown behavior.
+
+Link: https://github.com/openwrt/openwrt/issues/24744
+Signed-off-by: Namjae Jeon <linkinjeon@kernel.org>
+---
+ fs/smb/server/transport_tcp.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+--- a/fs/smb/server/transport_tcp.c
++++ b/fs/smb/server/transport_tcp.c
+@@ -544,6 +544,12 @@ static int create_socket(struct interfac
+ 	ksmbd_socket->sk->sk_rcvtimeo = KSMBD_TCP_RECV_TIMEOUT;
+ 	ksmbd_socket->sk->sk_sndtimeo = KSMBD_TCP_SEND_TIMEOUT;
+ 
++	/*
++	 * Accepted sockets inherit the listener's net reference. Keep TCP
++	 * timers alive after a kernel socket is released.
++	 */
++	sk_net_refcnt_upgrade(ksmbd_socket->sk);
++
+ 	ret = kernel_listen(ksmbd_socket, KSMBD_SOCKET_BACKLOG);
+ 	if (ret) {
+ 		pr_err("Port listen() error: %d\n", ret);


### PR DESCRIPTION
Backport two upstream ksmbd fixes to Linux 6.12 and 6.18:

- enable TCP keepalive for accepted connections
- keep TCP timers alive for kernel sockets

Without these fixes, stale ESTABLISHED and FIN-WAIT-1 sockets may remain after clients disconnect unexpectedly, eventually exhausting ksmbd's per-IP connection limit.

The patches were refreshed against Linux 6.12.105 and 6.18.44.

Upstream commits:
- https://git.kernel.org/torvalds/c/56549c18a4f75309161ca780feaa4d17904e3ee9
- https://git.kernel.org/torvalds/c/80b6367ec37faf61fbd11aae6fae64c51faa5bba

Fixes: #24744
Supersedes: #24871
