### PR TITLE
realtek: add support for RTL9607C PCIE Controller

### DIFF
--- a/target/linux/realtek/files-6.18/arch/mips/include/asm/mach-rtl-otto/spaces.h
+++ b/target/linux/realtek/files-6.18/arch/mips/include/asm/mach-rtl-otto/spaces.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#ifndef __ASM_MACH_RTL_OTTO_SPACES_H_
+#define __ASM_MACH_RTL_OTTO_SPACES_H_
+
+#ifdef CONFIG_RTL960X
+
+/* Double space for RTL9607C - for two PCIe ports */
+
+#define PCI_IOSIZE	(SZ_64K * 2)
+#define IO_SPACE_LIMIT	(PCI_IOSIZE - 1)
+#endif /* CONFIG_RTL960X */
+
+#include <asm/mach-generic/spaces.h>
+
+#endif /* __ASM_MACH_RTL_OTTO_SPACES_H */

--- a/target/linux/realtek/files-6.18/drivers/pci/controller/pcie-realtek.c
+++ b/target/linux/realtek/files-6.18/drivers/pci/controller/pcie-realtek.c
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/* PCIe host controller driver for Realtek SoCs */
+
+#include <linux/bitfield.h>
+#include <linux/bitops.h>
+#include <linux/delay.h>
+#include <linux/gpio/consumer.h>
+#include <linux/io.h>
+#include <linux/iopoll.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/pci.h>
+#include <linux/phy/phy.h>
+#include <linux/platform_device.h>
+
+#include "../pci.h"
+
+/* Host config register offsets */
+#define RTPCIE_HOSTCFG_CAP	0x70
+#define RTPCIE_HOSTCFG_ENABLE	0x80c
+#define RTPCIE_ENABLE_BIT17	BIT(17)
+#define RTPCIE_LINK_STATUS	0x728
+#define RTPCIE_LINKUP_MASK	GENMASK(4, 0)
+#define RTPCIE_IS_LINKUP	(BIT(4) | BIT(0))
+#define RTPCIE_PCI_CMD_BIT20	BIT(20)
+/**
+ * struct rtpcie_ctrl - Realtek PCIe port information
+ * @dev: pointer to PCIe device
+ * @hostcfg_base: host config register base
+ * @hostext_base: host extension register base
+ * @devcfg_base: device config register base
+ * @reset_gpio: gpio reset
+ * @phy: pointer to PHY control block
+ * @bus_number: assigned PCI bus number
+ */
+struct rtpcie_ctrl {
+	struct device *dev;
+	void __iomem *hostcfg_base;
+	void __iomem *hostext_base;
+	void __iomem *devcfg_base;
+	struct gpio_desc *reset_gpio;
+	struct phy *phy;
+	u8 bus_number;
+};
+
+static void __iomem *rtpcie_map_bus(struct pci_bus *bus, unsigned int devfn, int where)
+{
+	struct rtpcie_ctrl *pcie = bus->sysdata;
+
+	if (pcie->bus_number == 0xff)
+		pcie->bus_number = bus->number;
+
+	if (bus->number != pcie->bus_number)
+		return NULL;
+
+	writel(PCI_FUNC(devfn), pcie->hostext_base);
+
+	switch (PCI_SLOT(devfn)) {
+	case 0:
+		return pcie->hostcfg_base + where;
+	case 1:
+		return pcie->devcfg_base + where;
+	default:
+		return NULL;
+	}
+}
+
+static struct pci_ops rtpcie_ops = {
+	.map_bus = rtpcie_map_bus,
+	.read = pci_generic_config_read,
+	.write = pci_generic_config_write,
+};
+
+static int rtpcie_hw_init(struct rtpcie_ctrl *pcie)
+{
+	u16 devctl, link;
+	int err;
+	u32 val;
+
+	/* Assert reset pcie */
+	gpiod_set_value_cansleep(pcie->reset_gpio, 1);
+
+	err = phy_init(pcie->phy);
+	if (err) {
+		dev_err(pcie->dev, "failed to initialize pcie-phy\n");
+		return err;
+	}
+
+	/* Deassert reset pcie */
+	gpiod_set_value_cansleep(pcie->reset_gpio, 0);
+
+	/* Wait for Link Up */
+	err = readl_poll_timeout(pcie->hostcfg_base + RTPCIE_LINK_STATUS, val,
+				 (val & RTPCIE_LINKUP_MASK) == RTPCIE_IS_LINKUP,
+				 10000, 100000);
+
+	if (err) {
+		dev_err(pcie->dev, "PCIE Link Up Failed!\n");
+		phy_exit(pcie->phy);
+		return err;
+	}
+
+	msleep(100);
+
+	/* Enable PCIE host */
+	val = RTPCIE_PCI_CMD_BIT20 | PCI_COMMAND_IO | PCI_COMMAND_MEMORY | PCI_COMMAND_MASTER;
+	writel(val, pcie->hostcfg_base + PCI_COMMAND);
+
+	/* Clear max payload size bits in DEVCTL */
+	devctl = readw(pcie->hostcfg_base + RTPCIE_HOSTCFG_CAP + PCI_EXP_DEVCTL);
+	devctl &= ~PCI_EXP_DEVCTL_PAYLOAD;
+	writew(devctl, pcie->hostcfg_base + RTPCIE_HOSTCFG_CAP + PCI_EXP_DEVCTL);
+
+	val = readl(pcie->hostcfg_base + RTPCIE_HOSTCFG_ENABLE);
+	writel(val | RTPCIE_ENABLE_BIT17, pcie->hostcfg_base + RTPCIE_HOSTCFG_ENABLE);
+
+	usleep_range(1000, 2000);
+
+	link = readw(pcie->hostcfg_base + RTPCIE_HOSTCFG_CAP + PCI_EXP_LNKSTA);
+	dev_info(pcie->dev, "link up, %s\n",
+		 pci_speed_string(pcie_link_speed[FIELD_GET(PCI_EXP_LNKSTA_CLS, link)]));
+
+	return err;
+}
+
+static int rtpcie_probe(struct platform_device *pdev)
+{
+	struct device *dev = &pdev->dev;
+	struct rtpcie_ctrl *pcie;
+	struct pci_host_bridge *bridge;
+	int ret;
+
+	bridge = devm_pci_alloc_host_bridge(dev, sizeof(*pcie));
+	if (!bridge)
+		return -ENOMEM;
+
+	pcie = pci_host_bridge_priv(bridge);
+	pcie->dev = dev;
+	pcie->bus_number = 0xff;
+	platform_set_drvdata(pdev, pcie);
+
+	pcie->hostcfg_base = devm_platform_ioremap_resource_byname(pdev, "hostcfg");
+	if (IS_ERR(pcie->hostcfg_base))
+		return dev_err_probe(dev, PTR_ERR(pcie->hostcfg_base),
+				     "failed to map hostcfg\n");
+
+	pcie->hostext_base = devm_platform_ioremap_resource_byname(pdev, "hostext");
+	if (IS_ERR(pcie->hostext_base))
+		return dev_err_probe(dev, PTR_ERR(pcie->hostext_base),
+				     "failed to map hostext\n");
+
+	pcie->devcfg_base = devm_platform_ioremap_resource_byname(pdev, "devcfg");
+	if (IS_ERR(pcie->devcfg_base))
+		return dev_err_probe(dev, PTR_ERR(pcie->devcfg_base),
+				     "failed to map devcfg\n");
+
+	pcie->reset_gpio = devm_gpiod_get(dev, "reset", GPIOD_OUT_LOW);
+	if (IS_ERR(pcie->reset_gpio))
+		return dev_err_probe(dev, PTR_ERR(pcie->reset_gpio),
+				     "failed to get reset GPIO\n");
+
+	pcie->phy = devm_of_phy_get(dev, dev->of_node, NULL);
+	if (IS_ERR(pcie->phy))
+		return dev_err_probe(dev, PTR_ERR(pcie->phy), "failed to get pcie-phy");
+
+	ret = rtpcie_hw_init(pcie);
+	if (ret)
+		return ret;
+
+	bridge->sysdata = pcie;
+	bridge->ops = &rtpcie_ops;
+
+	ret = pci_host_probe(bridge);
+	if (ret) {
+		phy_exit(pcie->phy);
+		return ret;
+	}
+
+	return 0;
+}
+
+static const struct of_device_id rtpcie_of_match[] = {
+	{ .compatible = "realtek,rtl9607c-pcie" },
+	{ /* sentinel */ }
+};
+MODULE_DEVICE_TABLE(of, rtpcie_of_match);
+
+static struct platform_driver rtpcie_driver = {
+	.probe = rtpcie_probe,
+	.driver = {
+		.name = "realtek-pcie",
+		.of_match_table = rtpcie_of_match,
+	},
+};
+builtin_platform_driver(rtpcie_driver);
+
+MODULE_DESCRIPTION("PCIe host controller driver for Realtek SoC");
+MODULE_LICENSE("GPL");

