### PR TITLE
realtek: backport realtek-otto-gpio patches

### DIFF
--- a/target/linux/realtek/patches-6.18/039-01-v7.4-gpio-realtek-otto-use-__raw_readl-writel-in-realtek_.patch
+++ b/target/linux/realtek/patches-6.18/039-01-v7.4-gpio-realtek-otto-use-__raw_readl-writel-in-realtek_.patch
@@ -1,0 +1,37 @@
+From 61ef599b782e776437886f2be0623b3c9055e5d3 Mon Sep 17 00:00:00 2001
+From: Rustam Adilov <adilov@disroot.org>
+Date: Sat, 15 Aug 2026 14:44:50 +0500
+Subject: gpio: realtek-otto: use __raw_readl/writel in
+ realtek_gpio_update_line_imr()
+
+In preparation for upcoming changes to how bank reads and writes
+are defined in this driver, change the ioread32 and iowrite32 to
+their __raw variants. The realtek_gpio_update_line_imr() function
+is used by all devices regardless of GPIO_PORTS_REVERSED flag and
+thus this is the only place where there shouldn't be any byte
+swapping whether SWAP_IO_SPACE config is enabled or not and that
+is only possible with __raw_readl and __raw_writel.
+
+Reviewed-by: Linus Walleij <linusw@kernel.org>
+Signed-off-by: Rustam Adilov <adilov@disroot.org>
+Link: https://patch.msgid.link/20260815094451.31792-2-adilov@disroot.org
+Signed-off-by: Bartosz Golaszewski <bartosz.golaszewski@oss.qualcomm.com>
+---
+ drivers/gpio/gpio-realtek-otto.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/drivers/gpio/gpio-realtek-otto.c
++++ b/drivers/gpio/gpio-realtek-otto.c
+@@ -175,10 +175,10 @@ static void realtek_gpio_update_line_imr
+ 	u32 reg_val;
+ 
+ 	reg += 4 * (line_shift / 32);
+-	reg_val = ioread32(reg);
++	reg_val = __raw_readl(reg);
+ 	reg_val &= ~(REALTEK_GPIO_IMR_LINE_MASK << shift);
+ 	reg_val |= (irq_type & irq_mask & REALTEK_GPIO_IMR_LINE_MASK) << shift;
+-	iowrite32(reg_val, reg);
++	__raw_writel(reg_val, reg);
+ }
+ 
+ static void realtek_gpio_irq_ack(struct irq_data *data)

--- a/target/linux/realtek/patches-6.18/039-02-v7.4-gpio-realtek-otto-make-bank_read-write-overridable-b.patch
+++ b/target/linux/realtek/patches-6.18/039-02-v7.4-gpio-realtek-otto-make-bank_read-write-overridable-b.patch
@@ -1,0 +1,46 @@
+From 785ec26c37e56ee5f142b6684f7c15c7ca7430a3 Mon Sep 17 00:00:00 2001
+From: Rustam Adilov <adilov@disroot.org>
+Date: Sat, 15 Aug 2026 14:44:51 +0500
+Subject: gpio: realtek-otto: make bank_read/write overridable by endian
+ property
+
+In order to have a working gpio controller with SWAP_IO_SPACE,
+the bank_read/bank_write functions and the gen_gc_flag used for
+gpio_generic_chip_config must be able to be changed to their
+respective counterparts.
+
+To do that, introduce checks for the presence of endian property
+under the device tree node and if so, override what has been
+set by GPIO_PORTS_REVERSED quirk flag. This way, existing device
+trees are kept working as they were originally.
+
+Both big-endian and little-endian properties must be checked
+because there are devices that have GPIO_PORTS_REVERSED flag
+and the others that don't.
+
+Signed-off-by: Rustam Adilov <adilov@disroot.org>
+Link: https://patch.msgid.link/20260815094451.31792-3-adilov@disroot.org
+Signed-off-by: Bartosz Golaszewski <bartosz.golaszewski@oss.qualcomm.com>
+---
+ drivers/gpio/gpio-realtek-otto.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+--- a/drivers/gpio/gpio-realtek-otto.c
++++ b/drivers/gpio/gpio-realtek-otto.c
+@@ -405,6 +405,16 @@ static int realtek_gpio_probe(struct pla
+ 		ctrl->line_imr_pos = realtek_gpio_line_imr_pos_swapped;
+ 	}
+ 
++	if (device_property_read_bool(dev, "little-endian")) {
++		gen_gc_flags = 0;
++		ctrl->bank_read = realtek_gpio_bank_read;
++		ctrl->bank_write = realtek_gpio_bank_write;
++	} else if (device_is_big_endian(dev)) {
++		gen_gc_flags = GPIO_GENERIC_BIG_ENDIAN_BYTE_ORDER;
++		ctrl->bank_read = realtek_gpio_bank_read_swapped;
++		ctrl->bank_write = realtek_gpio_bank_write_swapped;
++	}
++
+ 	config = (struct gpio_generic_chip_config) {
+ 		.dev = dev,
+ 		.sz = 4,


### PR DESCRIPTION
Finally, the last of the patches has been accepted and with that all realtek drivers can now work with SWAP_IO_SPACE config enabled.