### PR TITLE
realtek: dsa: rtl83xx: two standalone tc flower / PIE fixes

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl838x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl838x.c
@@ -1481,10 +1481,10 @@ static int rtl838x_pie_verify_template(struct rtl838x_switch_priv *priv,
 			return -1;
 	}
 
-	if (ether_addr_to_u64(pr->smac) && !rtl838x_pie_templ_has(t, TEMPLATE_FIELD_SMAC0))
+	if (ether_addr_to_u64(pr->smac_m) && !rtl838x_pie_templ_has(t, TEMPLATE_FIELD_SMAC0))
 		return -1;
 
-	if (ether_addr_to_u64(pr->dmac) && !rtl838x_pie_templ_has(t, TEMPLATE_FIELD_DMAC0))
+	if (ether_addr_to_u64(pr->dmac_m) && !rtl838x_pie_templ_has(t, TEMPLATE_FIELD_DMAC0))
 		return -1;
 
 	if (pr->itag_m && !rtl838x_pie_templ_has(t, TEMPLATE_FIELD_ITAG))

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl839x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl839x.c
@@ -1377,10 +1377,10 @@ static int rtl839x_pie_verify_template(struct rtl838x_switch_priv *priv,
 			return -1;
 	}
 
-	if (ether_addr_to_u64(pr->smac) && !rtl839x_pie_templ_has(t, TEMPLATE_FIELD_SMAC0))
+	if (ether_addr_to_u64(pr->smac_m) && !rtl839x_pie_templ_has(t, TEMPLATE_FIELD_SMAC0))
 		return -1;
 
-	if (ether_addr_to_u64(pr->dmac) && !rtl839x_pie_templ_has(t, TEMPLATE_FIELD_DMAC0))
+	if (ether_addr_to_u64(pr->dmac_m) && !rtl839x_pie_templ_has(t, TEMPLATE_FIELD_DMAC0))
 		return -1;
 
 	if (pr->itag_m && !rtl839x_pie_templ_has(t, TEMPLATE_FIELD_ITAG))

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -1743,10 +1743,10 @@ static int rtl930x_pie_verify_template(struct rtl838x_switch_priv *priv,
 			return -1;
 	}
 
-	if (ether_addr_to_u64(pr->smac) && !rtl930x_pie_templ_has(t, TEMPLATE_FIELD_SMAC0))
+	if (ether_addr_to_u64(pr->smac_m) && !rtl930x_pie_templ_has(t, TEMPLATE_FIELD_SMAC0))
 		return -1;
 
-	if (ether_addr_to_u64(pr->dmac) && !rtl930x_pie_templ_has(t, TEMPLATE_FIELD_DMAC0))
+	if (ether_addr_to_u64(pr->dmac_m) && !rtl930x_pie_templ_has(t, TEMPLATE_FIELD_DMAC0))
 		return -1;
 
 	if (pr->itag_m && !rtl930x_pie_templ_has(t, TEMPLATE_FIELD_VLAN))

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl931x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl931x.c
@@ -1405,10 +1405,10 @@ static int rtl931x_pie_verify_template(struct rtl838x_switch_priv *priv,
 			return -1;
 	}
 
-	if (ether_addr_to_u64(pr->smac) && !rtl931x_pie_templ_has(t, TEMPLATE_FIELD_SMAC0))
+	if (ether_addr_to_u64(pr->smac_m) && !rtl931x_pie_templ_has(t, TEMPLATE_FIELD_SMAC0))
 		return -1;
 
-	if (ether_addr_to_u64(pr->dmac) && !rtl931x_pie_templ_has(t, TEMPLATE_FIELD_DMAC0))
+	if (ether_addr_to_u64(pr->dmac_m) && !rtl931x_pie_templ_has(t, TEMPLATE_FIELD_DMAC0))
 		return -1;
 
 	if (pr->itag_m && !rtl931x_pie_templ_has(t, TEMPLATE_FIELD_VLAN))

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
@@ -294,22 +294,24 @@ static int rtl83xx_delete_flower(struct rtl838x_switch_priv *priv,
 				 struct flow_cls_offload *cls_flower)
 {
 	struct rtl83xx_flow *flow;
+	int err;
 
 	pr_debug("In %s\n", __func__);
 	rcu_read_lock();
 	flow = rhashtable_lookup_fast(&priv->tc_ht, &cls_flower->cookie, tc_ht_params);
 	if (!flow) {
 		rcu_read_unlock();
-		return -EINVAL;
+		return -ENOENT;
 	}
+
+	err = rhashtable_remove_fast(&priv->tc_ht, &flow->node, tc_ht_params);
+	rcu_read_unlock();
+	if (err)
+		return err;
 
 	priv->r->pie_rule_rm(priv, &flow->rule);
 
-	rhashtable_remove_fast(&priv->tc_ht, &flow->node, tc_ht_params);
-
 	kfree_rcu(flow, rcu_head);
-
-	rcu_read_unlock();
 
 	return 0;
 }


### PR DESCRIPTION
Two self-contained fixes carved out of #24994 at @plappermaul's request — they apply against current code and do not depend on the offload series. #24994 will rebase on top once this lands.

**`drop the tc flow hashtable ref before HW teardown`**
`rtl83xx_delete_flower()` calls `pie_rule_rm()` — which takes `pie_mutex` — while still holding `rcu_read_lock()`, i.e. it can sleep inside an RCU read-side critical section. Remove the flow from the hashtable and drop the RCU lock first, tear down the hardware rule afterwards. Also propagate the `rhashtable_remove_fast()` error and return `-ENOENT` (not `-EINVAL`) when no flow matches the cookie.

**`verify the MAC template against the mask, not the value`**
`*_pie_verify_template()` gates the SMAC / DMAC template requirement on `ether_addr_to_u64(pr->smac)` / `pr->dmac`, i.e. on the match *value*, while every neighbouring field (`sip_m`, `dip_m`, `ethertype_m`, `itag_m`, `sport_m`, `dport_m`) is gated on its mask. A rule matching the all-zero MAC (`flower dst_mac 00:00:00:00:00:00`, full mask, zero value) then passes verification against a template that has no DMAC field and matches every frame. Gate on `smac_m` / `dmac_m` like the rest. Present in all four `*_pie_verify_template()` implementations; only rtl930x was exercised (tc cls_flower offload), the other three are changed for consistency.

Verified on a Zyxel XGS1210-12 (RTL9302C). CI covers all five realtek subtargets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)