### PR TITLE
airoha: add support for VSOL V2902A

### DIFF
--- a/package/boot/arm-trusted-firmware-airoha/Makefile
+++ b/package/boot/arm-trusted-firmware-airoha/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_VERSION:=2.10
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_HASH:=88215a62291b9ba87da8e50b077741103cdc08fb6c9e1ebd34dfaace746d3201
 
 PKG_MAINTAINER:=Christian Marangi <ansuelsmth@gmail.com>
@@ -30,7 +30,8 @@ define Trusted-Firmware-A/an7581-bl2
   $(call Trusted-Firmware-A/bl2/Default)
   BUILD_SUBTARGET:=an7581
   SOC:=EN7581
-  BUILD_DEVICES:=airoha_an7581-evb airoha_an7581-evb-emmc-eagle airoha_an7581-evb-emmc-kite nokia_valyrian nokia_xg-040g-md-ubi
+  BUILD_DEVICES:=airoha_an7581-evb airoha_an7581-evb-emmc-eagle airoha_an7581-evb-emmc-kite nokia_valyrian nokia_xg-040g-md-ubi \
+	vsol_v2902a
 endef
 
 define Trusted-Firmware-A/an7583-bl2
@@ -51,7 +52,8 @@ define Trusted-Firmware-A/an7581-bl31
   $(call Trusted-Firmware-A/bl31/Default)
   BUILD_SUBTARGET:=an7581
   SOC:=EN7581
-  BUILD_DEVICES:=airoha_an7581-evb airoha_an7581-evb-emmc-eagle airoha_an7581-evb-emmc-kite nokia_valyrian nokia_xg-040g-md-ubi
+  BUILD_DEVICES:=airoha_an7581-evb airoha_an7581-evb-emmc-eagle airoha_an7581-evb-emmc-kite nokia_valyrian nokia_xg-040g-md-ubi \
+	vsol_v2902a
 endef
 
 define Trusted-Firmware-A/an7583-bl31

--- a/package/boot/uboot-airoha/Makefile
+++ b/package/boot/uboot-airoha/Makefile
@@ -52,6 +52,14 @@ define U-Boot/an7581_rfb
   DEPENDS:=+trusted-firmware-a-an7581-bl31
 endef
 
+define U-Boot/an7581_vsol_v2902a
+  NAME:=VSOL V2902A
+  UBOOT_CONFIG:=an7581_vsol_v2902a
+  BUILD_DEVICES:=vsol_v2902a
+  BUILD_SUBTARGET:=an7581
+  DEPENDS:=+trusted-firmware-a-an7581-bl31
+endef
+
 define U-Boot/an7583_nokia_xg-040g-mf
   NAME:=Nokia XG-040G-MF
   UBOOT_CONFIG:=an7583_nokia_xg-040g-mf
@@ -86,6 +94,7 @@ UBOOT_TARGETS := \
 	an7581_nokia_valyrian \
 	an7581_nokia_xg-040g-md \
 	an7581_rfb \
+	an7581_vsol_v2902a \
 	an7583_nokia_xg-040g-mf \
 	an7583_rfb \
 	en7523_rfb

