### PR TITLE
mediatek: fix SPI bus-width spelling on the Zbtlink Z8102AX-v2

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax-v2.dts
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax-v2.dts
@@ -172,8 +172,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		mediatek,nmbm;
 		mediatek,bmt-max-ratio = <1>;


### PR DESCRIPTION
`spi-tx-buswidth` / `spi-rx-buswidth` on this board's flash node isn't a property `of_spi_parse_dt` reads; only the hyphenated `spi-tx-bus-width` / `spi-rx-bus-width` is. So the SPI-NAND has been running at 1-bit the whole time, despite the `<4>` already in the DTS.

Split out of #24809, where the same typo gets renamed on boards with a test or vendor evidence and dropped where there's neither. Nobody has this one, so it stays a draft.

If you do: boot the branch, then compare NAND read throughput before and after, e.g. `time dd if=/dev/mtdX of=/dev/null bs=1M count=64` against the same partition on both builds. Well above the ~6.5 MB/s ceiling 1-bit hits at 52 MHz means quad is really on. A `Tested-by:` in a comment here is enough to take this out of draft.
