### PR TITLE
ramips: add support for Keenetic KN-1913

### DIFF
--- a/target/linux/ramips/dts/mt7621_keenetic_kn-1913.dts
+++ b/target/linux/ramips/dts/mt7621_keenetic_kn-1913.dts
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "keenetic,kn-1913", "mediatek,mt7621-soc";
+	model = "Keenetic KN-1913";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &gmac0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		fn {
+			label = "fn";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 18 GPIO_ACTIVE_HIGH>;
+		};
+
+		internet {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		wifi {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "network";
+		};
+
+		usb {
+			function = LED_FUNCTION_USB;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "usbport";
+			trigger-sources = <&ehci_port2>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&firmware1 &firmware2 &storage_a &storage_b>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x7240000>;
+			};
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "U-Boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "U-Config";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "RF-EEPROM";
+			reg = <0x100000 0x80000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					compatible = "mac-base";
+					reg = <0x4 0x6>;
+					#nvmem-cell-cells = <1>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
+			};
+		};
+
+		firmware1: partition@180000 {
+			label = "Firmware_1";
+			reg = <0x180000 0x1a40000>;
+		};
+
+		partition@1bc0000 {
+			label = "Config_1";
+			reg = <0x1bc0000 0x80000>;
+			read-only;
+		};
+
+		partition@1c40000 {
+			label = "Storage_Legacy";
+			reg = <0x1c40000 0x200000>;
+			read-only;
+		};
+
+		partition@1e40000 {
+			label = "Dump";
+			reg = <0x1e40000 0x40000>;
+			read-only;
+		};
+
+		storage_a: partition@1e80000 {
+			label = "Storage_A";
+			reg = <0x1e80000 0x1fc0000>;
+		};
+
+		partition@3e40000 {
+			label = "U-State";
+			reg = <0x3e40000 0x80000>;
+			read-only;
+		};
+
+		partition@3ec0000 {
+			label = "U-Config_res";
+			reg = <0x3ec0000 0x80000>;
+			read-only;
+		};
+
+		partition@3f40000 {
+			label = "RF-EEPROM_res";
+			reg = <0x3f40000 0x80000>;
+			read-only;
+		};
+
+		firmware2: partition@3fc0000 {
+			label = "Firmware_2";
+			reg = <0x3fc0000 0x1a40000>;
+		};
+
+		partition@5a00000 {
+			label = "Config_2";
+			reg = <0x5a00000 0x80000>;
+			read-only;
+		};
+
+		storage_b: partition@5a80000 {
+			label = "Storage_B";
+			reg = <0x5a80000 0x2200000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&ethphy0 {
+	/delete-property/ interrupts;
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_4 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy0>;
+
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+};
+
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
+};
+
+&reg_vusb33 {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+		};
+
+		port@2 {
+			status = "okay";
+		};
+
+		port@3 {
+			status = "okay";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2066,6 +2066,20 @@ define Device/keenetic_kn-1910
 endef
 TARGET_DEVICES += keenetic_kn-1910
 
+define Device/keenetic_kn-1913
+  $(Device/nand)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 27525120
+  DEVICE_VENDOR := Keenetic
+  DEVICE_MODEL := KN-1913
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
+	kmod-usb3 kmod-usb-ledtrig-usbport kmod-ledtrig-network
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
+	append-ubi | check-size | zyimage -d 0x801913 -v "KN-1913"
+endef
+TARGET_DEVICES += keenetic_kn-1913
+
 define Device/keenetic_kn-3010
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -142,6 +142,9 @@ keenetic,kn-1910|\
 keenetic,kn-3010)
 	ucidef_set_led_netdev "internet" "internet" "green:internet" "wan"
 	;;
+keenetic,kn-1913)
+	ucidef_set_led_netdev "internet" "internet" "green:wan" "wan"
+	;;
 linksys,e5600)
 	ucidef_set_led_netdev "wan" "wan link" "blue:wan" "wan" "link"
 	;;

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -22,6 +22,7 @@ ramips_setup_interfaces()
 	h3c,tx1806|\
 	haier,har-20s2u1|\
 	hiwifi,hc5962|\
