### PR TITLE
realtek: dsa: don't clobber adjacent LOG counter on rtl838x/rtl839x

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl838x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl838x.c
@@ -1617,6 +1617,13 @@ static void rtl838x_packet_cntr_clear(int counter)
 	struct table_reg *r = rtl_table_get(RTL8380_TBL_0, 3);
 
 	pr_debug("In %s, id %d\n", __func__, counter);
+
+	/*
+	 * Two counters share one LOG table entry. Read the current entry
+	 * first so clearing one half preserves the adjacent counter.
+	 */
+	rtl_table_read(r, counter / 2);
+
 	/* The table has a size of 2 registers */
 	if (counter % 2)
 		sw_w32(0, rtl_table_data(r, 0));

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl839x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl839x.c
@@ -1522,6 +1522,13 @@ static void rtl839x_packet_cntr_clear(int counter)
 	struct table_reg *r = rtl_table_get(RTL8390_TBL_0, 4);
 
 	pr_debug("In %s, id %d\n", __func__, counter);
+
+	/*
+	 * Two counters share one LOG table entry. Read the current entry
+	 * first so clearing one half preserves the adjacent counter.
+	 */
+	rtl_table_read(r, counter / 2);
+
 	/* The table has a size of 2 registers */
 	if (counter % 2)
 		sw_w32(0, rtl_table_data(r, 0));


### PR DESCRIPTION
The RTL838x/RTL839x packet_cntr_clear() accessors write a shared
two-register LOG table entry back without reading it first, so clearing
one packet counter wipes the counter that shares its entry. Same
read-before-write bug and fix as the RTL930x variant (first commit of
#24994, "realtek: dsa: rtl930x: don't clobber adjacent LOG counter").

I did not go looking for this — it was raised in the review of #24994,
where it was asked whether leaving the RTL838x/RTL839x variants
untouched was intentional. It is not; this is the standalone fix I said
I would send.

Both paths are only reachable via tc cls_flower packet counters today,
so the bug is latent on current releases.

Built for realtek (rtl838x + rtl839x), no new warnings. Not
runtime-tested — I only have RTL930x hardware.
