### PR TITLE
wifi-scripts: fix macaddr 'random' on MLO interfaces

### DIFF
--- a/package/network/config/wifi-scripts/Makefile
+++ b/package/network/config/wifi-scripts/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wifi-scripts
 PKG_VERSION:=1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-2.0
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
@@ -1,6 +1,7 @@
 'use strict';
 
 import { append_value, log } from 'wifi.common';
+import { macaddr_random } from 'wifi.utils';
 import * as fs from 'fs';
 
 export function parse_encryption(config, dev_config, phy_features) {
@@ -258,17 +259,6 @@ export function wpa_key_mgmt(config, band) {
 
 	config.key_mgmt = config.wpa_key_mgmt;
 };
-
-function macaddr_random() {
-	let f = fs.open("/dev/urandom", "r");
-	let addr = f.read(6);
-
-	addr = map(split(addr, ""), (v) => ord(v));
-	addr[0] &= ~1;
-	addr[0] |= 2;
-
-	return join(":", map(addr, (v) => sprintf("%02x", v)));
-}
 
 let mac_idx = 0;
 export function prepare(data, phy, num_global_macaddr, macaddr_base) {

--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless.uc
+++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless.uc
@@ -7,7 +7,7 @@ import {
 	parse_attribute_list, parse_bool, parse_array,
 	TYPE_ARRAY, TYPE_STRING, TYPE_INT, TYPE_BOOL
 } from "./utils.uc";
-import { find_phy } from "wifi.utils";
+import { find_phy, macaddr_random } from "wifi.utils";
 import * as wdev from "./wireless-device.uc";
 
 let wireless = netifd.wireless = {
@@ -55,6 +55,16 @@ function supplicant_update_mlo()
 function mlo_vif_create(config, radio_config, vif_idx, mlo_vifs)
 {
 	let mlo_config = { ...config };
+
+	/*
+	 * The MLD netdev is created by hostapd from this config, which never
+	 * passes through iface.prepare(), so 'random' would reach nl80211
+	 * verbatim and the MLD would fail to come up.  Resolve it here, and
+	 * only for the MLD: the first link BSS keeps the literal value so that
+	 * prepare() draws its address and marks it random_macaddr.
+	 */
+	if (mlo_config.macaddr == 'random')
+		mlo_config.macaddr = macaddr_random();
 
 	if (config.wds)
 		mlo_config['4addr'] = config.wds;

--- a/package/network/config/wifi-scripts/files/usr/share/ucode/wifi/utils.uc
+++ b/package/network/config/wifi-scripts/files/usr/share/ucode/wifi/utils.uc
@@ -1,6 +1,6 @@
 'use strict';
 
-import { readfile, realpath, lsdir } from "fs";
+import { open, readfile, realpath, lsdir } from "fs";
 import * as nl80211 from "nl80211";
 
 function phy_filename(phy, name) {
@@ -131,4 +131,22 @@ export function find_phy(config, rename) {
 	return find_phy_by_path(phys, config.path) ??
 	       find_phy_by_macaddr(phys, config.macaddr) ??
 	       find_phy_by_name(phys, config.phy, rename);
+};
+
+/* Draw a random, locally administered MAC address. */
+export function macaddr_random() {
+	let f = open("/dev/urandom", "r");
+	if (!f)
+		return null;
+
+	let addr = map(split(f.read(6), ""), (v) => ord(v));
+	f.close();
+
+	if (length(addr) != 6)
+		return null;
+
+	addr[0] &= ~1;
+	addr[0] |= 2;
+
+	return join(":", map(addr, (v) => sprintf("%02x", v)));
 };


### PR DESCRIPTION
Setting `option macaddr 'random'` on an MLO wifi-iface (LuCI: *Advanced Settings → MAC address → "randomly generated"*) prevents the AP MLD from coming up at all:

```
hostapd: Failed to create MLD ap-mld0 on phy phy0: Invalid input data or parameter:
attribute `mac` has invalid value `random`: invalid MAC address
```

### Cause

The literal string reaches nl80211 because the MLD netdev is created from the **raw** vif config. `mlo_vif_create()` snapshots the parsed UCI section into `wireless.mlo`, which is shipped over ubus (`mld_set`) to `hostapd.uc`, where `mld_add_bss()` only checks whether the address is *empty* before handing it to `wdev_add()`:

```ucode
data.macaddr = config.macaddr;
if (!data.macaddr) {
        data.macaddr = phydev.macaddr_next();
        data.default_macaddr = true;
}
```

That path never runs `iface.prepare()`, which is the only place `'random'` is translated, so the string is forwarded verbatim.

### Fix

Resolve `'random'` in `mlo_vif_create()`, in the main netifd process, before the config is handed out. The MLD and its links then see one concrete address, and `'random'` behaves exactly like an explicitly configured one.

Doing it here rather than in `hostapd.uc` also covers MLO **station** mode: `wpa_supplicant.uc` (lines 48 and 183) carries the same empty-check-only pattern and is fed from the same `wireless.mlo` table.

If `/dev/urandom` cannot be opened the helper returns `null`, which falls through to hostapd's existing `macaddr_next()`.

### Note on reload behaviour

The address is redrawn on each reload, so the MLD is torn down and recreated and its BSSID changes (`mld_find_matching_config()` compares configs with `is_equal`, so a changed address never rename-matches). This matches how `random` already behaves for non-MLO BSSes, where `prepare()` also redraws. Persistent addresses remain available via an explicit `macaddr` or the factory default.

### Testing

Two GL.iNet Flint 3 (GL-BE9300, IPQ5332 + QCN6274, ath12k), 2 GHz + 5 GHz + 6 GHz AP MLD:

| device | unpatched | patched | resulting MLD MAC |
|---|---|---|---|
| ap1 (ch100 + ch37) | `invalid MAC address` | MLD up, no errors | `12:bb:bb:12:2f:37` |
| ap2 (ch40 + ch69) | `invalid MAC address` | MLD up, no errors | `56:e0:33:cb:46:17` |

Both addresses are locally administered and unicast; the SSID beaconed and clients completed SAE/EAPOL on both devices.

Reload behaviour measured separately on ap2: `fa:6b:4e:ac:95:53` (network restart) → `92:63:5f:2c:48:8d` (`wifi reload`) → `2a:7a:55:88:4d:c2` (`wifi reload`).