### PR TITLE
realtek: dsa: rtl83xx: assorted PIE / tc flower offload fixes

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl-otto.h
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl-otto.h
@@ -1262,7 +1262,7 @@ struct pie_rule {
 	u16 otag_m;
 	u8 smac_m[ETH_ALEN];
 	u8 dmac_m[ETH_ALEN];
-	u8 ethertype_m;
+	u16 ethertype_m;
 	u16 itag_m;
 	u16 field_range_check_m;
 	u32 sip_m;

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl838x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl838x.c
@@ -1487,6 +1487,15 @@ static int rtl838x_pie_verify_template(struct rtl838x_switch_priv *priv,
 	if (ether_addr_to_u64(pr->dmac) && !rtl838x_pie_templ_has(t, TEMPLATE_FIELD_DMAC0))
 		return -1;
 
+	if (pr->itag_m && !rtl838x_pie_templ_has(t, TEMPLATE_FIELD_ITAG))
+		return -1;
+
+	if (pr->sport_m && !rtl838x_pie_templ_has(t, TEMPLATE_FIELD_L4_SPORT))
+		return -1;
+
+	if (pr->dport_m && !rtl838x_pie_templ_has(t, TEMPLATE_FIELD_L4_DPORT))
+		return -1;
+
 	/* TODO: Check more */
 
 	i = find_first_zero_bit(&priv->pie_use_bm[block * 4], PIE_BLOCK_SIZE);

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl839x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl839x.c
@@ -1417,7 +1417,7 @@ static int rtl839x_pie_rule_add(struct rtl838x_switch_priv *priv, struct pie_rul
 			break;
 	}
 
-	if (block >= priv->r->n_pie_blocks) {
+	if (block >= max_block) {
 		mutex_unlock(&priv->pie_mutex);
 		return -EOPNOTSUPP;
 	}

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl839x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl839x.c
@@ -1383,6 +1383,15 @@ static int rtl839x_pie_verify_template(struct rtl838x_switch_priv *priv,
 	if (ether_addr_to_u64(pr->dmac) && !rtl839x_pie_templ_has(t, TEMPLATE_FIELD_DMAC0))
 		return -1;
 
+	if (pr->itag_m && !rtl839x_pie_templ_has(t, TEMPLATE_FIELD_ITAG))
+		return -1;
+
+	if (pr->sport_m && !rtl839x_pie_templ_has(t, TEMPLATE_FIELD_L4_SPORT))
+		return -1;
+
+	if (pr->dport_m && !rtl839x_pie_templ_has(t, TEMPLATE_FIELD_L4_DPORT))
+		return -1;
+
 	/* TODO: Check more */
 
 	i = find_first_zero_bit(&priv->pie_use_bm[block * 4], PIE_BLOCK_SIZE);

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -1787,7 +1787,7 @@ static int rtl930x_pie_rule_add(struct rtl838x_switch_priv *priv, struct pie_rul
 			break;
 	}
 
-	if (block >= priv->r->n_pie_blocks) {
+	if (block >= max_block) {
 		mutex_unlock(&priv->pie_mutex);
 		return -EOPNOTSUPP;
 	}

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -1749,6 +1749,15 @@ static int rtl930x_pie_verify_template(struct rtl838x_switch_priv *priv,
 	if (ether_addr_to_u64(pr->dmac) && !rtl930x_pie_templ_has(t, TEMPLATE_FIELD_DMAC0))
 		return -1;
 
+	if (pr->itag_m && !rtl930x_pie_templ_has(t, TEMPLATE_FIELD_VLAN))
+		return -1;
+
+	if (pr->sport_m && !rtl930x_pie_templ_has(t, TEMPLATE_FIELD_L4_SPORT))
+		return -1;
+
+	if (pr->dport_m && !rtl930x_pie_templ_has(t, TEMPLATE_FIELD_L4_DPORT))
+		return -1;
+
 	/* TODO: Check more */
 
 	i = find_first_zero_bit(&priv->pie_use_bm[block * 4], PIE_BLOCK_SIZE);

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -1904,6 +1904,12 @@ static void rtl930x_packet_cntr_clear(int counter)
 	struct table_reg *r = rtl_table_get(RTL9300_TBL_0, 3);
 
 	pr_debug("In %s, id %d\n", __func__, counter);
+
+	/* Two counters share one LOG table entry. Read the current entry
+	 * first so clearing one half preserves the adjacent counter.
+	 */
+	rtl_table_read(r, counter / 2);
+
 	/* The table has a size of 2 registers */
 	if (counter % 2)
 		sw_w32(0, rtl_table_data(r, 0));

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl931x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl931x.c
@@ -1450,7 +1450,7 @@ static int rtl931x_pie_rule_add(struct rtl838x_switch_priv *priv, struct pie_rul
 			break;
 	}
 
-	if (block >= priv->r->n_pie_blocks) {
+	if (block >= max_block) {
 		mutex_unlock(&priv->pie_mutex);
 		return -EOPNOTSUPP;
 	}

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl931x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl931x.c
@@ -1411,6 +1411,15 @@ static int rtl931x_pie_verify_template(struct rtl838x_switch_priv *priv,
 	if (ether_addr_to_u64(pr->dmac) && !rtl931x_pie_templ_has(t, TEMPLATE_FIELD_DMAC0))
 		return -1;
 
+	if (pr->itag_m && !rtl931x_pie_templ_has(t, TEMPLATE_FIELD_VLAN))
+		return -1;
+
+	if (pr->sport_m && !rtl931x_pie_templ_has(t, TEMPLATE_FIELD_L4_SPORT))
+		return -1;
+
+	if (pr->dport_m && !rtl931x_pie_templ_has(t, TEMPLATE_FIELD_L4_DPORT))
+		return -1;
+
 	/* TODO: Check more */
 
 	i = find_first_zero_bit(&priv->pie_use_bm[block * 4], PIE_BLOCK_SIZE);

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
@@ -158,6 +158,7 @@ static int rtl83xx_add_flow(struct rtl838x_switch_priv *priv, struct flow_cls_of
 
 		case FLOW_ACTION_TRAP:
 			pr_debug("%s: TRAP\n", __func__);
+			flow->rule.fwd_sel = true;
 			flow->rule.fwd_data = priv->r->cpu_port;
 			flow->rule.fwd_act = PIE_ACT_REDIRECT_TO_PORT;
 			rtl83xx_flow_bypass_all(flow);


### PR DESCRIPTION
Five small, independent fixes to the existing Realtek DSA PIE / tc-flower
offload code, split out of #24994 at the maintainer's request so they can
be reviewed on their own.

* **rtl930x: don't clobber adjacent LOG counter** — `rtl930x_packet_cntr_clear()`
  wrote a LOG table entry back without reading it first, wiping the counter
  that shares the same 64-bit entry.
* **rtl83xx: bound PIE rule search by the phase block range** — the
  "nothing found" check in `rtl{839,930,931}x_pie_rule_add()` compared against
  the full block count instead of the phase half, so an exhausted ingress
  range fell through with a stale block/index instead of `-EOPNOTSUPP`.
* **widen `pie_rule.ethertype_m` to u16** — the EtherType value is a u16
  but its mask was u8, so a full 16-bit match could not be expressed.
* **rtl83xx: set `fwd_sel` for the tc flower TRAP action** — the
  `FLOW_ACTION_TRAP` handler set `fwd_data`/`fwd_act` but not `fwd_sel`,
  so trapped packets were never actually redirected to the CPU port.
* **rtl83xx: check L4 port and VLAN template fields** — `*_pie_verify_template()`
  rejected a template missing the SIP/DIP/SMAC/DMAC field a rule needs, but
  silently accepted one missing the L4 port or VLAN fields, so the match was
  dropped without anyone noticing: a `dst_port 5353` offload matched every UDP
  frame instead of just mDNS. Fixed in all four SoCs (rtl838x/839x/930x/931x);
  reproduced and verified on rtl930x hardware (RTL9302C / Zyxel XGS1210-12).

No functional dependency between the five. #24994 will be rebased on top
once these land.

---
Discussion / testing feedback: https://forum.openwrt.org/t/tcfilter-luci-app-tcfilter-persistent-tc-ingress-filters-with-hardware-offload-on-realtek-switches/253331
