### PR TITLE
qualcommax: ipq60xx: enable lan4 port for link nn6000v2

### DIFF
--- a/target/linux/qualcommax/dts/ipq6000-nn6000-v2.dts
+++ b/target/linux/qualcommax/dts/ipq6000-nn6000-v2.dts
@@ -36,4 +36,5 @@
 
 &swport5 {
 	label = "lan4";
+	status = "okay";
 };


### PR DESCRIPTION
The swport5 node was disabled by mistake during the PPE conversion.

Fixes: f50435627d37 ("qualcommax: ipq60xx/ipq807x: convert to PPE networking stack")

Cc: @robimarko 