### PR TITLE
lantiq/xrx200: add support for Huawei B2268S

### DIFF
--- a/package/boot/uboot-lantiq/Makefile
+++ b/package/boot/uboot-lantiq/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=u-boot
 PKG_VERSION:=2013.10
-PKG_RELEASE:=67
+PKG_RELEASE:=68
 
 PKG_HASH:=0d71e62beb952b41ebafb20a7ee4df2f960db64c31b054721ceb79ff14014c55
 
@@ -201,6 +201,21 @@ define U-Boot/acmp252_nor
   BUILD_DEVICES:=audiocodes_mp-252
 endef
 
+define U-Boot/b2268s_ram
+  NAME:=Huawei B2268S (RAM)
+  BUILD_SUBTARGET:=xrx200
+  BUILD_DEVICES:=huawei_b2268s
+  DDR_SETTINGS:=board/huawei/b2268s/ddr_settings.h
+endef
+
+define U-Boot/b2268s_nandspl
+  NAME:=Huawei B2268S (NAND SPL)
+  BUILD_SUBTARGET:=xrx200
+  BUILD_DEVICES:=huawei_b2268s
+  UBOOT_IMAGE:=u-boot.ltq.lzo.nandspl
+  DEPENDS+=@BROKEN
+endef
+
 define U-Boot/bthomehubv5a_ram
   NAME:=BT Home Hub 5A (RAM)
   BUILD_SUBTARGET:=xrx200
@@ -341,6 +356,7 @@ UBOOT_TARGETS:= \
 	arv752dpw_ram arv752dpw_nor arv752dpw_brn \
 	arv752dpw22_ram arv752dpw22_nor arv752dpw22_brn \
 	arv8539pw22_brn arv8539pw22_nor arv8539pw22_ram \
+	b2268s_ram b2268s_nandspl \
 	bthomehubv5a_ram \
 	gigasx76x_ram gigasx76x_nor \
 	acmp252_ram acmp252_nor \

