### PR TITLE
airoha: add support for TP-Link XB432v

### DIFF
--- a/target/linux/airoha/an7581/base-files/etc/board.d/01_leds
+++ b/target/linux/airoha/an7581/base-files/etc/board.d/01_leds
@@ -25,6 +25,19 @@ nokia,xg-040g-md-ubi)
 	ucidef_set_led_netdev "lan3" "lan3" "mt7530-0:0b:green:lan-3" "lan3" "link tx rx"
 	ucidef_set_led_netdev "lan4" "lan4" "mt7530-0:0c:green:lan-4" "lan4" "link tx rx"
 	;;
+tplink,xb432v)
+	# GSW jack LEDs (active-low PHY LEDs; sysfs brightness 0 = lit without trigger).
+	ucidef_set_led_netdev "lan1" "LAN1" "mt7530-0:09::lan" "lan1" "link"
+	ucidef_set_led_netdev "lan2" "LAN2" "mt7530-0:0a::lan" "lan2" "link"
+	ucidef_set_led_netdev "lan3" "LAN3" "mt7530-0:0b::lan" "lan3" "link"
+	ucidef_set_led_netdev "wan_jack" "WAN jack" "mt7530-0:0c::lan" "lan4" "link"
+	# Front-panel status LEDs (stock led.conf GPIOs in DTS).
+	ucidef_set_led_netdev "wan" "Internet" "green:internet" "lan4" "link tx rx"
+	ucidef_set_led_usbdev "usb" "USB" "green:usb" "1-1"
+	ucidef_set_led_netdev "wifi_2g" "2.4 GHz" "green:pon" "phy0-ap0" "link tx rx"
+	ucidef_set_led_netdev "wifi_5g" "5 GHz" "green:los" "phy1-ap0" "link tx rx"
+	ucidef_set_led_heartbeat "power" "Power" "red:power"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/airoha/an7581/base-files/etc/board.d/02_network
+++ b/target/linux/airoha/an7581/base-files/etc/board.d/02_network
@@ -24,6 +24,14 @@ an7581_setup_interfaces()
 	nokia,xg-040g-md-ubi)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		;;
+	tplink,xb432v)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan5" "lan4"
+		lan_mac=$(mtd_get_mac_binary misc 0x8f100)
+		[ -n "$lan_mac" ] && {
+			ucidef_set_interface_macaddr "lan" "$lan_mac"
+			ucidef_set_interface_macaddr "wan" "$lan_mac"
+		}
+		;;
 	*)
 		echo "Unsupported hardware. Network interfaces not initialized"
 		;;

--- a/target/linux/airoha/an7581/base-files/lib/upgrade/platform.sh
+++ b/target/linux/airoha/an7581/base-files/lib/upgrade/platform.sh
@@ -1,6 +1,205 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (c) OpenWrt.org
+
 RAMFS_COPY_BIN='fitblk fit_check_sign'
 
+. /lib/functions.sh
+. /lib/upgrade/xb432v_wrap_tpv3.sh
+
 REQUIRE_IMAGE_METADATA=1
