### PR TITLE
quilt.mk: fix missing newline after patch refresh

### DIFF
--- a/include/quilt.mk
+++ b/include/quilt.mk
@@ -171,6 +171,7 @@ define Quilt/Template
 		cd "$(1)"; $(QUILT_CMD) pop -a -f >/dev/null 2>/dev/null; \
 		while $(QUILT_CMD) next 2>/dev/null >/dev/null && $(QUILT_CMD) push; do \
 			QUILT_DIFF_OPTS="-p" $(QUILT_CMD) refresh -p ab --no-index --no-timestamps; \
+			echo; \
 		done; ! $(QUILT_CMD) next 2>/dev/null >/dev/null; \
 	}
 	$(Quilt/Refresh/$(4))


### PR DESCRIPTION
before:
```
Applying patch 0001-configure-allow-disable-fortify_source.patch
patching file configure

Now at patch 0001-configure-allow-disable-fortify_source.patch
Patch 0001-configure-allow-disable-fortify_source.patch is unchanged
Applying patch 0002-util-mmap-alloc-fix-missing-MAP_SYNC.patch
patching file util/mmap-alloc.c

Now at patch 0002-util-mmap-alloc-fix-missing-MAP_SYNC.patch
Patch 0002-util-mmap-alloc-fix-missing-MAP_SYNC.patch is unchanged
Applying patch 0004-fix-meson-cross-build-compiler-sanity-check.patch
patching file configure

Now at patch 0004-fix-meson-cross-build-compiler-sanity-check.patch
Patch 0004-fix-meson-cross-build-compiler-sanity-check.patch is unchanged
```

after:
```
Applying patch 0001-configure-allow-disable-fortify_source.patch
patching file configure

Now at patch 0001-configure-allow-disable-fortify_source.patch
Patch 0001-configure-allow-disable-fortify_source.patch is unchanged

Applying patch 0002-util-mmap-alloc-fix-missing-MAP_SYNC.patch
patching file util/mmap-alloc.c

Now at patch 0002-util-mmap-alloc-fix-missing-MAP_SYNC.patch
Patch 0002-util-mmap-alloc-fix-missing-MAP_SYNC.patch is unchanged

Applying patch 0004-fix-meson-cross-build-compiler-sanity-check.patch
patching file configure

Now at patch 0004-fix-meson-cross-build-compiler-sanity-check.patch
Patch 0004-fix-meson-cross-build-compiler-sanity-check.patch is unchanged
```