--- a/package/boot/uboot-lantiq/patches/0117-MIPS-add-board-support-for-Huawei-B2268S.patch
+++ b/package/boot/uboot-lantiq/patches/0117-MIPS-add-board-support-for-Huawei-B2268S.patch
@@ -1,0 +1,299 @@
+From 4bc79594df533057c912b4d0cefa54fa91715ce6 Mon Sep 17 00:00:00 2001
+From: Mohamed Meddeb <mohamedmeddeb441@gmail.com>
+Date: Sat, 5 Sep 2026 16:41:16 +0100
+Subject: [PATCH] MIPS: add board support for Huawei B2268S
+
+Signed-off-by: Mohamed Meddeb <mohamedmeddeb441@gmail.com>
+
+--- /dev/null
++++ b/board/huawei/b2268s/Makefile
+@@ -0,0 +1,27 @@
++#
++# Copyright (C) 2000-2011 Wolfgang Denk, DENX Software Engineering, wd@denx.de
++#
++# SPDX-License-Identifier:	GPL-2.0+
++#
++
++include $(TOPDIR)/config.mk
++
++LIB	= $(obj)lib$(BOARD).o
++
++COBJS	= $(BOARD).o
++
++SRCS	:= $(SOBJS:.o=.S) $(COBJS:.o=.c)
++OBJS	:= $(addprefix $(obj),$(COBJS))
++SOBJS	:= $(addprefix $(obj),$(SOBJS))
++
++$(LIB):	$(obj).depend $(OBJS) $(SOBJS)
++	$(call cmd_link_o_target, $(OBJS) $(SOBJS))
++
++#########################################################################
++
++# defines $(obj).depend target
++include $(SRCTREE)/rules.mk
++
++sinclude $(obj).depend
++
++#########################################################################
+--- /dev/null
++++ b/board/huawei/b2268s/b2268s.c
+@@ -0,0 +1,90 @@
++/*
++ * Copyright (C) 2013 Luka Perkov <luka@openwrt.org>
++ * Copyright (C) 2026 Mohamed Meddeb <mohamedmeddeb441@gmail.com>
++ *
++ * SPDX-License-Identifier:	GPL-2.0+
++ */
++
++#include <common.h>
++#include <asm/gpio.h>
++#include <asm/lantiq/eth.h>
++#include <asm/lantiq/chipid.h>
++#include <asm/lantiq/cpu.h>
++#include <asm/arch/gphy.h>
++
++#if defined(CONFIG_SPL_BUILD)
++#define do_gpio_init	1
++#define do_pll_init	1
++#define do_dcdc_init	0
++#elif defined(CONFIG_SYS_BOOT_RAM)
++#define do_gpio_init	1
++#define do_pll_init	0
++#define do_dcdc_init	1
++#else
++#define do_gpio_init	0
++#define do_pll_init	0
++#define do_dcdc_init	1
++#endif
++
++static void gpio_init(void)
++{
++	/* EBU.FL_CS1 as output for NAND CE */
++	gpio_set_altfunc(23, GPIO_ALTSEL_SET, GPIO_ALTSEL_CLR, GPIO_DIR_OUT);
++	/* EBU.FL_A23 as output for NAND CLE */
++	gpio_set_altfunc(24, GPIO_ALTSEL_SET, GPIO_ALTSEL_CLR, GPIO_DIR_OUT);
++	/* EBU.FL_A24 as output for NAND ALE */
++	gpio_set_altfunc(13, GPIO_ALTSEL_SET, GPIO_ALTSEL_CLR, GPIO_DIR_OUT);
++	/* GPIO 3.0 as input for NAND Ready Busy */
++	gpio_set_altfunc(48, GPIO_ALTSEL_SET, GPIO_ALTSEL_CLR, GPIO_DIR_IN);
++	/* GPIO 3.1 as output for NAND Read */
++	gpio_set_altfunc(49, GPIO_ALTSEL_SET, GPIO_ALTSEL_CLR, GPIO_DIR_OUT);
++}
++
++int board_early_init_f(void)
++{
++	if (do_gpio_init)
++		gpio_init();
++
++	if (do_pll_init)
++		ltq_pll_init();
++
++	if (do_dcdc_init)
++		ltq_dcdc_init(0x7F);
++
++	return 0;
++}
++
++int checkboard(void)
++{
++	puts("Board: " CONFIG_BOARD_NAME "\n");
++	ltq_chip_print_info();
++
++	return 0;
++}
++
++static const struct ltq_eth_port_config eth_port_config[] = {
++	/* GMAC2: internal GPHY0 with 10/100/1000 firmware for LAN port 2 */
++	{ 2, 0x11, LTQ_ETH_PORT_PHY, PHY_INTERFACE_MODE_GMII },
++	/* GMAC4: internal GPHY1 with 10/100/1000 firmware for LAN port 1 */
++	{ 4, 0x13, LTQ_ETH_PORT_PHY, PHY_INTERFACE_MODE_GMII },
++};
++
++static const struct ltq_eth_board_config eth_board_config = {
++	.ports = eth_port_config,
++	.num_ports = ARRAY_SIZE(eth_port_config),
++};
++
++int board_eth_init(bd_t * bis)
++{
++	const enum ltq_gphy_clk clk = LTQ_GPHY_CLK_25MHZ_PLL0;
++	const ulong fw_addr = 0x80FF0000;
++
++	ltq_gphy_phy11g_a2x_load(fw_addr);
++
++	ltq_cgu_gphy_clk_src(clk);
++
++	ltq_rcu_gphy_boot(0, fw_addr);
++	ltq_rcu_gphy_boot(1, fw_addr);
++
++	return ltq_eth_initialize(&eth_board_config);
++}
+--- /dev/null
++++ b/board/huawei/b2268s/config.mk
+@@ -0,0 +1,7 @@
++#
++# Copyright (C) 2012-2013 Daniel Schwierzeck, daniel.schwierzeck@gmail.com
++#
++# SPDX-License-Identifier:	GPL-2.0+
++#
++
++PLATFORM_CPPFLAGS += -I$(TOPDIR)/board/$(BOARDDIR)
+--- /dev/null
++++ b/board/huawei/b2268s/ddr_settings.h
+@@ -0,0 +1,72 @@
++/*
++ * Copyright (C) 2013 Luka Perkov <luka@openwrt.org>
++ *
++ * The values are taken from the Zyxel P-2812HNU-Fx board
++ * (board/zyxel/p2812hnufx/ddr_settings.h) and have been
++ * verified working on the Huawei B2268S.
++ *
++ * SPDX-License-Identifier:     GPL-2.0+
++ */
++
++#define	MC_CCR00_VALUE	0x101
++#define	MC_CCR01_VALUE	0x1000100
++#define	MC_CCR02_VALUE	0x1010000
++#define	MC_CCR03_VALUE	0x101
++#define	MC_CCR04_VALUE	0x1000000
++#define	MC_CCR05_VALUE	0x1000101
++#define	MC_CCR06_VALUE	0x1000100
++#define	MC_CCR07_VALUE	0x1010000
++#define	MC_CCR08_VALUE	0x1000101
++#define	MC_CCR09_VALUE	0x0
++#define	MC_CCR10_VALUE	0x2000100
++#define	MC_CCR11_VALUE	0x2000300
++#define	MC_CCR12_VALUE	0x30000
++#define	MC_CCR13_VALUE	0x202
++#define	MC_CCR14_VALUE	0x7080A0F
++#define	MC_CCR15_VALUE	0x2040F
++#define	MC_CCR16_VALUE	0x40000
++#define	MC_CCR17_VALUE	0x70102
++#define	MC_CCR18_VALUE	0x4020002
++#define	MC_CCR19_VALUE	0x30302
++#define	MC_CCR20_VALUE	0x8000700
++#define	MC_CCR21_VALUE	0x40F020A
++#define	MC_CCR22_VALUE	0x0
++#define	MC_CCR23_VALUE	0xC020000
++#define	MC_CCR24_VALUE	0x4401B04
++#define	MC_CCR25_VALUE	0x0
++#define	MC_CCR26_VALUE	0x0
++#define	MC_CCR27_VALUE	0x6420000
++#define	MC_CCR28_VALUE	0x0
++#define	MC_CCR29_VALUE	0x0
++#define	MC_CCR30_VALUE	0x798
++#define	MC_CCR31_VALUE	0x0
++#define	MC_CCR32_VALUE	0x0
++#define	MC_CCR33_VALUE	0x650000
++#define	MC_CCR34_VALUE	0x200C8
++#define	MC_CCR35_VALUE	0x1D445D
++#define	MC_CCR36_VALUE	0xC8
++#define	MC_CCR37_VALUE	0xC351
++#define	MC_CCR38_VALUE	0x0
++#define	MC_CCR39_VALUE	0x141F04
++#define	MC_CCR40_VALUE	0x142704
++#define	MC_CCR41_VALUE	0x141B42
++#define	MC_CCR42_VALUE	0x141B42
++#define	MC_CCR43_VALUE	0x566504
++#define	MC_CCR44_VALUE	0x566504
++#define	MC_CCR45_VALUE	0x565F17
++#define	MC_CCR46_VALUE	0x565F17
++#define	MC_CCR47_VALUE	0x0
++#define	MC_CCR48_VALUE	0x0
++#define	MC_CCR49_VALUE	0x0
++#define	MC_CCR50_VALUE	0x0
++#define	MC_CCR51_VALUE	0x0
++#define	MC_CCR52_VALUE	0x133
++#define	MC_CCR53_VALUE	0xF3014B27
++#define	MC_CCR54_VALUE	0xF3014B27
++#define	MC_CCR55_VALUE	0xF3014B27
++#define	MC_CCR56_VALUE	0xF3014B27
++#define	MC_CCR57_VALUE	0x7800301
++#define	MC_CCR58_VALUE	0x7800301
++#define	MC_CCR59_VALUE	0x7800301
++#define	MC_CCR60_VALUE	0x7800301
++#define	MC_CCR61_VALUE	0x4
+--- a/boards.cfg
++++ b/boards.cfg
+@@ -548,6 +548,8 @@ Active  mips        mips32         vrx200      avm             fb3370
+ Active  mips        mips32         vrx200      avm             fb3370              fb3370_sfspl                         fb3370:SYS_BOOT_SFSPL                                                                                                             Daniel Schwierzeck <daniel.schwierzeck@gmail.com>
+ Active  mips        mips32         vrx200      bt              bthomehubv5a        bthomehubv5a_nandspl                 bthomehubv5a:SYS_BOOT_NANDSPL                                                                                                     Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+ Active  mips        mips32         vrx200      bt              bthomehubv5a        bthomehubv5a_ram                     bthomehubv5a:SYS_BOOT_RAM                                                                                                         Martin Blumenstingl <martin.blumenstingl@googlemail.com>
++Active  mips        mips32         vrx200      huawei          b2268s              b2268s_nandspl                       b2268s:SYS_BOOT_NANDSPL                                                                                                           Mohamed Meddeb <mohamedmeddeb441@gmail.com>
++Active  mips        mips32         vrx200      huawei          b2268s              b2268s_ram                           b2268s:SYS_BOOT_RAM                                                                                                               Mohamed Meddeb <mohamedmeddeb441@gmail.com>
+ Active  mips        mips32         vrx200      lantiq          easy80920           easy80920_nandspl                    easy80920:SYS_BOOT_NANDSPL                                                                                                        Daniel Schwierzeck <daniel.schwierzeck@gmail.com>
+ Active  mips        mips32         vrx200      lantiq          easy80920           easy80920_nor                        easy80920:SYS_BOOT_NOR                                                                                                            Daniel Schwierzeck <daniel.schwierzeck@gmail.com>
+ Active  mips        mips32         vrx200      lantiq          easy80920           easy80920_norspl                     easy80920:SYS_BOOT_NORSPL                                                                                                         Daniel Schwierzeck <daniel.schwierzeck@gmail.com>
+--- /dev/null
++++ b/include/configs/b2268s.h
+@@ -0,0 +1,70 @@
++/*
++ * Copyright (C) 2013 Luka Perkov <luka@openwrt.org>
++ * Copyright (C) 2026 Mohamed Meddeb <mohamedmeddeb441@gmail.com>
++ *
++ * SPDX-License-Identifier:	GPL-2.0+
++ */
++
++#ifndef __CONFIG_H
++#define __CONFIG_H
++
++#define CONFIG_MACH_TYPE	"B2268S"
++#define CONFIG_IDENT_STRING	" "CONFIG_MACH_TYPE
++#define CONFIG_BOARD_NAME	"Huawei B2268S"
++
++/* Configure SoC */
++#define CONFIG_LTQ_SUPPORT_UART			/* Enable ASC and UART */
++
++#define CONFIG_LTQ_SUPPORT_ETHERNET		/* Enable ethernet */
++
++#define CONFIG_LTQ_SUPPORT_NAND_FLASH		/* Have a S34ML01G2 NAND flash */
++
++#define CONFIG_LTQ_SUPPORT_SPL_NAND_FLASH	/* Build NAND flash SPL */
++#define CONFIG_LTQ_SPL_COMP_LZO			/* Compress SPL with LZO */
++#define CONFIG_LTQ_SPL_CONSOLE			/* Enable SPL console */
++
++#define CONFIG_SYS_NAND_PAGE_COUNT	64
++#define CONFIG_SYS_NAND_PAGE_SIZE	2048
++#define CONFIG_SYS_NAND_OOBSIZE		64
++#define CONFIG_SYS_NAND_BLOCK_SIZE	(128 * 1024)
++#define CONFIG_SYS_NAND_BAD_BLOCK_POS	NAND_LARGE_BADBLOCK_POS
++#define CONFIG_SYS_NAND_U_BOOT_OFFS	0x4000
++
++#define CONFIG_SYS_DRAM_PROBE
++
++#define CONFIG_SYS_BOOTM_LEN          0x1000000       /* 16 MB */
++
++/* Environment */
++#if defined(CONFIG_SYS_BOOT_NANDSPL)
++#define CONFIG_ENV_IS_IN_NAND
++#define CONFIG_ENV_OVERWRITE
++#define CONFIG_ENV_OFFSET		(256 * 1024)
++#define CONFIG_ENV_SECT_SIZE		(128 * 1024)
++#else
++#define CONFIG_ENV_IS_NOWHERE
++#endif
++
++#define CONFIG_ENV_SIZE			(8 * 1024)
++#define CONFIG_LOADADDR			CONFIG_SYS_LOAD_ADDR
++
++/* Console */
++#define CONFIG_LTQ_ADVANCED_CONSOLE
++#define CONFIG_BAUDRATE			115200
++#define CONFIG_CONSOLE_ASC		1
++#define CONFIG_CONSOLE_DEV		"ttyLTQ1"
++
++/* Pull in default board configs for Lantiq XWAY VRX200 */
++#include <asm/lantiq/config.h>
++#include <asm/arch/config.h>
++
++/* Pull in default OpenWrt configs for Lantiq SoC */
++#include "openwrt-lantiq-common.h"
++
++#define CONFIG_ENV_UPDATE_UBOOT_NAND					\
++	"update-uboot-nand=run load-uboot-nandspl-lzo write-uboot-nand\0"
++
++#define CONFIG_EXTRA_ENV_SETTINGS	\
++	CONFIG_ENV_LANTIQ_DEFAULTS	\
++	CONFIG_ENV_UPDATE_UBOOT_NAND
++
++#endif /* __CONFIG_H */

