### PR TITLE
realtek: dsa: rtl930x: offload ingress cls_flower to PIE

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/common.c
@@ -565,12 +565,28 @@ int rtldsa_93xx_lag_set_port_members(struct rtl838x_switch_priv *priv, int group
  */
 int rtldsa_packet_cntr_alloc(struct rtl838x_switch_priv *priv)
 {
-	int idx, j;
+	int idx, j, base = 0;
+
+	/* On SoCs where a PIE rule implicitly logs into the LOG table entry
+	 * with its own rule ID (RTL930x), the tc cls_flower offload consumes
+	 * one LOG counter per PIE rule and does not pass through this
+	 * allocator. Keep that range reserved so a route counter handed out
+	 * here cannot alias a flow's LOG entry.
+	 *
+	 * The offload is ingress-only, so PIE rule IDs currently populate
+	 * only the lower half of that range, and a route counter's LOG entry
+	 * (idx / 2) never dips below the upper half either. If egress PIE
+	 * rules are ever wired up, this reservation needs to grow so their
+	 * LOG entries stay clear of route counters too.
+	 */
+	if (priv->r->pie_rule_id_is_log_counter)
+		base = priv->r->n_pie_blocks * PIE_BLOCK_SIZE;
 
 	scoped_guard(mutex, &priv->reg_mutex) {
-		idx = find_first_bit(priv->packet_cntr_use_bm, priv->r->n_counters * 2);
+		idx = find_next_bit(priv->packet_cntr_use_bm, priv->r->n_counters * 2, base);
 		if (idx >= priv->r->n_counters * 2) {
-			j = find_first_zero_bit(priv->octet_cntr_use_bm, priv->r->n_counters);
+			j = find_next_zero_bit(priv->octet_cntr_use_bm, priv->r->n_counters,
+					       base / 2);
 			if (j >= priv->r->n_counters)
 				return -1;
 

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/dsa.c
@@ -243,9 +243,11 @@ static int rtldsa_93xx_setup(struct dsa_switch *ds)
 
 	priv->r->pie_init(priv);
 
-	err = rtldsa_tc_init(priv);
-	if (err)
-		return err;
+	if (priv->r->pie_rule_id_is_log_counter) {
+		err = rtldsa_tc_init(priv);
+		if (err)
+			return err;
+	}
 
 	priv->r->led_init(priv);
 
@@ -2551,16 +2553,20 @@ out:
 
 static const struct flow_action_entry *rtldsa_rate_policy_extract(struct flow_cls_offload *cls)
 {
-	struct flow_rule *rule;
+	struct flow_rule *rule = flow_cls_offload_flow_rule(cls);
 
 	/* only simple rules with a single action are supported */
-	rule = flow_cls_offload_flow_rule(cls);
-
-	if (!flow_action_basic_hw_stats_check(&cls->rule->action,
-					      cls->common.extack))
+	if (!flow_offload_has_one_action(&rule->action))
 		return NULL;
 
-	if (!flow_offload_has_one_action(&rule->action))
+	/* Anything that is not a policer is offloaded to PIE. Bail out before
+	 * flow_action_basic_hw_stats_check() so it does not stamp a "HW stats
+	 * type unsupported" extack onto a rule the PIE path accepts.
+	 */
+	if (rule->action.entries[0].id != FLOW_ACTION_POLICE)
+		return NULL;
+
+	if (!flow_action_basic_hw_stats_check(&rule->action, cls->common.extack))
 		return NULL;
 
 	return &rule->action.entries[0];
@@ -2596,13 +2602,14 @@ static int rtldsa_cls_flower_add(struct dsa_switch *ds, int port,
 	const struct flow_action_entry *act;
 	int ret;
 
-	if (!priv->r->port_rate_police_add)
-		return -EOPNOTSUPP;
-
-	/* the single action must be a rate/bandwidth limiter */
+	/* a single rate/bandwidth limiter action is handled as port policing */
 	act = rtldsa_rate_policy_extract(cls);
 
+	/* everything else is offloaded to the PIE engine */
 	if (!rtldsa_port_rate_police_validate(act))
+		return rtldsa_pie_cls_flower_add(priv, port, cls, ingress);
+
+	if (!priv->r->port_rate_police_add)
 		return -EOPNOTSUPP;
 
 	mutex_lock(&priv->reg_mutex);
@@ -2641,6 +2648,15 @@ static int rtldsa_cls_flower_del(struct dsa_switch *ds, int port,
 	struct rtldsa_port *p = &priv->ports[port];
 	int ret;
 
+	/* PIE flower rules are ingress only. Try to remove a PIE rule first;
+	 * if none exists for this cookie, fall back to port rate policing.
+	 */
+	if (ingress) {
+		ret = rtldsa_pie_cls_flower_del(priv, cls, ingress);
+		if (ret != -ENOENT)
+			return ret;
+	}
+
 	if (!priv->r->port_rate_police_del)
 		return -EOPNOTSUPP;
 
@@ -2657,6 +2673,23 @@ static int rtldsa_cls_flower_del(struct dsa_switch *ds, int port,
 
 unlock:
 	mutex_unlock(&priv->reg_mutex);
+
+	return ret;
+}
+
+static int rtldsa_cls_flower_stats(struct dsa_switch *ds, int port,
+				   struct flow_cls_offload *cls, bool ingress)
+{
+	struct rtl838x_switch_priv *priv = ds->priv;
+	int ret;
+
+	/* only PIE flower rules provide per-rule statistics, and only ingress */
+	if (!ingress)
+		return 0;
+
+	ret = rtldsa_pie_cls_flower_stats(priv, cls, ingress);
+	if (ret == -ENOENT)
+		return 0;
 
 	return ret;
 }
@@ -2786,4 +2819,5 @@ const struct dsa_switch_ops rtldsa_93xx_switch_ops = {
 
 	.cls_flower_add		= rtldsa_cls_flower_add,
 	.cls_flower_del		= rtldsa_cls_flower_del,
+	.cls_flower_stats	= rtldsa_cls_flower_stats,
 };

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl-otto.h
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl-otto.h
@@ -1385,6 +1385,10 @@ struct rtldsa_config {
 	int imr_glb;
 	int n_counters;
 	int n_pie_blocks;
+	/* PIE rule ID doubles as the LOG-table counter ID (RTL930x); also
+	 * gates ingress cls_flower offload, which relies on that property.
+	 */
+	bool pie_rule_id_is_log_counter;
 	u8 num_lag_ids;
 	u8 cpu_port;
 	u8 port_ignore;
@@ -1653,6 +1657,12 @@ void rtldsa_port_stp_state_set(struct dsa_switch *ds, int port, u8 state);
 int rtl83xx_setup_tc(struct net_device *dev, enum tc_setup_type type, void *type_data);
 int rtldsa_tc_init(struct rtl838x_switch_priv *priv);
 void rtldsa_tc_cleanup(struct rtl838x_switch_priv *priv);
+int rtldsa_pie_cls_flower_add(struct rtl838x_switch_priv *priv, int port,
+			       struct flow_cls_offload *cls, bool ingress);
+int rtldsa_pie_cls_flower_del(struct rtl838x_switch_priv *priv,
+			       struct flow_cls_offload *cls, bool ingress);
+int rtldsa_pie_cls_flower_stats(struct rtl838x_switch_priv *priv,
+				 struct flow_cls_offload *cls, bool ingress);
 
 /* Port register accessor functions for the RTL839x and RTL931X SoCs */
 void rtl839x_mask_port_reg_be(u64 clear, u64 set, int reg);

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl-otto.h
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl-otto.h
@@ -1654,7 +1654,6 @@ void rtldsa_packet_cntr_free(struct rtl838x_switch_priv *priv, int idx);
 int rtldsa_port_get_stp_state(struct rtl838x_switch_priv *priv, int port);
 int rtl83xx_port_is_under(const struct net_device *dev, struct rtl838x_switch_priv *priv);
 void rtldsa_port_stp_state_set(struct dsa_switch *ds, int port, u8 state);
-int rtl83xx_setup_tc(struct net_device *dev, enum tc_setup_type type, void *type_data);
 int rtldsa_tc_init(struct rtl838x_switch_priv *priv);
 void rtldsa_tc_cleanup(struct rtl838x_switch_priv *priv);
 int rtldsa_pie_cls_flower_add(struct rtl838x_switch_priv *priv, int port,

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -1708,6 +1708,9 @@ static int rtl930x_pie_verify_template(struct rtl838x_switch_priv *priv,
 	if (ether_addr_to_u64(pr->dmac_m) && !rtl930x_pie_templ_has(t, TEMPLATE_FIELD_DMAC0))
 		return -1;
 
+	if (pr->ethertype_m && !rtl930x_pie_templ_has(t, TEMPLATE_FIELD_ETHERTYPE))
+		return -1;
+
 	if (pr->itag_m && !rtl930x_pie_templ_has(t, TEMPLATE_FIELD_VLAN))
 		return -1;
 
@@ -2213,6 +2216,7 @@ const struct rtldsa_config rtldsa_930x_cfg = {
 	.imr_glb = RTL930X_IMR_GLB,
 	.n_counters = 2048,
 	.n_pie_blocks = 16,
+	.pie_rule_id_is_log_counter = true,
 	.port_ignore = 0x3f,
 	.vlan_tables_read = rtl930x_vlan_tables_read,
 	.vlan_set_tagged = rtl930x_vlan_set_tagged,

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -1846,22 +1846,32 @@ static void rtl930x_pie_init(struct rtl838x_switch_priv *priv)
 		sw_w32(template_selectors, RTL930X_PIE_BLK_TMPLTE_CTRL(i));
 }
 
+/* A PIE rule logs its matched packets into the LOG table entry that carries
+ * its own rule ID, in data word 1 - one entry per rule. Counters handed out
+ * by rtldsa_packet_cntr_alloc() for L3 route statistics start above the PIE
+ * rule ID range and pack two 32-bit counters into one 64-bit LOG entry.
+ */
+#define RTL930X_PIE_RULE_IDS	(rtldsa_930x_cfg.n_pie_blocks * PIE_BLOCK_SIZE)
+
 static u32 rtl930x_packet_cntr_read(struct rtl838x_switch_priv *priv, int counter)
 {
 	u32 buf[2];
 	u32 v;
 
 	dev_dbg(priv->dev, "reading LOG packet counter %d\n", counter);
-	/* Two counters share one entry, so the parity of counter picks which
-	 * half of it to return.
-	 */
-	otto_table_read(RTL9300_TBL_LOG, counter / 2, &buf);
+
+	if (counter < RTL930X_PIE_RULE_IDS) {
+		otto_table_read(RTL9300_TBL_LOG, counter, &buf);
+		v = buf[1];
+	} else {
+		/* Two counters share one entry, so the parity of counter picks
+		 * which half of it to return.
+		 */
+		otto_table_read(RTL9300_TBL_LOG, counter / 2, &buf);
+		v = counter % 2 ? buf[0] : buf[1];
+	}
 
 	dev_dbg(priv->dev, "LOG entry: %08x %08x\n", buf[0], buf[1]);
-	if (counter % 2)
-		v = buf[0];
-	else
-		v = buf[1];
 
 	return v;
 }
@@ -1874,12 +1884,19 @@ static void rtl930x_packet_cntr_clear(struct rtl838x_switch_priv *priv, int coun
 
 	dev_dbg(priv->dev, "clearing LOG packet counter %d\n", counter);
 
-	/* Two counters share one LOG table entry. Read the current entry
-	 * first so clearing one half preserves the adjacent counter.
+	/* Read-modify-write: for a route counter the other 32-bit counter in
+	 * the same 64-bit entry must be preserved; for a PIE rule ID the entry
+	 * is ours alone but the RMW is harmless.
 	 */
-	__otto_table_read(tbl, counter / 2, &v);
-	v[counter % 2 ? 0 : 1] = 0;
-	__otto_table_write(tbl, counter / 2, &v);
+	if (counter < RTL930X_PIE_RULE_IDS) {
+		__otto_table_read(tbl, counter, &v);
+		v[1] = 0;
+		__otto_table_write(tbl, counter, &v);
+	} else {
+		__otto_table_read(tbl, counter / 2, &v);
+		v[counter % 2 ? 0 : 1] = 0;
+		__otto_table_write(tbl, counter / 2, &v);
+	}
 
 	otto_table_release(tbl);
 }

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
@@ -415,6 +415,8 @@ static int rtldsa_configure_flower(struct rtl838x_switch_priv *priv,
 	if (!priv->r->packet_cntr_read || !priv->r->packet_cntr_clear)
 		return -EOPNOTSUPP;
 
+	pr_debug("Cookie %08lx\n", f->cookie);
+
 	mutex_lock(&priv->tc_flow_lock);
 
 	/* rtldsa_tc_cleanup() clears this under the lock before it destroys
@@ -426,10 +428,7 @@ static int rtldsa_configure_flower(struct rtl838x_switch_priv *priv,
 		goto out_unlock;
 	}
 
-	rcu_read_lock();
-	pr_debug("Cookie %08lx\n", f->cookie);
-	flow = rhashtable_lookup(&priv->tc_ht, &f->cookie, tc_ht_params);
-	rcu_read_unlock();
+	flow = rhashtable_lookup_fast(&priv->tc_ht, &f->cookie, tc_ht_params);
 	if (flow) {
 		pr_info("%s: Got flow\n", __func__);
 		err = -EEXIST;
@@ -526,16 +525,13 @@ static int rtldsa_delete_flower(struct rtl838x_switch_priv *priv,
 		goto out_unlock;
 	}
 
-	rcu_read_lock();
 	flow = rhashtable_lookup_fast(&priv->tc_ht, &cls_flower->cookie, tc_ht_params);
 	if (!flow) {
-		rcu_read_unlock();
 		err = -ENOENT;
 		goto out_unlock;
 	}
 
 	err = rhashtable_remove_fast(&priv->tc_ht, &flow->node, tc_ht_params);
-	rcu_read_unlock();
 	if (err)
 		goto out_unlock;
 
@@ -568,16 +564,14 @@ static int rtldsa_stats_flower(struct rtl838x_switch_priv *priv,
 		goto out_unlock;
 	}
 
-	rcu_read_lock();
 	flow = rhashtable_lookup_fast(&priv->tc_ht, &cls_flower->cookie, tc_ht_params);
-	rcu_read_unlock();
 	if (!flow) {
 		err = -ENOENT;
 		goto out_unlock;
 	}
 
 	/* tc_flow_lock keeps the flow alive for the duration of the sleeping
-	 * counter read, so it is safe to dereference it after the RCU lock.
+	 * counter read, so it is safe to dereference it here.
 	 */
 	if (flow->rule.packet_cntr >= 0) {
 		mutex_lock(&priv->reg_mutex);

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
@@ -343,6 +343,10 @@ int rtldsa_tc_init(struct rtl838x_switch_priv *priv)
 	return 0;
 }
 
+/* Zero a PIE rule's LOG-table packet counter. On RTL930x the counter id is
+ * the PIE rule id itself: the rule owns it and pie_rule_rm() releases it,
+ * so there is nothing to hand back to an allocator here.
+ */
 static void rtldsa_packet_cntr_clear(struct rtl838x_switch_priv *priv, int counter)
 {
 	if (counter < 0 || !priv->r->packet_cntr_clear)
@@ -353,31 +357,13 @@ static void rtldsa_packet_cntr_clear(struct rtl838x_switch_priv *priv, int count
 	mutex_unlock(&priv->reg_mutex);
 }
 
-/* Zero the hardware LOG counter and, for a counter that came from
- * rtldsa_packet_cntr_alloc(), hand its slot back - in that order, so a slot
- * is never returned to the allocator while the hardware entry still holds
- * the previous flow's count. On RTL930x the id is the PIE rule id itself:
- * the rule owns it and pie_rule_rm() releases it, so there is nothing to
- * hand back here.
- */
-static void rtldsa_packet_cntr_release(struct rtl838x_switch_priv *priv, int counter)
-{
-	if (counter < 0)
-		return;
-
-	rtldsa_packet_cntr_clear(priv, counter);
-
-	if (!priv->r->pie_rule_id_is_log_counter)
-		rtldsa_packet_cntr_free(priv, counter);
-}
-
 static void rtldsa_tc_flow_free(void *ptr, void *arg)
 {
 	struct rtl83xx_flow *flow = ptr;
 	struct rtl838x_switch_priv *priv = arg;
 
 	priv->r->pie_rule_rm(priv, &flow->rule);
-	rtldsa_packet_cntr_release(priv, flow->rule.packet_cntr);
+	rtldsa_packet_cntr_clear(priv, flow->rule.packet_cntr);
 
 	/* Readers may still hold an RCU-protected reference after the
 	 * object has been removed from the hash table.
@@ -457,37 +443,23 @@ static int rtldsa_configure_flower(struct rtl838x_switch_priv *priv,
 	if (err)
 		goto out_remove;
 
-	if (ingress_port >= 0) {
-		flow->rule.spn = ingress_port;
-		flow->rule.spn_m = 0x7f;
-	}
+	flow->rule.spn = ingress_port;
+	flow->rule.spn_m = 0x7f;
 
-	if (priv->r->pie_rule_id_is_log_counter) {
-		/* On RTL930x the PIE rule ID is also the LOG table counter ID,
-		 * so the counter is implied by the rule and is only known once
-		 * pie_rule_add() has assigned the ID. The PIE rule ID range is
-		 * kept out of rtldsa_packet_cntr_alloc() on these SoCs, so this
-		 * implied LOG entry cannot alias a counter allocated for an L3
-		 * route PIE rule.
-		 */
-		flow->rule.log_sel = true;
-	} else {
-		flow->rule.packet_cntr = rtldsa_packet_cntr_alloc(priv);
-		if (flow->rule.packet_cntr >= 0) {
-			flow->rule.log_sel = true;
-			flow->rule.log_data = flow->rule.packet_cntr;
-		}
-	}
+	/* The only caller, rtldsa_pie_cls_flower_add(), is RTL930x-only, where
+	 * the PIE rule ID is also the LOG table counter ID: the counter is
+	 * implied by the rule and only known once pie_rule_add() has assigned
+	 * the ID. That range is kept out of rtldsa_packet_cntr_alloc(), so the
+	 * implied LOG entry cannot alias an L3 route PIE rule's counter.
+	 */
+	flow->rule.log_sel = true;
 
 	err = priv->r->pie_rule_add(priv, &flow->rule);
 	if (err)
 		goto out_remove;
 
-	if (priv->r->pie_rule_id_is_log_counter) {
-		flow->rule.packet_cntr = flow->rule.id;
-		dev_dbg(priv->dev, "using PIE rule counter %d\n",
-			flow->rule.packet_cntr);
-	}
+	flow->rule.packet_cntr = flow->rule.id;
+	dev_dbg(priv->dev, "using PIE rule counter %d\n", flow->rule.packet_cntr);
 	rtldsa_packet_cntr_clear(priv, flow->rule.packet_cntr);
 
 	mutex_unlock(&priv->tc_flow_lock);
@@ -495,7 +467,7 @@ static int rtldsa_configure_flower(struct rtl838x_switch_priv *priv,
 
 out_remove:
 	rhashtable_remove_fast(&priv->tc_ht, &flow->node, tc_ht_params);
-	rtldsa_packet_cntr_release(priv, flow->rule.packet_cntr);
+	rtldsa_packet_cntr_clear(priv, flow->rule.packet_cntr);
 	/* published in tc_ht above; a concurrent reader may still hold a ref */
 	kfree_rcu(flow, rcu_head);
 	goto out_err;
@@ -536,7 +508,7 @@ static int rtldsa_delete_flower(struct rtl838x_switch_priv *priv,
 		goto out_unlock;
 
 	priv->r->pie_rule_rm(priv, &flow->rule);
-	rtldsa_packet_cntr_release(priv, flow->rule.packet_cntr);
+	rtldsa_packet_cntr_clear(priv, flow->rule.packet_cntr);
 
 	kfree_rcu(flow, rcu_head);
 
@@ -618,66 +590,4 @@ int rtldsa_pie_cls_flower_stats(struct rtl838x_switch_priv *priv,
 		return -ENOENT;
 
 	return rtldsa_stats_flower(priv, cls);
-}
-
-static int rtl83xx_setup_tc_cls_flower(struct rtl838x_switch_priv *priv,
-				       struct flow_cls_offload *cls_flower)
-{
-	pr_debug("%s: %d\n", __func__, cls_flower->command);
-	switch (cls_flower->command) {
-	case FLOW_CLS_REPLACE:
-		return rtldsa_configure_flower(priv, cls_flower, -1);
-	case FLOW_CLS_DESTROY:
-		return rtldsa_delete_flower(priv, cls_flower);
-	case FLOW_CLS_STATS:
-		return rtldsa_stats_flower(priv, cls_flower);
-	default:
-		return -EOPNOTSUPP;
-	}
-}
-
-static int rtl83xx_setup_tc_block_cb(enum tc_setup_type type, void *type_data,
-				     void *cb_priv)
-{
-	struct rtl838x_switch_priv *priv = cb_priv;
-
-	switch (type) {
-	case TC_SETUP_CLSFLOWER:
-		pr_debug("%s: TC_SETUP_CLSFLOWER\n", __func__);
-		return rtl83xx_setup_tc_cls_flower(priv, type_data);
-	default:
-		return -EOPNOTSUPP;
-	}
-}
-
-static LIST_HEAD(rtl83xx_block_cb_list);
-
-int rtl83xx_setup_tc(struct net_device *dev, enum tc_setup_type type, void *type_data)
-{
-	struct rtl838x_switch_priv *priv;
-	struct flow_block_offload *f = type_data;
-
-	pr_debug("%s: %d\n", __func__, type);
-
-	if (!netdev_uses_dsa(dev)) {
-		pr_err("%s: no DSA\n", __func__);
-		return 0;
-	}
-	priv = dev->dsa_ptr->ds->priv;
-
-	switch (type) {
-	case TC_SETUP_BLOCK:
-		/* tc_ht is set up for the switch's lifetime in
-		 * rtldsa_93xx_setup(); nothing to do here.
-		 */
-		f->unlocked_driver_cb = true;
-		return flow_block_cb_setup_simple(type_data,
-						  &rtl83xx_block_cb_list,
-						  rtl83xx_setup_tc_block_cb,
-						  priv, priv, true);
-	default:
-		return -EOPNOTSUPP;
-	}
-
-	return 0;
 }

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
@@ -51,14 +51,17 @@ static int rtl83xx_parse_flow_rule(struct rtl838x_switch_priv *priv,
 			if (match.mask->n_proto != htons(0xffff))
 				return -EOPNOTSUPP;
 
-			if (match.key->n_proto == htons(ETH_P_ARP))
+			if (match.key->n_proto == htons(ETH_P_ARP)) {
 				flow->rule.frame_type = 0;
-			else if (match.key->n_proto == htons(ETH_P_IP))
+			} else if (match.key->n_proto == htons(ETH_P_IP)) {
 				flow->rule.frame_type = 2;
-			else if (match.key->n_proto == htons(ETH_P_IPV6))
+			} else if (match.key->n_proto == htons(ETH_P_IPV6)) {
 				flow->rule.frame_type = 3;
-			else
-				return -EOPNOTSUPP;
+			} else {
+				flow->rule.frame_type = 1;
+				flow->rule.ethertype = ntohs(match.key->n_proto);
+				flow->rule.ethertype_m = ntohs(match.mask->n_proto);
+			}
 			flow->rule.frame_type_m = 3;
 		}
 		if (match.mask->ip_proto) {
@@ -340,22 +343,32 @@ int rtldsa_tc_init(struct rtl838x_switch_priv *priv)
 	return 0;
 }
 
-/* Zero the hardware LOG counter and hand its allocator slot back. Done
- * together so a slot is never returned to rtldsa_packet_cntr_alloc() while
- * the hardware entry still holds the previous flow's count.
+static void rtldsa_packet_cntr_clear(struct rtl838x_switch_priv *priv, int counter)
+{
+	if (counter < 0 || !priv->r->packet_cntr_clear)
+		return;
+
+	mutex_lock(&priv->reg_mutex);
+	priv->r->packet_cntr_clear(priv, counter);
+	mutex_unlock(&priv->reg_mutex);
+}
+
+/* Zero the hardware LOG counter and, for a counter that came from
+ * rtldsa_packet_cntr_alloc(), hand its slot back - in that order, so a slot
+ * is never returned to the allocator while the hardware entry still holds
+ * the previous flow's count. On RTL930x the id is the PIE rule id itself:
+ * the rule owns it and pie_rule_rm() releases it, so there is nothing to
+ * hand back here.
  */
 static void rtldsa_packet_cntr_release(struct rtl838x_switch_priv *priv, int counter)
 {
 	if (counter < 0)
 		return;
 
-	if (priv->r->packet_cntr_clear) {
-		mutex_lock(&priv->reg_mutex);
-		priv->r->packet_cntr_clear(priv, counter);
-		mutex_unlock(&priv->reg_mutex);
-	}
+	rtldsa_packet_cntr_clear(priv, counter);
 
-	rtldsa_packet_cntr_free(priv, counter);
+	if (!priv->r->pie_rule_id_is_log_counter)
+		rtldsa_packet_cntr_free(priv, counter);
 }
 
 static void rtldsa_tc_flow_free(void *ptr, void *arg)
@@ -392,12 +405,15 @@ void rtldsa_tc_cleanup(struct rtl838x_switch_priv *priv)
 }
 
 static int rtldsa_configure_flower(struct rtl838x_switch_priv *priv,
-				   struct flow_cls_offload *f)
+				   struct flow_cls_offload *f, int ingress_port)
 {
 	struct rtl83xx_flow *flow;
 	int err = 0;
 
 	pr_debug("In %s\n", __func__);
+
+	if (!priv->r->packet_cntr_read || !priv->r->packet_cntr_clear)
+		return -EOPNOTSUPP;
 
 	mutex_lock(&priv->tc_flow_lock);
 
@@ -442,17 +458,38 @@ static int rtldsa_configure_flower(struct rtl838x_switch_priv *priv,
 	if (err)
 		goto out_remove;
 
-	/* Add log action to flow */
-	flow->rule.packet_cntr = rtldsa_packet_cntr_alloc(priv);
-	if (flow->rule.packet_cntr >= 0) {
-		pr_debug("Using packet counter %d\n", flow->rule.packet_cntr);
+	if (ingress_port >= 0) {
+		flow->rule.spn = ingress_port;
+		flow->rule.spn_m = 0x7f;
+	}
+
+	if (priv->r->pie_rule_id_is_log_counter) {
+		/* On RTL930x the PIE rule ID is also the LOG table counter ID,
+		 * so the counter is implied by the rule and is only known once
+		 * pie_rule_add() has assigned the ID. The PIE rule ID range is
+		 * kept out of rtldsa_packet_cntr_alloc() on these SoCs, so this
+		 * implied LOG entry cannot alias a counter allocated for an L3
+		 * route PIE rule.
+		 */
 		flow->rule.log_sel = true;
-		flow->rule.log_data = flow->rule.packet_cntr;
+	} else {
+		flow->rule.packet_cntr = rtldsa_packet_cntr_alloc(priv);
+		if (flow->rule.packet_cntr >= 0) {
+			flow->rule.log_sel = true;
+			flow->rule.log_data = flow->rule.packet_cntr;
+		}
 	}
 
 	err = priv->r->pie_rule_add(priv, &flow->rule);
 	if (err)
 		goto out_remove;
+
+	if (priv->r->pie_rule_id_is_log_counter) {
+		flow->rule.packet_cntr = flow->rule.id;
+		dev_dbg(priv->dev, "using PIE rule counter %d\n",
+			flow->rule.packet_cntr);
+	}
+	rtldsa_packet_cntr_clear(priv, flow->rule.packet_cntr);
 
 	mutex_unlock(&priv->tc_flow_lock);
 	return 0;
@@ -562,13 +599,40 @@ out_unlock:
 	return err;
 }
 
+int rtldsa_pie_cls_flower_add(struct rtl838x_switch_priv *priv, int port,
+			       struct flow_cls_offload *cls, bool ingress)
+{
+	if (!ingress || !priv->r->pie_rule_id_is_log_counter)
+		return -EOPNOTSUPP;
+
+	return rtldsa_configure_flower(priv, cls, port);
+}
+
+int rtldsa_pie_cls_flower_del(struct rtl838x_switch_priv *priv,
+			       struct flow_cls_offload *cls, bool ingress)
+{
+	if (!ingress || !priv->r->pie_rule_id_is_log_counter)
+		return -ENOENT;
+
+	return rtldsa_delete_flower(priv, cls);
+}
+
+int rtldsa_pie_cls_flower_stats(struct rtl838x_switch_priv *priv,
+				 struct flow_cls_offload *cls, bool ingress)
+{
+	if (!ingress || !priv->r->pie_rule_id_is_log_counter)
+		return -ENOENT;
+
+	return rtldsa_stats_flower(priv, cls);
+}
+
 static int rtl83xx_setup_tc_cls_flower(struct rtl838x_switch_priv *priv,
 				       struct flow_cls_offload *cls_flower)
 {
 	pr_debug("%s: %d\n", __func__, cls_flower->command);
 	switch (cls_flower->command) {
 	case FLOW_CLS_REPLACE:
-		return rtldsa_configure_flower(priv, cls_flower);
+		return rtldsa_configure_flower(priv, cls_flower, -1);
 	case FLOW_CLS_DESTROY:
 		return rtldsa_delete_flower(priv, cls_flower);
 	case FLOW_CLS_STATS:

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
@@ -17,11 +17,11 @@ static int rtl83xx_parse_flow_rule(struct rtl838x_switch_priv *priv,
 	struct flow_dissector *dissector = rule->match.dissector;
 	u64 supported_keys;
 
-	pr_debug("In %s\n", __func__);
+	dev_dbg(priv->dev, "parsing flower match keys\n");
 	/* KEY_CONTROL and KEY_BASIC are needed for forming a meaningful key */
 	if ((dissector->used_keys & BIT(FLOW_DISSECTOR_KEY_CONTROL)) == 0 ||
 	    (dissector->used_keys & BIT(FLOW_DISSECTOR_KEY_BASIC)) == 0) {
-		pr_err("Cannot form TC key: used_keys = 0x%llx\n", dissector->used_keys);
+		dev_err(priv->dev, "cannot form a TC key: used_keys = 0x%llx\n", dissector->used_keys);
 		return -EOPNOTSUPP;
 	}
 
@@ -45,7 +45,7 @@ static int rtl83xx_parse_flow_rule(struct rtl838x_switch_priv *priv,
 	if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_BASIC)) {
 		struct flow_match_basic match;
 
-		pr_debug("%s: BASIC\n", __func__);
+		dev_dbg(priv->dev, "match BASIC\n");
 		flow_rule_match_basic(rule, &match);
 		if (match.mask->n_proto) {
 			if (match.mask->n_proto != htons(0xffff))
@@ -92,7 +92,7 @@ static int rtl83xx_parse_flow_rule(struct rtl838x_switch_priv *priv,
 	if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_ETH_ADDRS)) {
 		struct flow_match_eth_addrs match;
 
-		pr_debug("%s: ETH_ADDR\n", __func__);
+		dev_dbg(priv->dev, "match ETH_ADDR\n");
 		flow_rule_match_eth_addrs(rule, &match);
 		ether_addr_copy(flow->rule.dmac, match.key->dst);
 		ether_addr_copy(flow->rule.dmac_m, match.mask->dst);
@@ -103,7 +103,7 @@ static int rtl83xx_parse_flow_rule(struct rtl838x_switch_priv *priv,
 	if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_VLAN)) {
 		struct flow_match_vlan match;
 
-		pr_debug("%s: VLAN\n", __func__);
+		dev_dbg(priv->dev, "match VLAN\n");
 		flow_rule_match_vlan(rule, &match);
 		if (match.mask->vlan_priority || match.mask->vlan_dei ||
 		    match.mask->vlan_eth_type)
@@ -121,7 +121,7 @@ static int rtl83xx_parse_flow_rule(struct rtl838x_switch_priv *priv,
 	if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_IPV4_ADDRS)) {
 		struct flow_match_ipv4_addrs match;
 
-		pr_debug("%s: IPV4\n", __func__);
+		dev_dbg(priv->dev, "match IPV4\n");
 		flow_rule_match_ipv4_addrs(rule, &match);
 		flow->rule.is_ipv6 = false;
 		flow->rule.dip = match.key->dst;
@@ -131,7 +131,7 @@ static int rtl83xx_parse_flow_rule(struct rtl838x_switch_priv *priv,
 	} else if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_IPV6_ADDRS)) {
 		struct flow_match_ipv6_addrs match;
 
-		pr_debug("%s: IPV6\n", __func__);
+		dev_dbg(priv->dev, "match IPV6\n");
 		flow->rule.is_ipv6 = true;
 		flow_rule_match_ipv6_addrs(rule, &match);
 		flow->rule.dip6 = match.key->dst;
@@ -143,7 +143,7 @@ static int rtl83xx_parse_flow_rule(struct rtl838x_switch_priv *priv,
 	if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_PORTS)) {
 		struct flow_match_ports match;
 
-		pr_debug("%s: PORTS\n", __func__);
+		dev_dbg(priv->dev, "match PORTS\n");
 		flow_rule_match_ports(rule, &match);
 		flow->rule.dport = match.key->dst;
 		flow->rule.dport_m = match.mask->dst;
@@ -207,13 +207,13 @@ static int rtl83xx_parse_fwd(struct rtl838x_switch_priv *priv,
 
 	port = rtl83xx_port_is_under(dev, priv);
 	if (port < 0) {
-		netdev_info(dev, "%s: not a DSA device.\n", __func__);
+		netdev_info(dev, "not a DSA port on this switch\n");
 		return -EINVAL;
 	}
 
 	flow->rule.fwd_sel = true;
 	flow->rule.fwd_data = port;
-	pr_debug("Using port index: %d\n", port);
+	dev_dbg(priv->dev, "redirect/mirror to port %d\n", port);
 	rtl83xx_flow_bypass_all(flow);
 
 	return 0;
@@ -226,7 +226,7 @@ static int rtl83xx_add_flow(struct rtl838x_switch_priv *priv, struct flow_cls_of
 	const struct flow_action_entry *act;
 	int i, err;
 
-	pr_debug("%s\n", __func__);
+	dev_dbg(priv->dev, "adding flower rule\n");
 
 	if (flow_rule_match_has_control_flags(rule, f->common.extack))
 		return -EOPNOTSUPP;
@@ -246,13 +246,13 @@ static int rtl83xx_add_flow(struct rtl838x_switch_priv *priv, struct flow_cls_of
 	flow_action_for_each(i, act, &rule->action) {
 		switch (act->id) {
 		case FLOW_ACTION_DROP:
-			pr_debug("%s: DROP\n", __func__);
+			dev_dbg(priv->dev, "action DROP\n");
 			flow->rule.drop = true;
 			rtl83xx_flow_bypass_all(flow);
 			return 0;
 
 		case FLOW_ACTION_TRAP:
-			pr_debug("%s: TRAP\n", __func__);
+			dev_dbg(priv->dev, "action TRAP\n");
 			flow->rule.fwd_sel = true;
 			flow->rule.fwd_data = priv->r->cpu_port;
 			flow->rule.fwd_act = PIE_ACT_REDIRECT_TO_PORT;
@@ -260,15 +260,15 @@ static int rtl83xx_add_flow(struct rtl838x_switch_priv *priv, struct flow_cls_of
 			break;
 
 		case FLOW_ACTION_MANGLE:
-			pr_err("%s: FLOW_ACTION_MANGLE not supported\n", __func__);
+			dev_err(priv->dev, "unsupported action: MANGLE\n");
 			return -EOPNOTSUPP;
 
 		case FLOW_ACTION_ADD:
-			pr_err("%s: FLOW_ACTION_ADD not supported\n", __func__);
+			dev_err(priv->dev, "unsupported action: ADD\n");
 			return -EOPNOTSUPP;
 
 		case FLOW_ACTION_VLAN_PUSH:
-			pr_debug("%s: VLAN_PUSH\n", __func__);
+			dev_dbg(priv->dev, "action VLAN_PUSH\n");
 /*			TODO: act->vlan.proto */
 			flow->rule.ivid_act = PIE_ACT_VID_ASSIGN;
 			flow->rule.ivid_sel = true;
@@ -280,7 +280,7 @@ static int rtl83xx_add_flow(struct rtl838x_switch_priv *priv, struct flow_cls_of
 			break;
 
 		case FLOW_ACTION_VLAN_POP:
-			pr_debug("%s: VLAN_POP\n", __func__);
+			dev_dbg(priv->dev, "action VLAN_POP\n");
 			flow->rule.ivid_act = PIE_ACT_VID_ASSIGN;
 			flow->rule.ivid_data = 0;
 			flow->rule.ivid_sel = true;
@@ -291,11 +291,11 @@ static int rtl83xx_add_flow(struct rtl838x_switch_priv *priv, struct flow_cls_of
 			break;
 
 		case FLOW_ACTION_CSUM:
-			pr_err("%s: FLOW_ACTION_CSUM not supported\n", __func__);
+			dev_err(priv->dev, "unsupported action: CSUM\n");
 			return -EOPNOTSUPP;
 
 		case FLOW_ACTION_REDIRECT:
-			pr_debug("%s: REDIRECT\n", __func__);
+			dev_dbg(priv->dev, "action REDIRECT\n");
 			err = rtl83xx_parse_fwd(priv, act, flow);
 			if (err)
 				return err;
@@ -303,7 +303,7 @@ static int rtl83xx_add_flow(struct rtl838x_switch_priv *priv, struct flow_cls_of
 			break;
 
 		case FLOW_ACTION_MIRRED:
-			pr_debug("%s: MIRRED\n", __func__);
+			dev_dbg(priv->dev, "action MIRRED\n");
 			err = rtl83xx_parse_fwd(priv, act, flow);
 			if (err)
 				return err;
@@ -311,7 +311,7 @@ static int rtl83xx_add_flow(struct rtl838x_switch_priv *priv, struct flow_cls_of
 			break;
 
 		default:
-			pr_err("%s: Flow action not supported: %d\n", __func__, act->id);
+			dev_err(priv->dev, "unsupported action: %d\n", act->id);
 			return -EOPNOTSUPP;
 		}
 	}
@@ -396,12 +396,12 @@ static int rtldsa_configure_flower(struct rtl838x_switch_priv *priv,
 	struct rtl83xx_flow *flow;
 	int err = 0;
 
-	pr_debug("In %s\n", __func__);
+	dev_dbg(priv->dev, "configuring flower rule\n");
 
 	if (!priv->r->packet_cntr_read || !priv->r->packet_cntr_clear)
 		return -EOPNOTSUPP;
 
-	pr_debug("Cookie %08lx\n", f->cookie);
+	dev_dbg(priv->dev, "cookie %08lx\n", f->cookie);
 
 	mutex_lock(&priv->tc_flow_lock);
 
@@ -416,11 +416,11 @@ static int rtldsa_configure_flower(struct rtl838x_switch_priv *priv,
 
 	flow = rhashtable_lookup_fast(&priv->tc_ht, &f->cookie, tc_ht_params);
 	if (flow) {
-		pr_info("%s: Got flow\n", __func__);
+		dev_dbg(priv->dev, "cookie already offloaded\n");
 		err = -EEXIST;
 		goto out_unlock;
 	}
-	pr_debug("%s: New flow\n", __func__);
+	dev_dbg(priv->dev, "new flow\n");
 
 	flow = kzalloc(sizeof(*flow), GFP_KERNEL);
 	if (!flow) {
@@ -474,7 +474,7 @@ out_remove:
 out_free:
 	kfree(flow);
 out_err:
-	pr_err("%s: error %d\n", __func__, err);
+	dev_err(priv->dev, "flower rule setup failed: %d\n", err);
 out_unlock:
 	mutex_unlock(&priv->tc_flow_lock);
 
@@ -487,7 +487,7 @@ static int rtldsa_delete_flower(struct rtl838x_switch_priv *priv,
 	struct rtl83xx_flow *flow;
 	int err;
 
-	pr_debug("In %s\n", __func__);
+	dev_dbg(priv->dev, "deleting flower rule\n");
 
 	mutex_lock(&priv->tc_flow_lock);
 
@@ -526,7 +526,7 @@ static int rtldsa_stats_flower(struct rtl838x_switch_priv *priv,
 	u32 total_packets, new_packets = 0;
 	int err = 0;
 
-	pr_debug("%s:\n", __func__);
+	dev_dbg(priv->dev, "reading flower rule stats\n");
 
 	mutex_lock(&priv->tc_flow_lock);
 


### PR DESCRIPTION
> **Note:** the first four preparatory fixes are being reviewed separately in #25024. This branch still contains them for now and will be rebased on top once that PR lands.

Add hardware offload of ingress `tc`/`cls_flower` rules on RTL930x DSA
user ports, using the switch's existing Packet Inspection Engine, on top
of the port rate-policing path that is already wired to the RTL93xx
`cls_flower` ops.

### Changes

- `rtldsa_cls_flower_{add,del}` route every rule that is not a plain port
  rate limiter to the PIE path; a new `rtldsa_cls_flower_stats` op
  reports per-rule packet counts.
- The offload is gated on `family_id == RTL9300_FAMILY_ID`; RTL931x keeps
  its current behaviour and the RTL83xx SoC code is untouched.
- The flow-rule parser rejects unsupported dissector keys and partial
  masks up front, and gains generic EtherType matching alongside the
  ARP/IPv4/IPv6 fast paths. `pie_rule.ethertype_m` is widened to `u16`;
  `rtl930x_pie_verify_template()` refuses an EtherType match when the
  active template lacks the field.
- `rtl83xx_validate_flow_actions()` rejects nonsensical action
  combinations (multiple forwards; drop mixed with other actions).
- The rule is bound to the physical ingress port via the source-port
  field. On RTL930x the PIE rule ID is also the LOG counter ID, so the
  packet counter needs no separate allocation.
- The flow rhashtable is created in `rtldsa_93xx_setup()` (RTL9300 only)
  and destroyed RCU-safely in `rtl83xx_sw_remove()` and the probe error
  path.

The first commit is a standalone fix: `rtl930x_packet_cntr_clear()` wrote
a shared LOG table entry back without reading it first, clobbering the
adjacent counter. It is latent today and becomes reachable once the
offload clears counters at runtime.

### Testing

Built for `realtek` / `rtl930x` (kernel 6.18); `make target/linux/compile`
is clean with no new warnings.

Flashed and tested on a Zyxel XGS1210-12:

| Rule | Result |
|---|---|
| `flower protocol 0x8863 ... action drop` (PPPoE discovery) | installed, `in_hw in_hw_count 1` |
| `flower protocol ip ip_proto udp dst_port 67 ... action trap` | installed, `in_hw in_hw_count 1` |
| `flower ... action trap` on ARP + `tc -s filter show` | 3 real packets counted over 12 s (`Sent hardware 0 bytes 3 pkt`) |
| `tc filter del` + `tc qdisc del clsact` | no residue, no `dmesg` errors |

### Note

`rtl83xx_setup_tc()` (the older flow-block-cb path) has no `port_setup_tc`
op wired to it and is currently unreachable; it is kept building and now
shares `rtl83xx_tc_init()`.

---
Discussion / testing feedback: https://forum.openwrt.org/t/tcfilter-luci-app-tcfilter-persistent-tc-ingress-filters-with-hardware-offload-on-realtek-switches/253331
