### PR TITLE
ramips: mt7620: add RGMII1 DSA and D-Link DAP-1620 A2 support

### DIFF
--- a/package/utils/dap1620-leds/Makefile
+++ b/package/utils/dap1620-leds/Makefile
@@ -1,0 +1,35 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=dap1620-leds
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Boyler Fourcade <Boilerplate4U@gmail.com>
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/dap1620-leds
+  SECTION:=utils
+  PKGARCH:=all
+  CATEGORY:=Utilities
+  TITLE:=D-Link DAP-1620 A2 uplink and signal LEDs
+  DEPENDS:=@TARGET_ramips_mt7620 +iw +ubus +libubox +jshn
+endef
+
+define Package/dap1620-leds/conffiles
+/etc/config/dap1620-leds
+endef
+
+define Build/Compile
+endef
+
+define Package/dap1620-leds/install
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_DIR) $(1)/usr/libexec
+	$(INSTALL_CONF) ./files/config $(1)/etc/config/dap1620-leds
+	$(INSTALL_BIN) ./files/init $(1)/etc/init.d/dap1620-leds
+	$(INSTALL_BIN) ./files/daemon $(1)/usr/libexec/dap1620-leds
+endef
+
+$(eval $(call BuildPackage,dap1620-leds))

--- a/package/utils/dap1620-leds/files/config
+++ b/package/utils/dap1620-leds/files/config
@@ -1,0 +1,9 @@
+# Policy thresholds in dBm, not recovered stock firmware values.
+config leds 'main'
+	option mode 'auto'
+	option ethernet 'lan'
+	# For multiple enabled STA sections, select one explicitly:
+	# option station 'uplink'
+	option fair '-75'
+	option good '-65'
+	option best '-55'