--- a/target/linux/realtek/files-6.18/drivers/phy/realtek/phy-rtk-pcie.c
+++ b/target/linux/realtek/files-6.18/drivers/phy/realtek/phy-rtk-pcie.c
@@ -1,0 +1,384 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <linux/bitfield.h>
+#include <linux/delay.h>
+#include <linux/mfd/syscon.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/phy/phy.h>
+#include <linux/platform_device.h>
+#include <linux/regmap.h>
+#include <linux/reset.h>
+
+#define PCIE_MDIO_CTRL_PHY_REG		0x0
+#define PCIE_MDIO_CTRL_PHY_DATA_MASK	GENMASK(31, 16)
+#define PCIE_MDIO_CTRL_PHY_PAGE_MASK	GENMASK(15, 13)
+#define PCIE_MDIO_CTRL_PHY_ADDR_MASK	GENMASK(12, 8)
+#define PCIE_MDIO_CTRL_PHY_STATUS_MASK	GENMASK(6, 5)
+#define PCIE_MDIO_CTRL_PHY_STATUS_DONE	FIELD_PREP(PCIE_MDIO_CTRL_PHY_STATUS_MASK, 1)
+#define PCIE_MDIO_CTRL_PHY_READY	BIT(4)
+#define PCIE_MDIO_CTRL_PHY_WRITE	BIT(0)
+#define PCIE_MDIO_CTRL_PHY_READ		0
+
+#define PCIE_PHY_POWER_CTRL_REG		0x08
+#define PHY_RESET_BIT			BIT(7)
+#define ENABLE_LTSSM_BIT		BIT(0)
+
+#define PCIE_PHY_CTRL_MDRST0		BIT(24)
+#define PCIE_PHY_CTRL_MDRST1		BIT(21)
+#define PCIE_PHY_CTRL_DIS0		BIT(15)
+#define PCIE_PHY_CTRL_DIS1		BIT(14)
+
+#define MAX_PCIE_PHY_DATA_SIZE		0x30
+
+#define PHY_GEN1_PAGE			0x0
+#define PHY_GEN2_PAGE			0x2
+
+#define PHY_ADDR_0X09			0x09
+#define REG_0X09_FORCE_CALIBRATION	BIT(9)
+
+struct phy_data {
+	u8 page;
+	u8 addr;
+	u16 data;
+};
+
+struct phy_cfg {
+	struct phy_data gen1_param[MAX_PCIE_PHY_DATA_SIZE];
+	struct phy_data gen2_param[MAX_PCIE_PHY_DATA_SIZE];
+	bool do_toggle;
+	u32 mdio_reset_bit;
+	u32 disable_bit;
+};
+
+struct rtk_phy {
+	struct device *dev;
+	struct phy *phy;
+	const struct phy_cfg *phy_cfg;
+	struct regmap *regmap;
+	struct regmap *pcie_misc_map;
+	struct reset_control *phy_rst;
+};
+
+static int rtk_phy_wait_done_and_ready(struct regmap *regmap)
+{
+	u32 val, cond;
+
+	cond = PCIE_MDIO_CTRL_PHY_STATUS_DONE | PCIE_MDIO_CTRL_PHY_READY;
+
+	return regmap_read_poll_timeout(regmap, PCIE_MDIO_CTRL_PHY_REG, val,
+					(val & cond) == cond, 10, 2000);
+}
+
+static int rtk_phy_write(struct rtk_phy *rtk_phy, u8 page, u8 addr, u16 data)
+{
+	int ret;
+
+	ret = regmap_write(rtk_phy->regmap, PCIE_MDIO_CTRL_PHY_REG,
+			   FIELD_PREP(PCIE_MDIO_CTRL_PHY_PAGE_MASK, page) |
+			   FIELD_PREP(PCIE_MDIO_CTRL_PHY_DATA_MASK, data) |
+			   FIELD_PREP(PCIE_MDIO_CTRL_PHY_ADDR_MASK, addr) |
+			   PCIE_MDIO_CTRL_PHY_WRITE);
+	if (ret)
+		return ret;
+
+	return rtk_phy_wait_done_and_ready(rtk_phy->regmap);
+}
+
+static int rtk_phy_read(struct rtk_phy *rtk_phy, u8 page, u8 addr, u16 *data)
+{
+	u32 val;
+	int ret;
+
+	ret = regmap_write(rtk_phy->regmap, PCIE_MDIO_CTRL_PHY_REG,
+			   FIELD_PREP(PCIE_MDIO_CTRL_PHY_PAGE_MASK, page) |
+			   FIELD_PREP(PCIE_MDIO_CTRL_PHY_ADDR_MASK, addr) |
+			   PCIE_MDIO_CTRL_PHY_READ);
+	if (ret)
+		return ret;
+
+	ret = rtk_phy_wait_done_and_ready(rtk_phy->regmap);
+	if (ret)
+		return ret;
+
+	ret = regmap_read(rtk_phy->regmap, PCIE_MDIO_CTRL_PHY_REG, &val);
+	if (ret)
+		return ret;
+
+	*data = FIELD_GET(PCIE_MDIO_CTRL_PHY_DATA_MASK, val);
+
+	return 0;
+}
+
+static int rtk_phy_toggle_calibration(struct rtk_phy *rtk_phy, u8 page, u8 addr)
+{
+	const struct phy_cfg *phy_cfg = rtk_phy->phy_cfg;
+	u16 data;
+	int ret;
+
+	if (!phy_cfg->do_toggle)
+		return 0;
+
+	ret = rtk_phy_read(rtk_phy, page, addr, &data);
+	if (ret)
+		return ret;
+
+	ret = rtk_phy_write(rtk_phy, page, addr, data & (~REG_0X09_FORCE_CALIBRATION));
+	if (ret)
+		return ret;
+
+	return rtk_phy_write(rtk_phy, page, addr, data | REG_0X09_FORCE_CALIBRATION);
+}
+
+static int rtk_phy_init(struct phy *phy)
+{
+	struct rtk_phy *rtk_phy = phy_get_drvdata(phy);
+	const struct phy_cfg *phy_cfg = rtk_phy->phy_cfg;
+	int ret, i = 0;
+
+	/* PCIE phy mdio reset */
+	ret = regmap_clear_bits(rtk_phy->pcie_misc_map, 0, phy_cfg->disable_bit);
+	if (ret)
+		return ret;
+
+	ret = regmap_clear_bits(rtk_phy->pcie_misc_map, 0, phy_cfg->mdio_reset_bit);
+	if (ret)
+		return ret;
+
+	ret = regmap_set_bits(rtk_phy->pcie_misc_map, 0, phy_cfg->mdio_reset_bit);
+	if (ret)
+		return ret;
+
+	/* PCIE IP Reset */
+	ret = reset_control_deassert(rtk_phy->phy_rst);
+	if (ret)
+		return ret;
+
+	usleep_range(10000, 11000);
+
+	/* Pulse the active-low PCIe PHY reset bit to software reset the PHY */
+	ret = regmap_clear_bits(rtk_phy->regmap, PCIE_PHY_POWER_CTRL_REG, PHY_RESET_BIT);
+	if (ret)
+		goto err_assert_phy_reset;
+
+	/* TODO: Check if ENABLE_LTSSM_BIT need to set here */
+	ret = regmap_set_bits(rtk_phy->regmap, PCIE_PHY_POWER_CTRL_REG, PHY_RESET_BIT);
+	if (ret)
+		goto err_assert_phy_reset;
+
+	msleep(50);
+
+	/* Set gen 1 parameters */
+	for (i = 0; i < ARRAY_SIZE(phy_cfg->gen1_param); i++) {
+		if (phy_cfg->gen1_param[i].page == 0 &&
+		    phy_cfg->gen1_param[i].addr == 0 &&
+		    phy_cfg->gen1_param[i].data == 0)
+			break;
+
+		ret = rtk_phy_write(rtk_phy, phy_cfg->gen1_param[i].page,
+				    phy_cfg->gen1_param[i].addr, phy_cfg->gen1_param[i].data);
+		if (ret)
+			goto err_assert_phy_reset;
+	}
+
+	/* toggle calibration for gen 1 parameters */
+	ret = rtk_phy_toggle_calibration(rtk_phy, PHY_GEN1_PAGE, PHY_ADDR_0X09);
+	if (ret)
+		goto err_assert_phy_reset;
+
+	/* Set gen 2 parameters */
+	for (i = 0; i < ARRAY_SIZE(phy_cfg->gen2_param); i++) {
+		if (phy_cfg->gen2_param[i].page == 0 &&
+		    phy_cfg->gen2_param[i].addr == 0 &&
+		    phy_cfg->gen2_param[i].data == 0)
+			break;
+
+		ret = rtk_phy_write(rtk_phy, phy_cfg->gen2_param[i].page,
+				    phy_cfg->gen2_param[i].addr, phy_cfg->gen2_param[i].data);
+		if (ret)
+			goto err_assert_phy_reset;
+	}
+
+	/* toggle calibration for gen 2 parameters */
+	if (i != 0) {
+		ret = rtk_phy_toggle_calibration(rtk_phy, PHY_GEN2_PAGE, PHY_ADDR_0X09);
+		if (ret)
+			goto err_assert_phy_reset;
+	}
+
+	msleep(20);
+
+	return 0;
+
+err_assert_phy_reset:
+	reset_control_assert(rtk_phy->phy_rst);
+
+	return ret;
+}
+
+static int rtk_phy_exit(struct phy *phy)
+{
+	struct rtk_phy *rtk_phy = phy_get_drvdata(phy);
+
+	return reset_control_assert(rtk_phy->phy_rst);
+}
+
+static const struct phy_ops ops = {
+	.init		= rtk_phy_init,
+	.exit		= rtk_phy_exit,
+	.owner		= THIS_MODULE,
+};
+
+static int rtk_pcie_phy_probe(struct platform_device *pdev)
+{
+	static const struct regmap_config regmap_config = {
+		.reg_bits = 32,
+		.val_bits = 32,
+		.reg_stride = 4,
+		.max_register = PCIE_PHY_POWER_CTRL_REG,
+	};
+	struct rtk_phy *rtk_phy;
+	struct device *dev = &pdev->dev;
+	struct phy_provider *phy_provider;
+	const struct phy_cfg *phy_cfg;
+	void __iomem *base;
+
+	rtk_phy = devm_kzalloc(dev, sizeof(*rtk_phy), GFP_KERNEL);
+	if (!rtk_phy)
+		return -ENOMEM;
+
+	base = devm_platform_ioremap_resource(pdev, 0);
+	if (IS_ERR(base))
+		return dev_err_probe(dev, PTR_ERR(base),
+				     "Failed to map phy-reg-mdio base\n");
+
+	rtk_phy->regmap = devm_regmap_init_mmio(dev, base, &regmap_config);
+	if (IS_ERR(rtk_phy->regmap))
+		return PTR_ERR(rtk_phy->regmap);
+
+	rtk_phy->pcie_misc_map = syscon_regmap_lookup_by_phandle(dev->of_node, "realtek,pcie-misc");
+	if (IS_ERR(rtk_phy->pcie_misc_map))
+		return dev_err_probe(dev, PTR_ERR(rtk_phy->pcie_misc_map),
+				     "Failed to map pcie-misc registers\n");
+
+	rtk_phy->phy_rst = devm_reset_control_array_get_optional_exclusive(dev);
+	if (IS_ERR(rtk_phy->phy_rst))
+		return dev_err_probe(dev, PTR_ERR(rtk_phy->phy_rst),
+				     "Failed to get pcie phy resets\n");
+
+	rtk_phy->dev = dev;
+	phy_cfg = of_device_get_match_data(dev);
+	if (!phy_cfg)
+		return dev_err_probe(dev, -EINVAL, "phy config are not assigned!\n");
+
+	rtk_phy->phy_cfg = phy_cfg;
+
+	platform_set_drvdata(pdev, rtk_phy);
+
+	rtk_phy->phy = devm_phy_create(dev, NULL, &ops);
+	if (IS_ERR(rtk_phy->phy))
+		return dev_err_probe(dev, PTR_ERR(rtk_phy->phy),
+				     "Failed to create PCIe phy\n");
+
+	phy_set_drvdata(rtk_phy->phy, rtk_phy);
+
+	phy_provider = devm_of_phy_provider_register(dev, of_phy_simple_xlate);
+	if (IS_ERR(phy_provider))
+		return PTR_ERR(phy_provider);
+
+	return 0;
+}
+
+static const struct phy_cfg rtl9607c_revB_gen2x1_phy_cfg = {
+	.gen1_param = {
+		{0x0, 0x01, 0xa852}, {0x0, 0x06, 0x0017}, {0x0, 0x08, 0x3591},
+		{0x0, 0x09, 0x520c}, {0x0, 0x0a, 0xf670}, {0x0, 0x0b, 0xa90d},
+		{0x0, 0x0d, 0xe720}, {0x0, 0x0e, 0x1010}, {0x0, 0x1c, 0x2001},
+		{0x0, 0x1e, 0x66eb}, {0x1, 0x00, 0xd4a4}, {0x1, 0x01, 0x485a},
+		{0x1, 0x03, 0x0b66}, {0x1, 0x04, 0x4f0c}, {0x1, 0x09, 0xf0f3},
+		{0x1, 0x0b, 0xa0a1},
+	},
+	.gen2_param = {
+		{0x2, 0x01, 0xa849}, {0x2, 0x06, 0x0017}, {0x2, 0x08, 0x3591},
+		{0x2, 0x09, 0x520c}, {0x2, 0x0a, 0xf650}, {0x2, 0x0b, 0xa90d},
+		{0x2, 0x0d, 0xe720}, {0x2, 0x0e, 0x1010}, {0x2, 0x1c, 0x2001},
+		{0x3, 0x00, 0xd4a6}, {0x3, 0x01, 0x586a}, {0x3, 0x03, 0x0b66},
+		{0x3, 0x09, 0xf0f3}, {0x3, 0x0b, 0xa0a1}, {0x3, 0x0f, 0x5046},
+	},
+	.do_toggle = true,
+	.mdio_reset_bit = PCIE_PHY_CTRL_MDRST0,
+	.disable_bit = PCIE_PHY_CTRL_DIS0,
+};
+
+static const struct phy_cfg rtl9607c_revB_gen1x1_phy_cfg = {
+	.gen1_param = {
+		{0x0, 0x01, 0xa852}, {0x0, 0x06, 0x0017}, {0x0, 0x08, 0x3591},
+		{0x0, 0x09, 0x520c}, {0x0, 0x0a, 0xf670}, {0x0, 0x0b, 0xa90d},
+		{0x0, 0x0d, 0xe720}, {0x0, 0x0e, 0x1010}, {0x0, 0x1c, 0x2001},
+		{0x0, 0x1e, 0x66eb}, {0x1, 0x00, 0xd4a4}, {0x1, 0x01, 0x485a},
+		{0x1, 0x03, 0x0b66}, {0x1, 0x04, 0x4f0c}, {0x1, 0x09, 0xf0f3},
+		{0x1, 0x0b, 0xa0a1},
+	},
+	.gen2_param = { /* no parameter */ },
+	.do_toggle = true,
+	.mdio_reset_bit = PCIE_PHY_CTRL_MDRST1,
+	.disable_bit = PCIE_PHY_CTRL_DIS1,
+};
+
+static const struct phy_cfg rtl9607c_revA_gen2x1_phy_cfg = {
+	.gen1_param = {
+		{0x0, 0x00, 0x4008}, {0x0, 0x01, 0xa812}, {0x0, 0x02, 0x6042},
+		{0x0, 0x04, 0x5000}, {0x0, 0x05, 0x230a}, {0x0, 0x06, 0x0011},
+		{0x0, 0x09, 0x520c}, {0x0, 0x0a, 0xc670}, {0x0, 0x0b, 0xb905},
+		{0x0, 0x0d, 0xef16}, {0x0, 0x0e, 0x0000}, {0x1, 0x00, 0x9499},
+		{0x1, 0x01, 0x66aa}, {0x1, 0x07, 0x011a},
+	},
+	.gen2_param = {
+		{0x2, 0x00, 0x4008}, {0x2, 0x01, 0xa811}, {0x2, 0x02, 0x6042},
+		{0x2, 0x04, 0x5000}, {0x2, 0x05, 0x230a}, {0x2, 0x06, 0x0011},
+		{0x2, 0x09, 0x520c}, {0x2, 0x0a, 0xc670}, {0x2, 0x0b, 0xb905},
+		{0x2, 0x0d, 0xef16}, {0x2, 0x0e, 0x0000}, {0x2, 0x0f, 0x000c},
+		{0x2, 0x1b, 0xaea1}, {0x2, 0x1e, 0x28eb}, {0x3, 0x00, 0x94aa},
+		{0x3, 0x01, 0x88ff}, {0x3, 0x02, 0x0093}, {0x3, 0x07, 0x011a},
+		{0x3, 0x0f, 0x65bd},
+	},
+	.do_toggle = true,
+	.mdio_reset_bit = PCIE_PHY_CTRL_MDRST0,
+	.disable_bit = PCIE_PHY_CTRL_DIS0,
+};
+
+static const struct phy_cfg rtl9607c_revA_gen1x1_phy_cfg = {
+	.gen1_param = {
+		{0x0, 0x00, 0x8a50}, {0x0, 0x02, 0x26f9}, {0x0, 0x03, 0x6bcd},
+		{0x0, 0x04, 0x8049}, {0x0, 0x06, 0x1088}, {0x0, 0x07, 0x52b3},
+		{0x0, 0x08, 0x5285}, {0x0, 0x09, 0x6300}, {0x0, 0x0b, 0x0009},
+		{0x0, 0x0c, 0x0800}, {0x0, 0x0e, 0x0093}, {0x1, 0x00, 0x0105},
+		{0x1, 0x01, 0x1000},
+	},
+	.gen2_param = { /* no parameter */ },
+	.do_toggle = false,
+	.mdio_reset_bit = PCIE_PHY_CTRL_MDRST1,
+	.disable_bit = PCIE_PHY_CTRL_DIS1,
+};
+
+static const struct of_device_id rtk_pcie_phy_dt_match[] = {
+	{ .compatible = "realtek,rtl9607c-revA-gen1x1-pcie-phy", .data = &rtl9607c_revA_gen1x1_phy_cfg },
+	{ .compatible = "realtek,rtl9607c-revA-gen2x1-pcie-phy", .data = &rtl9607c_revA_gen2x1_phy_cfg },
+	{ .compatible = "realtek,rtl9607c-revB-gen1x1-pcie-phy", .data = &rtl9607c_revB_gen1x1_phy_cfg },
+	{ .compatible = "realtek,rtl9607c-revB-gen2x1-pcie-phy", .data = &rtl9607c_revB_gen2x1_phy_cfg },
+	{},
+};
+MODULE_DEVICE_TABLE(of, rtk_pcie_phy_dt_match);
+
+static struct platform_driver rtk_pcie_phy_driver = {
+	.probe		= rtk_pcie_phy_probe,
+	.driver		= {
+		.name	= "rtk-pcie-phy",
+		.of_match_table = rtk_pcie_phy_dt_match,
+	},
+};
+
+module_platform_driver(rtk_pcie_phy_driver);
+
+MODULE_DESCRIPTION("Realtek PCIe PHY driver");
+MODULE_LICENSE("GPL");