+
+# Slot A only. Stock slot B (kernel_slave/rootfs_slave/firmware_slave) is recovery.
+XB432V_KERNEL_MTD=$((10 * 1024 * 1024))
+XB432V_ROOTFS_MTD=$((0x3bc0000))
+XB432V_FIRMWARE_MTD=$((0x045c0000))
+XB432V_LOADADDR=0x80088000
+XB432V_TP_V3_TAG=512
+XB432V_TP_V3_VERSION=03000003
+
+# stage2 ramdisk may not have od/tr on PATH; prefer busybox applets.
+xb432v_bb() {
+	if command -v busybox >/dev/null 2>&1; then
+		busybox "$@"
+	else
+		"$@"
+	fi
+}
+
+xb432v_mtd_expect() {
+	local label="$1"
+	local size="$2"
+	local found size_hex
+
+	found=$(grep "\"$label\"" /proc/mtd | head -n1)
+	[ -n "$found" ] || {
+		v "missing MTD partition $label"
+		return 1
+	}
+	size_hex=$(echo "$found" | awk '{print $2}')
+	[ $((0x$size_hex)) -eq "$size" ] || {
+		v "MTD $label size 0x$size_hex != expected $(printf '0x%x' "$size")"
+		return 1
+	}
+	return 0
+}
+
+xb432v_verify_mtd_layout() {
+	xb432v_mtd_expect boot $((0xc0000)) || return 1
+	xb432v_mtd_expect art $((0x380000)) || return 1
+	xb432v_mtd_expect misc $((0x400000)) || return 1
+	xb432v_mtd_expect kernel $XB432V_KERNEL_MTD || return 1
+	xb432v_mtd_expect rootfs $XB432V_ROOTFS_MTD || return 1
+	xb432v_mtd_expect firmware $XB432V_FIRMWARE_MTD || return 1
+	xb432v_mtd_expect kernel_slave $XB432V_KERNEL_MTD || return 1
+	xb432v_mtd_expect rootfs_slave $XB432V_ROOTFS_MTD || return 1
+	xb432v_mtd_expect firmware_slave $XB432V_FIRMWARE_MTD || return 1
+	xb432v_mtd_expect reserve $((0x40000)) || return 1
+	return 0
+}
+
+xb432v_image_payload_len() {
+	local file="$1"
+	local len
+
+	len=$(wc -c < "$file")
+	# Allow OpenWrt append-metadata JSON trailer (typically a few KiB).
+	[ "$len" -le $((XB432V_FIRMWARE_MTD + 65536)) ] || {
+		v "image file $len exceeds firmware slot plus metadata"
+		return 1
+	}
+	echo "$len"
+}
+
+xb432v_check_sysupgrade_layout() {
+	local file="$1"
+	local payload_len rootfs_off magic
+
+	payload_len=$(xb432v_image_payload_len "$file")
+	[ "$payload_len" -ge $((XB432V_KERNEL_MTD + 64)) ] || {
+		v "image too small for kernel+rootfs layout"
+		return 1
+	}
+
+	magic=$(dd if="$file" bs=4 count=1 2>/dev/null | hexdump -v -n 4 -e '1/1 "%02x"')
+	[ "$magic" = "d00dfeed" ] || {
+		v "kernel region is not FIT (d00dfeed)"
+		return 1
+	}
+
+	rootfs_off=$XB432V_KERNEL_MTD
+	magic=$(dd if="$file" bs=1 skip="$rootfs_off" count=4 2>/dev/null | hexdump -v -n 4 -e '1/1 "%02x"')
+	[ "$magic" = "68737173" ] || {
+		v "rootfs region is not squashfs (hsqs)"
+		return 1
+	}
+
+	[ "$payload_len" -le $((XB432V_FIRMWARE_MTD + 4096)) ] || {
+		v "image payload $payload_len exceeds firmware slot"
+		return 1
+	}
+
+	return 0
+}
+
+xb432v_check_metadata() {
+	local file="$1"
+	local dev
+
+	# Sysupgrade already enforces REQUIRE_IMAGE_METADATA; this is a fail-closed
+	# board guard without invoking nand_do_platform_check / UBI helpers.
+	if ! command -v fwtool >/dev/null 2>&1; then
+		v "fwtool unavailable; relying on sysupgrade metadata gate"
+		return 0
+	fi
+
+	dev=$(fwtool -i - "$file" 2>/dev/null | jsonfilter -e '@.supported_devices[0]' 2>/dev/null)
+	[ -n "$dev" ] || {
+		v "missing supported_devices in image metadata"
+		return 1
+	}
+	echo "$dev" | grep -qx "tplink,xb432v" || {
+		v "image metadata device $dev != tplink,xb432v"
+		return 1
+	}
+	return 0
+}
+
+xb432v_squashfs_used() {
+	local file="$1"
+	local used hex off mult hbyte
+
+	hex=$(xb432v_bb dd if="$file" bs=1 skip=$((XB432V_KERNEL_MTD + 40)) count=8 2>/dev/null | \
+		xb432v_bb hexdump -v -e '8/1 "%02x"')
+	[ -n "$hex" ] || return 1
+	used=0
+	mult=1
+	off=0
+	while [ "$off" -lt 16 ]; do
+		hbyte=${hex:$off:2}
+		used=$((used + 0x$hbyte * mult))
+		mult=$((mult * 256))
+		off=$((off + 2))
+	done
+	[ "$used" -gt 0 ] || return 1
+	[ "$used" -le "$XB432V_ROOTFS_MTD" ] || {
+		v "squashfs claims $used bytes but rootfs MTD is $XB432V_ROOTFS_MTD"
+		return 1
+	}
+	echo "$used"
+}
+
+xb432v_erase_overlay_tail() {
+	local squashfs_len="$1"
+	local tail_len offset
+
+	tail_len=$((XB432V_ROOTFS_MTD - squashfs_len))
+	offset="$squashfs_len"
+	[ "$tail_len" -gt 0 ] || return 0
+
+	v "Wiping jffs2 overlay tail ($tail_len bytes from rootfs offset $offset)"
+	# Erased NAND flash is 0xFF; uci-defaults re-run after clean upgrade (-n).
+	xb432v_bb dd if=/dev/zero bs=65536 count=$(( (tail_len + 65535) / 65536 )) 2>/dev/null | \
+		xb432v_bb tr '\000' '\377' | \
+		xb432v_bb head -c "$tail_len" 2>/dev/null | \
+		mtd write -p "$offset" - rootfs || return 1
+	return 0
+}
+
+xb432v_do_upgrade() {
+	local file="$1"
+	local rootfs_len
+
+	rootfs_len=$(xb432v_squashfs_used "$file") || return 1
+
+	v "Writing kernel (TP v3 tag + FIT) to mtd:kernel"
+	xb432v_build_tpv3_kernel "$file" | mtd write - kernel || return 1
+
+	v "Writing rootfs (${rootfs_len} bytes squashfs) to mtd:rootfs"
+	# Rootfs may exceed one kernel-sized block; read exactly squashfs_used from offset.
+	xb432v_bb dd if="$file" bs=1 skip="$XB432V_KERNEL_MTD" count="$rootfs_len" 2>/dev/null | \
+		mtd write - rootfs || return 1
+
+	if [ "${SAVE_CONFIG:-1}" = "0" ]; then
+		xb432v_erase_overlay_tail "$rootfs_len" || return 1
+	else
+		v "Preserving jffs2 overlay tail after squashfs (config-preserving upgrade)"
+	fi
+
+	xb432v_bb sync
+	return 0
+}
+
+xb432v_check_tpv3() {
+	local file="$1"
+	local tagver
+
+	tagver=$(dd if="$file" bs=4 count=1 2>/dev/null | hexdump -v -n 4 -e '1/1 "%02x"')
+	[ "$tagver" = "$XB432V_TP_V3_VERSION" ] || {
+		v "missing TP-Link v3 tag (03000003)"
+		return 1
+	}
+	return 0
+}
 
 nokia_initial_setup()
 {
@@ -15,6 +214,12 @@ platform_check_image() {
 	[ "$#" -gt 1 ] && return 1
 
 	case "$board" in
+	tplink,xb432v)
+		xb432v_verify_mtd_layout || return 1
+		xb432v_check_sysupgrade_layout "$1" || return 1
+		xb432v_check_metadata "$1" || return 1
+		return 0
+		;;
 	nokia,xg-040g-md)
 		nand_do_platform_check "$board" "$1"
 		return $?
