### PR TITLE
qualcommax: qca_ppe: accept a multicast delete that is already done

### DIFF
--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -754,8 +754,20 @@ static int qca_ppe_port_mdb_del(struct dsa_switch *ds, int port,
 	int ret;
 
 	ret = ppe_fdb_lookup(priv, mdb->addr, mdb->vid, &portmap);
+
+	/* The bridge drops a port's multicast entries on every leave, STP
+	 * transition and membership expiry, without tracking which of them
+	 * this switch programmed, so a delete arrives for entries that were
+	 * never added and for entries an earlier delete already emptied.
+	 * Either way the requested state already holds.
+	 */
+	if (ret == -ENOENT)
+		return 0;
 	if (ret)
 		return ret;
+
+	if (!(portmap & BIT(port)))
+		return 0;
 
 	portmap &= ~BIT(port);
 


### PR DESCRIPTION
The bridge asks the switch to delete a multicast entry for a port every time that port leaves the group, changes STP state, or its membership expires. It does this per port and does not remember whether the switch ever had the entry. So the driver regularly gets a delete for an entry that is not in its FDB, or for a port that is no longer in the entry.

`qca_ppe_port_mdb_del()` returns `-ENOENT` in the first case and rewrites the entry in the second. Nothing acts on the return value: the delete runs from switchdev's deferred queue, and `switchdev_port_obj_del_deferred()` only prints it:

```
qca-ppe 3a000000.ppe lan3: Failed to del Port Multicast Database entry (object id=2) with error: -ENOENT (-2).
Failure in updating the port's Multicast Database could lead to
multicast forwarding issues.
```

In both cases the entry is already in the state the bridge asked for, so return 0. Removing a port that is still in the entry, and dropping the entry when its last non-CPU member leaves, is unchanged.

Tested on an AX3600 (IPQ8074, kernel 6.18): snooping on, one group joined from lan1, lan2 and lan3, then the three ports removed from the bridge one by one. The message appeared twice before the change and not at all after it. The ports rejoin the bridge fine either way.

Found by @Vladdrako on IPQ6018, reproduced here on IPQ8074. `qca8k` does the same thing with `-EINVAL`; not touched here.
