### PR TITLE
realtek: dsa: rtl839x: read PIE rules from the IACL table

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl839x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl839x.c
@@ -1277,7 +1277,7 @@ void rtl839x_pie_rule_dump(struct  pie_rule *pr)
 static int rtl839x_pie_rule_read(struct rtl838x_switch_priv *priv, int idx, struct  pie_rule *pr)
 {
 	/* Read IACL table (2) via register 0 */
-	struct table_reg *q = rtl_table_get(RTL8380_TBL_0, 2);
+	struct table_reg *q = rtl_table_get(RTL8390_TBL_0, 2);
 	u32 r[17];
 	int block = idx / PIE_BLOCK_SIZE;
 	u32 t_select = sw_r32(RTL839X_ACL_BLK_TMPLTE_CTRL(block));


### PR DESCRIPTION
`rtl839x_pie_rule_read()` selects table type 2 through `RTL8380_TBL_0`, the RTL838x table access block, while its own comment names the IACL table and the matching `rtl839x_pie_rule_write()` reaches it through `RTL8390_TBL_0`.

The two blocks differ in more than their address:

| | `RTL8380_TBL_0` | `RTL8390_TBL_0` |
|---|---|---|
| command register | `0x6914` | `0x1190` |
| data window | `0x6918` | `0x1194` |
| execute bit | 15 | 16 |
| read/write polarity | inverted (`rmode` 1) | normal |

So on an RTL839x the reader drives the RTL838x table register and takes its seventeen words from `0x6918` instead of `0x1194`. `rtl_table_get()` also locks the descriptor it is handed, so the reader holds a different mutex from the one the writer holds and the two do not serialise against each other.

Nothing reaches this today — `.pie_rule_read` is populated for RTL838x and RTL839x but is never invoked through `priv->r` — so the defect is latent and no failure has been observed. It is fixed because the reader and the writer have to agree before either becomes reachable.

Raised by @plappermaul on #25027, where naming the tables after themselves made the mismatch visible.

**Testing.** Compile-tested on realtek/rtl839x. Not run on hardware: no RTL839x board here, only an RTL9303. The change selects the table the writer already selects, and touches nothing outside `rtl839x_pie_rule_read()`.

*Analysis assisted by Claude Opus 5 (Anthropic AI).*