@@ -32,13 +237,17 @@ platform_do_upgrade() {
 	local board=$(board_name)
 
 	case "$board" in
-		gemtek,w1700k-ubi|\
-		nokia,xg-040g-md-ubi)
-			fit_do_upgrade "$1"
-			;;
-		*)
-			nand_do_upgrade "$1"
-			;;
+	tplink,xb432v)
+		# Raw MTD slot A only: kernel + rootfs. Never slave/recovery partitions.
+		xb432v_do_upgrade "$1"
+		;;
+	gemtek,w1700k-ubi|\
+	nokia,xg-040g-md-ubi)
+		fit_do_upgrade "$1"
+		;;
+	*)
+		nand_do_upgrade "$1"
+		;;
 	esac
 }
 
@@ -48,6 +257,12 @@ platform_pre_upgrade() {
 	case "$board" in
 	nokia,xg-040g-md)
 		nokia_initial_setup
+		;;
+	tplink,xb432v)
+		# Slot A kernel+rootfs only. JFFS2 overlay lives in the rootfs MTD tail
+		# after squashfs_used bytes. Default sysupgrade keeps that tail; -n / -F
+		# with SAVE_CONFIG=0 erases it so uci-defaults run again on first boot.
+		# Never touch firmware_slave (recovery B).
 		;;
 	*)
 		;;