--- a/target/linux/realtek/patches-6.18/821-add-realtek-pcie-phy-driver.patch
+++ b/target/linux/realtek/patches-6.18/821-add-realtek-pcie-phy-driver.patch
@@ -1,0 +1,33 @@
+--- a/drivers/phy/realtek/Kconfig
++++ b/drivers/phy/realtek/Kconfig
+@@ -3,7 +3,7 @@
+ # Phy drivers for Realtek platforms
+ #
+ 
+-if ARCH_REALTEK || COMPILE_TEST
++if ARCH_REALTEK || (MACH_REALTEK_RTL && RTL960X) || COMPILE_TEST
+ 
+ config PHY_RTK_RTD_USB2PHY
+ 	tristate "Realtek RTD USB2 PHY Transceiver Driver"
+@@ -29,4 +29,13 @@ config PHY_RTK_RTD_USB3PHY
+ 	  DWC3 USB IP. This driver will do the PHY initialization
+ 	  of the parameters.
+ 
+-endif # ARCH_REALTEK || COMPILE_TEST
++config PHY_RTK_PCIEPHY
++	tristate "Realtek PCIE PHY Transceiver Driver"
++	depends on OF
++	select GENERIC_PHY
++	help
++	  Say 'Y' here to add support for Realtek PCIE PHY driver.
++	  This driver create the basic PHY instance and provides initialize
++	  callback for PCIe port.
++
++endif # ARCH_REALTEK || (MACH_REALTEK_RTL && RTL960X) || COMPILE_TEST
+--- a/drivers/phy/realtek/Makefile
++++ b/drivers/phy/realtek/Makefile
+@@ -1,3 +1,4 @@
+ # SPDX-License-Identifier: GPL-2.0
+ obj-$(CONFIG_PHY_RTK_RTD_USB2PHY)	+= phy-rtk-usb2.o
+ obj-$(CONFIG_PHY_RTK_RTD_USB3PHY)	+= phy-rtk-usb3.o
++obj-$(CONFIG_PHY_RTK_PCIEPHY)		+= phy-rtk-pcie.o

