### PR TITLE
qualcommax: ipq5018-ax6000: set explicit NAND ECC strength/step-size

### DIFF
--- a/target/linux/qualcommax/dts/ipq5018-ax6000.dts
+++ b/target/linux/qualcommax/dts/ipq5018-ax6000.dts
@@ -124,6 +124,8 @@
 		reg = <0>;
 		nand-ecc-engine = <&qpic_nand>;
 		nand-bus-width = <8>;
+		nand-ecc-strength = <8>;
+		nand-ecc-step-size = <512>;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
Some Xiaomi AX6000 (RA72) units use SPI-NAND with page size 2048 and OOB size 128, requiring ECC strength 8 with step size 512 (matching stock firmware settings).

Without explicit ECC parameters in the DTS, the kernel defaults to ECC strength 4, which causes UBI ECC errors and a boot loop after sysupgrade to squashfs on affected units. Initramfs boots fine (RAM-based), but the permanent rootfs on NAND fails to mount correctly.

This adds explicit `nand-ecc-strength` and `nand-ecc-step-size` properties matching the stock firmware configuration, fixing UBI mount on affected NAND chip variants.

I'm not a kernel/DTS developer — found and fixed this through log analysis and testing on my own affected unit. Please review the ECC parameters for correctness.