--- a/package/boot/uboot-airoha/patches/403-airoha-add-vsol-an7581.patch
+++ b/package/boot/uboot-airoha/patches/403-airoha-add-vsol-an7581.patch
@@ -1,0 +1,305 @@
+From 3755d0f8e4f74bba315ad22cc2b6995cb6bf2404 Mon Sep 17 00:00:00 2001
+From: Yubo Zhang <zyb_1998@outlook.com>
+Date: Wed, 29 Jul 2026 15:00:00 +0800
+Subject: [PATCH] an7581: add support for VSOL V2902A
+
+Add a U-Boot config for the VSOL V2902A based on the Airoha AN7581 SoC.
+It uses the same boot flow as the VSOL AN7583 devices and retains the
+stock firmware partition start addresses.
+
+Partition and images
+--------------------
+Partitions
+- bootloader (tcboot.bin): payload/crc needed by BL2 but not BL31
+- tclinux (tclinux.bin): UBI image containing the fip/fit volumes
+- tclinux_slave (tclinux.bin): Identical to tclinux and used for backup
+- rootfs_data: Independent UBI partition used for OpenWrt overlay
+
+tcboot.bin (512 KiB)
+- 0x00000-0x007ff: padding with 0x0
+- 0x00800-0x1ffff: BL2 FIP, padding with 0xff
+- 0x20000-0x7bffb: BL31 + U-Boot FIP padding with 0xff, normally unused
+- 0x7bffc-0x7bfff: little-endian inverted CRC32 of 0x00000-0x7bffb
+- 0x7c000-0x7ffff: padding with 0xff
+
+tclinux.bin
+UBI volume 0 (fip):
+- BL31 + U-Boot FIP
+UBI volume 1 (fit):
+- Linux FIT
+  - LZMA Linux kernel
+  - V2902A DTB
+  - squashfs rootfs
+
+Since the name and offset of partitions and images are designed to be the
+same as stock firmware, switching to OpenWrt or back to stock will be
+less difficult.
+
+Boot flow
+---------
+AN7581 Boot ROM -> BL2 -> FIP -> BL31 -> U-Boot -> FIT -> Linux
+|      tcboot.bin       |             tclinux.bin             |
+
+If booting from the tclinux partition fails, tclinux_slave will be used
+for backup. These A/B partitions could also be manually selected by
+command `run boot_tclinux` and `run boot_tclinux_slave` in U-Boot.
+
+Rename the images for the target model to these names before using
+tftpboot or upgrade commands:
+- initramfs-uImage.itb
+- tcboot.bin
+- tclinux.bin
+
+To upgrade bootloader and firmware in U-Boot, use the command:
+`run upgrade_tcboot` and `run upgrade_tclinux`.
+
+Known limits
+------------
+- U-Boot network access is available only through the internal switch.
+- Persistent U-Boot environment (saveenv) is not supported.
+- The automatic adaptation of 64/128/256 MiB flash like stock firmware is
+  not implemented. Only the fixed 128 MiB partition layout is supported.
+- The bootflag based A/B partition switch logic is not implemented.
+
+Signed-off-by: Yubo Zhang <zyb_1998@outlook.com>
+---
+ arch/arm/dts/an7581-vsol-v2902a-u-boot.dtsi    |   7 ++
+ configs/an7581_vsol_v2902a_defconfig           |  89 ++++++++++++++++++
+ defenvs/an7581_vsol_v2902a_env                 |  16 ++++
+ .../src/arm64/airoha/an7581-vsol-v2902a.dts    | 106 +++++++++++++++++++++
+ 4 files changed, 218 insertions(+)
+ create mode 100644 arch/arm/dts/an7581-vsol-v2902a-u-boot.dtsi
+ create mode 100644 configs/an7581_vsol_v2902a_defconfig
+ create mode 100644 defenvs/an7581_vsol_v2902a_env
+ create mode 100644 dts/upstream/src/arm64/airoha/an7581-vsol-v2902a.dts
+
+--- /dev/null
++++ b/arch/arm/dts/an7581-vsol-v2902a-u-boot.dtsi
+@@ -0,0 +1,7 @@
++// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
++
++#include "an7581-u-boot.dtsi"
++
++&gdm1 {
++	status = "okay";
++};
+--- /dev/null
++++ b/configs/an7581_vsol_v2902a_defconfig
+@@ -0,0 +1,89 @@
++CONFIG_ARM=y
++CONFIG_POSITION_INDEPENDENT=y
++CONFIG_ARCH_AIROHA=y
++CONFIG_TARGET_AN7581=y
++CONFIG_TEXT_BASE=0x81E00000
++CONFIG_SYS_MALLOC_F_LEN=0x4000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_ENV_SIZE=0x4000
++CONFIG_DM_GPIO=y
++CONFIG_DEFAULT_DEVICE_TREE="airoha/an7581-vsol-v2902a"
++CONFIG_SYS_LOAD_ADDR=0x81800000
++CONFIG_BUILD_TARGET="u-boot.bin"
++# CONFIG_EFI_LOADER is not set
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_OF_ENV_SETUP=y
++CONFIG_BOOTDELAY=3
++CONFIG_DEFAULT_FDT_FILE="airoha/an7581-vsol-v2902a.dtb"
++CONFIG_SYS_PBSIZE=1049
++CONFIG_SYS_CONSOLE_IS_IN_ENV=y
++# CONFIG_DISPLAY_BOARDINFO is not set
++CONFIG_HUSH_PARSER=y
++CONFIG_SYS_PROMPT="AN7581> "
++CONFIG_SYS_MAXARGS=8
++CONFIG_CMD_BOOTZ=y
++CONFIG_CMD_BOOTMENU=y
++# CONFIG_CMD_ELF is not set
++# CONFIG_CMD_XIMG is not set
++CONFIG_CMD_BIND=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_MTD=y
++CONFIG_CMD_SF_TEST=y
++CONFIG_CMD_SPI=y
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_MII=y
++CONFIG_CMD_MDIO=y
++CONFIG_CMD_PING=y
++CONFIG_CMD_EXT4=y
++CONFIG_CMD_FAT=y
++CONFIG_CMD_FS_GENERIC=y
++CONFIG_CMD_MTDPARTS=y
++CONFIG_CMD_LOG=y
++CONFIG_CMD_UBI=y
++CONFIG_OF_UPSTREAM=y
++CONFIG_ENV_OVERWRITE=y
++# CONFIG_ENV_IS_IN_MTD is not set
++CONFIG_ENV_RELOC_GD_ENV_ADDR=y
++CONFIG_ENV_USE_DEFAULT_ENV_TEXT_FILE=y
++CONFIG_ENV_DEFAULT_ENV_TEXT_FILE="defenvs/an7581_vsol_v2902a_env"
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_SYS_RX_ETH_BUFFER=8
++CONFIG_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_CLK=y
++CONFIG_DMA=y
++CONFIG_LED=y
++CONFIG_LED_GPIO=y
++CONFIG_MMC_HS200_SUPPORT=y
++CONFIG_MMC_MTK=y
++CONFIG_MTD=y
++CONFIG_DM_MTD=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_DM_SPI_FLASH=y
++CONFIG_SPI_FLASH_EON=y
++CONFIG_SPI_FLASH_GIGADEVICE=y
++CONFIG_SPI_FLASH_ISSI=y
++CONFIG_SPI_FLASH_MACRONIX=y
++CONFIG_SPI_FLASH_SPANSION=y
++CONFIG_SPI_FLASH_STMICRO=y
++CONFIG_SPI_FLASH_WINBOND=y
++CONFIG_SPI_FLASH_MTD=y
++CONFIG_DM_MDIO=y
++CONFIG_AIROHA_ETH=y
++CONFIG_PHY=y
++CONFIG_PINCTRL=y
++CONFIG_PINCTRL_AIROHA_AN7581=y
++CONFIG_PINCONF=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_RAM=y
++CONFIG_DM_SERIAL=y
++CONFIG_SYS_NS16550=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_AIROHA_SNFI_SPI=y
++CONFIG_SHA512=y
+--- /dev/null
++++ b/defenvs/an7581_vsol_v2902a_env
+@@ -0,0 +1,16 @@
++loadaddr=0x81800000
++ipaddr=192.168.1.1
++serverip=192.168.1.10
++bootfile=initramfs-uImage.itb
++tcbootfile=tcboot.bin
++tclinuxfile=tclinux.bin
++bootconf=config@1
++rootdisk_prop=rootdisk
++fdt_fixup=fdt get value rootdisk_phandle /chosen ${rootdisk_prop}; fdt set /chosen rootdisk "<${rootdisk_phandle}>"
++bootargs=console=ttyS0,115200 earlycon ubi.mtd=tclinux,0,0,0 ubi.mtd=rootfs_data,0,0,1 root=/dev/fit0 rootwait
++boot_tclinux=setenv rootdisk_prop rootdisk; setenv bootargs "console=ttyS0,115200 earlycon ubi.mtd=tclinux,0,0,0 ubi.mtd=rootfs_data,0,0,1 root=/dev/fit0 rootwait"; ubi part tclinux && ubi read $loadaddr fit && bootm $loadaddr#$bootconf
++boot_tclinux_slave=setenv rootdisk_prop rootdisk-slave; setenv bootargs "console=ttyS0,115200 earlycon ubi.mtd=tclinux_slave,0,0,0 ubi.mtd=rootfs_data,0,0,1 root=/dev/fit0 rootwait"; ubi part tclinux_slave && ubi read $loadaddr fit && bootm $loadaddr#$bootconf
++boot_tftp=setenv bootargs "console=ttyS0,115200 earlycon"; tftpboot $loadaddr $bootfile && bootm $loadaddr#$bootconf
++upgrade_tcboot=tftpboot $loadaddr $tcbootfile && mtd erase bootloader && mtd write bootloader $loadaddr 0 $filesize
++upgrade_tclinux=tftpboot $loadaddr $tclinuxfile && mtd erase tclinux && mtd write tclinux $loadaddr 0 $filesize && mtd erase tclinux_slave && mtd write tclinux_slave $loadaddr 0 $filesize
++bootcmd=run boot_tclinux; run boot_tclinux_slave
+--- /dev/null
++++ b/dts/upstream/src/arm64/airoha/an7581-vsol-v2902a.dts
+@@ -0,0 +1,106 @@
++// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
++/dts-v1/;
++
++/* Bootloader installs ATF here */
++/memreserve/ 0x80000000 0x200000;
++
++#include <dt-bindings/gpio/gpio.h>
++#include "en7581.dtsi"
++
++/ {
++	model = "VSOL V2902A";
++	compatible = "vsol,v2902a", "airoha,an7581", "airoha,en7581";
++
++	aliases {
++		serial0 = &uart1;
++	};
++
++	chosen {
++		bootargs = "console=ttyS0,115200 earlycon";
++		stdout-path = "serial0:115200n8";
++		linux,usable-memory-range = <0x0 0x80200000 0x0 0x1fe00000>;
++	};
++
++	memory@80000000 {
++		device_type = "memory";
++		reg = <0x0 0x80000000 0x0 0x20000000>;
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-system {
++			label = "system";
++			gpios = <&en7581_pinctrl 20 GPIO_ACTIVE_LOW>;
++			default-state = "on";
++		};
++
++		led-los {
++			label = "los";
++			gpios = <&en7581_pinctrl 18 GPIO_ACTIVE_LOW>;
++			default-state = "on";
++		};
++	};
++};
++
++&en7581_pinctrl {
++	gpio-ranges = <&en7581_pinctrl 0 13 50>;
++};
++
++&snfi {
++	status = "okay";
++};
++
++&spi_nand {
++	partitions {
++		compatible = "fixed-partitions";
++		#address-cells = <1>;
++		#size-cells = <1>;
++
++		bootloader@0 {
++			label = "bootloader";
++			reg = <0x00000000 0x00080000>;
++		};
++
++		tclinux@80000 {
++			label = "tclinux";
++			reg = <0x00080000 0x02000000>;
++		};
++
++		tclinux_slave@2080000 {
++			label = "tclinux_slave";
++			reg = <0x02080000 0x02000000>;
++		};
++
++		rootfs_data@4080000 {
++			label = "rootfs_data";
++			reg = <0x04080000 0x02800000>;
++		};
++
++		factory@6880000 {
++			label = "factory";
++			reg = <0x06880000 0x00100000>;
++		};
++
++		art@6c80000 {
++			label = "art";
++			reg = <0x06c80000 0x00380000>;
++		};
++	};
++};
++
++&i2c0 {
++	status = "okay";
++};
++
++&i2c1 {
++	status = "okay";
++};
++
++&eth {
++	status = "okay";
++};
++
++&gdm1 {
++	status = "okay";
++};

