### PR TITLE
mediatek: filogic: fix D-Link Aquila MAC sold in multi packs

### DIFF
--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -118,8 +118,16 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && echo "$addr" > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_add $addr 1) > /sys${DEVPATH}/macaddress
 		;;
-	dlink,aquila-pro-ai-m30-a1)
-		addr=$(mtd_get_mac_binary "Odm" 0x81)
+	dlink,aquila-pro-ai-m30-a1|\
+	dlink,aquila-pro-ai-m60-a1)
+		part=$(find_mtd_part "Odm")
+		# locate the MAC record header, the MAC follows it
+		hex=$(hexdump -ve '1/1 "%.2x"' -n 256 "$part")
+		pos=$(echo "$hex" | awk -v RS='304200800600' '{print length($0); exit}')
+		[ -n "$pos" ] && [ "$pos" -lt "${#hex}" ] || return 0
+		offset=$((pos / 2 + 6))
+		addr=$(mtd_get_mac_binary "Odm" $offset)
+		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
 		;;
 	glinet,gl-mt6000|\

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -28,6 +28,25 @@ preinit_set_mac_address() {
 		ip link set dev eth0 address "$addr"
 		ip link set dev eth1 address "$addr"
 		;;
+	dlink,aquila-pro-ai-m30-a1|\
+	dlink,aquila-pro-ai-m60-a1)
+		part=$(find_mtd_part "Odm")
+		# locate the MAC record header, the MAC follows it
+		hex=$(hexdump -ve '1/1 "%.2x"' -n 256 "$part")
+		pos=$(echo "$hex" | awk -v RS='304200800600' '{print length($0); exit}')
+		[ -n "$pos" ] && [ "$pos" -lt "${#hex}" ] || return 0
+		offset=$((pos / 2 + 6))
+		wan_mac=$(mtd_get_mac_binary "Odm" $offset)
+		lan_mac=$(macaddr_add $wan_mac 1)
+		ip link set dev internet address "$wan_mac"
+		ip link set eth0 down
+		ip link set dev eth0 address "$lan_mac"
+		ip link set eth0 up
+		ip link set dev lan1 address "$lan_mac"
+		ip link set dev lan2 address "$lan_mac"
+		ip link set dev lan3 address "$lan_mac"
+		ip link set dev lan4 address "$lan_mac"
+		;;
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\
 	tplink,archer-ax80-v1-eu|\


### PR DESCRIPTION
Devices sold in multi-packs store MAC at a different offset on Odm partition due to a suffix added in a few places.

Implement finding MAC address by searching for header in Odm partition and calculating offset from header position.

MAC address is set for WAN, LAN and both WiFi radios by adding 0, 1, 2 and 3 to base address extracted from Odm - the same way OEM firmware sets them.

This is an alternative to https://github.com/openwrt/openwrt/pull/23902 and it does not hardcode the offset.