--- a/target/linux/airoha/an7581/base-files/lib/upgrade/xb432v_wrap_tpv3.sh
+++ b/target/linux/airoha/an7581/base-files/lib/upgrade/xb432v_wrap_tpv3.sh
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Build a TP-Link v3 kernel blob (512-byte tag + FIT) for U-Boot tpimg.
+# Mirrors scripts/mk_tp_v3_fit.py for stage2 ramdisk (no Python).
+
+XB432V_TP_V3_TAG_LEN=512
+XB432V_TP_V3_TAG_VERSION=50331651
+
+xb432v_be32_to_dec() {
+	local hex="$1"
+	local b0 b1 b2 b3
+	b0=$((0x${hex:0:2}))
+	b1=$((0x${hex:2:2}))
+	b2=$((0x${hex:4:2}))
+	b3=$((0x${hex:6:2}))
+	echo $((b0 * 16777216 + b1 * 65536 + b2 * 256 + b3))
+}
+
+xb432v_fit_payload_len() {
+	local file="$1"
+	local magic hex len
+
+	magic=$(xb432v_bb dd if="$file" bs=4 count=1 2>/dev/null | \
+		xb432v_bb hexdump -v -n 4 -e '1/1 "%02x"')
+	[ "$magic" = "d00dfeed" ] || return 1
+	hex=$(xb432v_bb dd if="$file" bs=1 skip=4 count=4 2>/dev/null | \
+		xb432v_bb hexdump -v -n 4 -e '1/1 "%02x"')
+	len=$(xb432v_be32_to_dec "$hex")
+	[ "$len" -ge 64 ] || return 1
+	echo "$len"
+}
+
+xb432v_crc32_file() {
+	local file="$1"
+	xb432v_bb hexdump -v -e '1/1 "%u\n"' "$file" 2>/dev/null | xb432v_bb awk '
+BEGIN { crc = 0xffffffff }
+{
+	b = $1 + 0
+	crc = xor(crc, b)
+	for (i = 0; i < 8; i++) {
+		if (and(crc, 1)) {
+			crc = xor(rshift(crc, 1), 0xedb88320)
+		} else {
+			crc = rshift(crc, 1)
+		}
+		crc = and(crc, 0xffffffff)
+	}
+}
+END { printf "%u", and(xor(crc, 0xffffffff), 0xffffffff) }
+'
+}
+
+xb432v_write_le32() {
+	local file="$1" offset="$2" val="$3"
+	local b0 b1 b2 b3
+	b0=$((val & 255))
+	b1=$(((val >> 8) & 255))
+	b2=$(((val >> 16) & 255))
+	b3=$(((val >> 24) & 255))
+	# Busybox printf lacks %b; emit four raw bytes for little-endian u32.
+	printf "\\$(printf '%03o' "$b0")\\$(printf '%03o' "$b1")\\$(printf '%03o' "$b2")\\$(printf '%03o' "$b3")" | \
+		xb432v_bb dd of="$file" bs=1 seek="$offset" count=4 conv=notrunc 2>/dev/null
+}
+
+xb432v_build_tpv3_kernel() {
+	local file="$1"
+	local fit_len fit_file tag_file out_file kernel_crc image_len
+	local loadaddr=$((${XB432V_LOADADDR:-0x80088000}))
+
+	fit_len=$(xb432v_fit_payload_len "$file") || return 1
+	fit_file="$(mktemp)"
+	tag_file="$(mktemp)"
+	out_file="$(mktemp)"
+	trap 'rm -f "$fit_file" "$tag_file" "$out_file"' RETURN
+
+	xb432v_bb dd if="$file" bs=1 count="$fit_len" 2>/dev/null >"$fit_file" || return 1
+
+	kernel_crc=$(xb432v_crc32_file "$fit_file")
+	[ -n "$kernel_crc" ] || return 1
+	image_len=$((XB432V_TP_V3_TAG_LEN + fit_len))
+
+	xb432v_bb dd if=/dev/zero bs="$XB432V_TP_V3_TAG_LEN" count=1 2>/dev/null >"$tag_file" || return 1
+	xb432v_write_le32 "$tag_file" 0 "$XB432V_TP_V3_TAG_VERSION"
+	xb432v_write_le32 "$tag_file" 104 "$loadaddr"
+	xb432v_write_le32 "$tag_file" 108 "$loadaddr"
+	xb432v_write_le32 "$tag_file" 112 "$image_len"
+	xb432v_write_le32 "$tag_file" 116 "$XB432V_TP_V3_TAG_LEN"
+	xb432v_write_le32 "$tag_file" 120 "$fit_len"
+	xb432v_write_le32 "$tag_file" 152 "$kernel_crc"
+	printf '\125\252\125\252\361\342\323\304\345\246\152\136\114\075\056\037\252\125\252\125' | \
+		xb432v_bb dd of="$tag_file" bs=1 seek=84 count=20 conv=notrunc 2>/dev/null
+
+	cat "$tag_file" "$fit_file" >"$out_file"
+	cat "$out_file"
+	return 0
+}