--- a/target/linux/airoha/an7581/base-files/etc/board.d/01_leds
+++ b/target/linux/airoha/an7581/base-files/etc/board.d/01_leds
@@ -25,6 +25,9 @@ nokia,xg-040g-md-ubi)
 	ucidef_set_led_netdev "lan3" "lan3" "mt7530-0:0b:green:lan-3" "lan3" "link tx rx"
 	ucidef_set_led_netdev "lan4" "lan4" "mt7530-0:0c:green:lan-4" "lan4" "link tx rx"
 	;;
+vsol,v2902a)
+	ucidef_set_led_timer "los" "los" "red:los" "1000" "1000"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/airoha/an7581/base-files/etc/board.d/02_network
+++ b/target/linux/airoha/an7581/base-files/etc/board.d/02_network
@@ -24,6 +24,9 @@ an7581_setup_interfaces()
 	nokia,xg-040g-md-ubi)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		;;
+	vsol,v2902a)
+		ucidef_set_interface_lan "lan1 lan2"
+		;;
 	*)
 		echo "Unsupported hardware. Network interfaces not initialized"
 		;;

--- a/target/linux/airoha/an7581/base-files/lib/upgrade/platform.sh
+++ b/target/linux/airoha/an7581/base-files/lib/upgrade/platform.sh
@@ -9,6 +9,23 @@ nokia_initial_setup()
 	fw_setenv bootcmd "flash read 0xc0000 0x800000 0x85000000; bootm 0x85000000"
 }
 
