### PR TITLE
dnsmasq: add barename hostname for static leases

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=dnsmasq
 PKG_UPSTREAM_VERSION:=2.93
 PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=https://thekelleys.org.uk/dnsmasq/

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -364,7 +364,7 @@ dhcp_host_add() {
 
 	config_get_bool dns "$cfg" dns 0
 	[ "$dns" = "1" ] && [ -n "$ip" ] && [ -n "$name" ] && {
-		echo "$ip $name${DOMAIN:+.$DOMAIN}" >> "$HOSTFILE_TMP"
+		echo "$ip $name${DOMAIN:+.$DOMAIN $name}" >> "$HOSTFILE_TMP"
 	}
 
 	config_get mac "$cfg" mac


### PR DESCRIPTION
Append the bare hostname to the auto-generated hosts file, so both the FQDN and the bare name resolve for static leases.

**Problem:**
Static DHCP entries with dns enabled only have their FQDN written to the generated hosts file, so the bare hostname does not resolve unless the host also had an active DHCP lease.

This means:
* A host with a static IP will never resolve by its bare name.
* After a router reboot, `/tmp/dhcp.leases` is empty, so a DHCP client will not resolve by its bare name until it decides to renew its lease.

e.g. 
A host with a static IP
```
$ dig +short dockbox-vm
$ dig +short dockbox-vm.lan
10.100.1.20
```

A host with a valid DHCP lease
```
$ cat /tmp/dhcp.leases
1788473962 b8:27:eb:e3:17:de 10.100.1.13 stereo-berry 01:b8:27:eb:e3:17:de

$ dig +short stereo-berry
10.100.1.13
$ dig +short stereo-berry.lan
10.100.1.13
```

Same host without a valid DHCP lease
```
$ cat /tmp/dhcp.leases

$ dig +short stereo-berry
$ dig +short stereo-berry.lan
10.100.1.13
```