--- a/target/linux/lantiq/dts/vr9_huawei_b2268s.dts
+++ b/target/linux/lantiq/dts/vr9_huawei_b2268s.dts
@@ -1,0 +1,195 @@
+/dts-v1/;
+#include "vr9.dtsi"
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/mips/lantiq_rcu_gphy.h>
+/ {
+	compatible = "huawei,b2268s", "lantiq,xway", "lantiq,vr9";
+	model = "Huawei B2268S";
+	chosen {
+		bootargs = "console=ttyLTQ0,115200 init=/etc/preinit";
+	};
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+		reset {
+			label = "reset";
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+	leds {
+		compatible = "gpio-leds";
+
+		green_lan1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			gpios = <&stp 18 GPIO_ACTIVE_HIGH>;
+		};
+		orange_lan1 {
+			color = <LED_COLOR_ID_ORANGE>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			gpios = <&stp 19 GPIO_ACTIVE_HIGH>;
+		};
+		green_lan2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&stp 21 GPIO_ACTIVE_HIGH>;
+		};
+		orange_lan2 {
+			color = <LED_COLOR_ID_ORANGE>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&stp 22 GPIO_ACTIVE_HIGH>;
+		};
+		lte {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_MOBILE;
+			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
+		};
+		rssi1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_INDICATOR;
+			function-enumerator = <1>;
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+		};
+		rssi2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_INDICATOR;
+			function-enumerator = <2>;
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+		rssi3 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_INDICATOR;
+			function-enumerator = <3>;
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+		rssi4 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_INDICATOR;
+			function-enumerator = <4>;
+			gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
+		};
+		rssi5 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_INDICATOR;
+			function-enumerator = <5>;
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+		};
+		wlan_orange {
+			color = <LED_COLOR_ID_ORANGE>;
+			function = LED_FUNCTION_WLAN;
+			gpios = <&stp 23 GPIO_ACTIVE_LOW>;
+		};
+		wlan_green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
+			gpios = <&stp 20 GPIO_ACTIVE_LOW>;
+		};
+		usb0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_USB;
+			gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+	};
+};
+&gphy0 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+	status = "okay";
+};
+&gphy1 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+	status = "okay";
+};
+&localbus {
+	flash@0 {
+		compatible = "lantiq,nand-xway";
+		lantiq,cs = <1>;
+		bank-width = <1>;
+		reg = <1 0x0 0x2000000>;
+		pinctrl-0 = <&nand_pins>, <&nand_cs1_pins>;
+		pinctrl-names = "default";
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			partition@0 {
+				label = "uboot";
+				reg = <0x00000 0x40000>;
+				read-only;
+			};
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x20000>;
+			};
+			partition@60000 {
+				label = "kernel";
+				reg = <0x60000 0x500000>;
+			};
+			partition@560000 {
+				label = "ubi";
+				reg = <0x560000 0x7aa0000>;
+			};
+		};
+	};
+};
+&gswip {
+	pinctrl-0 = <&mdio_pins>,
+		    <&gphy0_led1_pins>, <&gphy0_led2_pins>,
+		    <&gphy1_led1_pins>, <&gphy1_led2_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+&gswip_mdio {
+	status = "okay";
+	phy11: ethernet-phy@11 {
+		reg = <0x11>;
+		compatible = "ethernet-phy-ieee802.3-c22";
+	};
+	phy13: ethernet-phy@13 {
+		reg = <0x13>;
+		compatible = "ethernet-phy-ieee802.3-c22";
+	};
+};
+&gswip_ports {
+	status = "okay";
+	port@2 {
+		reg = <2>;
+		label = "lan2";
+		phy-mode = "internal";
+		phy-handle = <&phy11>;
+		status = "okay";
+	};
+	port@4 {
+		reg = <4>;
+		label = "lan1";
+		phy-mode = "internal";
+		phy-handle = <&phy13>;
+		status = "okay";
+	};
+};
+&pci0 {
+	status = "okay";
+	reset-gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+	wifi@e,0 {
+		compatible = "pci1814,5392";
+		reg = <0x7000 0 0 0 0>;
+		ralink,eeprom = "RT5392.eeprom";
+	};
+};
+&stp { status = "okay"; };
+&gpio { status = "okay"; };
+&usb_phy0 { status = "okay"; };
+&usb_phy1 { status = "okay"; };
+&usb0 { status = "okay"; };
+&usb1 { status = "okay"; };

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -334,6 +334,16 @@ define Device/buffalo_wbmr-300hpd
 endef
 TARGET_DEVICES += buffalo_wbmr-300hpd
 
+define Device/huawei_b2268s
+  $(Device/NAND)
+  DEVICE_VENDOR := Huawei
+  DEVICE_MODEL := B2268S
+  KERNEL_SIZE := 5120k
+  DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-mbedtls kmod-usb-dwc2 \
+	kmod-usb-ledtrig-usbport xrx200-rev1.2-phy11g-firmware
+endef
+TARGET_DEVICES += huawei_b2268s
+
 define Device/lantiq_easy80920-nand
   $(Device/dsa-migration)
   $(Device/lantiqFullImage)

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
@@ -66,6 +66,12 @@ buffalo,wbmr-300hpd)
 	ucidef_set_led_switch "lan3" "LAN3" "green:lan3" "switch0" "0x20"
 	ucidef_set_led_default "router" "router" "green:router" "1"
 	;;
