### PR TITLE
scripts: fix CycloneDX BOM version type

### DIFF
--- a/scripts/make-sbom.py
+++ b/scripts/make-sbom.py
@@ -168,7 +168,7 @@ if __name__ == "__main__":
         "bomFormat": "CycloneDX",
         "specVersion": "1.4",
         "serialNumber": "urn:uuid:" + str(uuid.uuid4()),
-        "version": "1",
+        "version": 1,
         "metadata": {
             "timestamp": timestamp,
         },


### PR DESCRIPTION
The APK CycloneDX SBOM generator emits the top-level `version` field as the string "1".

CycloneDX 1.4 requires this field to be an integer. Use the numeric value 1 so the generated BOM conforms to the CycloneDX 1.4 JSON schema.

This also keeps the Python implementation consistent with the existing Perl CycloneDX implementation.

Release notes: Fix invalid CycloneDX 1.4 JSON generated for APK indexes.


