### PR TITLE
realtek: rtl930x: describe CPUs and reserve IP7 for CP0 timer

### DIFF
--- a/target/linux/realtek/dts/rtl930x.dtsi
+++ b/target/linux/realtek/dts/rtl930x.dtsi
@@ -15,10 +15,25 @@
 		#size-cells = <0>;
 		frequency = <800000000>;
 
-		cpu@0 {
+		cpu0: cpu@0 {
+			device_type = "cpu";
 			compatible = "mips,mips34Kc";
 			reg = <0>;
+			clocks = <&cpu_clk>;
 		};
+
+		cpu1: cpu@1 {
+			device_type = "cpu";
+			compatible = "mips,mips34Kc";
+			reg = <1>;
+			clocks = <&cpu_clk>;
+		};
+	};
+
+	cpu_clk: cpu-clock {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <800000000>;
 	};
 
 	memory@0 {
@@ -69,7 +84,7 @@
 			#interrupt-cells = <2>;
 
 			interrupt-parent = <&cpuintc>;
-			interrupts = <2>, <3>, <4>, <5>, <6>, <7>;
+			interrupts = <2>, <3>, <4>, <5>, <6>;
 		};
 
 		snand: spi@1a400 {


### PR DESCRIPTION
Describe both MIPS 34Kc CPUs in the RTL930x device tree and provide their CPU clock through a fixed-clock provider instead of the custom frequency property.

The MIPS timer initialization obtains the CPU clock through the clock framework. Without a clock assigned to the CPU node, mips_hpt_frequency remains unset and the R4K clockevent cannot be initialized.

RTL930x has two CPU cores, so add both CPU nodes and reference the shared 800 MHz CPU clock from each of them.

Also stop routing the RTL930x interrupt controller through CPU interrupt IP7. The CP0 Count/Compare timer uses IP7, and having the RTL930x interrupt controller claim it prevents the R4K clockevent from requesting its timer IRQ with "Failed to request irq 7 (timer)".

Leave IP7 available for the per-CPU CP0 Count/Compare timer while the RTL930x interrupt controller continues to use IP2 through IP6. This allows the R4K clockevent to initialize correctly on both CPUs.