+tclinux_do_upgrade() {
+	local cmd="cat"
+
+	[ -e /dev/fit0 ] && fitblk /dev/fit0
+
+	if fwtool -q -i /dev/null "$1"; then
+		cmd="fwtool -i /dev/null -T -"
+	fi
+
+	CI_UBIPART="tclinux_slave"
+	nand_do_flash_file "$1" "$cmd" || nand_do_upgrade_failed
+	CI_UBIPART="tclinux"
+	nand_do_flash_file "$1" "$cmd" || nand_do_upgrade_failed
+	CI_DATA_UBIPART="rootfs_data"
+	nand_do_upgrade_success
+}
+
 platform_check_image() {
 	local board=$(board_name)
 
@@ -23,6 +40,10 @@ platform_check_image() {
 		fit_check_image "$1"
 		return $?
 		;;
+	vsol,v2902a)
+		nand_do_platform_check "$board" "$1" || return $?
+		notify_firmware_no_backup
+		;;
 	esac
 
 	return 0
@@ -35,6 +56,9 @@ platform_do_upgrade() {
 		gemtek,w1700k-ubi|\
 		nokia,xg-040g-md-ubi)
 			fit_do_upgrade "$1"
+			;;
+		vsol,v2902a)
+			tclinux_do_upgrade "$1"
 			;;
 		*)
 			nand_do_upgrade "$1"

