### PR TITLE
mediatek: filogic: add Adtran SmartRG SDG-8713

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -162,6 +162,7 @@ openembed,som7981)
 	ubootenv_add_uci_sys_config "/dev/mtd3" "0x0" "0x100000" "0x100000"
 	;;
 smartrg,sdg-8712|\
+smartrg,sdg-8713|\
 smartrg,sdg-8732|\
 smartrg,sdg-8733|\
 smartrg,sdg-8733a|\

--- a/target/linux/mediatek/dts/mt7988a-smartrg-sdg-8713.dts
+++ b/target/linux/mediatek/dts/mt7988a-smartrg-sdg-8713.dts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Copyright (C) 2025 SmartRG Inc.
+ * Author: Chad Monroe <chad.monroe@smartrg.com>
+ */
+
+#include "mt7988a-smartrg-sdg-8713.dtsi"
+
+/ {
+	model = "SmartRG SDG-8713";
+	compatible = "smartrg,sdg-8713", "mediatek,mt7988a";
+};

--- a/target/linux/mediatek/dts/mt7988a-smartrg-sdg-8713.dtsi
+++ b/target/linux/mediatek/dts/mt7988a-smartrg-sdg-8713.dtsi
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Copyright (C) 2025 SmartRG Inc.
+ * Author: Chad Monroe <chad.monroe@smartrg.com>
+ *
+ * Mt. Stuart phase 4: dual Realtek RTL8261 10G PHYs, MT7992 radio on
+ * pcie1, built-in switch as lan2..lan4.
+ */
+
+#include "mt7988-smartrg-base.dtsi"
+#include "mt7988-smartrg-sysled.dtsi"
+#include "mt7988-smartrg-mt-stuart-gsw.dtsi"
+#include "mt798x-smartrg-factory.dtsi"
+
+/ {
+	aliases {
+		label-mac-device = &gmac2;
+	};
+
+	gpio-keys {
+		button-sync {
+			label = "sync";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&button_pins {
+	pins = "GPIO_RESET", "GPIO_WPS";
+};
+
+&gmac1 {
+	nvmem-cells = <&macaddr 0x1>;
+	nvmem-cell-names = "mac-address";
+	label = "lan1";
+	phy-mode = "usxgmii";
+	phy = <&phy1>;
+
+	status = "okay";
+};
+
+&gmac2 {
+	nvmem-cells = <&macaddr 0x0>;
+	nvmem-cell-names = "mac-address";
+	label = "wan";
+	phy-mode = "usxgmii";
+	phy = <&phy2>;
+
+	status = "okay";
+};
+
+&mdio_bus {
+	phy1: ethernet-phy@1 {
+		/* Realtek RTL8261 - LAN1 */
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <1>;
+
+		reset-gpios = <&pio 62 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <100000>;
+		reset-deassert-us = <221000>;
+
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led@0 {
+				reg = <0>;
+				color = <LED_COLOR_ID_WHITE>;
+				function = LED_FUNCTION_LAN;
+			};
+
+			led@1 {
+				reg = <1>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_LAN;
+				active-low;
+			};
+
+			led@3 {
+				reg = <3>;
+				color = <LED_COLOR_ID_ORANGE>;
+				function = LED_FUNCTION_LAN;
+				active-low;
+			};
+		};
+	};
+
+	phy2: ethernet-phy@2 {
+		/* Realtek RTL8261 - WAN */
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <2>;
+
+		reset-gpios = <&pio 71 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <100000>;
+		reset-deassert-us = <221000>;
+
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led@0 {
+				reg = <0>;
+				color = <LED_COLOR_ID_WHITE>;
+				function = LED_FUNCTION_WAN;
+				active-low;
+			};
+
+			led@1 {
+				reg = <1>;
+				color = <LED_COLOR_ID_ORANGE>;
+				function = LED_FUNCTION_WAN;
+			};
+
+			led@3 {
+				reg = <3>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_WAN;
+			};
+		};
+	};
+};
+
+&pcie1 {
+	wifi-reset-gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+	wifi-reset-msleep = <100>;
+	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+
+		radio0: wifi@0,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			nvmem-cells = <&eeprom_factory_0>;
+			nvmem-cell-names = "eeprom";
+			ieee80211-freq-limit = <2400000 2500000>, <5170000 5835000>;
+
+			band@0 {
+				/* 2.4 GHz */
+				reg = <0>;
+				nvmem-cells = <&macaddr 0x4>;
+				nvmem-cell-names = "mac-address";
+			};
+
+			band@1 {
+				/* 5 GHz */
+				reg = <1>;
+				nvmem-cells = <&macaddr 0xa>;
+				nvmem-cell-names = "mac-address";
+			};
+		};
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -317,6 +317,20 @@ smartrg,sdg-8732)
 	ucidef_set_led_netdev "wan-amber" "WAN" "mdio-bus:04:amber:wan" "wan" "link_10 link_100"
 	ucidef_set_led_netdev "wan-white" "WAN" "mdio-bus:04:white:wan" "wan" "link_2500"
 	;;
