### PR TITLE
realtek: fix NicGiga S100-0800S-M flash size

### DIFF
--- a/target/linux/realtek/dts/rtl9303_nicgiga_s100-0800s-m.dts
+++ b/target/linux/realtek/dts/rtl9303_nicgiga_s100-0800s-m.dts
@@ -191,7 +191,7 @@
 
 			partition@300000 {
 				compatible = "openwrt,uimage", "denx,uimage";
-				reg = <0x300000 0x1d00000>;
+				reg = <0x300000 0xd00000>;
 				label = "firmware";
 				openwrt,ih-magic = <0x93030000>;
 			};

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -146,7 +146,7 @@ define Device/nicgiga_s100-0800s-m
   DEVICE_VENDOR := NicGiga
   DEVICE_MODEL := S100-0800S-M
   DEVICE_PACKAGES := kmod-gpio-pca953x
-  IMAGE_SIZE := 29696k
+  IMAGE_SIZE := 13312k
   $(Device/kernel-lzma)
 endef
 TARGET_DEVICES += nicgiga_s100-0800s-m


### PR DESCRIPTION
The NicGiga S100-0800S-M has a **16 MiB** SPI-NOR, not 32 MiB.

### Background

This is the follow-up to @jonasjelonek's last review comment on #23579:

> Just one last thing. In the last AI review, it noted the IMAGE_SIZE not being
> correct regarding the partition. I know TL-ST1008F is wrong too, but I'll fix
> this later.

I fixed the symptom at the time — aligning `IMAGE_SIZE` down from the inherited
31808k to 29696k so it matched the firmware partition. I also said the partition
"fills the 32 MiB flash", which was wrong. The partition had been inherited from
`rtl9303_tplink_tl-st1008f-v2.dts` along with everything else, but I should have
validated against the actual chip. Both numbers were describing the TL-ST1008F's
flash, not this board's.

This PR corrects both of them for the NicGiga.

### Evidence

The chip identifies itself as a Winbond W25Q128 (JEDEC `ef 40 18` = 128 Mbit):

```
# cd /sys/bus/spi/devices/spi0.0/spi-nor
# cat jedec_id manufacturer partname
ef4018
winbond
w25q128
```

so the kernel truncates the oversized partition at every boot:

```
[    0.679519] 6 fixed-partitions partitions found on MTD device spi0.0
[    0.687292] Creating 6 MTD partitions on "spi0.0":
[    0.740421] mtd: partition "firmware" extends beyond the end of device "spi0.0" -- size truncated to 0xd00000
```

The vendor firmware uses the same layout and fills the chip exactly, which
rules out this being a smaller variant of a 32 MiB product:

```
mtd0: 000e0000 "u-boot"       896K
mtd1: 00010000 "u-boot-env"    64K
mtd2: 00010000 "u-boot-env2"   64K
mtd3: 00100000 "jffs2-cfg"   1024K
mtd4: 00100000 "jffs2-log"   1024K
mtd5: 00d00000 "firmware"   13312K
                            ------
                            16384K = 16 MiB
```

### The fix

Corrects the partition to `<0x300000 0xd00000>` and `IMAGE_SIZE` to `13312k`,
which is exactly what the other RTL9303 boards on this Realtek reference layout
already use with 16 MiB flash — Vimin VM-S100-0800MS and Sirivision SR-ST3408F.

### Impact

Latent, not currently breaking. The current snapshot sysupgrade image is 5.6 MiB,
far under the truncated 13312k, and mtdsplit already derives `rootfs_data` from
the truncated partition, so running installs behave correctly. The problem is
that `check-size` accepts builds up to 29696k — more than twice what the flash
can hold — so a future growth in image size would produce an image that silently
passes the build and then cannot be written.

No `DEVICE_COMPAT_VERSION` bump: the board name is unchanged and no released
image has ever exceeded 13312k, so no existing installation is affected.

### Testing

The evidence above was gathered on hardware running the current unmodified
snapshot (r35984-aa86f992b2, kernel 6.18.44). I have not built and flashed an
image containing this patch.

That is a deliberate choice rather than an oversight. The kernel already
truncates the partition to `0xd00000` on every boot, so a build with this patch
produces a partition layout byte-identical to what the device runs today —
nothing about the flashed image, the mtdsplit result or `rootfs_data` changes.
The only behavioural difference is at build time, where `check-size` starts
rejecting images over 13312k instead of 29696k. Structurally everything else is
the same; this is a corrected note on the real headroom plus the one-line
`IMAGE_SIZE` change that follows from it.

This device is my production switch and reflashing it costs a real outage on my
network, so I would rather not do that for a change with no runtime delta. I
found the discrepancy while taking the box up to a recent snapshot, and I would
rather correct it now than leave a `check-size` limit at more than twice the
flash size for someone to walk into later — unlikely as that is, given how small
the install base for this board probably is and will stay.

If a full build-test is necessary before merge, I am happy to do one when time
allows — just let me know.

### Note for a follow-up (not touched here)

For the record, `tplink_tl-st1008f-v2` is still `IMAGE_SIZE := 31808k` against a
29696k firmware partition — the same mismatch from the comment above. Leaving it
to you rather than patching it blind, since I don't have that hardware and can't
confirm whether its partition or its `IMAGE_SIZE` is the wrong one.