--- a/target/linux/airoha/dts/an7581-tplink-xb432v.dts
+++ b/target/linux/airoha/dts/an7581-tplink-xb432v.dts
@@ -1,0 +1,459 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
+
+/dts-v1/;
+
+/* Stock DTB also memreserves 16 KiB at 0xabff9000 (see /proc/iomem reserved). */
+/memreserve/ 0xabff9000 0x4000;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include "an7581.dtsi"
+#include "an7581-npu-mt7992.dtsi"
+
+/ {
+	model = "TP-Link XB432v (ITWIND3)";
+	compatible = "tplink,xb432v", "econet,en7581", "airoha,an7581", "airoha,en7581";
+
+	aliases {
+		serial0 = &uart1;
+		led-boot = &led_power;
+		led-failsafe = &led_internet;
+		led-running = &led_power;
+		led-upgrade = &led_internet;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8 earlycon root=/dev/mtdblock5 rootfstype=squashfs,jffs2";
+		stdout-path = "serial0:115200n8";
+	};
+
+	/* Live cmdline: dram_limit=1024M */
+	memory@80000000 {
+		device_type = "memory";
+		reg = <0x0 0x80000000 0x0 0x40000000>;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			/* Stock led.conf LED_SYS_RESET: gpio 0, mode INPUT. */
+			gpios = <&en7581_pinctrl 0 GPIO_ACTIVE_LOW>;
+		};
+
+		/*
+		 * Do not bind WPS (stock gpio 1) or Wi-Fi radio (stock gpio 3).
+		 * One of those keys is physically broken. Mapping a damaged
+		 * switch can short a GPIO. pinctrl also rejects gpio 1 as pin-14.
+		 */
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: led-power {
+			label = "red:power";
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_POWER;
+			/* EVB uses gpio 17; XB432v mapping not confirmed on-device. */
+			gpios = <&en7581_pinctrl 17 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led_internet: led-internet {
+			label = "green:internet";
+			function = LED_FUNCTION_WAN;
+			/* Stock led.conf LED_INTERNET_STATUS gpio 9. */
+			gpios = <&en7581_pinctrl 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led_pon: led-pon {
+			label = "green:pon";
+			function = LED_FUNCTION_WAN;
+			/* Stock led.conf LED_XPON_STATUS gpio 6. */
+			gpios = <&en7581_pinctrl 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led_los: led-los {
+			label = "green:los";
+			function = LED_FUNCTION_FAULT;
+			/* Stock led.conf LED_XPON_LOS gpio 7. */
+			gpios = <&en7581_pinctrl 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led_usb: led-usb {
+			label = "green:usb";
+			function = LED_FUNCTION_USB;
+			gpios = <&en7581_pinctrl 22 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "usb-host";
+		};
+
+		led_wps: led-wps {
+			label = "green:wps";
+			function = LED_FUNCTION_WPS;
+			gpios = <&en7581_pinctrl 32 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+/* Stock DTB: ATF 256 KiB, NPU binary 1 MiB. Override an7581.dtsi (2 MiB / 10 MiB). */
+&atf {
+	reg = <0x0 0x80000000 0x0 0x40000>;
+};
+
+&npu_binary {
+	reg = <0x0 0x84000000 0x0 0x100000>;
+};
+
+&npu {
+	status = "okay";
+};
+
+&en7581_pinctrl {
+	gpio-ranges = <&en7581_pinctrl 0 13 50>;
+
+	mdio_pins: mdio-pins {
+		mux {
+			function = "mdio";
+			groups = "mdio";
+		};
+
+		conf {
+			pins = "gpio2";
+			output-high;
+		};
+	};
+
+	pcie0_rst_pins: pcie0-rst-pins {
+		conf {
+			pins = "pcie_reset0";
+			drive-open-drain = <1>;
+		};
+	};
+
+	pcie1_rst_pins: pcie1-rst-pins {
+		conf {
+			pins = "pcie_reset1";
+			drive-open-drain = <1>;
+		};
+	};
+
+	gswp1_led0_pins: gswp1-led0-pins {
+		mux {
+			function = "phy1_led0";
+			pins = "gpio33";
+		};
+	};
+
+	gswp2_led0_pins: gswp2-led0-pins {
+		mux {
+			function = "phy2_led0";
+			pins = "gpio34";
+		};
+	};
+
+	gswp3_led0_pins: gswp3-led0-pins {
+		mux {
+			function = "phy3_led0";
+			pins = "gpio35";
+		};
+	};
+
+	gswp4_led0_pins: gswp4-led0-pins {
+		mux {
+			function = "phy4_led0";
+			pins = "gpio42";
+		};
+	};
+};
+
+&snfi {
+	status = "okay";
+};
+
+&spi_nand {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Stock /proc/mtd order. U-Boot still passes root=/dev/mtdblock5. */
+		partition-whole {
+			label = "whole";
+			reg = <0x00000000 0x09c00000>;
+			read-only;
+		};
+
+		partition-boot {
+			label = "boot";
+			reg = <0x00000000 0x000c0000>;
+			read-only;
+		};
+
+		partition-art {
+			label = "art";
+			reg = <0x000c0000 0x00380000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				/* Stock l1profile.dat FLASH_offset=0x40000; mt76 EEPROM is 0x1e00. */
+				eeprom_art_40000: eeprom@40000 {
+					reg = <0x40000 0x1e00>;
+				};
+			};
+		};
+
+		partition-misc {
+			label = "misc";
+			reg = <0x00440000 0x00400000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_misc_8f100: macaddr@8f100 {
+					compatible = "mac-base";
+					reg = <0x8f100 0x6>;
+					#nvmem-cell-cells = <1>;
+				};
+			};
+		};
+
+		partition-kernel {
+			label = "kernel";
+			reg = <0x00840000 0x00a00000>;
+		};
+
+		partition-rootfs {
+			label = "rootfs";
+			reg = <0x01240000 0x03bc0000>;
+		};
+
+		/*
+		 * firmware spans kernel+rootfs (71424 KiB). U-Boot tpimg reads this
+		 * alias; Linux also exposes separate kernel/rootfs nodes at the same
+		 * offsets. sysupgrade writes kernel and rootfs MTDs independently.
+		 */
+		partition-firmware {
+			label = "firmware";
+			reg = <0x00840000 0x045c0000>;
+		};
+
+		partition-kernel-slave {
+			label = "kernel_slave";
+			reg = <0x04e00000 0x00a00000>;
+			read-only;
+		};
+
+		partition-rootfs-slave {
+			label = "rootfs_slave";
+			reg = <0x05800000 0x03bc0000>;
+			read-only;
+		};
+
+		partition-firmware-slave {
+			label = "firmware_slave";
+			reg = <0x04e00000 0x045c0000>;
+			read-only;
+		};
+
+		/* Live sysfs: mtd10 offset 0x09bc0000. 8 MiB before this is NAND BMT. */
+		partition-reserve {
+			label = "reserve";
+			reg = <0x09bc0000 0x00040000>;
+			read-only;
+		};
+	};
+};
+
+&i2c0 {
+	status = "okay";
+};
+
+&pcie0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_rst_pins>;
+	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+
+		/* MT799A HIF companion; EEPROM lives on the MT7992 node. */
+		wifi0: wifi@0,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+			airoha,npu = <&npu>;
+			airoha,eth = <&eth>;
+		};
+	};
+};
+
+&pcie1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie1_rst_pins>;
+	status = "okay";
+
+	pcie@1,0 {
+		reg = <0x0000 0 0 0 0>;
+
+		wifi1: wifi@0,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+			nvmem-cells = <&eeprom_art_40000>;
+			nvmem-cell-names = "eeprom";
+			airoha,npu = <&npu>;
+			airoha,eth = <&eth>;
+
+			band@0 {
+				reg = <0>;
+				nvmem-cells = <&macaddr_misc_8f100 0>;
+				nvmem-cell-names = "mac-address";
+			};
+
+			band@1 {
+				reg = <1>;
+				nvmem-cells = <&macaddr_misc_8f100 2>;
+				nvmem-cell-names = "mac-address";
+			};
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+};
+
+&gdm1 {
+	status = "okay";
+	nvmem-cells = <&macaddr_misc_8f100 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+	status = "okay";
+};
+
+&gsw_port1 {
+	status = "okay";
+	label = "lan1";
+};
+
+&gsw_phy1 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gswp1_led0_pins>;
+	status = "okay";
+};
+
+&gsw_phy1_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_GREEN>;
+	default-state = "off";
+};
+
+&gsw_port2 {
+	status = "okay";
+	label = "lan2";
+};
+
+&gsw_phy2 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gswp2_led0_pins>;
+	status = "okay";
+};
+
+&gsw_phy2_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_GREEN>;
+	default-state = "off";
+};
+
+&gsw_port3 {
+	status = "okay";
+	label = "lan3";
+};
+
+&gsw_phy3 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gswp3_led0_pins>;
+	status = "okay";
+};
+
+&gsw_phy3_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_GREEN>;
+	default-state = "off";
+};
+
+&gsw_port4 {
+	status = "okay";
+	label = "lan4";
+};
+
+&gsw_phy4 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gswp4_led0_pins>;
+	status = "okay";
+};
+
+&gsw_phy4_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_GREEN>;
+	default-state = "off";
+};
+
+/*
+ * One USB 2.0 jack. Stock serdes_usb2=02 maps to usb1 PHY, but the
+ * jack may be on usb0 (SERDES_USB1). Enable both as USB2-only like
+ * other AN7581 boards; do not guess a VBUS GPIO.
+ */
+&usb0 {
+	status = "okay";
+	mediatek,u3p-dis-msk = <0x1>;
+	phys = <&usb0_phy PHY_TYPE_USB2>;
+};
+
+&usb1 {
+	status = "okay";
+	mediatek,u3p-dis-msk = <0x1>;
+	phys = <&usb1_phy PHY_TYPE_USB2>;
+};
+
+/* Live 8811phy_addr=E-F-0-0-0. One eth PCS (GDM4); probe 0xF first, no reset GPIO. */
+&mdio {
+	en8811: ethernet-phy@f {
+		compatible = "ethernet-phy-id03a2.a411";
+		reg = <0xf>;
+	};
+};
+
+&eth_pcs {
+	status = "okay";
+};
+
+&gdm4 {
+	status = "okay";
+	openwrt,netdev-name = "lan5";
+	phy-handle = <&en8811>;
+	phy-mode = "2500base-x";
+};
+
+/*
+ * GPON (en7571 / GDM2 / pon_pcs) has no usable OpenWrt driver on 6.18 yet.
+ * Do not enable gdm2 until an xPON MAC exists.
+ */