--- a/target/linux/airoha/base-files/lib/preinit/75_rootfs_prepare
+++ b/target/linux/airoha/base-files/lib/preinit/75_rootfs_prepare
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-2.0-or-later OR BSD-2-Clause
+
+rootfs_prepare() {
+	case "$(board_name)" in
+	vsol,v2902a)
+		local mtd_num ubi_dev
+
+		mtd_num=$(find_mtd_index "rootfs_data")
+
+		if [ -n "$mtd_num" ] && [ "$(cat /sys/class/ubi/ubi1/mtd_num)" = "$mtd_num" ]; then
+			if ! ubinfo "/dev/ubi1" -N "rootfs_data" >/dev/null 2>&1; then
+				echo 'Creating "rootfs_data" UBI volume'
+				ubimkvol "/dev/ubi1" -m -n 0 -N "rootfs_data"
+				ubi_dev=$(cat "/sys/class/ubi/ubi1_0/dev")
+				mknod -m 0600 "/dev/ubi1_0" c "${ubi_dev%%:*}" "${ubi_dev##*:}"
+			fi
+		fi
+		;;
+	esac
+}
+
+boot_hook_add preinit_main rootfs_prepare

--- a/target/linux/airoha/dts/an7581-vsol-v2902a.dts
+++ b/target/linux/airoha/dts/an7581-vsol-v2902a.dts
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include "an7581.dtsi"
+
+/ {
+	model = "VSOL V2902A";
+	compatible = "vsol,v2902a", "airoha,an7581", "airoha,en7581";
+
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+		label-mac-device = &gdm1;
+		serial0 = &uart1;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200 earlycon \
+			   ubi.mtd=tclinux,0,0,0 ubi.mtd=rootfs_data,0,0,1 \
+			   root=/dev/fit0 rootwait";
+		rootdisk = <&tclinux_fit>;
+		rootdisk-slave = <&tclinux_slave_fit>;
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@80000000 {
+		device_type = "memory";
+		reg = <0x0 0x80000000 0x0 0x20000000>;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		btn-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&en7581_pinctrl 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: led-system {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&en7581_pinctrl 20 GPIO_ACTIVE_LOW>;
+		};
+
+		led-pon {
+			color = <LED_COLOR_ID_GREEN>;
+			function = "pon";
+			gpios = <&en7581_pinctrl 19 GPIO_ACTIVE_LOW>;
+		};
+
+		led-los {
+			color = <LED_COLOR_ID_RED>;
+			function = "los";
+			gpios = <&en7581_pinctrl 18 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&en7581_pinctrl {
+	gpio-ranges = <&en7581_pinctrl 0 13 50>;
+
+	mdio_pins: mdio-pins {
+		mux {
+			function = "mdio";
+			groups = "mdio";
+		};
+
+		conf {
+			pins = "gpio2";
+			output-high;
+		};
+	};
+
+	gswp1_led0_pins: gswp1-led0-pins {
+		mux {
+			function = "phy1_led0";
+			pins = "gpio33";
+		};
+	};
+};
+
+&snfi {
+	status = "okay";
+};
+
+&spi_nand {
+	/*
+	 * The auto adaption of 64M/128M/256M nand flash like stock rom is not implemented.
+	 * 64M: 21m[tclinux],21m[tclinux_slave],4m[rootfs_data],4m[framework],4m[framework_slave]
+	 * 256M: 64m[tclinux],64m[tclinux_slave],25m[rootfs_data],
+	 *       30m[framework],30m[framework_slave]
+	 */
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		bootloader@0 {
+			label = "bootloader";
+			reg = <0x00000000 0x00080000>;
+		};
+
+		tclinux@80000 {
+			label = "tclinux";
+			reg = <0x00080000 0x02000000>;
+
+			volumes {
+				tclinux_fit: ubi-volume-fit {
+					volname = "fit";
+				};
+			};
+		};
+
+		tclinux_slave@2080000 {
+			label = "tclinux_slave";
+			reg = <0x02080000 0x02000000>;
+
+			volumes {
+				tclinux_slave_fit: ubi-volume-fit {
+					volname = "fit";
+				};
+			};
+		};
+
+		rootfs_data@4080000 {
+			label = "rootfs_data";
+			reg = <0x04080000 0x02800000>;
+		};
+
+		factory@6880000 {
+			label = "factory";
+			reg = <0x06880000 0x00100000>;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_factory: mac@2 {
+					compatible = "mac-base";
+					reg = <0x2 0xc>;
+					#nvmem-cell-cells = <1>;
+				};
+			};
+		};
+
+		art@6c80000 {
+			label = "art";
+			reg = <0x06c80000 0x00380000>;
+		};
+	};
+};
+
+&i2c0 {
+	status = "okay";
+};
+
+&i2c1 {
+	status = "okay";
+};
+
+&npu {
+	status = "okay";
+};
+
+&eth {
+	status = "okay";
+};
+
+&gdm1 {
+	status = "okay";
+	openwrt,netdev-name = "eth0";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_factory 0>;
+};
+
+&eth_pcs {
+	status = "okay";
+};
+
+&gdm4 {
+	status = "okay";
+	openwrt,netdev-name = "lan2";
+	managed = "in-band-status";
+	phy-handle = <&rtl8261be>;
+	phy-mode = "usxgmii";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_factory 0>;
+};
+
+&switch {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+};
+
+&mdio {
+	rtl8261be: ethernet-phy@0 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <0>;
+		reset-gpios = <&en7581_pinctrl 31 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <500000>;
+		reset-deassert-us = <500000>;
+	};
+};
+
+&gsw_port1 {
+	status = "okay";
+	label = "lan1";
+};
+
+&gsw_phy1 {
+	status = "okay";
+	interrupts = <1>;
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gswp1_led0_pins>;
+};
+
+&gsw_phy1_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_GREEN>;
+	active-low;
+};

