### PR TITLE
realtek: increase memory size for Zyxel XMG1915

### DIFF
--- a/target/linux/realtek/dts/rtl9302_zyxel_xmg1915.dtsi
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xmg1915.dtsi
@@ -16,6 +16,11 @@
 		led-upgrade = &led_pwr_sys_green;
 	};
 
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>;
+	};
+
 	leds {
 		compatible = "gpio-leds";
 


### PR DESCRIPTION
The commit adding support for the Zyxel XMG1915-10E didn't carry a dedicated memory node in the DTS. The device has actually 256MiB, but because this node is missing from the DTS, it falls back to the 128MiB-sized memory node in rtl930x.dtsi.

The commits refactoring support for XMG1915-10E and adding support for XMG1915-10EP didn't fix that either. Thus, add the needed memory node to unlock the full memory.

Fixes: 94607d6285cc ("realtek: add support for Zyxel XMG1915-10E")
Fixes: bdddc753c5a1 ("realtek: add support for Zyxel XMG1915-10EP")
