### PR TITLE
mac80211: package missing ath12k_wifi7 module

### DIFF
--- a/package/kernel/mac80211/ath.mk
+++ b/package/kernel/mac80211/ath.mk
@@ -372,8 +372,10 @@ define KernelPackage/ath12k
   +kmod-crypto-michael-mic +kmod-qrtr-mhi \
   +kmod-qcom-qmi-helpers +@DRIVER_11BE_SUPPORT \
   +ATH12K_THERMAL:kmod-hwmon-core +ATH12K_THERMAL:kmod-thermal
-  FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/ath/ath12k/ath12k.ko
-  AUTOLOAD:=$(call AutoProbe,ath12k)
+  FILES:= \
+	$(PKG_BUILD_DIR)/drivers/net/wireless/ath/ath12k/ath12k.ko \
+	$(PKG_BUILD_DIR)/drivers/net/wireless/ath/ath12k/wifi7/ath12k_wifi7.ko
+  AUTOLOAD:=$(call AutoProbe,ath12k ath12k_wifi7)
 endef
 
 define KernelPackage/ath12k/description


### PR DESCRIPTION
After the recent update to `mac80211` version 7.2, the `ath12k` driver stopped probing devices. 

This occurred because the hardware-specific HAL code was moved out of the core `ath12k.ko` module and into a new `ath12k_wifi7.ko` module. Since `ath12k_wifi7.ko` was not packaged, `ath12k` silently failed to initialize the radios.

This PR fixes the issue by properly packaging the missing `ath12k_wifi7.ko` module in `kmod-ath12k` and probing it at boot.