### PR TITLE
ramips: add support for KuWFi C900GL

### DIFF
--- a/target/linux/ramips/dts/mt7621_kuwfi_c900gl.dts
+++ b/target/linux/ramips/dts/mt7621_kuwfi_c900gl.dts
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "kuwfi,c900gl", "mediatek,mt7621-soc";
+	model = "KuWFi C900GL";
+
+	aliases {
+		led-failsafe = &led_wlan;
+		led-upgrade = &led_wlan;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_mobile: led-0 {
+			function = LED_FUNCTION_MOBILE;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wlan: led-1 {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "network";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		/* GPIO 16 is in the jtag group, GPIO 18 the wdt pin. */
+		groups = "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Bootloader";
+				reg = <0x000000 0x030000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "Config";
+				reg = <0x030000 0x010000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "Factory";
+				reg = <0x040000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x200>;
+					};
+
+					/*
+					 * One contiguous run of addresses, based
+					 * at the one printed on the case: +0 is
+					 * 2.4 GHz and the label, +2 lan, +3 wan,
+					 * +4 5 GHz.  Both radios read their own
+					 * copy out of their EEPROM block.
+					 */
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x050000 0xfa0000>;
+			};
+
+			partition@ff0000 {
+				label = "Second_Config";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_4 2>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		/* port@4 has no socket on this board. */
+		port@0 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_4 3>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2093,6 +2093,31 @@ define Device/keenetic_kn-3510
 endef
 TARGET_DEVICES += keenetic_kn-3510
 
+define Device/kuwfi_c900gl
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 16000k
+  # The stock web updater accepts a legacy uImage named MT7621A_11AC_8_64 and
+  # writes ih_size + 64 bytes of it; the vendor U-Boot checksums that same
+  # range on every boot.  An initramfs is complete in itself, so it is what
+  # the updater installs, and sysupgrade from it writes the flash layout.
+  # No UIMAGE_NAME: sysupgrade.bin must keep a name the updater rejects.
+  KERNEL_INITRAMFS := $$(KERNEL/lzma-loader) | uImage none -n MT7621A_11AC_8_64
+ifeq ($(IB),)
+ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
+  ARTIFACTS := initramfs-factory.bin
+  ARTIFACT/initramfs-factory.bin := append-image-stage initramfs-kernel.bin | \
+	check-size 8192k
+endif
+endif
+  DEVICE_VENDOR := KuWFi
+  DEVICE_MODEL := C900GL
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
+	kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi \
+	kmod-ledtrig-network -uboot-envtools
+endef
+TARGET_DEVICES += kuwfi_c900gl
+
 define Device/lenovo_newifi-d1
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -142,6 +142,9 @@ keenetic,kn-1910|\
 keenetic,kn-3010)
 	ucidef_set_led_netdev "internet" "internet" "green:internet" "wan"
 	;;
+kuwfi,c900gl)
+	ucidef_set_led_netdev "mobile" "MOBILE" "blue:mobile" "wwan0" "link tx rx"
+	;;
 linksys,e5600)
 	ucidef_set_led_netdev "wan" "wan link" "blue:wan" "wan" "link"
 	;;

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -152,6 +152,13 @@ ramips_setup_interfaces()
 	gnubee,gb-pc2)
 		ucidef_set_interface_lan "ethblack ethblue ethyellow"
 		;;
+	kuwfi,c900gl)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
+		ucidef_set_interface "wwan" device "/dev/cdc-wdm0" protocol "qmi"
+		# board.d runs again after every sysupgrade; keep the entry single.
+		uci -q del_list firewall.@zone[1].network='wwan'
+		uci add_list firewall.@zone[1].network='wwan'
+		;;
 	mikrotik,routerboard-760igs)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4 lan5" "wan sfp"
 		;;
@@ -267,6 +274,9 @@ ramips_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii config mac)
 		wan_mac=$lan_mac
 		label_mac=$lan_mac
+		;;
+	kuwfi,c900gl)
+		label_mac=$(mtd_get_mac_binary Factory 0x4)
 		;;
 	belkin,rt1800|\
 	linksys,e7350)


### PR DESCRIPTION
KuWFi C900GL is an MT7621 based dual-band LTE router with three LAN ports, one
WAN port and a Telit modem in an M.2 Key-B socket.

Hardware specifications:
- SoC: MediaTek MT7621AT (880 MHz, 2 cores)
- RAM: 128 MiB DDR3 (Nanya NT5CB64M16DP-DH)
- Flash: 16 MiB SPI-NOR (Winbond W25Q128BV)
- WiFi: MT7603E 2x2 2.4 GHz and MT7612E 2x2 5 GHz, both on PCIe
- Ethernet: 4x 1GbE (3x LAN, 1x WAN) on the built-in MT7530 switch
- LTE: Telit LN940A9 over USB, QMI
- LEDs/Buttons: 2 LEDs (WIFI, 4G), 2 buttons (reset, WPS)
- Serial: 1x4 header, 3.3V TTL, 57600 8N1
- Power: 12 VDC, 1 A

Installation uses the route other mt7621 devices with a name-checking vendor
updater already take — I-O DATA WN-AX1167GR2, ELECOM WRC-X1800GS: upload the
initramfs image through the stock firmware's own upgrade page, then run
sysupgrade from it. A factory image carrying a rootfs is not possible on this
device because the vendor updater couples its write length to the same uImage
header the bootloader checksums on every boot; the commit message has the
detail.

Tested on hardware on 2026-09-07 against main at 3809dfe5, kernel 6.18.44:
install from the stock firmware, cold start, sysupgrade with and without -n,
failsafe, factory reset from the button, both radios with a client and a
30 MiB transfer per band, all four Ethernet ports, both buttons and an LTE
data session.

Re-tested on 2026-09-08 with the modem preconfigured as interface `wwan`:
install from the stock firmware again, an APN alone brings LTE up with NAT,
and config-preserving sysupgrades keep the firewall zone entry single.

Re-tested on 2026-09-10 with the WLAN LED on the network trigger: install
from the stock firmware again, and the LED follows both radios.