--- a/target/linux/airoha/image/an7581.mk
+++ b/target/linux/airoha/image/an7581.mk
@@ -188,3 +188,26 @@ define Device/nokia_xg-040g-md-ubi
   ARTIFACTS := bl31-uboot.fip preloader.bin
 endef
 TARGET_DEVICES += nokia_xg-040g-md-ubi
+define Device/tplink_xb432v
+  $(call Device/FitImageLzma)
+  DEVICE_VENDOR := TP-Link
+  DEVICE_MODEL := XB432v
+  DEVICE_VARIANT := ITWIND3
+  DEVICE_DTS := an7581-tplink-xb432v
+  DEVICE_DTS_CONFIG := config@1
+  DEVICE_PACKAGES := kmod-leds-gpio kmod-usb3 \
+	airoha-en7581-npu-firmware kmod-mt7992-firmware wpad-basic-mbedtls \
+	kmod-phy-airoha-en8811h
+  # Stock U-Boot loads FIT at 0x81800200; vendor load/entry below initramfs.
+  KERNEL_LOADADDR := 0x80088000
+  BLOCKSIZE := 256k
+  PAGESIZE := 2048
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 256k
+  KERNEL_INITRAMFS_SUFFIX := -initramfs.itb
+  KERNEL_SIZE := 10240k
+  IMAGE_SIZE := 71424k
+  IMAGES := sysupgrade.bin
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-rootfs | pad-rootfs | check-size | append-metadata
+endef
+TARGET_DEVICES += tplink_xb432v


