### PR TITLE
mediatek: filogic: add support for Globitel BT-RB300

### DIFF
--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -496,6 +496,18 @@ define U-Boot/mt7981_globitel_bt-r320
   DEPENDS:=+trusted-firmware-a-mt7981-emmc-ddr4
 endef
 
+define U-Boot/mt7981_globitel_bt-rb300
+  NAME:=Globitel BT-RB300
+  BUILD_SUBTARGET:=filogic
+  BUILD_DEVICES:=globitel_bt-rb300
+  UBOOT_CONFIG:=mt7981_globitel_bt-rb300
+  UBOOT_IMAGE:=u-boot.fip
+  BL2_BOOTDEV:=spim-nand
+  BL2_SOC:=mt7981
+  BL2_DDRTYPE:=ddr3-1866
+  DEPENDS:=+trusted-firmware-a-mt7981-spim-nand-ddr3-1866
+endef
+
 define U-Boot/mt7981_h3c_magic-nx30-pro
   NAME:=H3C Magic NX30 Pro
   BUILD_SUBTARGET:=filogic
@@ -1394,6 +1406,7 @@ UBOOT_TARGETS := \
 	mt7981_glinet_gl-x3000 \
 	mt7981_glinet_gl-xe3000 \
 	mt7981_globitel_bt-r320 \
+	mt7981_globitel_bt-rb300 \
 	mt7981_h3c_magic-nx30-pro \
 	mt7981_imou_hx21 \
 	mt7981_jcg_q30-pro \

