### PR TITLE
mediatek: improved support for TP-Link XDR series

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-tplink-tl-xdr-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-tplink-tl-xdr-common.dtsi
@@ -136,6 +136,17 @@
 		reset-deassert-us = <100000>;
 		reset-gpios = <&pio 13 GPIO_ACTIVE_LOW>;
 		realtek,aldps-enable;
+
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led@0 {
+				reg = <0>;
+				function = LED_FUNCTION_LAN;
+				color = <LED_COLOR_ID_GREEN>;
+			};
+		};
 	};
 
 	phy7: ethernet-phy@7 {
@@ -145,6 +156,17 @@
 		reset-deassert-us = <100000>;
 		reset-gpios = <&pio 17 GPIO_ACTIVE_LOW>;
 		realtek,aldps-enable;
+
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led@0 {
+				reg = <0>;
+				function = LED_FUNCTION_WAN;
+				color = <LED_COLOR_ID_GREEN>;
+			};
+		};
 	};
 
 	switch: switch@1f {

--- a/target/linux/mediatek/dts/mt7986a-tplink-tl-xdr-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-tplink-tl-xdr-common.dtsi
@@ -307,8 +307,21 @@
 };
 
 &wifi {
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+	#address-cells = <1>;
+	#size-cells = <0>;
 	status = "okay";
 
-	nvmem-cells = <&eeprom_factory_0>, <&macaddr_config_1c 2>;
-	nvmem-cell-names = "eeprom", "mac-address";
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_config_1c 0>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_config_1c 2>;
+		nvmem-cell-names = "mac-address";
+	};
 };

--- a/target/linux/mediatek/dts/mt7986a-tplink-tl-xtr8488.dts
+++ b/target/linux/mediatek/dts/mt7986a-tplink-tl-xtr8488.dts
@@ -405,10 +405,24 @@
 };
 
 &wifi {
+	ieee80211-freq-limit = <2400000 2500000>, <5170000 5350000>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 	pinctrl-names = "default";
 	pinctrl-0 = <&wf_2g_5g_pins>;
-	ieee80211-freq-limit = <2400000 2500000>, <5170000 5350000>;
-	nvmem-cells = <&eeprom_factory_0>, <&macaddr_config_1c 2>;
-	nvmem-cell-names = "eeprom", "mac-address";
+	#address-cells = <1>;
+	#size-cells = <0>;
 	status = "okay";
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_config_1c 0>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_config_1c 2>;
+		nvmem-cell-names = "mac-address";
+	};
 };

--- a/target/linux/mediatek/dts/mt7986a-tplink-tl-xtr8488.dts
+++ b/target/linux/mediatek/dts/mt7986a-tplink-tl-xtr8488.dts
@@ -138,12 +138,34 @@
 		compatible = "ethernet-phy-ieee802.3-c45";
 		reg = <5>;
 		realtek,aldps-enable;
+
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led@0 {
+				reg = <0>;
+				function = LED_FUNCTION_LAN;
+				color = <LED_COLOR_ID_GREEN>;
+			};
+		};
 	};
 
 	phy7: phy@7 {
 		compatible = "ethernet-phy-ieee802.3-c45";
 		reg = <7>;
 		realtek,aldps-enable;
+
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led@0 {
+				reg = <0>;
+				function = LED_FUNCTION_WAN;
+				color = <LED_COLOR_ID_GREEN>;
+			};
+		};
 	};
 
 	switch: switch@1f {

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -348,6 +348,16 @@ tplink,re6000xd)
 	ucidef_set_led_netdev "lan-2" "lan-2" "blue:lan-1" "lan2" "link tx rx"
 	ucidef_set_led_netdev "eth1" "lan-3" "blue:lan-2" "eth1" "link tx rx"
 	;;
+tplink,tl-xdr4288|\
+tplink,tl-xdr6088|\
+tplink,tl-xtr8488)
+	ucidef_set_led_netdev "lan" "LAN" "mdio-bus:05:green:lan" "lan5" "link tx rx"
+	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:07:green:wan" "eth1" "link tx rx"
+	;;
+tplink,tl-xdr6086)
+	ucidef_set_led_netdev "lan" "LAN" "mdio-bus:05:green:lan" "lan2" "link tx rx"
+	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:07:green:wan" "eth1" "link tx rx"
+	;;
 wavlink,wl-wn536ax6-a)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "eth1" "link tx rx"
 	;;

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -259,14 +259,6 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && echo $addr > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
 		;;
-	tplink,tl-xdr4288|\
-	tplink,tl-xdr6086|\
-	tplink,tl-xdr6088)
-		[ "$PHYNBR" = "0" ] && get_mac_label > /sys${DEVPATH}/macaddress
-		;;
-	tplink,tl-xtr8488)
-		[ "$PHYNBR" = "1" ] && get_mac_label > /sys${DEVPATH}/macaddress
-		;;
 	wavlink,wl-wn536ax6-a)
 		addr=$(mtd_get_mac_binary "Factory" 0x4)
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_setbit $addr 26) > /sys${DEVPATH}/macaddress


### PR DESCRIPTION
- enable rtl8221 phy leds, replace #12446 
- use band mac in the device tree