### PR TITLE
ath79: add support for MikroTik RouterBOARD 450G

### DIFF
--- a/target/linux/ath79/dts/ar7100_mikrotik_routerboard-4xx.dtsi
+++ b/target/linux/ath79/dts/ar7100_mikrotik_routerboard-4xx.dtsi
@@ -142,7 +142,7 @@
 					reg = <0x0040000 0x0800000>;
 				};
 
-				partition@840000 {
+				ubi: partition@840000 {
 					label = "ubi";
 					reg = <0x0840000 0x77c0000>;
 				};

--- a/target/linux/ath79/dts/ar7161_mikrotik_routerboard-450g.dts
+++ b/target/linux/ath79/dts/ar7161_mikrotik_routerboard-450g.dts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar7100_mikrotik_routerboard-4xx.dtsi"
+
+/ {
+	compatible = "mikrotik,routerboard-450g", "qca,ar7161";
+	model = "MikroTik RouterBOARD 450G";
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&gpio {
+	gpio-line-names =
+		"",     "", "", "", "LED", "RDY",  "",  "reset",
+		"", "", "", "";
+};
+
+&pcie0 {
+	status = "disabled";
+};
+
+&mdio0 {
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	phy-handle = <&phy4>;
+};
+
+&spi {
+	sdcard: mmc-slot@2 {
+		compatible = "mmc-spi-slot";
+
+		reg = <2>;
+		spi-max-frequency = <25000000>;
+	};
+};
+
+&ubi {
+	reg = <0x0840000 0x0>;
+};

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -11,6 +11,15 @@ define Device/mikrotik_routerboard-2011uias-2hnd
 endef
 TARGET_DEVICES += mikrotik_routerboard-2011uias-2hnd
 
+define Device/mikrotik_routerboard-450g
+  $(Device/mikrotik_nand)
+  SOC := ar7161
+  DEVICE_MODEL := RouterBOARD 450G
+  DEVICE_PACKAGES += -kmod-ath9k -wpad-basic-mbedtls
+  SUPPORTED_DEVICES += rb-450g
+endef
+TARGET_DEVICES += mikrotik_routerboard-450g
+
 define Device/mikrotik_routerboard-493g
   $(Device/mikrotik_nand)
   SOC := ar7161

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
@@ -13,6 +13,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch1" \
 			"0@eth1" "1:lan:5" "2:lan:4" "3:lan:3" "4:lan:2" "5:lan:1"
 		;;
+	mikrotik,routerboard-450g)
+		ucidef_set_interfaces_lan_wan "eth0.1" "eth1"
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan:1" "2:lan:4" "3:lan:3" "4:lan:2"
+		;;
 	mikrotik,routerboard-493g)
 		ucidef_set_interfaces_lan_wan "eth0.1 eth1.1" "eth0.2"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/05_compat-version
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/05_compat-version
@@ -7,6 +7,7 @@ board_config_update
 
 case "$(board_name)" in
 	mikrotik,routerboard-2011uias-2hnd|\
+	mikrotik,routerboard-450g|\
 	mikrotik,routerboard-493g|\
 	mikrotik,routerboard-911g-5hpacd|\
 	mikrotik,routerboard-911g-xhpnd|\

--- a/target/linux/ath79/mikrotik/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/mikrotik/base-files/lib/upgrade/platform.sh
@@ -30,6 +30,7 @@ platform_check_image() {
 
 	case "$board" in
 	mikrotik,routerboard-2011uias-2hnd|\
+	mikrotik,routerboard-450g|\
 	mikrotik,routerboard-493g|\
 	mikrotik,routerboard-911g-5hpacd|\
 	mikrotik,routerboard-911g-xhpnd|\
@@ -73,6 +74,7 @@ platform_do_upgrade() {
 
 	case "$board" in
 	mikrotik,routerboard-2011uias-2hnd|\
+	mikrotik,routerboard-450g|\
 	mikrotik,routerboard-493g|\
 	mikrotik,routerboard-911g-5hpacd|\
 	mikrotik,routerboard-911g-xhpnd|\


### PR DESCRIPTION
SoC: Atheros AR7161 (MIPS 24K)
CPU: 680 MHz (max 800 MHz)
RAM: 256 MiB DDR
NAND Flash: 512 MiB (HY27UT084G2A or Samsung K9F4G08U0B-PIB0)
Boot SPI Flash: PMC Pm25LV512 512Kbit
Switch: Atheros AR8316
CPLD: Xilinx XC9536XL
Ethernet: 5×Gigabit (1 WAN + 4 LAN ports)

https://openwrt.org/toh/mikrotik/rb450g