--- a/target/linux/airoha/image/Makefile
+++ b/target/linux/airoha/image/Makefile
@@ -5,6 +5,39 @@ loadaddr-$(CONFIG_TARGET_airoha_an7581) := 0x80200000
 loadaddr-$(CONFIG_TARGET_airoha_an7583) := 0x80200000
 loadaddr-$(CONFIG_TARGET_airoha_en7523) := 0x80200000
 
+define Build/airoha-image-tcboot
+  $(STAGING_DIR_HOST)/bin/fiptool create \
+		--tb-fw $(STAGING_DIR_IMAGE)/$(word 1,$1)-bl2.bin $@.bl2.fip
+  $(STAGING_DIR_HOST)/bin/fiptool create \
+		--soc-fw $(STAGING_DIR_IMAGE)/$(word 1,$1)-bl31.lzma \
+		--nt-fw $(STAGING_DIR_IMAGE)/$(word 2,$1)-u-boot.lzma $@.bl31-u-boot.fip
+  [ "$$(stat -c "%s" "$@.bl2.fip")" -le 129024 ] || { \
+	echo "ERROR: bl2 exceeds the maximum size 129024 bytes" >&2; \
+	exit 1; \
+  }
+  [ "$$(stat -c "%s" "$@.bl31-u-boot.fip")" -le 376828 ] || { \
+	echo "ERROR: bl31 exceeds the maximum size 376828 bytes" >&2; \
+	exit 1; \
+  }
+  dd if=/dev/zero bs=524288 count=1 | tr '\000' '\377' > "$@"
+  dd if=/dev/zero of="$@" bs=2048 count=1 conv=notrunc
+  dd if=$@.bl2.fip of="$@" bs=2048 seek=1 conv=notrunc
+  dd if=$@.bl31-u-boot.fip of="$@" bs=131072 seek=1 conv=notrunc
+  head -c 507900 "$@" | gzip -n -c | tail -c 8 | head -c 4 | \
+	$(STAGING_DIR_HOST)/bin/xorimage -p ff -x | dd of="$@" bs=1 seek=507900 conv=notrunc
+  rm -f $@.bl2.fip $@.bl31-u-boot.fip
+endef
+
+define Build/airoha-image-tclinux
+  $(STAGING_DIR_HOST)/bin/fiptool create \
+		--soc-fw $(STAGING_DIR_IMAGE)/$(word 1,$1)-bl31.lzma \
+		--nt-fw $(STAGING_DIR_IMAGE)/$(word 2,$1)-u-boot.lzma $@.fip
+  cp "$@" "$@.fit"
+  $(TOPDIR)/scripts/ubinize-image.sh --part fip=:$@.fip --part fit=:"$@.fit" "$@.new" -p 128KiB -m 2048 -E 5
+  mv "$@.new" "$@"
+  rm -f "$@.fip" "$@.fit"
+endef
+
 # default all platform image(fit) build
 define Device/Default
   PROFILES = Default $$(DEVICE_NAME)

