### PR TITLE
wireguard-tools: fix interface existence check

### DIFF
--- a/package/network/utils/wireguard-tools/Makefile
+++ b/package/network/utils/wireguard-tools/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=wireguard-tools
 
 PKG_VERSION:=1.0.20250521
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=wireguard-tools-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://git.zx2c4.com/wireguard-tools/snapshot/

--- a/package/network/utils/wireguard-tools/files/wireguard.sh
+++ b/package/network/utils/wireguard-tools/files/wireguard.sh
@@ -57,7 +57,7 @@ proto_wireguard_setup() {
 	config_get tunlink "${config}" "tunlink"
 
 	# Add the link only if it didn't already exist
-	ip -br link show "${config}" >/dev/null 2>&1 || ip link add dev "${config}" type wireguard
+	ip -br link show dev "${config}" >/dev/null 2>&1 || ip link add dev "${config}" type wireguard
 
 	[ -n "${mtu}" ] && ip link set mtu "${mtu}" dev "${config}"
 


### PR DESCRIPTION
The WireGuard protocol handler currently checks whether an interface exists using:

```sh
ip -br link show "${config}"
```

With the iproute2 version shipped in OpenWrt 25.12, this command may return exit status 0 and list all interfaces even when the specified interface does not exist.

As a result, the following `ip link add` command is skipped, and `wg syncconf` subsequently fails because the WireGuard device was never created.

Observed log output:

```text
netifd: Interface 'home' is setting up now
netifd: home: Unable to retrieve current interface configuration: No such device
netifd: home: Could not sync WireGuard configuration
```

The issue can be reproduced with:

```sh
ip -br link show home >/dev/null 2>&1
echo $?
```

when `home` does not exist.

Using the explicit `dev` selector correctly returns failure:

```sh
ip -br link show dev home >/dev/null 2>&1
echo $?
```

This patch changes the existence check to:

```sh
ip -br link show dev "${config}"
```

Tested on OpenWrt 25.12. Before the change, the WireGuard interface remained in the pending state and no WireGuard device was created. After the change, the interface is created successfully and netifd reports:

```text
"up": true,
"pending": false
```

This change targets openwrt-25.12 specifically.

The corresponding WireGuard protocol handling on main has already
diverged from this shell-based implementation, so there is no
corresponding main branch commit to cherry-pick.

Related issue:
https://github.com/openwrt/openwrt/issues/22718