+huawei,b2268s)
+	ucidef_set_led_netdev "lan1_green" "lan1" "green:lan-1" "lan1" "link"
+	ucidef_set_led_netdev "lan1_orange" "lan1" "orange:lan-1" "lan1" "rx tx"
+	ucidef_set_led_netdev "lan2_green" "lan2" "green:lan-2" "lan2" "link"
+	ucidef_set_led_netdev "lan2_orange" "lan2" "orange:lan-2" "lan2" "rx tx"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
@@ -47,6 +47,9 @@ lantiq_setup_interfaces()
 	avm,fritz7412)
 		ucidef_set_interface_lan "lan"
 		;;
+	huawei,b2268s)
+		ucidef_set_interface_lan "lan1 lan2"
+		;;
 	*)
 		ucidef_set_interface_lan 'eth0'
 		;;
@@ -75,7 +78,8 @@ lantiq_setup_dsl()
 		annex="b"
 		;;
 	avm,fritz5490|\
-	avm,fritz5490-micron)
+	avm,fritz5490-micron|\
+	huawei,b2268s)
 		return
 		;;
 	esac
@@ -135,6 +139,9 @@ lantiq_setup_macs()
 		;;
 	buffalo,wbmr-300hpd)
 		wan_mac="$(mtd_get_mac_ascii u-boot-env ethaddr)"