+smartrg,sdg-8713)
+	ucidef_set_led_netdev "lan-1-green" "LAN1" "mdio-bus:01:green:lan" "lan1" "link_2500 link_5000"
+	ucidef_set_led_netdev "lan-1-orange" "LAN1" "mdio-bus:01:orange:lan" "lan1" "link_100 link_1000"
+	ucidef_set_led_netdev "lan-1-white" "LAN1" "mdio-bus:01:white:lan" "lan1" "link_10000"
+	ucidef_set_led_netdev "lan-2-green" "LAN2" "mt7530-0:01:green:lan" "lan2" "link_1000"
+	ucidef_set_led_netdev "lan-2-amber" "LAN2" "mt7530-0:01:amber:lan" "lan2" "link_100 link_10"
+	ucidef_set_led_netdev "lan-3-green" "LAN3" "mt7530-0:02:green:lan" "lan3" "link_1000"
+	ucidef_set_led_netdev "lan-3-amber" "LAN3" "mt7530-0:02:amber:lan" "lan3" "link_100 link_10"
+	ucidef_set_led_netdev "lan-4-green" "LAN4" "mt7530-0:03:green:lan" "lan4" "link_1000"
+	ucidef_set_led_netdev "lan-4-amber" "LAN4" "mt7530-0:03:amber:lan" "lan4" "link_100 link_10"
+	ucidef_set_led_netdev "wan-green" "WAN" "mdio-bus:02:green:wan" "wan" "link_2500 link_5000"
+	ucidef_set_led_netdev "wan-orange" "WAN" "mdio-bus:02:orange:wan" "wan" "link_100 link_1000"
+	ucidef_set_led_netdev "wan-white" "WAN" "mdio-bus:02:white:wan" "wan" "link_10000"
+	;;
 smartrg,sdg-8733|\
 smartrg,sdg-8734)
 	ucidef_set_led_netdev "lan-1-green" "LAN1" "mdio-bus:08:green:lan" "lan1" "link_2500 link_5000"

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -229,6 +229,7 @@ platform_do_upgrade() {
 	smartrg,sdg-8622|\
 	smartrg,sdg-8632|\
 	smartrg,sdg-8712|\
+	smartrg,sdg-8713|\
 	smartrg,sdg-8732|\
 	smartrg,sdg-8733|\
 	smartrg,sdg-8733a|\
@@ -516,6 +517,7 @@ platform_copy_config() {
 	smartrg,sdg-8622|\
 	smartrg,sdg-8632|\
 	smartrg,sdg-8712|\
+	smartrg,sdg-8713|\
 	smartrg,sdg-8732|\
 	smartrg,sdg-8733|\
 	smartrg,sdg-8733a|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -354,6 +354,14 @@ $(call Device/adtran_smartrg)
 endef
 TARGET_DEVICES += smartrg_sdg-8712
 
+define Device/smartrg_sdg-8713
+$(call Device/adtran_smartrg)
+  DEVICE_MODEL := SDG-8713
+  DEVICE_DTS := mt7988a-smartrg-sdg-8713
+  DEVICE_PACKAGES += kmod-mt7992-firmware kmod-phy-realtek mt7988-wo-firmware
+endef
+TARGET_DEVICES += smartrg_sdg-8713
+
 define Device/smartrg_sdg-8732
 $(call Device/adtran_smartrg)
   DEVICE_MODEL := SDG-8732


### PR DESCRIPTION
Hardware specifications:
 * MediaTek MT7988A (4x Cortex-A73)
 * 4 GiB eMMC
 * 1 GiB DDR4 RAM
 * 1x 10000M/5000M/2500M/1000M/100M WAN port (Realtek RTL8261D PHY)
 * 1x 10000M/5000M/2500M/1000M/100M LAN port (Realtek RTL8261D PHY)
 * 3x 1000M/100M/10M LAN ports (MT7988 built-in switch)
 * 3x LED for each 10G port, 2x LED for each 1G port
 * MT7992 dual-band 802.11be Wi-Fi (2.4G 4T4R, 5G 4T5R)
 * 2 buttons (Reset, Mesh/WPS)
 * uC-controlled RGB LED via I2C
 * 3.3V-level 115200 baud UART console

The model is also available as SDG-8713v including 1x FXS POTS interface for analog phones. That interface is not supported by OpenWrt.

Installation:

1. Prepare a TFTP server at 192.168.1.10 and serve the OpenWrt initramfs image, renamed to "openwrt.435".
2. Connect to one of the LAN ports.
3. Connect to the UART port.
4. Power on the device and type "st" to enter the U-Boot command line. The window to do that might be very short (below 1s), so type it as soon as the "U-Boot ..." string appears.
5. Run "bootmenu" and select option 6 (TFTP openwrt image and boot); "run boot5" is a shortcut for the same. This downloads openwrt.435 from the TFTP server and boots it.
6. After OpenWrt finishes booting, download the OpenWrt sysupgrade image and write it to eMMC using "sysupgrade".
7. After sysupgrade finishes writing, the device reboots into OpenWrt. When the front LED is solid white the device is ready for configuration.