--- a/target/linux/realtek/patches-6.18/822-add-realtek-pcie-controller-driver.patch
+++ b/target/linux/realtek/patches-6.18/822-add-realtek-pcie-controller-driver.patch
@@ -1,0 +1,28 @@
+--- a/drivers/pci/controller/Kconfig
++++ b/drivers/pci/controller/Kconfig
+@@ -223,6 +223,15 @@ config PCIE_MT7621
+ 	help
+ 	  This selects a driver for the MediaTek MT7621 PCIe Controller.
+ 
++config PCIE_REALTEK
++	bool "Realtek PCIe controller"
++	depends on (MACH_REALTEK_RTL && RTL960X) || COMPILE_TEST
++	select PHY_RTK_PCIEPHY
++	default MACH_REALTEK_RTL && RTL960X
++	help
++	  Say Y here to enable PCIe controller support for the Realtek SoCs
++	  like RTL9607C.
++
+ config PCI_HYPERV_INTERFACE
+ 	tristate "Microsoft Hyper-V PCI Interface"
+ 	depends on ((X86 && X86_64) || ARM64) && HYPERV && PCI_MSI
+--- a/drivers/pci/controller/Makefile
++++ b/drivers/pci/controller/Makefile
+@@ -39,6 +39,7 @@ obj-$(CONFIG_PCI_LOONGSON) += pci-loongs
+ obj-$(CONFIG_PCIE_HISI_ERR) += pcie-hisi-error.o
+ obj-$(CONFIG_PCIE_APPLE) += pcie-apple.o
+ obj-$(CONFIG_PCIE_MT7621) += pcie-mt7621.o
++obj-$(CONFIG_PCIE_REALTEK) += pcie-realtek.o
+ 
+ # pcie-hisi.o quirks are needed even without CONFIG_PCIE_DW
+ obj-y				+= dwc/


### PR DESCRIPTION
There has been a recent pull request about fixing PCI IO panic without apparent user (i.e PCIE controller driver) to other people. Well, that is no more.

This pull request adds support for PCIE controller found on RTL9607C / RTL8198D SoCs. It comes with 2 commits, 1st one that adds the PCIE PHY driver and the 2nd that adds PCIE controller driver that makes use of it.

Thanks to @naseef for the initial work from which me and @ProMix0 improved upon. Some things could still be improved probably (like make the driver function with SWAP_IO_SPACE).