### PR DESCRIPTION
## Summary

Add TP-Link XB432v (AN7581, MT7992 + NPU, EN8811H 2.5G LAN) to the airoha/an7581 subtarget.

- Device tree: raw NAND dual-bank layout matching stock U-Boot (`kernel`/`rootfs` slot A, read-only slot B recovery), MT7530 GSW, EN8811H on `lan5`.
- Image: 10 MiB kernel + 71424 KiB firmware, FIT sysupgrade, KERNEL_LOADADDR 0x80088000 (vendor U-Boot load address).
- Sysupgrade: board-specific raw MTD path (not UBI). Kernel partition requires TP-Link v3 512-byte tag wrapping the FIT at upgrade time (`xb432v_wrap_tpv3.sh`). Rootfs uses squashfs_used bytes from the image; slot B is never written.

Reference: Nokia XG-040G-MD (EN8811H PHY, an7581 target).

## Tested-by

Offline: sysupgrade.bin layout validation, platform.sh dry-run (kernel tag 03000003, rootfs hsqs, jffs2 tail wipe). Device boot on OpenWrt slot A with recovery-check PASS.

## Flashing warnings

- Dual NAND banks: incorrect sysupgrade can brick slot A; slot B retains stock recovery.
- Do not use mktplinkfw3 web-upgrade images; U-Boot expects tpimg v3 tag + FIT.
- First install typically requires UART/tftp or vendor recovery; not web UI.
