### PR TITLE
realtek: pcs: enhance link state reporting

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -4116,18 +4116,12 @@ static int rtpcs_sds_config_polarity(struct rtpcs_serdes *sds, phy_interface_t i
 	return sds->ops->config_polarity(sds, tx_pol, rx_pol);
 }
 
-static void rtpcs_pcs_get_state(struct phylink_pcs *pcs, unsigned int neg_mode,
-				struct phylink_link_state *state)
+static void rtpcs_pcs_get_state_mac(struct rtpcs_link *link,
+				    struct phylink_link_state *state)
 {
-	struct rtpcs_link *link = rtpcs_phylink_pcs_to_link(pcs);
 	struct rtpcs_ctrl *ctrl = link->ctrl;
 	int port = link->port;
 	int linkup, speed;
-
-	state->link = 0;
-	state->speed = SPEED_UNKNOWN;
-	state->duplex = DUPLEX_UNKNOWN;
-	state->pause &= ~(MLO_PAUSE_RX | MLO_PAUSE_TX);
 
 	/* Read MAC side link twice */
 	for (int i = 0; i < 2; i++)
@@ -4176,6 +4170,62 @@ static void rtpcs_pcs_get_state(struct phylink_pcs *pcs, unsigned int neg_mode,
 		state->pause |= MLO_PAUSE_RX;
 	if (rtpcs_regmap_read_bits(ctrl, ctrl->cfg->mac_tx_pause_sts, port, port))
 		state->pause |= MLO_PAUSE_TX;
+}
+
+/*
+ * Decode PCS state from the SerDes clause-37 / Cisco-SGMII MII regs at page 0x2.
+ * Used for SGMII, 1000BASE-X and 2500BASE-X where the standard phylink helper applies.
+ */
+static void rtpcs_pcs_get_state_c37(struct rtpcs_serdes *sds, unsigned int neg_mode,
+				    struct phylink_link_state *state)
+{
+	const struct rtpcs_config *cfg = sds->ctrl->cfg;
+	int bmsr, lpa;
+
+	/* BMSR link status may be latched low; the second read is current state. */
+	bmsr = rtpcs_sds_read(sds, cfg->phy_page, MII_BMSR);
+	if (bmsr < 0)
+		return;
+	bmsr = rtpcs_sds_read(sds, cfg->phy_page, MII_BMSR);
+	if (bmsr < 0)
+		return;
+
+	lpa = rtpcs_sds_read(sds, cfg->phy_page, MII_LPA);
+	if (lpa < 0)
+		return;
+
+	phylink_mii_c22_pcs_decode_state(state, neg_mode, bmsr, lpa);
+}
+
+/* Decode the Clause 37 modes directly and use the MAC-side mirror otherwise. */
+static void rtpcs_pcs_get_state(struct phylink_pcs *pcs, unsigned int neg_mode,
+				struct phylink_link_state *state)
+{
+	struct rtpcs_link *link = rtpcs_phylink_pcs_to_link(pcs);
+	struct rtpcs_ctrl *ctrl = link->ctrl;
+	struct rtpcs_serdes *sds = link->sds;
+
+	state->link = 0;
+	/* Forced SGMII parameters are supplied by phylink out of band. */
+	if (state->interface != PHY_INTERFACE_MODE_SGMII ||
+	    neg_mode == PHYLINK_PCS_NEG_INBAND_ENABLED) {
+		state->speed = SPEED_UNKNOWN;
+		state->duplex = DUPLEX_UNKNOWN;
+		state->pause &= ~(MLO_PAUSE_RX | MLO_PAUSE_TX);
+	}
+
+	mutex_lock(&ctrl->lock);
+	switch (sds->hw_mode) {
+	case RTPCS_SDS_MODE_SGMII:
+	case RTPCS_SDS_MODE_1000BASEX:
+	case RTPCS_SDS_MODE_2500BASEX:
+		rtpcs_pcs_get_state_c37(sds, neg_mode, state);
+		break;
+	default:
+		rtpcs_pcs_get_state_mac(link, state);
+		break;
+	}
+	mutex_unlock(&ctrl->lock);
 }
 
 static void rtpcs_pcs_an_restart(struct phylink_pcs *pcs)

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -1307,6 +1307,18 @@ static const s16 rtpcs_93xx_sds_hw_mode_vals[RTPCS_SDS_MODE_MAX] = {
 	[RTPCS_SDS_MODE_USXGMII]		= RTPCS_93XX_SDS_MODE_USXGMII,
 };
 
+static bool rtpcs_93xx_sds_10gr_link_up(struct rtpcs_serdes *sds)
+{
+	int link;
+
+	/* Link status may be latched low; the second read is current state. */
+	link = rtpcs_sds_read_bits(sds, PAGE_TGR_STD_1, 0x0, 12, 12);
+	if (link < 0)
+		return false;
+
+	return rtpcs_sds_read_bits(sds, PAGE_TGR_STD_1, 0x0, 12, 12) == 1;
+}
+
 static int rtpcs_93xx_sds_set_autoneg(struct rtpcs_serdes *sds, unsigned int neg_mode,
 				      const unsigned long *advertising)
 {
@@ -1951,7 +1963,7 @@ static void rtpcs_930x_sds_reset_state_machine(struct rtpcs_serdes *sds)
 static int rtpcs_930x_sds_init_state_machine(struct rtpcs_serdes *sds,
 					     enum rtpcs_sds_mode hw_mode)
 {
-	int loopback, link, cnt = 20, ret = -EBUSY;
+	int loopback, cnt = 20, ret = -EBUSY;
 
 	if (hw_mode != RTPCS_SDS_MODE_10GBASER)
 		return 0;
@@ -1966,10 +1978,7 @@ static int rtpcs_930x_sds_init_state_machine(struct rtpcs_serdes *sds,
 	while (cnt-- && ret) {
 		rtpcs_930x_sds_reset_state_machine(sds);
 
-		/* 10G link state (latched) */
-		link = rtpcs_sds_read_bits(sds, PAGE_TGR_STD_1, 0x00, 12, 12);
-		link = rtpcs_sds_read_bits(sds, PAGE_TGR_STD_1, 0x00, 12, 12);
-		if (link)
+		if (rtpcs_93xx_sds_10gr_link_up(sds))
 			ret = 0;
 	}
 
@@ -3155,11 +3164,6 @@ static int rtpcs_931x_sds_fiber_get_symerr(struct rtpcs_serdes *sds,
 	return symerr;
 }
 
-static bool rtpcs_931x_sds_10gr_link_up(struct rtpcs_serdes *sds)
-{
-	return rtpcs_sds_read_bits(sds, PAGE_TGR_STD_1, 0x0, 12, 12) == 1;
-}
-
 static void rtpcs_931x_sds_clear_symerr(struct rtpcs_serdes *sds,
 					enum rtpcs_sds_mode hw_mode)
 {
@@ -3596,7 +3600,7 @@ static void rtpcs_931x_sds_rxcal_fiber_adapt(struct rtpcs_serdes *sds)
 		rtpcs_931x_sds_clear_symerr(sds, RTPCS_SDS_MODE_10GBASER);
 		msleep(300);
 		symerr = rtpcs_931x_sds_fiber_get_symerr(sds, RTPCS_SDS_MODE_10GBASER);
-		link_up = rtpcs_931x_sds_10gr_link_up(sds);
+		link_up = rtpcs_93xx_sds_10gr_link_up(sds);
 		dev_dbg(dev, "SerDes %u symErr check %d: linkUp=%d symErr=0x%x\n", sds->id,
 			i + 1, link_up, symerr);
 

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3712,38 +3712,6 @@ static int rtpcs_931x_sds_reconfigure_to_pll(struct rtpcs_serdes *sds, enum rtpc
 	return rtpcs_931x_sds_power(sds, true);
 }
 
-__always_unused
-static int rtpcs_931x_sds_link_sts_get(struct rtpcs_serdes *sds)
-{
-	u32 sts, sts1, latch_sts, latch_sts1;
-
-	switch (sds->hw_mode) {
-	case RTPCS_SDS_MODE_XSGMII:
-		sts = rtpcs_sds_read_bits(sds, DIGI_1(PAGE_SDS_EXT), 29, 8, 0);
-		sts1 = rtpcs_sds_read_bits(sds, DIGI_2(PAGE_SDS_EXT), 29, 8, 0);
-		latch_sts = rtpcs_sds_read_bits(sds, DIGI_1(PAGE_SDS_EXT), 30, 8, 0);
-		latch_sts1 = rtpcs_sds_read_bits(sds, DIGI_2(PAGE_SDS_EXT), 30, 8, 0);
-		break;
-
-	case RTPCS_SDS_MODE_SGMII:
-	case RTPCS_SDS_MODE_2500BASEX:
-		sts = rtpcs_sds_read_bits(sds, DIGI_1(PAGE_SDS_EXT), 29, 8, 0);
-		latch_sts = rtpcs_sds_read_bits(sds, DIGI_1(PAGE_SDS_EXT), 30, 8, 0);
-		break;
-
-	default:
-		sts = rtpcs_sds_read_bits(sds, PAGE_TGR_STD_1, 0, 12, 12);
-		latch_sts = rtpcs_sds_read_bits(sds, PAGE_TGR_STD_0, 1, 2, 2);
-		latch_sts1 = rtpcs_sds_read_bits(sds, DIGI_1(PAGE_FIB), 1, 2, 2);
-		sts1 = rtpcs_sds_read_bits(sds, DIGI_1(PAGE_FIB), 1, 2, 2);
-	}
-
-	dev_info(sds->ctrl->dev, "SerDes %d sts %d, sts1 %d, latch_sts %d, latch_sts1 %d\n",
-		 sds->id, sts, sts1, latch_sts, latch_sts1);
-
-	return sts1;
-}
-
 static int rtpcs_931x_sds_config_polarity(struct rtpcs_serdes *sds, unsigned int tx_pol,
 					  unsigned int rx_pol)
 {


### PR DESCRIPTION
This series enhances link state reporting for specific modes. It always seemed somewhat odd to me that the PCS reports the link from MAC side since this kinda violates the clear separation between both. In an utopia, the SerDes should have one or more registers which always report the correct link state for a given mode, no matter how that mode logically works. However, we don't live in that ideal world.

The SDK has several ways to report the link state depending on the mode, but it uses that mostly for calibration purposes. Issue #23055 reports an issue connected to this, showing that the MAC-side mirror of the state isn't always an up-to-date, trustworthy source.

To address this issue, take a split approach. Decode the status from known, direct-PCS registers for C37 modes. The SerDes registers always report the link state for the whole SerDes lane, and for such modes lane and link can be seen equal. This applies to 1000Base-X/2500Base-X/SGMII. Other modes might be switched in the future too if dedicated PCS registers are discovered. Yet, since we create a phylink_pcs instance for each link, phylink subsystems expects us to deliver the link state for such a single link, not the whole lane.

Multiple links are rather a responsibility of the MAC side. Thus, still use the MAC registers for those. FWIW, those multi-link modes are always used with PHYs. In such cases, phylink always uses PHY-reported link state only, not really paying much attention to the PCS-reported link state.

The two additional commits are not directly connected, however can also be considered as small enhancements around link state.

@janh I've carried this for some time but actually neglected the mentioned issue. Since you raised this, do you mind to check again? The mentioned SGMII up-down-up cycle might be fixed by the latching read builtin here. Though this might not be a fix to my previous solution since I've seen that behavior also entirely without these changes here.