--- a/target/linux/airoha/image/an7581.mk
+++ b/target/linux/airoha/image/an7581.mk
@@ -188,3 +188,25 @@ define Device/nokia_xg-040g-md-ubi
   ARTIFACTS := bl31-uboot.fip preloader.bin
 endef
 TARGET_DEVICES += nokia_xg-040g-md-ubi
+
+define Device/vsol_v2902a
+  DEVICE_VENDOR := VSOL
+  DEVICE_MODEL := V2902A
+  DEVICE_DTS := an7581-vsol-v2902a
+  DEVICE_DTS_CONFIG := config@1
+  DEVICE_PACKAGES := fitblk kmod-phy-realtek rtl826x-firmware
+  KERNEL_SUFFIX := -kernel.bin
+  KERNEL := kernel-bin | lzma
+  KERNEL_NAME := Image
+  KERNEL_INITRAMFS = kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(DEVICE_DTS).dtb
+  KERNEL_INITRAMFS_SUFFIX := -uImage.itb
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 32768k
+  IMAGE/sysupgrade.bin = append-kernel | fit lzma $$(KDIR)/image-$$(DEVICE_DTS).dtb \
+	external-static-with-rootfs | airoha-image-tclinux an7581 an7581_vsol_v2902a | check-size | append-metadata
+  ARTIFACT/tcboot.bin := airoha-image-tcboot an7581 an7581_vsol_v2902a | check-size 512k
+  ARTIFACT/tclinux.bin := append-image squashfs-sysupgrade.bin
+  ARTIFACTS := tcboot.bin tclinux.bin
+endef
+TARGET_DEVICES += vsol_v2902a


### PR DESCRIPTION
## Summary

This PR adds OpenWrt support for the VSOL V2902A ONU based on the Airoha AN7581ST SoC.