--- a/package/utils/dap1620-leds/files/daemon
+++ b/package/utils/dap1620-leds/files/daemon
@@ -1,0 +1,175 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+# Owns all six LED channels. No WPS or Internet reachability checks.
+
+. /lib/functions.sh
+. /usr/share/libubox/jshn.sh
+
+LED_ROOT=/sys/class/leds
+NET_ROOT=/sys/class/net
+LEDS='red:status green:status red:indicator-1 green:indicator-1 green:indicator-2 green:indicator-3'
+
+brightness() {
+	local path="$LED_ROOT/$1/brightness" value
+	read -r value < "$path" || return
+	[ "$value" = "$2" ] || echo "$2" > "$path"
+}
+
+clear_leds() {
+	local led
+	for led in $LEDS; do brightness "$led" 0; done
+}
+
+station_config() {
+	local mode disabled
+	config_get mode "$1" mode
+	config_get_bool disabled "$1" disabled 0
+	[ "$mode" = sta ] && [ "$disabled" = 0 ] || return 0
+	[ -z "$requested" ] || [ "$requested" = "$1" ] || return 0
+	sta_count=$((sta_count + 1))
+	sta_section="$1"
+}
+
+load_settings() {
+	config_load dap1620-leds || return 1
+	config_get mode main mode auto
+	config_get ethernet main ethernet lan
+	config_get requested main station
+	config_get fair main fair -75
+	config_get good main good -65
+	config_get best main best -55
+	case "$mode" in auto|ethernet|repeater) ;; *) return 1;; esac
+	case "$ethernet" in ''|*[!a-zA-Z0-9_.-]*) return 1;; esac
+	local v
+	for v in "$fair" "$good" "$best"; do
+		case "$v" in -[0-9]|-[0-9][0-9]|-1[0-9][0-9]) ;; *) return 1;; esac
+	done
+	[ "$fair" -lt "$good" ] && [ "$good" -lt "$best" ] || return 1
+	sta_count=0
+	sta_section=
+
+	if [ "$mode" != ethernet ]; then
+		config_load wireless || return 1
+		config_foreach station_config wifi-iface
+	fi
+
+	if [ "$mode" = auto ]; then
+		# An enabled STA selects repeater mode even while its radio is down.
+		# Never mistake a wired client for the uplink in repeater mode.
+		if [ "$sta_count" -gt 0 ] || [ -n "$requested" ]; then
+			mode=repeater
+		else
+			mode=ethernet
+		fi
+	fi
+}
+
+station_ifname() {
+	local data radios radio entries entry section ifname
+	data="$(ubus call network.wireless status 2>/dev/null)" || return 1
+	json_load "$data" || return 1
+	json_get_keys radios
+	for radio in $radios; do
+		json_select "$radio" || continue
+		if json_select interfaces; then
+			json_get_keys entries
+			for entry in $entries; do
+				json_select "$entry" || continue
+				json_get_var section section
+				json_get_var ifname ifname
+				if [ "$section" = "$sta_section" ] && [ -n "$ifname" ]; then
+					printf '%s\n' "$ifname"
+					return 0
+				fi
+				json_select ..
+			done
+			json_select ..
+		fi
+		json_select ..
+	done
+	return 1
+}
+
+sample_uplink() {
+	local iface station carrier
+	up=0
+	level=0
+	[ "$settings_valid" = 1 ] || return 0
+	if [ "$mode" = ethernet ]; then
+		read -r carrier 2>/dev/null < "$NET_ROOT/$ethernet/carrier" || carrier=0
+		[ "$carrier" = 1 ] && up=1
+		return 0
+	fi
+	# Ambiguous configurations fail closed until a station is selected.
+	[ "$sta_count" = 1 ] || return 0
+	iface="$(station_ifname)" || return 0
+	# Confirm the live interface is a STA, not an AP serving local clients.
+	iw dev "$iface" info 2>/dev/null | awk '
+		$1 == "type" && $2 == "managed" { ok = 1 }
+		END { exit !ok }
+	' || return 0
+	station="$(iw dev "$iface" station dump 2>/dev/null)" || return 0
+	# AUTHORIZED confirms the controlled port is open, beyond association.
+	# Require exactly one peer; do not combine different peers' attributes.
+	signal="$(printf '%s\n' "$station" | awk '
+		$1 == "Station" { peers++ }
+		$1 == "authorized:" && $2 == "yes" { authorized = 1 }
+		$1 == "signal:" { signal = $2 }
+		END {
+			if (peers != 1 || !authorized) exit 1
+			if (signal ~ /^-[0-9]+$/) print signal
+		}
+	')" || return 0
+	up=1
+	# Missing RSSI is unknown, not the strongest or weakest signal level.
+	[ -n "$signal" ] || return 0
+	level=1
+	[ "$signal" -ge "$fair" ] && level=2
+	[ "$signal" -ge "$good" ] && level=3
+	[ "$signal" -ge "$best" ] && level=4
+	return 0
+}
+
+show_leds() {
+	local phase="$1" red=0 green=0 second=0 third=0
+	if [ "$up" = 1 ]; then
+		brightness red:status 0
+		brightness green:status 1
+	else
+		# Drive both channels together; visually verify amber on hardware.
+		brightness red:status "$phase"
+		brightness green:status "$phase"
+	fi
+	case "$level" in
+		1) red=1; green=1;;
+		2) green=1;;
+		3) green=1; second=1;;
+		4) green=1; second=1; third=1;;
+	esac
+	brightness red:indicator-1 "$red"
+	brightness green:indicator-1 "$green"
+	brightness green:indicator-2 "$second"
+	brightness green:indicator-3 "$third"
+}
+
+main() {
+	local led
+	for led in $LEDS; do
+		[ -w "$LED_ROOT/$led/brightness" ] || return 1
+	done
+	for led in $LEDS; do echo none > "$LED_ROOT/$led/trigger"; done
+	trap 'clear_leds; exit 0' TERM INT
+	settings_valid=0
+	if load_settings; then
+		settings_valid=1
+	fi
+	while :; do
+		sample_uplink
+		show_leds 1
+		sleep 1
+		show_leds 0
+		sleep 1
+	done
+}
+
+main "$@"