--- a/package/boot/uboot-mediatek/patches/477-add-globitel-bt-rb300.patch
+++ b/package/boot/uboot-mediatek/patches/477-add-globitel-bt-rb300.patch
@@ -1,0 +1,292 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Murad Rabadanov <the21.21@mail.ru>
+Date: Fri, 4 Sep 2026 21:32:06 +0300
+Subject: [PATCH] board: mediatek: add BT-RB300
+
+Add U-Boot support for the BT-RB300 router based on the MediaTek
+MT7981B SoC with 256 MiB DDR3-1866 RAM and 128 MiB SPI-NAND.
+
+Use an NMBM-backed ubootmod layout and provide boot menu entries for
+TFTP recovery, production and recovery UBI volumes, and bootloader
+installation.
+
+Signed-off-by: Murad Rabadanov <the21.21@mail.ru>
+---
+ configs/mt7981_globitel_bt-rb300_defconfig | 102 ++++++++++++++++++++++++++++++
+ arch/arm/dts/mt7981-globitel-bt-rb300.dts |  82 +++++++++++++++++++++++++
+ defenvs/mt7981_globitel_bt-rb300_env      |  54 ++++++++++++++++
+ arch/arm/mach-mediatek/Kconfig    |  15 +++++
+ 4 files changed, 253 insertions(+)
+ create mode 100644 configs/mt7981_globitel_bt-rb300_defconfig
+ create mode 100644 arch/arm/dts/mt7981-globitel-bt-rb300.dts
+ create mode 100644 defenvs/mt7981_globitel_bt-rb300_env
+
+--- /dev/null
++++ b/configs/mt7981_globitel_bt-rb300_defconfig
+@@ -0,0 +1,102 @@
++CONFIG_ARM=y
++CONFIG_ARM_SMCCC=y
++CONFIG_SYS_HAS_NONCACHED_MEMORY=y
++CONFIG_POSITION_INDEPENDENT=y
++CONFIG_ARCH_MEDIATEK=y
++CONFIG_TEXT_BASE=0x41e00000
++CONFIG_SYS_MALLOC_F_LEN=0x4000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEFAULT_DEVICE_TREE="mt7981-globitel-bt-rb300"
++CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_TARGET_MT7981=y
++CONFIG_SYS_LOAD_ADDR=0x46000000
++CONFIG_PRE_CON_BUF_ADDR=0x4007ef00
++CONFIG_DEBUG_UART_BASE=0x11002000
++CONFIG_DEBUG_UART_CLOCK=40000000
++CONFIG_DEBUG_UART=y
++CONFIG_FIT=y
++CONFIG_BOOTDELAY=30
++CONFIG_AUTOBOOT_KEYED=y
++CONFIG_AUTOBOOT_MENU_SHOW=y
++CONFIG_DEFAULT_FDT_FILE="mt7981-globitel-bt-rb300"
++CONFIG_LOGLEVEL=7
++CONFIG_PRE_CONSOLE_BUFFER=y
++CONFIG_LOG=y
++CONFIG_BOARD_LATE_INIT=y
++# CONFIG_BOARD_INIT is not set
++CONFIG_HUSH_PARSER=y
++CONFIG_SYS_PROMPT="MT7981> "
++CONFIG_CMD_BOOTMENU=y
++CONFIG_CMD_ASKENV=y
++CONFIG_CMD_ERASEENV=y
++CONFIG_CMD_ENV_FLAGS=y
++CONFIG_CMD_DM=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_MTD=y
++CONFIG_CMD_TFTPSRV=y
++CONFIG_CMD_DHCP=y
++CONFIG_CMD_PING=y
++CONFIG_CMD_PSTORE=y
++CONFIG_CMD_PSTORE_MEM_ADDR=0x42ff0000
++CONFIG_CMD_HASH=y
++CONFIG_CMD_UBI=y
++CONFIG_CMD_UBI_RENAME=y
++CONFIG_CMD_NMBM=y
++CONFIG_OF_EMBED=y
++CONFIG_ENV_OVERWRITE=y
++CONFIG_ENV_IS_IN_UBI=y
++CONFIG_ENV_REDUNDANT=y
++CONFIG_ENV_UBI_PART="ubi"
++CONFIG_ENV_UBI_VOLUME="ubootenv"
++CONFIG_ENV_UBI_VOLUME_REDUND="ubootenv2"
++CONFIG_ENV_RELOC_GD_ENV_ADDR=y
++CONFIG_ENV_USE_DEFAULT_ENV_TEXT_FILE=y
++CONFIG_ENV_DEFAULT_ENV_TEXT_FILE="defenvs/mt7981_globitel_bt-rb300_env"
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_VERSION_VARIABLE=y
++CONFIG_USE_IPADDR=y
++CONFIG_IPADDR="192.168.1.1"
++CONFIG_USE_SERVERIP=y
++CONFIG_SERVERIP="192.168.1.254"
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_BUTTON=y
++CONFIG_BUTTON_GPIO=y
++CONFIG_CLK=y
++CONFIG_LED=y
++CONFIG_LED_BLINK=y
++CONFIG_LED_GPIO=y
++CONFIG_MTD=y
++CONFIG_DM_MTD=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_MTD_UBI_FASTMAP=y
++CONFIG_NMBM=y
++CONFIG_NMBM_MTD=y
++CONFIG_ENABLE_NAND_NMBM=y
++CONFIG_NMBM_MAX_RATIO=1
++CONFIG_NMBM_MAX_BLOCKS=64
++CONFIG_MTDIDS_DEFAULT="nmbm0=nmbm0"
++CONFIG_MTDPARTS_DEFAULT="nmbm0:1024k(BL2),512k(u-boot-env),2048k(Factory),2048k(FIP),116736k(ubi)"
++CONFIG_PHY_FIXED=y
++CONFIG_MEDIATEK_ETH=y
++CONFIG_PHY=y
++CONFIG_PHY_MTK_TPHY=y
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++CONFIG_PINCTRL_MT7981=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MTK_POWER_DOMAIN=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_RAM=y
++CONFIG_DM_RNG=y
++CONFIG_RNG_MTK_V2=y
++CONFIG_CMD_RNG=y
++CONFIG_DM_SERIAL=y
++CONFIG_SERIAL_RX_BUFFER=y
++CONFIG_MTK_SERIAL=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_MTK_SPIM=y
++CONFIG_ZSTD=y
++CONFIG_HEXDUMP=y
+--- /dev/null
++++ b/arch/arm/dts/mt7981-globitel-bt-rb300.dts
+@@ -0,0 +1,82 @@
++// SPDX-License-Identifier: GPL-2.0
++/dts-v1/;
++#include "mt7981.dtsi"
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/linux-event-codes.h>
++
++/ {
++	#address-cells = <1>;
++	#size-cells = <1>;
++	model = "Globitel BT-RB300";
++	compatible = "globitel,bt-rb300", "mediatek,mt7981";
++
++	chosen {
++		stdout-path = &uart0;
++		tick-timer = &timer0;
++	};
++
++	memory@40000000 {
++		device_type = "memory";
++		reg = <0x40000000 0x10000000>;
++	};
++
++	gpio-keys {
++		compatible = "gpio-keys";
++		reset {
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&uart0 {
++	mediatek,force-highspeed;
++	status = "okay";
++};
++
++&eth {
++	status = "okay";
++	mediatek,gmac-id = <0>;
++	phy-mode = "2500base-x";
++	mediatek,switch = "mt7531";
++	reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
++	fixed-link {
++		speed = <2500>;
++		full-duplex;
++	};
++};
++
++&pio {
++	spi_flash_pins: spi0-pins-func-1 {
++		mux {
++			function = "flash";
++			groups = "spi0", "spi0_wp_hold";
++		};
++	};
++};
++
++&spi0 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi_flash_pins>;
++	status = "okay";
++	must_tx;
++	enhance_timing;
++	dma_ext;
++	ipm_design;
++	support_quad;
++	tick_dly = <2>;
++	sample_sel = <0>;
++
++	spi_nand@0 {
++		compatible = "spi-nand";
++		reg = <0>;
++		spi-max-frequency = <52000000>;
++	};
++};
++
++&watchdog {
++	status = "disabled";
++};
+--- /dev/null
++++ b/defenvs/mt7981_globitel_bt-rb300_env
+@@ -0,0 +1,54 @@
++ipaddr=192.168.1.1
++serverip=192.168.1.254
++loadaddr=0x46000000
++console=earlycon=uart8250,mmio32,0x11002000 console=ttyS0
++bootcmd=if pstore check ; then run boot_recovery ; else run boot_ubi ; fi
++bootconf=config-1
++bootdelay=0
++bootfile=openwrt-mediatek-filogic-globitel_bt-rb300-initramfs-recovery.itb
++bootfile_bl2=openwrt-mediatek-filogic-globitel_bt-rb300-preloader.bin
++bootfile_fip=openwrt-mediatek-filogic-globitel_bt-rb300-bl31-uboot.fip
++bootfile_upg=openwrt-mediatek-filogic-globitel_bt-rb300-squashfs-sysupgrade.itb
++bootmenu_confirm_return=askenv - Press ENTER to return to menu ; bootmenu 60
++bootmenu_default=0
++bootmenu_delay=0
++bootmenu_title=      ( ( ( OpenWrt ) ) )
++bootmenu_0=Initialize environment.=run _firstboot
++bootmenu_0d=Run default boot command.=run boot_default
++bootmenu_1=Boot system via TFTP.=run boot_tftp ; run bootmenu_confirm_return
++bootmenu_2=Boot production system from NAND.=run boot_production ; run bootmenu_confirm_return
++bootmenu_3=Boot recovery system from NAND.=run boot_recovery ; run bootmenu_confirm_return
++bootmenu_4=Load production system via TFTP then write to NAND.=setenv noboot 1 ; setenv replacevol 1 ; run boot_tftp_production ; setenv noboot ; setenv replacevol ; run bootmenu_confirm_return
++bootmenu_5=Load recovery system via TFTP then write to NAND.=setenv noboot 1 ; setenv replacevol 1 ; run boot_tftp_recovery ; setenv noboot ; setenv replacevol ; run bootmenu_confirm_return
++bootmenu_6=Load BL31+U-Boot FIP via TFTP then write to NAND.=run boot_tftp_write_fip ; run bootmenu_confirm_return
++bootmenu_7=Load BL2 preloader via TFTP then write to NAND.=run boot_tftp_write_bl2 ; run bootmenu_confirm_return
++bootmenu_8=Reboot.=reset
++bootmenu_9=Reset all settings to factory defaults.=run reset_factory ; reset
++boot_first=if button reset ; then run boot_tftp_recovery ; setenv flag_recover 1 ; run boot_default ; fi ; bootmenu
++boot_default=if env exists flag_recover ; then else run bootcmd ; fi ; run boot_recovery ; setenv replacevol 1 ; run boot_tftp_forever
++boot_production=run ubi_read_production && bootm $loadaddr#$bootconf
++boot_recovery=run ubi_read_recovery && bootm $loadaddr#$bootconf
++boot_ubi=run boot_production ; run boot_recovery ; run boot_tftp_forever
++boot_tftp_forever=while true ; do run boot_tftp_recovery ; sleep 1 ; done
++boot_tftp_production=tftpboot $loadaddr $bootfile_upg && env exists replacevol && iminfo $loadaddr && run ubi_write_production ; if env exists noboot ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp_recovery=tftpboot $loadaddr $bootfile && env exists replacevol && iminfo $loadaddr && run ubi_write_recovery ; if env exists noboot ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp=tftpboot $loadaddr $bootfile && bootm $loadaddr#$bootconf
++boot_tftp_write_fip=tftpboot $loadaddr $bootfile_fip && run mtd_write_fip && run reset_factory
++boot_tftp_write_bl2=tftpboot $loadaddr $bootfile_bl2 && run mtd_write_bl2
++part_default=production
++part_recovery=recovery
++reset_factory=ubi part ubi ; mw $loadaddr 0x0 0x800 ; ubi write $loadaddr ubootenv 0x800 ; ubi write $loadaddr ubootenv2 0x800
++mtd_write_fip=mtd erase FIP && mtd write FIP $loadaddr
++mtd_write_bl2=mtd erase BL2 && mtd write BL2 $loadaddr
++ubi_create_env=ubi check ubootenv || ubi create ubootenv 0x1f000 dynamic || run ubi_format ; ubi check ubootenv2 || ubi create ubootenv2 0x1f000 dynamic || run ubi_format
++ubi_format=ubi detach ; mtd erase ubi && ubi part ubi ; reset
++ubi_prepare_rootfs=if ubi check rootfs_data ; then else ubi create rootfs_data - dynamic ; fi
++ubi_read_production=ubi read $loadaddr fit && iminfo $loadaddr && run ubi_prepare_rootfs
++ubi_read_recovery=ubi check recovery && ubi read $loadaddr recovery
++ubi_remove_rootfs=ubi check rootfs_data && ubi remove rootfs_data
++ubi_write_production=ubi detach ; ubi part ubi ; ubi check fit && ubi remove fit ; run ubi_remove_rootfs ; ubi create fit $filesize dynamic && ubi write $loadaddr fit $filesize
++ubi_write_recovery=ubi detach ; ubi part ubi ; ubi check recovery && ubi remove recovery ; run ubi_remove_rootfs ; ubi create recovery $filesize dynamic && ubi write $loadaddr recovery $filesize
++_init_env=setenv _init_env ; run ubi_create_env ; saveenv ; saveenv
++_firstboot=setenv _firstboot ; run _switch_to_menu ; run _init_env ; run boot_first
++_switch_to_menu=setenv _switch_to_menu ; setenv bootdelay 3 ; setenv bootmenu_delay 3 ; setenv bootmenu_0 $bootmenu_0d ; setenv bootmenu_0d ; run _bootmenu_update_title
++_bootmenu_update_title=setenv _bootmenu_update_title ; setenv bootmenu_title "$bootmenu_title       $ver"
+--- a/arch/arm/mach-mediatek/Kconfig
++++ b/arch/arm/mach-mediatek/Kconfig
+@@ -180,4 +180,19 @@ config RESET_BUTTON_LABEL
+ config RESET_BUTTON_SETTLE_DELAY
+ 	int "Delay to wait for button to settle"
+ 	default 0
++
++config ENABLE_NAND_NMBM
++	bool
++	depends on NMBM_MTD
++	default y if NMBM_MTD
++
++config NMBM_MAX_RATIO
++	int
++	depends on ENABLE_NAND_NMBM
++	default 1
++
++config NMBM_MAX_BLOCKS
++	int
++	depends on ENABLE_NAND_NMBM
++	default 64
+ endif

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -37,6 +37,7 @@ cudy,wr3000e-v1-ubootmod|\
 cudy,wr3000s-v1-ubootmod|\
 cudy,wr3000h-v1-ubootmod|\
 cudy,wr3000p-v1-ubootmod|\
+globitel,bt-rb300|\
 h3c,magic-nx30-pro|\
 imou,hx21|\
 jcg,q30-pro|\

--- a/target/linux/mediatek/dts/mt7981b-globitel-bt-rb300.dts
+++ b/target/linux/mediatek/dts/mt7981b-globitel-bt-rb300.dts
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+#include "mt7981b.dtsi"
+
+/ {
+	model = "Globitel BT-RB300";
+	compatible = "globitel,bt-rb300", "mediatek,mt7981";
+
+	aliases {
+		label-mac-device = &gmac0;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		rootdisk = <&ubi_rootdisk>;
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_2a 0>;
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+};
+
+&mdio_bus {
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <0x1f>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		mediatek,mt7531-phy-tuning;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "lan0";
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "lan1";
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan2";
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan3";
+			};
+
+			port@4 {
+				reg = <4>;
+				label = "wan";
+
+				nvmem-cell-names = "mac-address";
+				nvmem-cells = <&macaddr_factory_24 0>;
+			};
+
+			port@6 {
+				reg = <6>;
+				ethernet = <&gmac0>;
+				phy-mode = "2500base-x";
+
+				fixed-link {
+					speed = <2500>;
+					full-duplex;
+					pause;
+				};
+			};
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand: flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x000000 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x080000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_24: macaddr@24 {
+						compatible = "mac-base";
+						reg = <0x24 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_factory_2a: macaddr@2a {
+						compatible = "mac-base";
+						reg = <0x2a 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			ubi: partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x7200000>;
+				compatible = "linux,ubi";
+
+				volumes {
+					ubi_rootdisk: ubi-volume-fit {
+						volname = "fit";
+					};
+
+					ubi_ubootenv: ubi-volume-ubootenv {
+						volname = "ubootenv";
+					};
+
+					ubi_ubootenv2: ubi-volume-ubootenv2 {
+						volname = "ubootenv2";
+					};
+				};
+			};
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&ubi_ubootenv {
+	nvmem-layout {
+		compatible = "u-boot,env-redundant-bool";
+	};
+};
+
+&ubi_ubootenv2 {
+	nvmem-layout {
+		compatible = "u-boot,env-redundant-bool";
+	};
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	nvmem-cell-names = "eeprom";
+	nvmem-cells = <&eeprom_factory_0>;
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -162,6 +162,9 @@ mediatek_setup_interfaces()
 	wavlink,wl-wnt100x3-ubootmod)
 		ucidef_set_interfaces_lan_wan eth0 eth1
 		;;
+	globitel,bt-rb300)
+		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3" wan
+		;;
 	bazis,ax3000wm|\
 	cudy,m3000-v1|\
 	cudy,m3000-v1-ubootmod|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -174,6 +174,7 @@ platform_do_upgrade() {
 	cudy,wr3000p-v1-ubootmod|\
 	gatonetworks,gdsp|\
 	globitel,bt-r320|\
+	globitel,bt-rb300|\
 	h3c,magic-nx30-pro|\
 	imou,hx21|\
 	jcg,q30-pro|\
@@ -425,6 +426,7 @@ platform_check_image() {
 	cudy,wr3000p-v1-ubootmod|\
 	gatonetworks,gdsp|\
 	globitel,bt-r320|\
+	globitel,bt-rb300|\
 	h3c,magic-nx30-pro|\
 	jcg,q30-pro|\
 	jdcloud,re-cp-03|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2026,6 +2026,31 @@ define Device/globitel_bt-r320
 endef
 TARGET_DEVICES += globitel_bt-r320
 
+define Device/globitel_bt-rb300
+  DEVICE_VENDOR := Globitel
+  DEVICE_MODEL := BT-RB300
+  DEVICE_DTS := mt7981b-globitel-bt-rb300
+  DEVICE_DTS_DIR := ../dts
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_IN_UBI := 1
+  UBOOTENV_IN_UBI := 1
+  IMAGES := sysupgrade.itb
+  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
+  KERNEL := kernel-bin | libdeflate-gzip
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/sysupgrade.itb := append-kernel | \
+	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | \
+	append-metadata
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  ARTIFACTS := preloader.bin bl31-uboot.fip
+  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3-1866
+  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot globitel_bt-rb300
+endef
+TARGET_DEVICES += globitel_bt-rb300
+
 define Device/h3c_magic-nx30-pro
   DEVICE_VENDOR := H3C
   DEVICE_MODEL := Magic NX30 Pro

--- a/target/linux/mediatek/patches-6.18/799-net-phy-mediatek-mt7531-mlt3-random-update.patch
+++ b/target/linux/mediatek/patches-6.18/799-net-phy-mediatek-mt7531-mlt3-random-update.patch
@@ -1,0 +1,82 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Murad Rabadanov <the21.21@mail.ru>
+Date: Fri, 4 Sep 2026 21:40:00 +0300
+Subject: [PATCH] net: phy: mediatek: restore MT7531 MLT3 and random-update
+ tuning
+
+The BT-RB300 connects MT7531 PHY 0 to the Allwinner AC300 PHY of its
+integrated TV-box over a board-internal 100BASE-T link. With the upstream
+Linux 6.18 MT7531 initialization, both peers observe repeated one-to-three
+second link windows and 12 to 16 carrier changes during the first minute.
+
+The device's stock ImmortalWrt 6.6 build carries MediaTek's MT7531 internal
+PHY fine-tuning patch. That patch programs a broad set of analog, timing,
+EEE, MLT3 and token-ring settings and states that they originate from the
+Linux 5.4 drivers/net/dsa/mt7531_phy.c implementation.
+
+A/B testing isolated the required settings. The complete SDK block remained
+stable, while analog line-driving alone and the random-update bit alone did
+not. The MLT3 table alone greatly improved the link but still produced a
+drop after about 203 seconds. Combining the MLT3 table with the
+random-update bit remained stable across warm and cold boots, with one
+carrier event, no RX/TX errors, and simultaneous gigabit links on external
+MT7531 ports.
+
+An overnight soak test then ran for 38,615 seconds without a link change.
+The link carried 163,319 RX and 122,691 TX packets with no errors or drops.
+
+Restore only those two settings for MT7531 PHYs.
+The tuning is enabled only for boards that opt in through the switch
+device tree, so other MT7531 boards retain the upstream settings.
+
+Link: https://github.com/mediatek/mtk-openwrt-feeds/blob/main/24.10/files/target/linux/mediatek/patches-6.6/999-2746-mt7531-dsa-iphy-fine-tuning.patch
+Signed-off-by: Murad Rabadanov <the21.21@mail.ru>
+
+---
+ drivers/net/phy/mediatek/mtk-ge.c | 26 ++++++++++++++++++++++++++
+ 1 file changed, 26 insertions(+)
+
+--- a/drivers/net/phy/mediatek/mtk-ge.c
++++ b/drivers/net/phy/mediatek/mtk-ge.c
+@@ -19,6 +19,9 @@
+ /* ch_addr = 0x1, node_addr = 0xf, data_addr = 0x17 */
+ #define SLAVE_DSP_READY_TIME_MASK		GENMASK(22, 15)
+ 
++/* ch_addr = 0x1, node_addr = 0xf, data_addr = 0x18 */
++#define ENABLE_RANDOM_UPDOWN_COUNTER_TRIGGER	BIT(8)
++
+ /* Registers on MDIO_MMD_VEND1 */
+ #define MTK_PHY_GBE_MODE_TX_DELAY_SEL		0x13
+ #define MTK_PHY_TEST_MODE_TX_DELAY_SEL		0x14
+@@ -106,8 +109,31 @@ static int mt7530_led_config_of(struct p
+ 
+ static int mt7531_phy_config_init(struct phy_device *phydev)
+ {
++	static const u16 mlt3_shaper[12] = {
++		0x0187, 0x01c9, 0x01c6, 0x0182,
++		0x0208, 0x0205, 0x0384, 0x03cb,
++		0x03c4, 0x030a, 0x000b, 0x0002,
++	};
++	int i;
++
++	bool tune_phy = of_property_read_bool(phydev->mdio.bus->parent->of_node,
++					      "mediatek,mt7531-phy-tuning");
++
++	if (tune_phy) {
++		for (i = 0; i < ARRAY_SIZE(mlt3_shaper); i++)
++			phy_write_mmd(phydev, MDIO_MMD_VEND1, i, mlt3_shaper[i]);
++	}
++
+ 	mtk_gephy_config_init(phydev);
+ 
++	if (tune_phy) {
++		/* Enable the random update mechanism. */
++		phy_select_page(phydev, MTK_PHY_PAGE_EXTENDED_52B5);
++		__mtk_tr_set_bits(phydev, 0x1, 0xf, 0x18,
++				  ENABLE_RANDOM_UPDOWN_COUNTER_TRIGGER);
++		phy_restore_page(phydev, MTK_PHY_PAGE_STANDARD, 0);
++	}
++
+ 	/* PHY link down power saving enable */
+ 	phy_set_bits(phydev, 0x17, BIT(4));
+ 	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RXADC_CTRL_RG7,


### PR DESCRIPTION
BT-RB300 combines a MediaTek Filogic router and an Allwinner H618 TV box on
one board. The two systems are connected through an internal 100BASE-T link.
The external HDMI and USB ports belong exclusively to the H618 side and are
therefore not represented in the MT7981B device tree.

The partition map, GPIOs, switch ports, factory-data offsets, and recovery
path were derived from the vendor device tree, bootloader environment, flash
backups, and live testing on the physical device. All Ethernet ports were
verified using link/carrier tests.

<img width="2400" height="1800" alt="Board BT-RB300" src="https://github.com/user-attachments/assets/767ade2c-4e75-4e26-9753-efa503ab992a" />

Hardware:
SoC: MediaTek MT7981B (Filogic 820)
RAM: 256 MiB Nanya DDR3-1866
Flash: 128 MiB Winbond W25N01GV SPI-NAND
Ethernet: MT7531 switch with 3x external LAN, 1x external WAN,
1x internal 100BASE-T link to the H618 TV box (lan0),
2.5GbE internal CPU-switch link (gmac0, 2500base-x)
WiFi: MT7981 integrated 2.4 GHz + MT7976C 5 GHz radio,
802.11ax, 2x2 MU-MIMO, HE160 supported
Buttons: reset (GPIO 1, active low)
LEDs: WLAN 2.4 GHz (GPIO 34), WLAN 5 GHz (GPIO 35),
both active low
UART: 115200n8, UART0

The separate TV-box side has an Allwinner H618, 4 GiB RAM, 128 GB eMMC,
HDMI, and USB.

MAC addresses and calibration data:

| Interface/data | Source | Offset |
|---|---|---|
| WAN MAC | Factory | 0x24 |
| LAN/CPU MAC | Factory | 0x2a |
| WiFi EEPROM | Factory | 0x0 (size 0x1000) |

The board uses NMBM and an ubootmod layout:

| Partition | Offset | Size |
|---|---:|---:|
| BL2 | 0x000000 | 0x100000 |
| u-boot-env | 0x100000 | 0x080000 |
| Factory | 0x180000 | 0x200000 |
| FIP | 0x380000 | 0x200000 |
| ubi | 0x580000 | 0x7200000 |

MT7531 port 0 is connected internally to the Allwinner AC300 PHY. With the
upstream Linux 6.18 MT7531 initialization, the link came up for only one to
three seconds at a time and produced 12 to 16 carrier changes during the
first minute.

The stock ImmortalWrt 6.6 image carries MediaTek's broader MT7531 internal
PHY fine-tuning patch. A/B testing isolated the required parts to the MLT3
shaper table and the token-ring random-update bit. The random-update bit
alone did not help, while MLT3 alone still produced a rare dropout after
about 203 seconds. The two settings together remained stable across warm and
cold boots and did not disturb simultaneous gigabit links on the external
MT7531 ports.

An overnight 38,615-second test completed without a carrier change. The
internal link carried 163,319 RX and 122,691 TX packets with no errors or
drops. The minimal PHY change is kept in a separate preceding commit and
links to the original MediaTek patch.

Installation:
Requires a TFTP server at 192.168.1.254 and temporary Internet access from
the initramfs system.

1. Serve
   `openwrt-mediatek-filogic-globitel_bt-rb300-initramfs-recovery.itb` over TFTP.
2. Power the device off. Hold reset while powering it on and keep the button
   pressed for about nine seconds to enter the stock U-Boot Web failsafe at
   192.168.1.1.
3. Select **Load initramfs** and upload the BT-RB300 initramfs recovery image.
4. Once initramfs has booted, give it Internet access and install `kmod-mtd-rw`:

       apk update
       apk add kmod-mtd-rw

5. Copy `openwrt-mediatek-filogic-globitel_bt-rb300-bl31-uboot.fip` to `/tmp`, unlock
   the read-only MTD partitions, and write the OpenWrt FIP:

       insmod mtd-rw i_want_a_brick=1
       mtd write /tmp/openwrt-mediatek-filogic-globitel_bt-rb300-bl31-uboot.fip FIP

6. Verify that the FIP write succeeded. Do not continue if it reports an
   error. Erase UBI and reboot:

       mtd erase ubi
       reboot

7. The OpenWrt U-Boot detects the missing production image and fetches the
   recovery image from the TFTP server. Once recovery has booted, install the
   production image:

       sysupgrade openwrt-mediatek-filogic-globitel_bt-rb300-squashfs-sysupgrade.itb

Do not flash the preloader during normal installation. This procedure keeps
the stock BL2 and the per-device Factory partition intact.

Tested:
- stock U-Boot Web failsafe and initramfs boot
- OpenWrt U-Boot recovery boot through TFTP
- sysupgrade and persistent overlay
- all external Ethernet ports and the internal H618 link
- 2.4 GHz and 5 GHz WiFi
- reset button and WLAN LEDs
- warm reboot and full-board cold boot
- 38,615-second internal-link soak test