### PR TITLE
realtek: add support for Zyxel GS1920-24 v1

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -97,6 +97,7 @@ realtek_setup_macs()
 	plasmacloud,psx28|\
 	sirivision,sr-st3408f|\
 	ubnt,usw-pro-xg-8-poe|\
+	zyxel,gs1920-24-v1|\
 	zyxel,gs1920-24hp-v2)
 		lan_mac="$(get_mac_label)"
 		;;

--- a/target/linux/realtek/dts/rtl8392_zyxel_gs1920-24-v1-common.dtsi
+++ b/target/linux/realtek/dts/rtl8392_zyxel_gs1920-24-v1-common.dtsi
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/ {
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	chosen {
+		stdout-path = "serial0:9600n8";
+	};
+
+	leds {
+		alarm {
+			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+			function = LED_FUNCTION_FAULT;
+			color = <LED_COLOR_ID_RED>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		mode {
+			label = "reset";
+			gpios = <&gpio1 32 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&flash_partitions {
+	partition@20000 {
+		label = "reserved";
+		reg = <0x20000 0x90000>;
+		read-only;
+	};
+
+	partition@b0000 {
+		reg = <0xb0000 0xf50000>;
+		label = "factory";
+
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "loader";
+			reg = <0x0 0x10000>;
+		};
+
+		partition@10000 {
+			label = "firmware";
+			reg = <0x10000 0xf40000>;
+			compatible = "openwrt,uimage", "denx,uimage";
+		};
+	};
+};
+
+&mdio_bus1 {
+	ethernet-phy-package@24 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <24>;
+
+		PHY_C22_SFP(48, 24, 0)
+		PHY_C22_SFP(49, 25, 1)
+		PHY_C22_SFP(50, 26, 2)
+		PHY_C22_SFP(51, 27, 3)
+	};
+};
+
+&switch0 {
+	ethernet-ports {
+		SWITCH_PORT_SDS(48, 25, 12, 0, qsgmii)
+		SWITCH_PORT_SDS(49, 26, 12, 1, qsgmii)
+		SWITCH_PORT_SDS(50, 27, 12, 2, qsgmii)
+		SWITCH_PORT_SDS(51, 28, 12, 3, qsgmii)
+	};
+};

--- a/target/linux/realtek/dts/rtl8392_zyxel_gs1920-24-v1.dts
+++ b/target/linux/realtek/dts/rtl8392_zyxel_gs1920-24-v1.dts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/dts-v1/;
+
+#include "rtl839x_zyxel_gs1920-24-common.dtsi"
+#include "rtl8392_zyxel_gs1920-24-v1-common.dtsi"
+
+/ {
+	compatible = "zyxel,gs1920-24-v1", "realtek,rtl8392-soc";
+	model = "Zyxel GS1920-24v1";
+
+	aliases {
+		label-mac-device = &ethernet0;
+	};
+};
+
+&i2c4 {
+	adt7463: adt7463@2e {
+		compatible = "adi,adt7463";
+		reg = <0x2e>;
+	};
+};

--- a/target/linux/realtek/dts/rtl8392_zyxel_gs1920-24hp-v1.dts
+++ b/target/linux/realtek/dts/rtl8392_zyxel_gs1920-24hp-v1.dts
@@ -1,38 +1,11 @@
 /dts-v1/;
 
 #include "rtl839x_zyxel_gs1920-24hp-common.dtsi"
+#include "rtl8392_zyxel_gs1920-24-v1-common.dtsi"
 
 / {
 	compatible = "zyxel,gs1920-24hp-v1", "realtek,rtl8392-soc";
 	model = "Zyxel GS1920-24HPv1";
-
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
-	chosen {
-		stdout-path = "serial0:9600n8";
-	};
-
-	leds {
-		alarm {
-			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
-			function = LED_FUNCTION_FAULT;
-			color = <LED_COLOR_ID_RED>;
-		};
-	};
-
-	keys {
-		compatible = "gpio-keys-polled";
-		poll-interval = <20>;
-
-		mode {
-			label = "reset";
-			gpios = <&gpio1 32 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
-		};
-	};
 };
 
 &i2c4 {
@@ -42,56 +15,6 @@
 	};
 };
 
-&flash_partitions {
-	partition@20000 {
-		label = "reserved";
-		reg = <0x20000 0x90000>;
-		read-only;
-	};
-
-	partition@b0000 {
-		reg = <0xb0000 0xf50000>;
-		label = "factory";
-
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		partition@0 {
-			label = "loader";
-			reg = <0x0 0x10000>;
-		};
-
-		partition@10000 {
-			label = "firmware";
-			reg = <0x10000 0xf40000>;
-			compatible = "openwrt,uimage", "denx,uimage";
-		};
-	};
-};
-
-&mdio_bus1 {
-	ethernet-phy-package@24 {
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg = <24>;
-
-		PHY_C22_SFP(48, 24, 0)
-		PHY_C22_SFP(49, 25, 1)
-		PHY_C22_SFP(50, 26, 2)
-		PHY_C22_SFP(51, 27, 3)
-	};
-};
-
 &pse {
 	compatible = "zyxel,gs1920-24hp-v1-pse", "realtek,pse-mcu-gen1-smbus";
-};
-
-&switch0 {
-	ethernet-ports {
-		SWITCH_PORT_SDS(48, 25, 12, 0, qsgmii)
-		SWITCH_PORT_SDS(49, 26, 12, 1, qsgmii)
-		SWITCH_PORT_SDS(50, 27, 12, 2, qsgmii)
-		SWITCH_PORT_SDS(51, 28, 12, 3, qsgmii)
-	};
 };

--- a/target/linux/realtek/dts/rtl839x_zyxel_gs1920-24-common.dtsi
+++ b/target/linux/realtek/dts/rtl839x_zyxel_gs1920-24-common.dtsi
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/dts-v1/;
+
+#include "rtl839x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	aliases {
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+	};
+
+	leds {
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinmux_disable_sys_led>;
+		compatible = "gpio-leds";
+
+		led_sys: sys {
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+		};
+
+		locator {
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
+			function = LED_FUNCTION_INDICATOR;
+			color = <LED_COLOR_ID_BLUE>;
+		};
+	};
+
+	/* i2c of port 25 SFP cage */
+	i2c0: i2c-gpio-0 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 4 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 3 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp0: sfp-p25 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		los-gpio = <&gpio1 1 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 23 GPIO_ACTIVE_LOW>;
+		tx-fault-gpio = <&gpio1 0 GPIO_ACTIVE_HIGH>;
+	};
+
+	/* i2c of port 26 SFP cage */
+	i2c1: i2c-gpio-1 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 10 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 9 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp1: sfp-p26 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		los-gpio = <&gpio1 7 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 17 GPIO_ACTIVE_LOW>;
+		tx-fault-gpio = <&gpio1 6 GPIO_ACTIVE_HIGH>;
+	};
+
+	/* i2c of port 27 SFP cage */
+	i2c2: i2c-gpio-2 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 11 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 15 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp2: sfp-p27 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2>;
+		los-gpio = <&gpio1 13 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		tx-fault-gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+	};
+
+	/* i2c of port 28 SFP cage */
+	i2c3: i2c-gpio-3 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 22 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 21 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp3: sfp-p28 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c3>;
+		los-gpio = <&gpio1 29 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 20 GPIO_ACTIVE_LOW>;
+		tx-fault-gpio = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+	};
+
+	/* i2c for hwmon and PoE MCU */
+	i2c4: i2c-gpio-4 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio0 18 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio0 16 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		flash_partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bootbase";
+				reg = <0x0 0x20000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					factory_macaddr: macaddr@1fff8 {
+						reg = <0x1fff8 0x6>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	nvmem-cells = <&factory_macaddr>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio_bus0 {
+	ethernet-phy-package@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0>;
+
+		PHY_C22(0, 0)
+		PHY_C22(1, 1)
+		PHY_C22(2, 2)
+		PHY_C22(3, 3)
+		PHY_C22(4, 4)
+		PHY_C22(5, 5)
+		PHY_C22(6, 6)
+		PHY_C22(7, 7)
+	};
+	ethernet-phy-package@8 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <8>;
+
+		PHY_C22(8, 8)
+		PHY_C22(9, 9)
+		PHY_C22(10, 10)
+		PHY_C22(11, 11)
+		PHY_C22(12, 12)
+		PHY_C22(13, 13)
+		PHY_C22(14, 14)
+		PHY_C22(15, 15)
+	};
+	ethernet-phy-package@16 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <16>;
+
+		PHY_C22(16, 16)
+		PHY_C22(17, 17)
+		PHY_C22(18, 18)
+		PHY_C22(19, 19)
+		PHY_C22(20, 20)
+		PHY_C22(21, 21)
+		PHY_C22(22, 22)
+		PHY_C22(23, 23)
+	};
+};
+
+&switch0 {
+	ethernet-ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT_SDS(0, 1, 0, 0, qsgmii)
+		SWITCH_PORT_SDS(1, 2, 0, 1, qsgmii)
+		SWITCH_PORT_SDS(2, 3, 0, 2, qsgmii)
+		SWITCH_PORT_SDS(3, 4, 0, 3, qsgmii)
+		SWITCH_PORT_SDS(4, 5, 1, 0, qsgmii)
+		SWITCH_PORT_SDS(5, 6, 1, 1, qsgmii)
+		SWITCH_PORT_SDS(6, 7, 1, 2, qsgmii)
+		SWITCH_PORT_SDS(7, 8, 1, 3, qsgmii)
+
+		SWITCH_PORT_SDS(8, 9, 2, 0, qsgmii)
+		SWITCH_PORT_SDS(9, 10, 2, 1, qsgmii)
+		SWITCH_PORT_SDS(10, 11, 2, 2, qsgmii)
+		SWITCH_PORT_SDS(11, 12, 2, 3, qsgmii)
+		SWITCH_PORT_SDS(12, 13, 3, 0, qsgmii)
+		SWITCH_PORT_SDS(13, 14, 3, 1, qsgmii)
+		SWITCH_PORT_SDS(14, 15, 3, 2, qsgmii)
+		SWITCH_PORT_SDS(15, 16, 3, 3, qsgmii)
+
+		SWITCH_PORT_SDS(16, 17, 4, 0, qsgmii)
+		SWITCH_PORT_SDS(17, 18, 4, 1, qsgmii)
+		SWITCH_PORT_SDS(18, 19, 4, 2, qsgmii)
+		SWITCH_PORT_SDS(19, 20, 4, 3, qsgmii)
+		SWITCH_PORT_SDS(20, 21, 5, 0, qsgmii)
+		SWITCH_PORT_SDS(21, 22, 5, 1, qsgmii)
+		SWITCH_PORT_SDS(22, 23, 5, 2, qsgmii)
+		SWITCH_PORT_SDS(23, 24, 5, 3, qsgmii)
+
+		/* CPU-Port */
+		port@52 {
+			ethernet = <&ethernet0>;
+			reg = <52>;
+			phy-mode = "internal";
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&mdio_aux {
+	status = "okay";
+
+	gpio1: expander@3 {
+		compatible = "realtek,rtl8231";
+		reg = <3>;
+
+		gpio-controller;
+		#gpio-cells = <2>;
+		gpio-ranges = <&gpio1 0 0 37>;
+
+		led-controller {
+			compatible = "realtek,rtl8231-leds";
+			status = "disabled";
+		};
+	};
+};

--- a/target/linux/realtek/dts/rtl839x_zyxel_gs1920-24hp-common.dtsi
+++ b/target/linux/realtek/dts/rtl839x_zyxel_gs1920-24hp-common.dtsi
@@ -1,294 +1,39 @@
 /dts-v1/;
 
-#include "rtl839x.dtsi"
+#include "rtl839x_zyxel_gs1920-24-common.dtsi"
 
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/leds/common.h>
+&i2c4 {
+	pse: ethernet-pse@20 {
+		reg = <0x20>;
 
-/ {
-	aliases {
-		led-boot = &led_sys;
-		led-failsafe = &led_sys;
-		led-running = &led_sys;
-		led-upgrade = &led_sys;
-	};
-
-	leds {
-		pinctrl-names = "default";
-		pinctrl-0 = <&pinmux_disable_sys_led>;
-		compatible = "gpio-leds";
-
-		led_sys: sys {
-			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
-			function = LED_FUNCTION_STATUS;
-			color = <LED_COLOR_ID_GREEN>;
-		};
-
-		locator {
-			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
-			function = LED_FUNCTION_INDICATOR;
-			color = <LED_COLOR_ID_BLUE>;
-		};
-	};
-
-	/* i2c of port 25 SFP cage */
-	i2c0: i2c-gpio-0 {
-		compatible = "i2c-gpio";
-		sda-gpios = <&gpio1 4 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		scl-gpios = <&gpio1 3 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		i2c-gpio,delay-us = <2>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-	};
-
-	sfp0: sfp-p25 {
-		compatible = "sff,sfp";
-		i2c-bus = <&i2c0>;
-		los-gpio = <&gpio1 1 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 23 GPIO_ACTIVE_LOW>;
-		tx-fault-gpio = <&gpio1 0 GPIO_ACTIVE_HIGH>;
-	};
-
-	/* i2c of port 26 SFP cage */
-	i2c1: i2c-gpio-1 {
-		compatible = "i2c-gpio";
-		sda-gpios = <&gpio1 10 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		scl-gpios = <&gpio1 9 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		i2c-gpio,delay-us = <2>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-	};
-
-	sfp1: sfp-p26 {
-		compatible = "sff,sfp";
-		i2c-bus = <&i2c1>;
-		los-gpio = <&gpio1 7 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 17 GPIO_ACTIVE_LOW>;
-		tx-fault-gpio = <&gpio1 6 GPIO_ACTIVE_HIGH>;
-	};
-
-	/* i2c of port 27 SFP cage */
-	i2c2: i2c-gpio-2 {
-		compatible = "i2c-gpio";
-		sda-gpios = <&gpio1 11 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		scl-gpios = <&gpio1 15 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		i2c-gpio,delay-us = <2>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-	};
-
-	sfp2: sfp-p27 {
-		compatible = "sff,sfp";
-		i2c-bus = <&i2c2>;
-		los-gpio = <&gpio1 13 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 13 GPIO_ACTIVE_LOW>;
-		tx-fault-gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
-	};
-
-	/* i2c of port 28 SFP cage */
-	i2c3: i2c-gpio-3 {
-		compatible = "i2c-gpio";
-		sda-gpios = <&gpio1 22 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		scl-gpios = <&gpio1 21 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		i2c-gpio,delay-us = <2>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-	};
-
-	sfp3: sfp-p28 {
-		compatible = "sff,sfp";
-		i2c-bus = <&i2c3>;
-		los-gpio = <&gpio1 29 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 20 GPIO_ACTIVE_LOW>;
-		tx-fault-gpio = <&gpio1 23 GPIO_ACTIVE_HIGH>;
-	};
-
-	/* i2c for hwmon/PoE */
-	i2c4: i2c-gpio-4 {
-		compatible = "i2c-gpio";
-		sda-gpios = <&gpio0 18 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		scl-gpios = <&gpio0 16 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		i2c-gpio,delay-us = <2>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		pse: ethernet-pse@20 {
-			reg = <0x20>;
-
-			pse-pis {
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				PSE_PI(0)
-				PSE_PI(1)
-				PSE_PI(2)
-				PSE_PI(3)
-				PSE_PI(4)
-				PSE_PI(5)
-				PSE_PI(6)
-				PSE_PI(7)
-				PSE_PI(8)
-				PSE_PI(9)
-				PSE_PI(10)
-				PSE_PI(11)
-				PSE_PI(12)
-				PSE_PI(13)
-				PSE_PI(14)
-				PSE_PI(15)
-				PSE_PI(16)
-				PSE_PI(17)
-				PSE_PI(18)
-				PSE_PI(19)
-				PSE_PI(20)
-				PSE_PI(21)
-				PSE_PI(22)
-				PSE_PI(23)
-			};
-		};
-	};
-};
-
-&spi0 {
-	status = "okay";
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <10000000>;
-
-		flash_partitions: partitions {
-			compatible = "fixed-partitions";
+		pse-pis {
 			#address-cells = <1>;
-			#size-cells = <1>;
+			#size-cells = <0>;
 
-			partition@0 {
-				label = "bootbase";
-				reg = <0x0 0x20000>;
-				read-only;
-
-				nvmem-layout {
-					compatible = "fixed-layout";
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					factory_macaddr: macaddr@1fff8 {
-						reg = <0x1fff8 0x6>;
-					};
-				};
-			};
-		};
-	};
-};
-
-&ethernet0 {
-	nvmem-cells = <&factory_macaddr>;
-	nvmem-cell-names = "mac-address";
-};
-
-&mdio_bus0 {
-	ethernet-phy-package@0 {
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg = <0>;
-
-		PHY_C22(0, 0)
-		PHY_C22(1, 1)
-		PHY_C22(2, 2)
-		PHY_C22(3, 3)
-		PHY_C22(4, 4)
-		PHY_C22(5, 5)
-		PHY_C22(6, 6)
-		PHY_C22(7, 7)
-	};
-	ethernet-phy-package@8 {
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg = <8>;
-
-		PHY_C22(8, 8)
-		PHY_C22(9, 9)
-		PHY_C22(10, 10)
-		PHY_C22(11, 11)
-		PHY_C22(12, 12)
-		PHY_C22(13, 13)
-		PHY_C22(14, 14)
-		PHY_C22(15, 15)
-	};
-	ethernet-phy-package@16 {
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg = <16>;
-
-		PHY_C22(16, 16)
-		PHY_C22(17, 17)
-		PHY_C22(18, 18)
-		PHY_C22(19, 19)
-		PHY_C22(20, 20)
-		PHY_C22(21, 21)
-		PHY_C22(22, 22)
-		PHY_C22(23, 23)
-	};
-};
-
-&switch0 {
-	ethernet-ports {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		SWITCH_PORT_SDS(0, 1, 0, 0, qsgmii)
-		SWITCH_PORT_SDS(1, 2, 0, 1, qsgmii)
-		SWITCH_PORT_SDS(2, 3, 0, 2, qsgmii)
-		SWITCH_PORT_SDS(3, 4, 0, 3, qsgmii)
-		SWITCH_PORT_SDS(4, 5, 1, 0, qsgmii)
-		SWITCH_PORT_SDS(5, 6, 1, 1, qsgmii)
-		SWITCH_PORT_SDS(6, 7, 1, 2, qsgmii)
-		SWITCH_PORT_SDS(7, 8, 1, 3, qsgmii)
-
-		SWITCH_PORT_SDS(8, 9, 2, 0, qsgmii)
-		SWITCH_PORT_SDS(9, 10, 2, 1, qsgmii)
-		SWITCH_PORT_SDS(10, 11, 2, 2, qsgmii)
-		SWITCH_PORT_SDS(11, 12, 2, 3, qsgmii)
-		SWITCH_PORT_SDS(12, 13, 3, 0, qsgmii)
-		SWITCH_PORT_SDS(13, 14, 3, 1, qsgmii)
-		SWITCH_PORT_SDS(14, 15, 3, 2, qsgmii)
-		SWITCH_PORT_SDS(15, 16, 3, 3, qsgmii)
-
-		SWITCH_PORT_SDS(16, 17, 4, 0, qsgmii)
-		SWITCH_PORT_SDS(17, 18, 4, 1, qsgmii)
-		SWITCH_PORT_SDS(18, 19, 4, 2, qsgmii)
-		SWITCH_PORT_SDS(19, 20, 4, 3, qsgmii)
-		SWITCH_PORT_SDS(20, 21, 5, 0, qsgmii)
-		SWITCH_PORT_SDS(21, 22, 5, 1, qsgmii)
-		SWITCH_PORT_SDS(22, 23, 5, 2, qsgmii)
-		SWITCH_PORT_SDS(23, 24, 5, 3, qsgmii)
-
-		/* CPU-Port */
-		port@52 {
-			ethernet = <&ethernet0>;
-			reg = <52>;
-			phy-mode = "internal";
-			fixed-link {
-				speed = <1000>;
-				full-duplex;
-			};
-		};
-	};
-};
-
-&mdio_aux {
-	status = "okay";
-
-	gpio1: expander@3 {
-		compatible = "realtek,rtl8231";
-		reg = <3>;
-
-		gpio-controller;
-		#gpio-cells = <2>;
-		gpio-ranges = <&gpio1 0 0 37>;
-
-		led-controller {
-			compatible = "realtek,rtl8231-leds";
-			status = "disabled";
+			PSE_PI(0)
+			PSE_PI(1)
+			PSE_PI(2)
+			PSE_PI(3)
+			PSE_PI(4)
+			PSE_PI(5)
+			PSE_PI(6)
+			PSE_PI(7)
+			PSE_PI(8)
+			PSE_PI(9)
+			PSE_PI(10)
+			PSE_PI(11)
+			PSE_PI(12)
+			PSE_PI(13)
+			PSE_PI(14)
+			PSE_PI(15)
+			PSE_PI(16)
+			PSE_PI(17)
+			PSE_PI(18)
+			PSE_PI(19)
+			PSE_PI(20)
+			PSE_PI(21)
+			PSE_PI(22)
+			PSE_PI(23)
 		};
 	};
 };

--- a/target/linux/realtek/image/rtl839x.mk
+++ b/target/linux/realtek/image/rtl839x.mk
@@ -126,7 +126,7 @@ define Device/zyxel_gs1900-48hp-a1
 endef
 TARGET_DEVICES += zyxel_gs1900-48hp-a1
 
-define Device/zyxel_gs1920-24hp
+define Device/zyxel_gs1920
 ifeq ($(IB),)
   ARTIFACTS := loader.bin
   ARTIFACT/loader.bin := \
@@ -134,9 +134,14 @@ ifeq ($(IB),)
     zynsig
 endif
   DEVICE_VENDOR := Zyxel
-  DEVICE_MODEL := GS1920-24HP
-  DEVICE_PACKAGES := kmod-hwmon-lm85 kmod-pse-realtek-mcu-i2c
+  DEVICE_PACKAGES += kmod-hwmon-lm85
   $(Device/rt-loader-bootbase)
+endef
+
+define Device/zyxel_gs1920-24hp
+  $(Device/zyxel_gs1920)
+  DEVICE_MODEL := GS1920-24HP
+  DEVICE_PACKAGES += kmod-pse-realtek-mcu-i2c
 endef
 
 define Device/zyxel_gs1920-24hp-v1

--- a/target/linux/realtek/image/rtl839x.mk
+++ b/target/linux/realtek/image/rtl839x.mk
@@ -138,6 +138,16 @@ endif
   $(Device/rt-loader-bootbase)
 endef
 
+define Device/zyxel_gs1920-24-v1
+  $(Device/zyxel_gs1920)
+  SOC := rtl8392
+  FLASH_ADDR := 0xb40c0000
+  IMAGE_SIZE := 12144k
+  DEVICE_MODEL := GS1920-24
+  DEVICE_VARIANT := v1
+endef
+TARGET_DEVICES += zyxel_gs1920-24-v1
+
 define Device/zyxel_gs1920-24hp
   $(Device/zyxel_gs1920)
   DEVICE_MODEL := GS1920-24HP


### PR DESCRIPTION
Add support for the non-PoE Zyxel GS1920-24 v1.

The device is the fanless, non-PoE sibling of the already supported
GS1920-24HP v1 and shares most of its hardware.

The first commit factors the GS1920-24 support into shared and
model-specific parts.

The device tree description is split into common hardware, RTL8392
v1-specific hardware, and GS1920-24HP-specific PoE configuration.

The shared `rtl839x_zyxel_gs1920-24-common.dtsi` contains the hardware
common to the GS1920-24 family. The new
`rtl8392_zyxel_gs1920-24-v1-common.dtsi` contains the board details shared
by the GS1920-24 v1 and GS1920-24HP v1, including memory size, console
configuration, flash layout, and combo-port configuration.

The PSE controller and per-PHY PSE references remain confined to the
GS1920-24HP-specific DTSI. The shared `i2c4` bus remains in the family
common DTSI because it also carries the hardware monitor.

The image recipe is likewise split into GS1920 family-common and
GS1920-24HP-specific parts. `kmod-hwmon-lm85` is supplied by the shared
GS1920 recipe, while the PSE driver remains HP-specific.

This factoring is a functional no-op for the existing devices: the
generated GS1920-24HP v1 and v2 DTBs are byte-identical before and after
the first commit. Both HP profiles were also regression-built at the
final series HEAD and retain `kmod-hwmon-lm85` and the PSE packages.

The second commit adds the GS1920-24 v1 DTS and device profile, together
with its label-MAC handling.

The factory MAC is read from the bootbase partition at offset `0x1fff8`
through the `factory_macaddr` nvmem cell. `ethernet0` is the
`label-mac-device`, and the board is handled alongside the GS1920-24HP
v2 in `02_network`, making the factory MAC explicit for the LAN/bridge
without assigning individual per-port MAC addresses.

This was verified on hardware: `get_mac_label` returns the factory MAC,
the generated LAN and bridge configuration use that address, and no
per-port MAC addresses are generated.

The non-PoE v1 carries an Analog Devices ADT7463C hardware monitor at
I2C address `0x2e`, identified on hardware by company ID `0x41` and
VERSTEP `0x6a`. The HP v1 uses an ADT7468 and the HP v2 describes an
lm85-family hardware monitor at the same address.

Tested on hardware:

- boot and cold boot
- reboot
- sysupgrade from an existing OpenWrt installation, preserving configuration
- board identification and factory MAC handling
- all 24 standard copper ports and the copper side of all 4 combo ports
- VLAN and switch forwarding
- link LEDs
- reset button
- ADT7463C hardware monitoring, including temperature and voltage readings

The final GS1920-24 v1 image contains `kmod-hwmon-lm85` and no PSE
driver.

The four SFP cages initialise correctly, but the SFP side of the combo
ports has not been functionally tested because no SFP modules were
available.

Signed-off-by: David Evans <git@d4vid.uk>
Cc: @jonasjelonek @andyboeh