### PR TITLE
qualcommax: qca_ppe: fix BPDU trapping and CPU transmission

### DIFF
--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -276,6 +276,12 @@
 #define PPE_RFDB_TBL(idx)		(PPE_L2_BASE + 0x1000 + (idx) * 0x8)
 
 #define PPE_APP_CTRL(idx)		(PPE_L2_BASE + 0x1400 + (idx) * 0x10)
+/* Fields in the third 32-bit word of APP_CTRL. */
+#define   PPE_APP_CTRL_PORT_BITMAP_EN	BIT(2)
+#define   PPE_APP_CTRL_PORT_BITMAP	GENMASK(10, 3)
+#define   PPE_APP_CTRL_STP_BYPASS		BIT(12)
+#define   PPE_APP_CTRL_CMD		GENMASK(16, 15)
+#define   PPE_APP_CTRL_REDIRECT_CPU	3
 
 #define PPE_VSI_TBL(vsi)		(PPE_L2_BASE + 0x1800 + (vsi) * 0x10)
 #define   PPE_VSI_TBL_MEMBER		GENMASK(7, 0)

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -1683,6 +1683,12 @@ static void ppe_mac_hw_init(struct qca_ppe_priv *priv)
 
 static void ppe_ctrlpkt_init(struct qca_ppe_priv *priv)
 {
+	u32 ports;
+
+	/* Trap external BPDUs, but let CPU-originated BPDUs reach the wire. */
+	ports = GENMASK(priv->data->num_ports - 1, 0) &
+		~(BIT(QCA_PPE_CPU_PORT) | BIT(priv->data->loopback_port));
+
 	/* RFDB_TBL[31]: STP multicast MAC 01:80:c2:00:00:00 */
 	regmap_write(priv->regmap, PPE_RFDB_TBL(31), 0xc2000000);
 	regmap_write(priv->regmap, PPE_RFDB_TBL(31) + 4, 0x00010180);
@@ -1690,7 +1696,11 @@ static void ppe_ctrlpkt_init(struct qca_ppe_priv *priv)
 	/* APP_CTRL[0]: match RFDB profile 31, bypass STP, redirect to CPU */
 	regmap_write(priv->regmap, PPE_APP_CTRL(0), 0x00000003);
 	regmap_write(priv->regmap, PPE_APP_CTRL(0) + 4, 0x00000002);
-	regmap_write(priv->regmap, PPE_APP_CTRL(0) + 8, 0x000093fc);
+	regmap_write(priv->regmap, PPE_APP_CTRL(0) + 8,
+		     PPE_APP_CTRL_PORT_BITMAP_EN |
+		     FIELD_PREP(PPE_APP_CTRL_PORT_BITMAP, ports) |
+		     PPE_APP_CTRL_STP_BYPASS |
+		     FIELD_PREP(PPE_APP_CTRL_CMD, PPE_APP_CTRL_REDIRECT_CPU));
 }
 
 static int ppe_ipq6018_mux_setup(struct qca_ppe_priv *priv)


### PR DESCRIPTION
## Problem

The BPDU trap in `ppe_ctrlpkt_init()` currently programs `0x93fc` into
APP_CTRL[0] word 2. CMD is entry bits 80:79 (word-2 bits 16:15), so that
value selects **DROP=1**, despite the comment saying "redirect to CPU".

Changing CMD to **REDIRECT=3** alone is insufficient: the existing ingress
port bitmap includes CPU port 0, which traps locally generated BPDUs back
to the CPU RX path. Excluding the CPU port fixes that second problem.

## Change

- Encode the third word with named fields and the correct redirect action.
- Derive the ingress bitmap from the SoC port count, excluding CPU and
  loopback ports (IPQ8074: `0x7e`; IPQ6018: `0x3e`).
- Leave the STP destination MAC, RFDB profile and STP-state bypass unchanged.
- No changes to ordinary FDB learning, bridge forwarding, VLANs or WLAN.

## Hardware validation

Xiaomi AX3600/IPQ8074, OpenWrt snapshot r36077-fe4bb13256, Linux 6.18.44,
userspace RSTP, attached to a managed RSTP switch:

| APP_CTRL[0] word 2 | Observed result |
| --- | --- |
| `0x93fc` (original, live readback confirmed) | No incoming BPDUs; bridge declares itself root; adjacent switch BPDU RX counter does not advance. |
| `0x193fc` (redirect only) | Incoming BPDUs arrive and upstream root is learned; locally generated BPDUs appear on the conduit **RX** path. |
| `0x193f4` (redirect, CPU excluded) | CPU RX reflections disappear; adjacent switch receives bridge protocol traffic. After a reboot, both sides use RSTP and the bridge advertises the correct upstream root. |

The live test used a small local, model- and register-guarded module through
the existing driver's regmap, with readback and rollback. A kernel-version-
pinned package then reapplied the exact IPQ8074 value at boot; this survived
a real reboot. **This is not a claim that a complete firmware image rebuilt
from this source patch has been flashed.**

The three patched PPE driver translation units were built and linked as a
module against the matching aarch64 OpenWrt 6.18.44 SDK. `checkpatch.pl`
reports zero errors and warnings. IPQ6018 field/mask calculations were
checked, but that SoC was not hardware-tested. No redundant-link loop test
was performed.

## References / overlap

The field offsets and forwarding values are defined in Qualcomm's reference
[APP_CTRL layout](https://github.com/openwrt/qca-ssdk/blob/bb4f3f0b947ebfce51c78a8d39f57c7c758521c9/include/hsl/hppe/hppe_ctrlpkt_reg.h)
and [forwarding command enum](https://github.com/openwrt/qca-ssdk/blob/bb4f3f0b947ebfce51c78a8d39f57c7c758521c9/include/fal/fal_type.h).

The larger open series #24806 also replaces the raw APP_CTRL constants and
corrects CMD; its current mask still includes CPU port 0. This PR isolates
the small, hardware-tested RSTP fix so it need not depend on the larger
offload series. Please coordinate/rebase the overlapping hunk as appropriate.

AI-assisted implementation and investigation: OpenAI Codex.
