### PR TITLE
ramips: ASUS 4G-AX56 modem, LED, GPIO and MAC support

### DIFF
--- a/target/linux/ramips/dts/mt7621_asus_4g-ax56.dts
+++ b/target/linux/ramips/dts/mt7621_asus_4g-ax56.dts
@@ -180,7 +180,9 @@
 				};
 
 				macaddr_factory_4: macaddr@4 {
+					compatible = "mac-base";
 					reg = <0x4 0x6>;
+					#nvmem-cell-cells = <1>;
 				};
 
 				precal_factory_e10: precal@e10 {
@@ -243,7 +245,7 @@
 };
 
 &gmac0 {
-	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cells = <&macaddr_factory_4 0>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -252,7 +254,7 @@
 	label = "wan";
 	phy-handle = <&ethphy0>;
 
-	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cells = <&macaddr_factory_4 1>;
 	nvmem-cell-names = "mac-address";
 };
 

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -529,7 +529,7 @@ define Device/asus_4g-ax56
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
 	check-size
   DEVICE_PACKAGES := kmod-mt7915-firmware kmod-usb3 kmod-usb-serial-option \
-	kmod-usb-net-cdc-ncm
+	kmod-usb-net-cdc-ncm comgt-ncm
 endef
 TARGET_DEVICES += asus_4g-ax56
 

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -13,6 +13,10 @@ alfa-network,ax1800rm)
 	ucidef_set_led_netdev "lan3" "lan3" "green:lan3" "lan3"
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan"
 	;;
+asus,4g-ax56)
+	ucidef_set_led_netdev "wan" "WAN" "white:wan" "wan" "link tx rx"
+	ucidef_set_led_netdev "mobile" "Mobile" "white:mobile" "usb0" "link tx rx"
+	;;
 asus,rp-ac87)
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_rssimon "wlan1" "200000" "1"

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -42,6 +42,11 @@ ramips_setup_interfaces()
 	arcadyan,we420223-99)
 		ucidef_set_interface_lan "swp0 swp1"
 		;;
+	asus,4g-ax56)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
+		ucidef_set_interface "wwan" device "/dev/ttyUSB0" protocol "ncm"
+		uci add_list firewall.@zone[1].network='wwan'
+		;;
 	ampedwireless,ally-00x19k|\
 	arcadyan,we410443|\
 	asus,rp-ac56|\

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
@@ -6,6 +6,10 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
+asus,4g-ax56)
+	ucidef_add_gpio_switch "modem_reboot" "Modem reboot" "reboot:modem" "1"
+	ucidef_add_gpio_switch "modem_reset" "Modem reset" "reset:modem" "1"
+	;;
 mikrotik,routerboard-760igs)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "529"
 	;;


### PR DESCRIPTION
Board-side support for the ASUS 4G-AX56. **Depends on #24974**, which adds the Fibocom profile to `comgt`'s `ncm.json`; without it `proto ncm` reports `UNSUPPORTED_MODEM`.

`asus,4g-ax56` currently appears in only four files in the tree and has no `board.d` wiring at all — no `01_leds`, no `02_network`, no `03_gpio_switches`. Commit 929b3d0e52 added ten LEDs and two gpio-exports to the DTS in Feb 2025 and wired none of them up. The result is an LTE router that boots with no WAN and no working indicators.

### Commits

1. **wwan interface + `comgt-ncm`** — configures the modem as `proto ncm`, mirroring `tozed,zlt-s12-pro` on the same subtarget. Ethernet WAN stays the default; the modem is added alongside in the wan zone. Most owners run LTE only, so `wwan` simply comes up; anyone using both can set metrics themselves.
2. **LEDs** — WAN and mobile indicators.
3. **Modem control GPIO switches** — `reboot:modem` / `reset:modem` were exported but unreachable from UCI/LuCI.
4. **MAC addressing** — LAN and WAN currently share one MAC. Fix by @mrhaav (Henrik Ginstmark), who diagnosed and tested it on the forum but never submitted it; credited in the commit. Happy to hand him authorship if preferred.

### Testing

Hardware, HW rev A1, on both `main` and `openwrt-25.12`. Each change verified from a factory-reset first boot, with the relevant state reset to inert beforehand so a no-op patch could not pass.

- `wwan` up via `proto ncm`, unattended, modem autoconnect flag still `0`
- `white:mobile` confirmed blinking with LTE traffic; WAN LED dark with no cable
- `br-lan 10:7c:61:a4:47:00` / `wan 10:7c:61:a4:47:01`, and the incremented WAN MAC successfully obtained a DHCP lease on a real network
- `system.modem_reboot` / `system.modem_reset` present after boot

### Notes / not addressed

- The OEM also sets 2.4 GHz WiFi to base+2 and gives 5 GHz its own factory cell. Left alone as a riskier change.
- `asus,rt-ax53u` has the same non-incrementing MAC pattern. Untouched, since I cannot test that device.
- `white:rssi-1..3` are real and correctly ordered (`rssi-1` is the weak end, filling right to left), but nothing in-tree drives cellular signal LEDs. Relevant to #24845.
- On my unit the white half of the WAN LED never lights — **even under vendor firmware**, which drives GPIO 15 high with the wired WAN online. The DTS node is therefore correct and should stay; the element appears unpopulated or dead on this particular board. Recording it as an observation only.
