### PR TITLE
mediatek: add Ruijie RG-EW6000GX PRO support

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-ruijie-rg-ew6000gx-pro.dts
+++ b/target/linux/mediatek/dts/mt7986a-ruijie-rg-ew6000gx-pro.dts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+#include "mt7986a-ruijie-rg-ew6000gx-pro.dtsi"
+
+/ {
+	model = "Ruijie RG-EW6000GX PRO";
+	compatible = "ruijie,rg-ew6000gx-pro", "mediatek,mt7986a";
+
+	aliases {
+		led-boot = &red_led;
+		led-failsafe = &red_led;
+		led-running = &green_led;
+		led-upgrade = &green_led;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-mesh {
+			label = "mesh";
+			linux,code = <BTN_9>;
+			linux,input-type = <EV_SW>;
+			gpios = <&pio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		green_led: led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		red_led: led-1 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led-2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = "mesh";
+			gpios = <&pio 22 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&gmac1 {
+	phy-handle = <&phy15>;
+};
+
+&mdio {
+	phy15: phy@f {
+		compatible = "ethernet-phy-id03a2.a411";
+		reg = <15>;
+		reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <10000>;
+		reset-deassert-us = <10000>;
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan4";
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};

--- a/target/linux/mediatek/dts/mt7986a-ruijie-rg-ew6000gx-pro.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-ruijie-rg-ew6000gx-pro.dtsi
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+
+#include "mt7986a.dtsi"
+
+/ {
+	aliases {
+		label-mac-device = &gmac1;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x20000000>;
+		device_type = "memory";
+	};
+};
+
+&crypto {
+	status = "okay";
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cells = <&macaddr_product_info 1>;
+		nvmem-cell-names = "mac-address";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "2500base-x";
+
+		nvmem-cells = <&macaddr_product_info 0>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+};
+
+&mdio {
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
+	};
+};
+
+&pio {
+	spi_flash_pins: spi-flash-pins-33-to-38 {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-disable; /* bias-disable */
+		};
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-disable; /* bias-disable */
+		};
+	};
+
+	wf_2g_5g_pins: wf-2g-5g-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_2g", "wf_5g";
+		};
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+			       "WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+			       "WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+			       "WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+			       "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+			       "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+			       "WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <MTK_DRIVE_4mA>;
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_flash_pins>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bl2";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+				read-only;
+			};
+
+			partition@180000 {
+				label = "factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "fip";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "product_info";
+				reg = <0x580000 0x80000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+					env-size = <0x20000>;
+
+					macaddr_product_info: ethaddr {
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@600000 {
+				label = "kdump";
+				reg = <0x600000 0x80000>;
+				read-only;
+			};
+
+			partition@680000 {
+				label = "ubi";
+				reg = <0x680000 0x6b00000>;
+				compatible = "linux,ubi";
+			};
+		};
+	};
+};
+
+&trng {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+	pinctrl-names = "default";
+	pinctrl-0 = <&wf_2g_5g_pins>;
+	status = "okay";
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_product_info 2>;
+		nvmem-cell-names = "mac-address";
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -88,6 +88,7 @@ mediatek_setup_interfaces()
 	netcore,n60|\
 	netcore,n60-pro|\
 	nradio,c8-668gl|\
+	ruijie,rg-ew6000gx-pro|\
 	ruijie,rg-x60-pro|\
 	unielec,u7981-01*|\
 	wavlink,wl-wn536ax6-a|\

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -243,6 +243,9 @@ case "$board" in
 		addr=$(mtd_get_mac_binary "Factory" 0x4)
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
 		;;
+	ruijie,rg-ew6000gx-pro)
+		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_add $(get_mac_label) 0xb00002) > /sys${DEVPATH}/macaddress
+		;;
 	ruijie,rg-x60-pro)
 		addr=$(mtd_get_mac_ascii product_info ethaddr)
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -3248,6 +3248,16 @@ define Device/routerich_be7200
 endef
 TARGET_DEVICES += routerich_be7200
 
+define Device/ruijie_rg-ew6000gx-pro
+  DEVICE_VENDOR := Ruijie
+  DEVICE_MODEL := RG-EW6000GX PRO
+  DEVICE_DTS := mt7986a-ruijie-rg-ew6000gx-pro
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware kmod-phy-airoha-en8811h
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += ruijie_rg-ew6000gx-pro
+
 define Device/ruijie_rg-x60-pro
   DEVICE_VENDOR := Ruijie
   DEVICE_MODEL := RG-X60 Pro


### PR DESCRIPTION
Add device tree support for Ruijie RG-EW6000GX-PRO, based on MediaTek MT7986A + MT7531 switch.

Hardware specification:
  SoC: MediaTek MT7986A 4x A53
  Flash: 128MB SPI-NAND (W25N01GVZEIG)
  RAM: 512MB DDR3 (W634GU6QB)
  Ethernet: 4x 1GbE (MT7531) + 1x 2.5GbE (AQR111C / EN8811H)
  WiFi: MediaTek MT7975PN
  Buttons:
  * Reset: PIO14 (KEY_RESTART, active-low)
  * Mesh: PIO15 (BTN_9, EV_SW, active-low)
  Power: DC Jack 12V
  UART: unpopulated 4-pin header near SPI-NAND flash;
        pinout: GND, TX, RX, 3.3V (5V forbidden); baud 115200 8N1
  LEDs: total 4 GPIO-driven LEDs (all active-low):
  1. Green status LED (PIO9)
  2. Red status LED (PIO10)
  3. Blue LED (PIO11)
  4. Green Mesh LED (PIO22)

Installation:
- Initial installation: Cannot flash OpenWrt via stock ReyeeOS web UI.
  OEM Web UI address: http://192.168.110.1 (ReyeeOS E-WEBOS)
  Credentials: No fixed default username; password printed on bottom device label.
  Two supported install methods:
  1. U-Boot TFTP recovery:
     * Use initramfs-kernel.bin to boot OpenWrt in-RAM,
       then perform sysupgrade using:
       openwrt-mediatek-filogic-ruijie_rg-ew6000gx-pro-squashfs-sysupgrade.bin
  2. Serial UART load initramfs-kernel.bin via U-Boot console,
     run sysupgrade to write sysupgrade.bin to flash.
- Upgrade existing OpenWrt installation:
  * Use sysupgrade image: openwrt-mediatek-filogic-ruijie_rg-ew6000gx-pro-squashfs-sysupgrade.bin
  * Flash via LuCI or sysupgrade CLI.

Revert-to-stock:
Direct sysupgrade back to stock from OpenWrt is unsupported.
Primary recovery: U-Boot TFTP via UART console.
Interrupt U-Boot on power-on, set host static IP 192.168.1.2/24,
load official ReyeeOS firmware via TFTP to flash.
Fallback: writing stock image to mtd partition "firmware" over SSH,
this is risky and may require TFTP rescue on partition header mismatch.

Warning: Flashing custom firmware may void hardware warranty.

Signed-off-by: HQ Ong <hquu@outlook.com>