### PR TITLE
[24.10] openssl: update to version 3.0.22

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
-PKG_VERSION:=3.0.21
+PKG_VERSION:=3.0.22
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
@@ -21,7 +21,7 @@ PKG_SOURCE_URL:= \
 	https://www.openssl.org/source/old/$(PKG_BASE)/ \
 	https://github.com/openssl/openssl/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
 
-PKG_HASH:=617e29af8e421f46649484a4937e48c685e47f46488167c982f88bc4ec1d522f
+PKG_HASH:=67ebca7e50d17383028045486653492195b83db95f8558709701bb47b5c1ef81
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE.txt


### PR DESCRIPTION
OpenSSL 3.0.22 is a security patch release. The most severe CVE fixed in this release is Moderate.

This release incorporates the following bug fixes and mitigations:

 * Fixed heap buffer overflow in CMS key unwrapping. (CVE-2026-63072)

 * Fixed invalid pointer dereference in CMP server via crafted protectionAlg. (CVE-2026-63076)

 * Fixed excessive memory use buffering DTLS records for a future epoch. (CVE-2026-54874)

 * Fixed CMP indefinite cache growth of extraCerts. (CVE-2026-63074)

 * Fixed possibility of AEAD forgeries with empty ciphertext when using EVP_Cipher(). (CVE-2026-75803)

 * Fixed checking of authentication tags for empty ciphertexts for AEAD ciphers in CCM cipher mode.
