### PR TITLE
realtek: dsa: release the LAG table on error paths

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/common.c
@@ -527,6 +527,7 @@ static int rtldsa_93xx_lag_set_group2ports(struct rtl838x_switch_priv *priv, int
 		pr_err("%s: Number of LAG ports too high: %u", __func__,
 		       num_of_lag_ports);
 
+		rtl_table_release(r);
 		return -ENOSPC;
 	}
 
@@ -574,6 +575,7 @@ static int rtldsa_93xx_lag_set_group2ports(struct rtl838x_switch_priv *priv, int
 			e.ip4_hash_mask_idx = RTL93XX_HASH_MASK_INDEX_L23;
 			e.ip6_hash_mask_idx = RTL93XX_HASH_MASK_INDEX_L23;
 		} else {
+			rtl_table_release(r);
 			return -EOPNOTSUPP;
 		}
 	}


### PR DESCRIPTION
Fixes the lock leak reported in #25029.

`rtldsa_93xx_lag_set_group2ports()` takes the LAG table lock through `priv->r->lag_table()` and releases it only when it succeeds, so both error returns leave the mutex held permanently. The lock covers a whole table access register, not a single table, so on RTL930x `RTL9300_TBL_0` also gates VLAN (sub-table 1), the ingress ACL (2), the packet counters (3), spanning tree state (4), port isolation (6) and the trunk map (8) — all of which block afterwards. On RTL931x the LAG table shares `RTL9310_TBL_2` with port isolation.

Only the `-ENOSPC` path is reachable today (a bond with more than eight member ports; nothing caps the member count earlier). The `-EOPNOTSUPP` path is currently dead, because `rtldsa_port_lag_join()` filters the hash type in `rtldsa_83xx_lag_can_offload()` before the call chain and the other callers pass a NULL `info` — I got that wrong in the issue and corrected it there. It is still released here, since the missing unlock is a trap for anyone who changes that guard.

**Testing:** compile-tested on realtek/rtl930x and realtek/rtl838x. **Not reproduced on hardware:** my board is a Hasivo S1100W-8XGT-SE (RTL9303, 8 ports), one port short of what the reachable path needs, and I have no RTL931x. If someone with a larger RTL93xx board wants to confirm, a bond of nine or more ports followed by any VLAN or FDB operation should hang before this patch and not after.

*Analysis assisted by Claude Opus 5 (Anthropic AI).*
