### PR TITLE
wifi-scripts: silence iw antenna/distance failures like shell did

### DIFF
--- a/package/network/config/wifi-scripts/Makefile
+++ b/package/network/config/wifi-scripts/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wifi-scripts
 PKG_VERSION:=1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-2.0
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>

--- a/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
@@ -103,9 +103,9 @@ function setup_phy(phy, config, data) {
 	log(`Configuring '${phy}' distance: ${config.distance}`);
 	if (antenna_changed) {
 		log(`Setting antenna for '${phy}' txantenna: ${config.txantenna}, rxantenna: ${config.rxantenna}`);
-		system(`iw phy ${phy} set antenna ${config.txantenna} ${config.rxantenna}`);
+		system(`iw phy ${phy} set antenna ${config.txantenna} ${config.rxantenna} >/dev/null 2>&1`);
 	}
-	system(`iw phy ${phy} set distance ${config.distance}`);
+	system(`iw phy ${phy} set distance ${config.distance} >/dev/null 2>&1`);
 	system(`iw phy ${phy} set txpower ${config.txpower}`);
 
 	if (config.frag)


### PR DESCRIPTION
The shell `mac80211.sh` ran both of these with `>/dev/null 2>&1`:

```
iw phy "$phy" set antenna $txantenna $rxantenna >/dev/null 2>&1
iw phy "$phy" set distance "$distance" >/dev/null 2>&1
```

The ucode rewrite (`files-ucode/`) dropped the redirect, so on any driver
without `->set_coverage_class` every `wifi up` now logs

```
netifd: radio0 (3302): command failed: Not supported (-95)
```

with no indication of which command failed. Neither `system()` return
value is checked, so the message is pure noise — but it reads like
`wifi up` failed. On ath12k/IPQ5332 it cost real debugging time before
the line was traced back to `iw.c:616` (`iw` printing to stderr on
`-EOPNOTSUPP` from `set distance`) rather than to the driver.

Restore the redirect on both calls. `distance` defaults to 0 and antenna
to `0xffffffff`, so both run on every setup for every radio.

`PKG_RELEASE` bumped 1 → 2.