+		;;
+	huawei,b2268s)
+		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		;;
 	tplink,vr200|\
 	tplink,vr200v)

--- a/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
+++ b/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
@@ -23,6 +23,7 @@ platform_do_upgrade() {
 	avm,fritz7490|\
 	avm,fritz7490-micron|\
 	bt,homehub-v5a|\
+	huawei,b2268s|\
 	zyxel,p-2812hnu-f1|\
 	zyxel,p-2812hnu-f3)
 		nand_do_upgrade $1


### PR DESCRIPTION
This commit adds support for the Huawei B2268S

SoC: Lantiq GRX200 rev 1.2 (VR9/xrx200)
RAM: 128 MB
Flash: NAND
Ethernet: 2x LAN
USB: 1x USB 2.0
VoIP: 1x FXS (phone) port
PoE: PoE port present

Didn't test VoIP, might test and add support if required in the future.
Didn't test PoE, might test and add support if required in the future.

### Installation guide
-------------------

1. Short R228 to ground while powering on the device. This forces
   the board into UART mode.

2. Send the generated `u-boot.asc` (from `u-boot-b2268s_ram/`) over
   the UART using CuteCom.

3. Once the U-Boot loaded to RAM is running, wipe NAND, tftpboot
   the new U-Boot image, then write it to NAND.

4. Power-cycle the device (power off, power on). This will drop
   you to a U-Boot command line.

5. TFTP-boot the initramfs image:
   openwrt-lantiq-xrx200-huawei_b2268s-initramfs-kernel.bin

6. From the running initramfs system, run sysupgrade with the
   final OpenWrt image to complete installation.