### PR TITLE
ipq806x: enlarge R7500 flash - use netgear partition

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/05_compat-version
+++ b/target/linux/ipq806x/base-files/etc/board.d/05_compat-version
@@ -19,7 +19,6 @@ case "$(board_name)" in
 	nec,wg2600hp|\
 	nec,wg2600hp3|\
 	netgear,d7800|\
-	netgear,r7500|\
 	netgear,r7500v2|\
 	netgear,r7800|\
 	netgear,xr450|\
@@ -34,6 +33,9 @@ case "$(board_name)" in
 	tplink,vr2600v|\
 	zyxel,nbg6817)
 		ucidef_set_compat_version "1.1"
+		;;
+	netgear,r7500)
+		ucidef_set_compat_version "2.0"
 		;;
 	linksys,ea7500-v1|\
 	linksys,ea8500)

--- a/target/linux/ipq806x/dts/qcom-ipq8064-r7500.dts
+++ b/target/linux/ipq806x/dts/qcom-ipq8064-r7500.dts
@@ -250,18 +250,12 @@
 
 			ubi@1740000 {
 				label = "ubi";
-				reg = <0x1740000 0x1600000>;
+				reg = <0x1740000 0x61c0000>;
 			};
 
-			netgear@2d40000 {
-				label = "netgear";
-				reg = <0x2d40000 0x0c00000>;
-				read-only;
-			};
-
-			reserve@3940000 {
+			reserve@7900000 {
 				label = "reserve";
-				reg = <0x3940000 0x46c0000>;
+				reg = <0x7900000 0x0700000>;
 				read-only;
 			};
 		};

--- a/target/linux/ipq806x/image/generic.mk
+++ b/target/linux/ipq806x/image/generic.mk
@@ -413,6 +413,9 @@ define Device/netgear_r7500
 	BOARD_NAME := r7500
 	SUPPORTED_DEVICES += r7500
 	DEVICE_PACKAGES := ath10k-firmware-qca988x-ct
+	DEVICE_COMPAT_VERSION := 2.0
+	DEVICE_COMPAT_MESSAGE := Sysupgrade does not work due to rootfs ubi partition size change. \
+		Use factory image with the TFTP recovery flash routine.
 endef
 TARGET_DEVICES += netgear_r7500
 


### PR DESCRIPTION
Absorb the unused read-only netgear partition and most of the reserve into the UBI partition, taking available flash space for kernel+rootfs+overlay from 22 MB to ~97 MB.

This mirrors the change made for the R7800 in commit 618d59aec2 (ipq806x: Enlarge R7800 flash - use netgear partition).

Reverting to OEM firmware remains possible as the OEM firmware re-initialises the netgear partition when its contents do not match expectations.

Fixes: https://github.com/openwrt/openwrt/issues/24989

author claims this works soo.