### PR TITLE
nat46: pass NAT46_VERSION through CFLAGS_MODULE

### DIFF
--- a/package/kernel/nat46/Makefile
+++ b/package/kernel/nat46/Makefile
@@ -28,7 +28,7 @@ include $(INCLUDE_DIR)/kernel-defaults.mk
 define Build/Compile
 	$(KERNEL_MAKE) M="$(PKG_BUILD_DIR)/nat46/modules" \
 		MODFLAGS="-DMODULE -mlong-calls" \
-		EXTRA_CFLAGS="-DNAT46_VERSION=\\\"$(PKG_SOURCE_VERSION)\\\"" \
+		CFLAGS_MODULE="-DNAT46_VERSION=\\\"$(PKG_SOURCE_VERSION)\\\"" \
 		modules
 endef
 


### PR DESCRIPTION
kbuild dropped EXTRA_CFLAGS in 6.15 ([e966ad0edd00](https://git.kernel.org/torvalds/c/e966ad0edd00), "kbuild: remove EXTRA_*FLAGS support"), so on 6.18 the define never reaches the compiler and the module logs "nat46: module (version unknown) loaded". CFLAGS_MODULE is read by both 6.12 and 6.18.