+	keenetic,kn-1913|\
 	mercusys,mr70x-v1|\
 	netgear,wax202|\
 	sim,simax1800t|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -114,6 +114,7 @@ platform_do_upgrade() {
 	iptime,t5004|\
 	jcg,q20|\
 	keenetic,kn-1910|\
+	keenetic,kn-1913|\
 	keenetic,kn-3510|\
 	linksys,e5600|\
 	linksys,e7350|\


### PR DESCRIPTION
The Keenetic KN-1913 is a dual-band Wi-Fi router from the Keenetic Viva line, based on MediaTek MT7621A. Unlike the closely related KN-1910, which uses a single MT7615DN combo radio, this board carries two separate PCIe radio chips (MT7603E + MT7613BEN); the wireless config was therefore reverse-engineered independently rather than copied from KN-1910, and confirmed on real hardware.

Specifications:
- SoC: MediaTek MT7621A, 880 MHz, 2 cores / 4 threads
- RAM: 256 MB DDR3
- Flash: 128 MB NAND (ESMT PSU1GA30DT)
- WLAN: MT7603E 2.4 GHz + MT7613BEN 5 GHz, separate PCIe radios
- ETH: 4x 1000 Mbps (3x LAN + 1x WAN), MT7530 switch, via DSA
- USB: 1x USB 2.0. The SoC's xHCI controller exposes a combo
  USB2/USB3 port and a separate USB2-only port; only the USB2-only
  port has a physical connector on this board.
- Btns: WPS, FN
- LEDs: 4x (green), all GPIO-controlled
- Power: 12V/1.5A DC
- UART: not tested

MAC addresses as verified on real hardware:
- LAN/label   *:a3   RF-EEPROM 0x4
- WAN         *:a4   RF-EEPROM 0x28 (coincidentally = label + 1)
- 2.4 GHz     *:a3   RF-EEPROM 0x4 (coincidentally = label)
- 5 GHz       *:a5   RF-EEPROM 0x8000 (coincidentally = label + 2)

Buttons (active low):
- WPS: GPIO 10
- FN:  GPIO 12 (side panel, next to the USB port; unassigned)

LEDs (green, active high unless noted):
- Power:    GPIO 18
- Internet: GPIO 13
- WLAN:     GPIO 15 (single combined indicator, tracks both radios)
- USB/FN:   GPIO 16, active low, ledtrig-usbport

This board has no dedicated reset button. The physical button silkscreened "WPS" was confirmed by button-hotplug testing to be wired to GPIO 10, not GPIO 12 as assumed by analogy with KN-1910. It is wired to KEY_WPS_BUTTON only, with no factory-reset function on this build.

The 5 GHz radio's RF-EEPROM offset (0x8000) is not documented anywhere; the radio came up with a random MAC and non-functional TX power (3 dBm instead of the expected ~20 dBm) at the naively-assumed 0x0400 before the real offset was found from a known-identical mt7603+mt7615e pairing on another vendor's board.

Flash layout (from a live /proc/mtd dump, matches vendor firmware):
  0x0000000-0x0080000   U-Boot
  0x0080000-0x0100000   U-Config
  0x0100000-0x0180000   RF-EEPROM
  0x0180000-0x1bc0000   Firmware_1
  0x1bc0000-0x1c40000   Config_1
  0x1c40000-0x1e40000   Storage_Legacy
  0x1e40000-0x1e80000   Dump
  0x1e80000-0x3e40000   Storage_A
  0x3e40000-0x3ec0000   U-State
  0x3ec0000-0x3f40000   U-Config_res
  0x3f40000-0x3fc0000   RF-EEPROM_res
  0x3fc0000-0x5a00000   Firmware_2
  0x5a00000-0x5a80000   Config_2
  0x5a80000-0x7c80000   Storage_B
Firmware_1/2 and Storage_A/B are concatenated into a single
mtd-concat device, split into "kernel" (4 MB) and "ubi" (the
remainder), the same scheme already used for KN-1910.

Installation:
This device has no dedicated Reset button; use the WPS button in
its place for both methods below.

Flashing via OEM recovery software:
1. Download the OEM recovery software from Keenetic's website.
2. Rename the *-factory.bin image to KN-1913_recovery.bin.
3. Replace the file in the recovery software's fw folder with the
   file from step 2.
4. Run the OEM recovery software and follow its instructions.

Flashing via TFTP:
1. Connect a PC to a LAN port (not WAN); configure the PC's
   interface with IP 192.168.1.2, mask 255.255.255.252.
2. Serve the *-factory.bin image, renamed to KN-1913_recovery.bin,
   from a TFTP server's root directory.
3. Hold the WPS button while powering the device on, release it
   once the Status LED starts blinking fast.
4. Wait ~5-7 minutes for the flash to complete; do not remove power.

To revert to OEM firmware, use either method above with the
appropriate OEM firmware image instead. When using the OEM
bootloader, the firmware image size cannot exceed the size of one
OEM "Firmware_x" partition.

The build was tested on real hardware.