The V2902A shares most implementations with [V2901Q-A and V2902A-S](https://github.com/openwrt/openwrt/pull/24465), refer to #24465 for more details.

| Model | Ethernet |
| --- | --- |
| [V2902A](https://www.vsolcn.com/product/10g-pon-1ge-10ge-sfu-onu-v2902a) | 1× internal 1GbE port and 1× 10GbE through an RTL8261BE PHY |
| [V2901Q-A](https://www.vsolcn.com/product/10g-pon-2-5gbe-onu-v2901q-a) | 1× 2.5GbE through an AN8811 PHY |
| [V2902A-S](https://www.vsolcn.com/product/10g-pon-1ge-1sfp-hgu-onu-v2902a-s) | 1× internal 1GbE port and 1× SFP cage through USXGMII |

## Commit series

1. `airoha: add support for VSOL V2902A`
   - Adds the device trees, network and LED configuration.
   - Adds image generation and sysupgrade support.
   - Adds automatic initialization of the independent `rootfs_data` UBI volume.

2. `arm-trusted-firmware-airoha: add VSOL AN7581 device`
   - Adds the V2902A to `arm-trusted-firmware-airoha` for the AN7581 BL2/BL31.

3. `uboot-airoha: add support for VSOL V2902A`
   - Adds the U-Boot configuration for V2902A devices.
   - Enables SPI-NAND, UBI, Ethernet, LEDs and firmware upgrade commands.
   - Adds `tcboot.bin` and `tclinux.bin` boot support.

## Hardware

- SoC: Airoha AN7581ST
  - Quad-core ARM Cortex-A53
  - Up to 1.2 GHz
- RAM: 512 MiB DDR3L
- Flash: SPI-NAND
  - Devices are available with 64, 128 or 256 MiB flash
  - This PR currently supports the 128 MiB layout
  - `W25N01GV` is widely used by VSOL and supported by OpenWrt, as `W25N01KV` is for newer products with fewer amount.
- PON:
  - EN7573 XE/XG/XGS-PON
  - EN7572 XG-PON
- Ethernet: internal 1GbE PHY and RTL8261BE 10GbE PHY
- Buttons: RESET
- UART: 115200 8N1
- Power: 12V / 1A
- WLAN: N/A

## Boot flow

```text
AN7581 Boot ROM
  -> BL2 from tcboot.bin
  -> BL31 and U-Boot from the fip UBI volume
  -> Linux FIT from the fit UBI volume
  -> Linux
```

The generated `tclinux.bin` contains:

```text
UBI volume 0: fip
  - BL31
  - U-Boot
UBI volume 1: fit
  - LZMA-compressed Linux kernel
  - AN7581 device tree
  - squashfs root filesystem
```

`tclinux` and `tclinux_slave` contain identical images. U-Boot tries
`tclinux` first and falls back to `tclinux_slave`.

## Flash layout

The partition offsets remain aligned with the stock layout to simplify installation and returning to stock firmware.

| Offset | Size | Partition | Contents |
| --- | ---: | --- | --- |
| `0x00000000` | 512 KiB | `bootloader` | `tcboot.bin` containing BL2 |
| `0x00080000` | 32 MiB | `tclinux` | UBI image containing `fip` and `fit` |
| `0x02080000` | 32 MiB | `tclinux_slave` | Identical backup image |
| `0x04080000` | 40 MiB | `rootfs_data` | Independent OpenWrt overlay UBI |
| `0x06880000` | 1 MiB | `factory` | Factory data and MAC address |
| `0x06c80000` | 3.5 MiB | `art` | Calibration data |

The stock `rootfs_data`, `framework` and `framework_slave` partitions occupy the same 40 MiB region. OpenWrt merges them into a single `rootfs_data` partition.

**Do not erase factory/art partitions.** Otherwise the factory parameters (MAC, SN, etc.) and calibration data will lost, a factory repare is needed. It's recommended to make backups of these partitions.

## Images

The following images are generated for each device:

- `tcboot.bin`
  - Written directly to the `bootloader` partition.
- `tclinux.bin`
  - Written directly to both `tclinux` and `tclinux_slave`.
- `squashfs-sysupgrade.bin`
  - Used for normal OpenWrt sysupgrade.
- `initramfs-uImage.itb`
  - Used for recovery or temporary booting.

The image names follow the stock firmware convention where practical. Detailed installation and back to stock procedures are included in the message of commit 3. The shared image builders `Build/airoha-image-tcboot` and `Build/airoha-image-tclinux` will make it easier for most Airoha SDK (OpenWrt 21.02) based devices to bring up support of OpenWrt mainline.

## Sysupgrade

Sysupgrade writes the new UBI image in this order:

1. `tclinux_slave`
2. `tclinux`

The independent `rootfs_data` partition is not erased or reformatted during sysupgrade, so the existing overlay remains available. Both slots receive the same firmware image. The bootflag-based switching from the stock firmware is intentionally not implemented.

## Testing

Tested on VSOL V2902A hardware with a 128 MiB W25N01GV SPI-NAND and 512 MiB DDR. Similar to the AN7583 devices, 256 MiB DDR will also work properly.

## Known limitations

- XPON/OAM/OMCI functionality is not supported by mainline OpenWrt.
- Only the fixed 128 MiB SPI-NAND layout is currently supported. Automatic 64/128/256 MiB flash layout detection from stock firmware is not implemented. However, only 128 MiB version is in mass production and it should not be a problem for a long while.
- Stock (Airoha SDK) bootflag-based A/B switching is not implemented.
- U-Boot network access is available only through the internal switch. No plan to import PHY driver in U-Boot to reduce downstream changes.