### PR TITLE
realtek: fix PCI IO map panic with set_io_port_base(KSEG1)

### DIFF
--- a/target/linux/realtek/patches-6.18/300-02-enhance-realtek-board-setup.patch
+++ b/target/linux/realtek/patches-6.18/300-02-enhance-realtek-board-setup.patch
@@ -334,16 +334,27 @@ Signed-off-by: Markus Stockhausen <markus.stockhausen@gmx.de>
  static __init int realtek_add_initrd(void *fdt)
  {
  	int node, err;
-@@ -55,6 +361,8 @@ static __init const void *realtek_fixup_
+@@ -55,6 +361,19 @@ static __init const void *realtek_fixup_
  	static unsigned char fdt_buf[16 << 10] __initdata;
  	int err;
  
++	/*
++	 * The RTL9607C PCIe controller has 2 io regions, with the 2nd one
++	 * being at an offset from the 1st one. This does not work with
++	 * MIPS specific pci_remap_iospace() as it expects the region start
++	 * address to be 0, which is not the case for 2nd io region of
++	 * RTL9607C PCIe controller. Thus set the io port base to KSEG1,
++	 * a common base for majority of MIPS platforms, for the generic
++	 * pci_remap_iospace() to work here.
++	 */
++	set_io_port_base(KSEG1);
++
 +	realtek_prom_init(match_data);
 +
  	if (fdt_check_header(fdt))
  		panic("Corrupt DT");
  
-@@ -68,12 +376,76 @@ static __init const void *realtek_fixup_
+@@ -68,12 +387,76 @@ static __init const void *realtek_fixup_
  
  }
  

--- a/target/linux/realtek/patches-6.18/300-03-realtek-board-increase-fixup_fdt-buffer-to-32-KiB.patch
+++ b/target/linux/realtek/patches-6.18/300-03-realtek-board-increase-fixup_fdt-buffer-to-32-KiB.patch
@@ -28,4 +28,4 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 +	static unsigned char fdt_buf[32 << 10] __initdata;
  	int err;
  
- 	realtek_prom_init(match_data);
+ 	/*


### PR DESCRIPTION
When the realtek target changed to generic mips initialization the set_io_port_base(KSEG1); from plat_mem_setup was't brought over to the realtek board file. 
This results in boot hang when trying to load PCIE driver on RTL9607C machine as it panics after devm_pci_alloc_host_bridge due to lack of mips_io_port_base definition.

<details>

<summary>Boot hang part</summary>

```
[    0.667186] realtek-pcie 18b20000.pcie: host bridge /pcie@18b20000 ranges:
[    0.675144] realtek-pcie 18b20000.pcie:      MEM 0x001a000000..0x001affffff -> 0x001a000000
[    0.684561] realtek-pcie 18b20000.pcie:       IO 0x0018e00000..0x0018e0ffff -> 0x0000000000
[    0.693970] Kernel bug detected[#1]:
[    0.697967] CPU: 2 UID: 0 PID: 1 Comm: swapper/0 Not tainted 6.18.44 #0 NONE 
[    0.705931] Hardware name: BT-PON BT-G711AX
[    0.710591] $ 0   : 00000000 00000001 00000001 81320000
[    0.716434] $ 4   : ffffffff 0000ffff 18e00000 000005cf
[    0.722283] $ 8   : 00000000 809564bc 80009310 00000100
[    0.728137] $12   : 80a70000 8183b9fc 0000005e 00000000
[    0.733975] $16   : 819e90e0 18e00000 819e95a0 8193c810
[    0.739815] $20   : 000005cf 819e9680 ffffffff 00000100
[    0.745656] $24   : 00000000 80b4b6f0                  
[    0.751510] $28   : 8183a000 8183bc10 00000001 803186f0
[    0.757347] Hi    : 00000044
[    0.760556] Lo    : 73333445
[    0.763766] epc   : 80313074 vmap_range_noflush.constprop.0+0x44/0x20c
[    0.771072] ra    : 803186f0 vmap_page_range+0x14/0x4c
[    0.776804] Status: 1100fc03 KERNEL EXL IE 
[    0.781474] Cause : 50800034 (ExcCode 0d)
[    0.785943] PrId  : 0001a120 (MIPS interAptiv (multi))
[    0.791673] Modules linked in:
[    0.795073] Process swapper/0 (pid: 1, threadinfo=(ptrval), task=(ptrval), tls=00000000)
[    0.804106] Stack : 00000000 00000000 8193c810 80631680 80141428 819e90c0 00000004 00000dc0
[    0.813465]         819e90e0 18e00000 819e95a0 8193c810 8193c810 819e9680 819e95a0 00000100
[    0.822823]         00000001 803186f0 819e9680 0000ffff 18e00000 8193c810 819e90e0 805de600
[    0.832183]         00000100 819e00b0 81f3c200 8193c810 80a6ae44 81f3c200 8193c810 819e9680
[    0.841534]         81f3c328 00000000 81f3c328 805e451c 805c8cd8 00000000 819e9bc0 8063223c
[    0.850886]         ...
[    0.853630] Call Trace:
[    0.856353] [<80313074>] vmap_range_noflush.constprop.0+0x44/0x20c
[    0.863256] [<803186f0>] vmap_page_range+0x14/0x4c
[    0.868622] [<805de600>] devm_pci_remap_iospace+0x5c/0xc4
[    0.874647] [<805e451c>] devm_of_pci_bridge_init+0x12c/0x1f4
[    0.880977] [<805c8d58>] devm_pci_alloc_host_bridge+0x78/0x94
[    0.887411] [<805e950c>] rtpcie_probe+0x2c/0x198
[    0.892589] [<8062f638>] platform_probe+0x50/0xb0
[    0.897855] [<8062cacc>] really_probe+0xd4/0x34c
[    0.903013] [<8062d054>] driver_probe_device+0x48/0x110
[    0.908856] [<8062d2e4>] __driver_attach+0xb0/0x180
[    0.914299] [<8062a2e4>] bus_for_each_dev+0x70/0xb8
[    0.919741] [<8062badc>] bus_add_driver+0x17c/0x228
[    0.925190] [<8062dedc>] driver_register+0x88/0x154
[    0.930644] [<8010d10c>] do_one_initcall+0x50/0x2e0
[    0.936088] [<80bcd164>] do_initcalls+0x130/0x178
[    0.941345] [<80bcd3cc>] kernel_init_freeable+0x1b0/0x20c
[    0.947374] [<80956db4>] kernel_init+0x20/0x110
[    0.952447] [<8010e478>] ret_from_kernel_thread+0x14/0x1c
[    0.958480] 
[    0.960132] Code: afa5004c  afa60050  00e0a025 <00020336> 3c0280bb  8c5e4698  00041582  00021080  03c2f021 
[    0.971041] 
[    0.972803] ---[ end trace 0000000000000000 ]---
[    0.977965] Kernel panic - not syncing: Fatal exception
```

</details>

Fix it by adding set_io_port_base(KSEG1) to realtek_fixup_fdt. Generic MIPS calls it during plat_mem_setup so that roughly matches that of an old initialization from before.

@ProMix0 Is this enough to fix the problem or is `PCI_IOBASE` also needed to be specified?
