### PR TITLE
uboot-rockchip: switch to dedicated profile for NanoPi R76S

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -335,18 +335,18 @@ define U-Boot/rk3576/Default
   TPL:=rk3576_ddr_lp4_2112MHz_lp5_2736MHz_v1.09.bin
 endef
 
-define U-Boot/generic-rk3576
-  $(U-Boot/rk3576/Default)
-  NAME:=Generic RK3576
-  BUILD_DEVICES:= \
-    friendlyarm_nanopi-r76s
-endef
-
 define U-Boot/nanopi-m5-rk3576
   $(U-Boot/rk3576/Default)
   NAME:=NanoPi M5
   BUILD_DEVICES:= \
     friendlyarm_nanopi-m5
+endef
+
+define U-Boot/nanopi-r76s-rk3576
+  $(U-Boot/rk3576/Default)
+  NAME:=NanoPi R76S
+  BUILD_DEVICES:= \
+    friendlyarm_nanopi-r76s
 endef
 
 define U-Boot/rock-4d-rk3576
@@ -473,8 +473,8 @@ UBOOT_TARGETS := \
   radxa-e25-rk3568 \
   rock-3a-rk3568 \
   rock-3b-rk3568 \
-  generic-rk3576 \
   nanopi-m5-rk3576 \
+  nanopi-r76s-rk3576 \
   rock-4d-rk3576 \
   generic-rk3588 \
   nanopc-t6-rk3588 \

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -191,7 +191,6 @@ define Device/friendlyarm_nanopi-r76s
   $(Device/rk3576)
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi R76S
-  UBOOT_DEVICE_NAME := generic-rk3576
   DEVICE_PACKAGES := kmod-r8169 kmod-rtw88-8822cs wpad-basic-mbedtls
 endef
 TARGET_DEVICES += friendlyarm_nanopi-r76s


### PR DESCRIPTION
Support for NanoPi R76S has been merged upstream u-boot, so use it instead of the generic profile.