### PR TITLE
netifd: avoid pinning mt76 TX worker to NAPI CPU

### DIFF
--- a/package/network/config/netifd/Makefile
+++ b/package/network/config/netifd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netifd
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/netifd.git

--- a/package/network/config/netifd/files/usr/libexec/network/packet-steering.uc
+++ b/package/network/config/netifd/files/usr/libexec/network/packet-steering.uc
@@ -89,8 +89,6 @@ function set_netdev_cpu(dev, cpu, rx_queue) {
 function task_device_match(name, device)
 {
 	let napi_match = match(name, /napi\/([^-]*)-\d+/);
-	if (!napi_match)
-		napi_match = match(name, /mt76-tx (phy\d+)/);
 	if (napi_match &&
 	    (index(device.phy, napi_match[1]) >= 0 ||
 	     index(device.netdev, napi_match[1]) >= 0))


### PR DESCRIPTION
The packet steering script treats both threaded NAPI and the mt76 TX worker as tasks belonging to the same wireless device. assign_dev_cpu() then assigns all of these tasks to the same CPU.

This unnecessarily restricts the mt76 TX worker to the NAPI CPU even though its affinity does not otherwise need to be constrained.

On MT7988A with MT7996 this caused the TX worker to share CPU3 with the NAPI thread. Moving it to another CPU increased measured TX throughput from 1.45 Gbit/s to 2.09 Gbit/s.

Stop matching the mt76 TX worker in the packet steering script. This leaves its CPU affinity unrestricted and lets the scheduler place it more appropriately.

Fixes: #24697