--- a/package/utils/dap1620-leds/files/init
+++ b/package/utils/dap1620-leds/files/init
@@ -1,0 +1,23 @@
+#!/bin/sh /etc/rc.common
+# SPDX-License-Identifier: GPL-2.0-only
+
+START=99
+STOP=01
+USE_PROCD=1
+
+start_service() {
+	[ "$(board_name)" = 'dlink,dap-1620-a2' ] || return 0
+	procd_open_instance
+	procd_set_param command /usr/libexec/dap1620-leds
+	procd_set_param respawn
+	procd_set_param stderr 1
+	procd_close_instance
+}
+
+reload_service() {
+	restart "$@"
+}
+
+service_triggers() {
+	procd_add_reload_trigger dap1620-leds wireless
+}

--- a/target/linux/ramips/dts/mt7620a_dlink_dap-1620-a2.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dap-1620-a2.dts
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "dlink,dap-1620-a2", "ralink,mt7620a-soc";
+	model = "D-Link DAP-1620 A2";
+
+	aliases {
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_green;
+		led-running = &led_status_red;
+		led-upgrade = &led_status_red;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: status_red {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led_status_green: status_green {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi_low_red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_INDICATOR;
+			function-enumerator = <1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi_low_green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_INDICATOR;
+			function-enumerator = <1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi_med_green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_INDICATOR;
+			function-enumerator = <2>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi_high_green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_INDICATOR;
+			function-enumerator = <3>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "nvram";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x200>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x200>;
+					};
+
+					macaddr_factory_ffd4: macaddr@ffd4 {
+						compatible = "mac-base";
+						reg = <0xffd4 0x11>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_factory_ffe8: macaddr@ffe8 {
+						compatible = "mac-base";
+						reg = <0xffe8 0x11>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uartf", "ephy";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins>, <&mdio_pins>;
+
+	nvmem-cells = <&macaddr_factory_ffe8 0>;
+	nvmem-cell-names = "mac-address";
+
+	mdio-bus {
+		status = "okay";
+
+		phy1: ethernet-phy@1 {
+			reg = <1>;
+		};
+	};
+};
+
+&gsw {
+	mediatek,ephy-base = /bits/ 8 <12>;
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@5 {
+			reg = <5>;
+			label = "lan";
+			phy-handle = <&phy1>;
+			phy-mode = "rgmii-id";
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&ethernet>;
+			phy-mode = "rgmii";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&wmac {
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_ffe8 1>;
+	nvmem-cell-names = "eeprom", "mac-address";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_ffd4 0>;
+		nvmem-cell-names = "eeprom", "mac-address";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.c
@@ -37,6 +37,53 @@ u32 mtk_switch_r32(struct mt7620_gsw *gsw, unsigned reg)
 }
 EXPORT_SYMBOL_GPL(mtk_switch_r32);
 
+int mt7620_gsw_config_rgmii1(struct mt7620_gsw *gsw, phy_interface_t interface)
+{
+	u32 mode, val;
+	u32 delay_mask = GSW_REG_GPCx_TXDELAY | GSW_REG_GPCx_RXDELAY;
+	u32 delay_val = 0;
+
+	switch (interface) {
+	case PHY_INTERFACE_MODE_RGMII:
+	case PHY_INTERFACE_MODE_RGMII_ID:
+	case PHY_INTERFACE_MODE_RGMII_RXID:
+	case PHY_INTERFACE_MODE_RGMII_TXID:
+		mode = 0;
+		/*
+		 * For RGMII *ID modes the PHY provides the requested internal
+		 * delay. Disable both MT7620 MAC-side delays to avoid doubling
+		 * the delay. The RX delay control is active-low on MT7620.
+		 */
+		delay_val = GSW_REG_GPCx_RXDELAY;
+		break;
+	case PHY_INTERFACE_MODE_MII:
+		mode = 1;
+		break;
+	case PHY_INTERFACE_MODE_RMII:
+		mode = 2;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	val = rt_sysc_r32(SYSC_REG_CFG1);
+	val &= ~(3 << 12);
+	val |= mode << 12;
+	rt_sysc_w32(val, SYSC_REG_CFG1);
+
+	if (delay_mask) {
+		mutex_lock(&gsw->reg_mutex);
+		val = mtk_switch_r32(gsw, GSW_REG_GPC1);
+		val &= ~delay_mask;
+		val |= delay_val & delay_mask;
+		mtk_switch_w32(gsw, val, GSW_REG_GPC1);
+		mutex_unlock(&gsw->reg_mutex);
+	}
+
+	return 0;
+}
+EXPORT_SYMBOL_GPL(mt7620_gsw_config_rgmii1);
+
 static irqreturn_t gsw_interrupt_mt7620(int irq, void *_priv)
 {
 	struct fe_priv *priv = (struct fe_priv *)_priv;

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.h
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.h
@@ -13,6 +13,7 @@
  */
 
 #include <linux/mutex.h>
+#include <linux/phy.h>
 #include <linux/reset.h>
 #include <linux/workqueue.h>
 
@@ -136,6 +137,7 @@ struct mt7620_gsw {
 	struct mt7620_gsw_vlan	vlans[GSW_NUM_VLANS];
 	struct delayed_work	mib_work;
 	unsigned long		mib_active_ports;
+	unsigned long		mib_gige_ports;
 	u8			mib_port_intervals;
 	/* Protects the software-extended MIB counter state. */
 	spinlock_t		mib_lock;
@@ -147,6 +149,7 @@ struct mt7620_gsw {
 
 void mtk_switch_w32(struct mt7620_gsw *gsw, u32 val, unsigned reg);
 u32 mtk_switch_r32(struct mt7620_gsw *gsw, unsigned reg);
+int mt7620_gsw_config_rgmii1(struct mt7620_gsw *gsw, phy_interface_t interface);
 int mtk_gsw_init(struct fe_priv *priv);
 #if IS_ENABLED(CONFIG_NET_DSA_MT7620)
 int mt7620_gsw_dsa_device_register(struct mt7620_gsw *gsw,

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620_dsa.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620_dsa.c
@@ -19,7 +19,8 @@
 
 #define MT7620_DSA_NUM_PORTS		7
 #define MT7620_DSA_CPU_PORT		6
-#define MT7620_DSA_USER_PORTS		GENMASK(4, 0)
+#define MT7620_DSA_EXTERNAL_PORT	5
+#define MT7620_DSA_INTERNAL_PORTS	GENMASK(4, 0)
 #define MT7620_DSA_ALL_PORTS		GENMASK(6, 0)
 
 #define MT7620_GSW_SSC(p)		(0x2000 + ((p) * 0x100))
@@ -132,9 +133,10 @@
 
 /*
  * At minimum-sized line-rate traffic, the 16-bit packet counters wrap in
- * about 440 ms on the 100BASE-T user ports and 44 ms on the 1000BASE-T CPU
- * port. Sample the CPU port every 20 ms and the full port set every tenth
- * tick (200 ms), keeping both well inside their wrap intervals.
+ * about 440 ms on the 100BASE-T user ports and 44 ms on 1000BASE-T ports.
+ * Sample the CPU port and any active external 1000BASE-T port every 20 ms,
+ * and the full port set every tenth tick (200 ms), keeping all counters well
+ * inside their wrap intervals.
  */
 #define MT7620_MIB_CPU_INTERVAL		msecs_to_jiffies(20)
 #define MT7620_MIB_PORT_INTERVALS	10
@@ -248,10 +250,17 @@ static void mt7620_gsw_mib_work(struct work_struct *work)
 {
 	struct mt7620_gsw *gsw =
 		container_of(to_delayed_work(work), struct mt7620_gsw, mib_work);
-	unsigned long ports = BIT(MT7620_DSA_CPU_PORT);
+	/*
+	 * Fast polling covers the CPU port and port 5 when linked at
+	 * 1 Gbit/s. All ports are sampled every tenth tick.
+	 * Revisit this selection when adding more Gigabit user ports.
+	 */
+	unsigned long ports = BIT(MT7620_DSA_CPU_PORT) |
+			      (READ_ONCE(gsw->mib_gige_ports) &
+			       BIT(MT7620_DSA_EXTERNAL_PORT));
 
 	if (++gsw->mib_port_intervals == MT7620_MIB_PORT_INTERVALS) {
-		ports = MT7620_DSA_ALL_PORTS;
+		ports |= MT7620_DSA_ALL_PORTS;
 		gsw->mib_port_intervals = 0;
 	}
 
@@ -521,7 +530,7 @@ static int mt7620_gsw_setup(struct dsa_switch *ds)
 	}
 
 	mt7620_gsw_set_port_matrix(gsw, MT7620_DSA_CPU_PORT,
-				   MT7620_DSA_USER_PORTS);
+				   dsa_user_ports(ds));
 	mt7620_gsw_rmw(gsw, MT7620_GSW_PSC(MT7620_DSA_CPU_PORT),
 		       MT7620_PSC_SA_DIS, 0);
 	mt7620_gsw_rmw(gsw, MT7620_GSW_MFC,
@@ -554,6 +563,7 @@ static int mt7620_gsw_setup(struct dsa_switch *ds)
 	memset(gsw->mib_stats, 0, sizeof(gsw->mib_stats));
 	gsw->mib_initialized = false;
 	gsw->mib_active_ports = 0;
+	gsw->mib_gige_ports = 0;
 	gsw->mib_port_intervals = 0;
 	mt7620_gsw_mib_update(gsw, MT7620_DSA_ALL_PORTS);
 
@@ -585,9 +595,11 @@ static int mt7620_gsw_port_enable(struct dsa_switch *ds, int port,
 					   BIT(MT7620_DSA_CPU_PORT));
 		start_mib = !READ_ONCE(gsw->mib_active_ports);
 		set_bit(port, &gsw->mib_active_ports);
-		if (start_mib)
+		if (start_mib) {
+			gsw->mib_port_intervals = 0;
 			schedule_delayed_work(&gsw->mib_work,
 					      MT7620_MIB_CPU_INTERVAL);
+		}
 	}
 
 	return 0;
@@ -600,9 +612,11 @@ static void mt7620_gsw_port_disable(struct dsa_switch *ds, int port)
 	if (dsa_is_user_port(ds, port)) {
 		mt7620_gsw_set_port_matrix(gsw, port, 0);
 		clear_bit(port, &gsw->mib_active_ports);
+		clear_bit(port, &gsw->mib_gige_ports);
 		if (!READ_ONCE(gsw->mib_active_ports)) {
 			cancel_delayed_work_sync(&gsw->mib_work);
 			mt7620_gsw_mib_update(gsw, MT7620_DSA_ALL_PORTS);
+			gsw->mib_port_intervals = 0;
 		}
 	}
 }
@@ -1203,6 +1217,17 @@ static void mt7620_gsw_mac_config(struct phylink_config *config,
 				  unsigned int mode,
 				  const struct phylink_link_state *state)
 {
+	struct dsa_port *dp = dsa_phylink_to_port(config);
+	struct mt7620_gsw *gsw = dp->ds->priv;
+	int ret;
+
+	if (dp->index != MT7620_DSA_EXTERNAL_PORT)
+		return;
+
+	ret = mt7620_gsw_config_rgmii1(gsw, state->interface);
+	if (ret)
+		dev_err(gsw->dev, "port %d: unsupported PHY interface %d\n",
+			dp->index, state->interface);
 }
 
 static void mt7620_gsw_mac_link_down(struct phylink_config *config,
@@ -1214,6 +1239,8 @@ static void mt7620_gsw_mac_link_down(struct phylink_config *config,
 
 	if (dsa_is_cpu_port(dp->ds, dp->index))
 		return;
+
+	clear_bit(dp->index, &gsw->mib_gige_ports);
 
 	mt7620_gsw_rmw(gsw, GSW_REG_PORT_PMCR(dp->index),
 		       PMCR_FORCE | PMCR_LINK, PMCR_FORCE);
@@ -1237,6 +1264,11 @@ static void mt7620_gsw_mac_link_up(struct phylink_config *config,
 	hw_speed = mt7620_gsw_pmcr_speed(speed);
 	if (hw_speed < 0)
 		return;
+
+	if (speed == SPEED_1000)
+		set_bit(dp->index, &gsw->mib_gige_ports);
+	else
+		clear_bit(dp->index, &gsw->mib_gige_ports);
 
 	val = PMCR_IPG | PMCR_MAC_MODE | PMCR_FORCE | PMCR_TX_EN |
 	      PMCR_RX_EN | PMCR_BACKOFF | PMCR_BACKPRES | PMCR_LINK |
@@ -1264,17 +1296,20 @@ static void mt7620_gsw_phylink_get_caps(struct dsa_switch *ds, int port,
 	bitmap_zero(config->supported_interfaces, PHY_INTERFACE_MODE_MAX);
 	config->mac_capabilities = MAC_SYM_PAUSE | MAC_ASYM_PAUSE;
 
-	/*
-	 * Port 5 is an external MAC whose pinmux and PHY mode are
-	 * board-specific. It matches neither case below and is therefore
-	 * left without a supported interface until a DSA device tree
-	 * describes it.
-	 */
-	if (port >= 0 && BIT(port) & MT7620_DSA_USER_PORTS) {
+	if (port >= 0 && BIT(port) & MT7620_DSA_INTERNAL_PORTS) {
 		__set_bit(PHY_INTERFACE_MODE_MII,
 			  config->supported_interfaces);
 		config->mac_capabilities |= MAC_10HD | MAC_10FD |
 					    MAC_100HD | MAC_100FD;
+	} else if (port == MT7620_DSA_EXTERNAL_PORT) {
+		phy_interface_set_rgmii(config->supported_interfaces);
+		__set_bit(PHY_INTERFACE_MODE_MII,
+			  config->supported_interfaces);
+		__set_bit(PHY_INTERFACE_MODE_RMII,
+			  config->supported_interfaces);
+		config->mac_capabilities |= MAC_10HD | MAC_10FD |
+					    MAC_100HD | MAC_100FD |
+					    MAC_1000FD;
 	} else if (port == MT7620_DSA_CPU_PORT) {
 		phy_interface_set_rgmii(config->supported_interfaces);
 		config->mac_capabilities |= MAC_10HD | MAC_10FD |

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -216,6 +216,16 @@ define Device/devolo_rac
 endef
 TARGET_DEVICES += devolo_rac
 
+define Device/dlink_dap-1620-a2
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DAP-1620
+  IMAGE_SIZE := 7872k
+  DEVICE_VARIANT := A2
+  SOC := mt7620a
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-phy-realtek dap1620-leds kmod-dsa-mt7620 -swconfig
+endef
+TARGET_DEVICES += dlink_dap-1620-a2
+
 define Device/dlink_dch-m225
   $(Device/seama)
   SOC := mt7620a

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -114,6 +114,9 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"4:lan" "6@eth0"
 		;;
+	dlink,dap-1620-a2)
+		ucidef_set_interface_lan "lan"
+		;;
 	dlink,dir-510l)
 		ucidef_add_switch "switch0" \
 			"0:lan" "6@eth0"


### PR DESCRIPTION
## Summary

Add DSA support for the external RGMII1 interface on MT7620 switch port 5 and use it to add support for the D-Link DAP-1620 A2.

This PR contains two commits: the generic MT7620 DSA/RGMII1 change and DAP-1620 A2 device support, including the device-specific LED service.

## MT7620 RGMII1 support

MT7620 switch port 5 is the external MAC exposed through RGMII1. The DSA driver supports internal user ports 0-4 and CPU port 6, but does not support external port 5.

Add phylink capabilities and MAC configuration for port 5 and add `mt7620_gsw_config_rgmii1()` to configure the interface from the DSA MAC configuration callback while keeping the legacy `mt7620_port_init()` path unchanged.

The DAP-1620 A2 uses `rgmii-id`. For the RGMII *ID modes, the PHY supplies the requested internal delays while the MT7620 MAC-side delays remain disabled. Leave `RX_SKEW` unchanged.

The helper also contains MII and RMII interface handling, but these modes are outside the tested DAP-1620 A2 device path and are not changed further as part of this work.

Derive the CPU forwarding matrix from the actual DSA user ports, allowing traffic between external port 5 and CPU port 6.

Include port 5 in fast MIB polling while linked at 1 Gbps. The hardware packet counters are only 16 bits, requiring frequent sampling to extend them in software without missing wraps.

Track negotiated Gigabit state separately from administratively enabled ports through `mib_gige_ports`. Request a 20 ms polling interval for CPU port 6 and Gigabit port 5, with all ports sampled every tenth tick. These are requested scheduling intervals, not guaranteed deadlines. Slower or down external links use the normal full-port polling cadence.

Keep the explicit interval resets when polling is stopped and restarted. The fast-polling selection is limited to CPU port 6 and external port 5 and must be revisited if support for additional Gigabit user ports is added.

Use a single DSA-local definition, `MT7620_DSA_EXTERNAL_PORT`, for external port 5.

The legacy swconfig path remains unchanged. PPE hardware flow offload is outside this PR's scope.

## D-Link DAP-1620 A2

The D-Link DAP-1620 A2 is a dual-band Wi-Fi range extender with one Gigabit Ethernet port.

Hardware:

- MediaTek MT7620A, 580 MHz
- 64 MiB RAM
- 8 MiB SPI NOR flash
- Integrated MT7620 2.4 GHz Wi-Fi
- MediaTek MT7612E 5 GHz 802.11ac radio over PCIe
- Realtek RTL8211E Gigabit Ethernet PHY
- Reset and WPS buttons
- Red/green status LED and three signal-strength indicators

Connect the RTL8211E at MDIO address 1 to DSA user port 5 through RGMII1. Use `rgmii-id` so the PHY supplies both internal clock delays while the MT7620 MAC-side delays remain disabled. Describe port 6 as the fixed 1 Gbps full-duplex CPU connection.

Select `kmod-mt76x2`, `kmod-phy-realtek`, `kmod-dsa-mt7620` and the device-specific `dap1620-leds` service. Drop `swconfig` and `rssileds`, and configure the DSA `lan` interface as the default LAN.

Flash layout, with exclusive end addresses:

- U-Boot: `0x000000-0x030000`
- NVRAM: `0x030000-0x040000`
- Factory: `0x040000-0x050000`
- Firmware: `0x050000-0x800000`

Calibration and MAC addresses:

- 2.4 GHz calibration: factory + `0x0000`
- 5 GHz calibration: factory + `0x8000`
- Ethernet MAC: factory + `0xffe8`
- 2.4 GHz MAC: Ethernet MAC incremented by 1
- 5 GHz MAC: factory + `0xffd4`

Preserve U-Boot, NVRAM and factory data as read-only partitions. The MAC increment changes the address value, not the flash offset.

### Flash constraints

U-Boot, NVRAM and factory data occupy the first 320 KiB of the 8 MiB flash. The firmware partition is limited to 7872 KiB, or 8,060,928 bytes.

The separately built AP test profile excludes these PPP and PPPoE packages:

- `ppp`
- `kmod-ppp`
- `ppp-mod-pppoe`
- `kmod-pppoe`
- `kmod-pppox`
- `kmod-slhc`
- `luci-proto-ppp`

It includes `luci-light`, `dap1620-leds` and `kmod-dsa-mt7620`. `rssileds` and WPS functionality are not included.

The verified AP build artifacts were built from commit `60a9fbe8dc19a666bfa8a1c0ae846e8579d2af1c`:

- Sysupgrade: `dap1620-20260909-aa0bbbb2-ap-no-ppp-sysupgrade.bin`
  - Size: 7,078,166 bytes
  - SHA256: `e3b9a5861a8b458ce6ff540f052b089cb4d274be84d0d4f430dd9f7d84997be1`
  - Margin below the firmware limit: 982,762 bytes, approximately 0.94 MiB
- Initramfs: `dap1620-20260909-aa0bbbb2-ap-no-ppp-initramfs.bin`
  - Size: 6,901,132 bytes
  - SHA256: `71c9eb3dbac933db7ea3731de2b516301791455069fe49629fbfa0866985935e`

The `aa0bbbb2` identifier in the artifact names is a build label. The recorded source commit for these builds is `60a9fbe8dc19a666bfa8a1c0ae846e8579d2af1c`.

These figures apply only to these build artifacts. The final upstream device image must remain within the 8,060,928-byte firmware limit.

### LED behaviour

Add the `dap1620-leds` service in place of `rssileds`.

The status LED is red by default during startup using the normal OpenWrt boot LED handling. Once `dap1620-leds` starts, it shows solid green when the selected uplink is connected and blinking amber when it is unavailable.

In Ethernet mode, use physical carrier on `lan` as the uplink condition and keep the signal indicators off. In repeater mode, require an associated and authorized Wi-Fi station and follow that station's signal strength. No DHCP, DNS or Internet-reachability checks are performed.

Use these configurable signal thresholds:

- Below -75 dBm: first indicator amber
- -75 to below -65 dBm: one green indicator
- -65 to below -55 dBm: two green indicators
- -55 dBm or stronger: three green indicators

These thresholds are policy defaults, not recovered stock firmware values. Keep the signal indicators off when disconnected or when RSSI is unavailable. Require explicit station selection when multiple STA configurations exist.

### Installation

Use the U-Boot serial console at 57600 baud, 8N1, without flow control. Connect Ethernet to a TFTP server at `192.168.0.100`.

Start from a cold power-on. Press 4 at the bootloader menu to enter the command line.

For RAM-only testing:

```text
setenv ipaddr 192.168.0.1
setenv serverip 192.168.0.100
tftpboot 0x81000000 openwrt-ramips-mt7620-dlink_dap-1620-a2-initramfs-kernel.bin
bootm 0x81000000
```

This loads and runs OpenWrt without writing the firmware to flash.

For persistent installation, cold-start the device and select U-Boot menu option 2, `Load system code then write to Flash via TFTP`. Confirm with `Y` and provide the device and server addresses above and this filename:

```text
openwrt-ramips-mt7620-dlink_dap-1620-a2-squashfs-sysupgrade.bin
```

After flashing has completed, disconnect power, allow the device to power down fully, and reconnect it. Verify that OpenWrt boots from flash before considering the installation complete.

Subsequent upgrades can use the normal OpenWrt sysupgrade procedure.

### Testing

Hardware testing across the tested DAP-1620 A2 development revisions confirmed:

- DSA initialization and RTL8211E detection through MDIO
- Port 5 operating with `rgmii-id`
- 1 Gbps full-duplex Ethernet negotiation
- LAN traffic and link recovery
- Detection of both Wi-Fi radios
- Initramfs boot through U-Boot and TFTP
- Flashing and booting a squashfs sysupgrade image
- Cold power cycle after the initial flash
- Ethernet LED behaviour with carrier disconnected and connected
- Wi-Fi station association and authorized-state detection
- Three green signal indicators at an observed RSSI of -54 dBm

A 60-minute bidirectional TCP soak completed successfully at approximately 250 Mbit/s DAP TX and 217 Mbit/s DAP RX. All iperf3 phases exited successfully. The sampled link status remained at 1 Gbps full duplex, with no observed link drops or increases in the switch MIB bad-packet or error counters.

Additional 30-second TCP tests:

- DAP TX: 578 Mbit/s, 27 retransmissions
- DAP RX: 377 Mbit/s, 37 retransmissions
- Bidirectional: 254 + 221 Mbit/s, 0 + 231 retransmissions

CPU usage was close to saturation during the tests. The higher retransmission count in the server-to-DAP direction during bidirectional traffic could be related to CPU or softirq pressure, but the cause has not been established. The generic `rx_dropped` counter increased by 124 during the 60-minute soak.

These tests terminate TCP on the device itself and are not a forwarding or hardware flow-offload benchmark. Hardware offload such as PR #24515 may help forwarding workloads, but is outside the scope of this device support. With only one external Ethernet port, a conventional wired LAN-to-WAN forwarding test is not available.

The results support basic Ethernet and DSA stability under sustained load. Negotiation at 100 Mbit/s, repeated link-cycle testing and weaker-RSSI LED threshold testing remain separate tests.

The AP artifacts listed under flash constraints were separately verified for successful build, package contents, file size and checksum. The build record does not identify them as the revision used for every hardware result above.

This support builds on Senthil Durairaj's original DAP-1620 A2 work in PR #17027 and the MT7620 DSA driver introduced in PR #24493.

Link: https://github.com/openwrt/openwrt/pull/17027
Link: https://github.com/openwrt/openwrt/pull/24493
Link: https://forum.openwrt.org/t/253264

Signed-off-by: Senthil Durairaj <sendura1@outlook.com>
Signed-off-by: Boyler Fourcade <Boilerplate4U@gmail.com>
