### PR TITLE
realtek: dsa: rtl930x PIE action VID fix + tc flower match validation

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/common.c
@@ -6,6 +6,7 @@
 #include <net/nexthop.h>
 #include <net/neighbour.h>
 #include <net/netevent.h>
+#include <linux/cleanup.h>
 #include <linux/etherdevice.h>
 #include <linux/if_vlan.h>
 #include <linux/inetdevice.h>
@@ -664,38 +665,77 @@ int rtldsa_93xx_lag_set_port_members(struct rtl838x_switch_priv *priv, int group
 // 	return idx;
 // }
 
-/* Allocate a 32-bit packet counter
- * 2 32-bit packet counters share the location of a 64-bit octet counter
- * Initially there are no free packet counters and 2 new ones need to be freed
- * by allocating the corresponding octet counter
+/*
+ * Packet counters share hardware memory with octet counters (2 packet counters
+ * per 1 octet block). Allocation relies on two complementary bitmaps:
+ *
+ *   octet_cntr_use_bm:  0 = free block, 1 = used (or split into packet counters)
+ *   packet_cntr_use_bm: 1 = free standalone counter, 0 = unavailable
+ *
+ * Allocation strategy:
+ * 1. Look for a free standalone counter from an already split block (bit = 1).
+ * 2. If none are free, claim a new octet block 'j', use counter index (2 * j),
+ *    and mark counter (2 * j + 1) as available for future allocations.
  */
-int rtl83xx_packet_cntr_alloc(struct rtl838x_switch_priv *priv)
+
+/**
+ * rtldsa_packet_cntr_alloc - Allocate a hardware packet counter.
+ * @priv: Switch driver private structure.
+ *
+ * Return: Counter index (>= 0) on success, or -1 if full.
+ */
+int rtldsa_packet_cntr_alloc(struct rtl838x_switch_priv *priv)
 {
 	int idx, j;
 
-	mutex_lock(&priv->reg_mutex);
+	scoped_guard(mutex, &priv->reg_mutex) {
+		idx = find_first_bit(priv->packet_cntr_use_bm, priv->r->n_counters * 2);
+		if (idx >= priv->r->n_counters * 2) {
+			j = find_first_zero_bit(priv->octet_cntr_use_bm, priv->r->n_counters);
+			if (j >= priv->r->n_counters)
+				return -1;
 
-	/* Because initially no packet counters are free, the logic is reversed:
-	 * a 0-bit means the counter is already allocated (for octets)
-	 */
-	idx = find_first_bit(priv->packet_cntr_use_bm, MAX_COUNTERS * 2);
-	if (idx >= priv->r->n_counters * 2) {
-		j = find_first_zero_bit(priv->octet_cntr_use_bm, MAX_COUNTERS);
-		if (j >= priv->r->n_counters) {
-			mutex_unlock(&priv->reg_mutex);
-			return -1;
+			__set_bit(j, priv->octet_cntr_use_bm);
+			idx = j * 2;
+			__set_bit(j * 2 + 1, priv->packet_cntr_use_bm);
+		} else {
+			__clear_bit(idx, priv->packet_cntr_use_bm);
 		}
-		set_bit(j, priv->octet_cntr_use_bm);
-		idx = j * 2;
-		set_bit(j * 2 + 1, priv->packet_cntr_use_bm);
-
-	} else {
-		clear_bit(idx, priv->packet_cntr_use_bm);
 	}
 
-	mutex_unlock(&priv->reg_mutex);
-
 	return idx;
+}
+
+/**
+ * rtldsa_packet_cntr_free - Release a packet counter from rtldsa_packet_cntr_alloc().
+ * @priv: Switch driver private structure.
+ * @idx: Packet counter index to free; a negative id is ignored.
+ *
+ * Marks the counter free again and, once both halves of its octet block are
+ * free, returns the whole block to the octet counter pool.
+ */
+void rtldsa_packet_cntr_free(struct rtl838x_switch_priv *priv, int idx)
+{
+	int j;
+
+	if (idx < 0 || idx >= priv->r->n_counters * 2)
+		return;
+
+	scoped_guard(mutex, &priv->reg_mutex) {
+		/* already free - guard against a double release */
+		if (test_bit(idx, priv->packet_cntr_use_bm))
+			return;
+
+		__set_bit(idx, priv->packet_cntr_use_bm);
+
+		j = idx / 2;
+		if (test_bit(j, priv->octet_cntr_use_bm) &&
+		    test_bit(idx ^ 1, priv->packet_cntr_use_bm)) {
+			__clear_bit(idx, priv->packet_cntr_use_bm);
+			__clear_bit(idx ^ 1, priv->packet_cntr_use_bm);
+			__clear_bit(j, priv->octet_cntr_use_bm);
+		}
+	}
 }
 
 /* Add an L2 nexthop entry for the L3 routing system / PIE forwarding in the SoC

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/l3.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/l3.c
@@ -930,7 +930,7 @@ static int otto_l3_nexthop_update(struct otto_l3_ctrl *ctrl, __be32 ip_addr, u64
 			ctrl->cfg->set_nexthop(ctrl, r->nh.id, r->nh.l2_id, r->nh.if_id);
 
 		if (r->pr.id < 0) {
-			r->pr.packet_cntr = rtl83xx_packet_cntr_alloc(priv);
+			r->pr.packet_cntr = rtldsa_packet_cntr_alloc(priv);
 			if (r->pr.packet_cntr >= 0) {
 				dev_info(ctrl->dev, "Using packet counter %d\n",
 					 r->pr.packet_cntr);
@@ -1222,7 +1222,7 @@ static int otto_l3_fib_del_v4(struct otto_l3_ctrl *ctrl, struct fib_entry_notifi
 	rtl83xx_l2_nexthop_rm(priv, &route->nh);
 
 	dev_info(ctrl->dev, "releasing packet counter %d\n", route->pr.packet_cntr);
-	set_bit(route->pr.packet_cntr, priv->packet_cntr_use_bm);
+	rtldsa_packet_cntr_free(priv, route->pr.packet_cntr);
 	priv->r->pie_rule_rm(priv, &route->pr);
 
 	otto_l3_route_remove(ctrl, route);

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl-otto.h
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl-otto.h
@@ -1690,7 +1690,8 @@ void rtldsa_838x_qos_init(struct rtl838x_switch_priv *priv);
 void rtldsa_839x_qos_init(struct rtl838x_switch_priv *priv);
 
 void rtldsa_port_fast_age(struct dsa_switch *ds, int port);
-int rtl83xx_packet_cntr_alloc(struct rtl838x_switch_priv *priv);
+int rtldsa_packet_cntr_alloc(struct rtl838x_switch_priv *priv);
+void rtldsa_packet_cntr_free(struct rtl838x_switch_priv *priv, int idx);
 int rtldsa_port_get_stp_state(struct rtl838x_switch_priv *priv, int port);
 int rtl83xx_port_is_under(const struct net_device *dev, struct rtl838x_switch_priv *priv);
 void rtldsa_port_stp_state_set(struct dsa_switch *ds, int port, u8 state);

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -1635,9 +1635,9 @@ static void rtl930x_write_pie_action(u32 r[],  struct pie_rule *pr)
 	r[15] |= pr->log_octets ? BIT(31) : 0;
 	r[15] |= (u32)(pr->meter_data) << 23;
 
-	r[15] |= ((u32)(pr->ivid_act) << 21) & 0x3;
-	r[15] |= ((u32)(pr->ivid_data) << 9) & 0xfff;
-	r[16] |= ((u32)(pr->ovid_act) << 30) & 0x3;
+	r[15] |= ((u32)(pr->ivid_act) & 0x3) << 21;
+	r[15] |= ((u32)(pr->ivid_data) & 0xfff) << 9;
+	r[16] |= ((u32)(pr->ovid_act) & 0x3) << 30;
 	r[16] |= ((u32)(pr->ovid_data) & 0xfff) << 16;
 	r[16] |= (pr->mir_data & 0x3) << 6;
 	r[17] |= ((u32)(pr->tagst_data) & 0xf) << 28;

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
@@ -242,34 +242,31 @@ static int rtl83xx_configure_flower(struct rtl838x_switch_priv *priv,
 	rcu_read_lock();
 	pr_debug("Cookie %08lx\n", f->cookie);
 	flow = rhashtable_lookup(&priv->tc_ht, &f->cookie, tc_ht_params);
+	rcu_read_unlock();
 	if (flow) {
 		pr_info("%s: Got flow\n", __func__);
-		err = -EEXIST;
-		goto rcu_unlock;
+		return -EEXIST;
 	}
-
-rcu_unlock:
-	rcu_read_unlock();
-	if (flow)
-		goto out;
 	pr_debug("%s: New flow\n", __func__);
 
 	flow = kzalloc(sizeof(*flow), GFP_KERNEL);
-	if (!flow) {
-		err = -ENOMEM;
-		goto out;
-	}
+	if (!flow)
+		return -ENOMEM;
 
 	flow->cookie = f->cookie;
 	flow->priv = priv;
+	/* kzalloc() leaves this at 0, a valid counter id; -1 means "none". */
+	flow->rule.packet_cntr = -1;
 
 	err = rhashtable_insert_fast(&priv->tc_ht, &flow->node, tc_ht_params);
 	if (err) {
-		pr_err("Could not insert add new rule\n");
+		dev_err(priv->dev, "could not insert new rule\n");
 		goto out_free;
 	}
 
-	rtl83xx_add_flow(priv, f, flow); /* TODO: check error */
+	err = rtl83xx_add_flow(priv, f, flow);
+	if (err)
+		goto out_remove;
 
 	/* Add log action to flow */
 	flow->rule.packet_cntr = rtldsa_packet_cntr_alloc(priv);
@@ -280,11 +277,20 @@ rcu_unlock:
 	}
 
 	err = priv->r->pie_rule_add(priv, &flow->rule);
-	return err;
+	if (err)
+		goto out_remove;
 
+	return 0;
+
+out_remove:
+	rhashtable_remove_fast(&priv->tc_ht, &flow->node, tc_ht_params);
+	rtldsa_packet_cntr_free(priv, flow->rule.packet_cntr);
+	/* published in tc_ht above; a concurrent reader may still hold a ref */
+	kfree_rcu(flow, rcu_head);
+	goto out_err;
 out_free:
 	kfree(flow);
-out:
+out_err:
 	pr_err("%s: error %d\n", __func__, err);
 
 	return err;

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
@@ -272,7 +272,7 @@ rcu_unlock:
 	rtl83xx_add_flow(priv, f, flow); /* TODO: check error */
 
 	/* Add log action to flow */
-	flow->rule.packet_cntr = rtl83xx_packet_cntr_alloc(priv);
+	flow->rule.packet_cntr = rtldsa_packet_cntr_alloc(priv);
 	if (flow->rule.packet_cntr >= 0) {
 		pr_debug("Using packet counter %d\n", flow->rule.packet_cntr);
 		flow->rule.log_sel = true;

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
@@ -15,6 +15,7 @@ static int rtl83xx_parse_flow_rule(struct rtl838x_switch_priv *priv,
 				   struct flow_rule *rule, struct rtl83xx_flow *flow)
 {
 	struct flow_dissector *dissector = rule->match.dissector;
+	u64 supported_keys;
 
 	pr_debug("In %s\n", __func__);
 	/* KEY_CONTROL and KEY_BASIC are needed for forming a meaningful key */
@@ -24,30 +25,64 @@ static int rtl83xx_parse_flow_rule(struct rtl838x_switch_priv *priv,
 		return -EOPNOTSUPP;
 	}
 
+	supported_keys = BIT_ULL(FLOW_DISSECTOR_KEY_CONTROL) |
+			 BIT_ULL(FLOW_DISSECTOR_KEY_BASIC) |
+			 BIT_ULL(FLOW_DISSECTOR_KEY_ETH_ADDRS) |
+			 BIT_ULL(FLOW_DISSECTOR_KEY_VLAN) |
+			 BIT_ULL(FLOW_DISSECTOR_KEY_IPV4_ADDRS) |
+			 BIT_ULL(FLOW_DISSECTOR_KEY_IPV6_ADDRS) |
+			 BIT_ULL(FLOW_DISSECTOR_KEY_PORTS);
+	if (dissector->used_keys & ~supported_keys) {
+		dev_err(priv->dev, "unsupported TC keys: used_keys = 0x%llx\n",
+			dissector->used_keys & ~supported_keys);
+		return -EOPNOTSUPP;
+	}
+
+	if ((dissector->used_keys & BIT_ULL(FLOW_DISSECTOR_KEY_IPV4_ADDRS)) &&
+	    (dissector->used_keys & BIT_ULL(FLOW_DISSECTOR_KEY_IPV6_ADDRS)))
+		return -EOPNOTSUPP;
+
 	if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_BASIC)) {
 		struct flow_match_basic match;
 
 		pr_debug("%s: BASIC\n", __func__);
 		flow_rule_match_basic(rule, &match);
-		if (match.key->n_proto == htons(ETH_P_ARP))
-			flow->rule.frame_type = 0;
-		if (match.key->n_proto == htons(ETH_P_IP))
-			flow->rule.frame_type = 2;
-		if (match.key->n_proto == htons(ETH_P_IPV6))
-			flow->rule.frame_type = 3;
-		if ((match.key->n_proto == htons(ETH_P_ARP)) || flow->rule.frame_type)
+		if (match.mask->n_proto) {
+			if (match.mask->n_proto != htons(0xffff))
+				return -EOPNOTSUPP;
+
+			if (match.key->n_proto == htons(ETH_P_ARP))
+				flow->rule.frame_type = 0;
+			else if (match.key->n_proto == htons(ETH_P_IP))
+				flow->rule.frame_type = 2;
+			else if (match.key->n_proto == htons(ETH_P_IPV6))
+				flow->rule.frame_type = 3;
+			else
+				return -EOPNOTSUPP;
 			flow->rule.frame_type_m = 3;
-		if (flow->rule.frame_type >= 2) {
-			if (match.key->ip_proto == IPPROTO_UDP)
+		}
+		if (match.mask->ip_proto) {
+			if (flow->rule.frame_type < 2 || match.mask->ip_proto != 0xff)
+				return -EOPNOTSUPP;
+
+			switch (match.key->ip_proto) {
+			case IPPROTO_UDP:
 				flow->rule.frame_type_l4 = 0;
-			if (match.key->ip_proto == IPPROTO_TCP)
+				break;
+			case IPPROTO_TCP:
 				flow->rule.frame_type_l4 = 1;
-			if (match.key->ip_proto == IPPROTO_ICMP || match.key->ip_proto == IPPROTO_ICMPV6)
+				break;
+			case IPPROTO_ICMP:
+			case IPPROTO_ICMPV6:
 				flow->rule.frame_type_l4 = 2;
-			if (match.key->ip_proto == IPPROTO_TCP)
+				break;
+			case IPPROTO_IGMP:
 				flow->rule.frame_type_l4 = 3;
-			if ((match.key->ip_proto == IPPROTO_UDP) || flow->rule.frame_type_l4)
-				flow->rule.frame_type_l4_m = 7;
+				break;
+			default:
+				return -EOPNOTSUPP;
+			}
+			flow->rule.frame_type_l4_m = 7;
 		}
 	}
 
@@ -67,9 +102,17 @@ static int rtl83xx_parse_flow_rule(struct rtl838x_switch_priv *priv,
 
 		pr_debug("%s: VLAN\n", __func__);
 		flow_rule_match_vlan(rule, &match);
+		if (match.mask->vlan_priority || match.mask->vlan_dei ||
+		    match.mask->vlan_eth_type)
+			return -EOPNOTSUPP;
+		/* cls_flower sets a full vlan_tpid mask for every VLAN-ethertype
+		 * rule; only reject a TPID the PIE cannot match on.
+		 */
+		if (match.mask->vlan_tpid &&
+		    match.key->vlan_tpid != htons(ETH_P_8021Q))
+			return -EOPNOTSUPP;
 		flow->rule.itag = match.key->vlan_id;
 		flow->rule.itag_m = match.mask->vlan_id;
-		/* TODO: What about match.key->vlan_priority? */
 	}
 
 	if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_IPV4_ADDRS)) {
@@ -117,6 +160,42 @@ static void rtl83xx_flow_bypass_all(struct rtl83xx_flow *flow)
 	flow->rule.bypass_ibc_sc = true;
 }
 
+static int rtldsa_validate_flow_actions(struct flow_rule *rule)
+{
+	const struct flow_action_entry *act;
+	bool drop = false, fwd = false;
+	int i, count = 0;
+
+	flow_action_for_each(i, act, &rule->action) {
+		count++;
+		switch (act->id) {
+		case FLOW_ACTION_DROP:
+			drop = true;
+			break;
+		case FLOW_ACTION_TRAP:
+		case FLOW_ACTION_REDIRECT:
+		case FLOW_ACTION_MIRRED:
+			if (fwd)
+				return -EOPNOTSUPP;
+			fwd = true;
+			break;
+		default:
+			/* FLOW_ACTION_VLAN_PUSH / _POP map to the ivid/ovid PIE
+			 * action fields via the translation in rtl83xx_add_flow(),
+			 * which predates this offload and has never been exercised
+			 * through it. Keep them - and every other action - rejected
+			 * until that path is reviewed.
+			 */
+			return -EOPNOTSUPP;
+		}
+	}
+
+	if (!count || (drop && count != 1))
+		return -EOPNOTSUPP;
+
+	return 0;
+}
+
 static int rtl83xx_parse_fwd(struct rtl838x_switch_priv *priv,
 			     const struct flow_action_entry *act, struct rtl83xx_flow *flow)
 {
@@ -146,7 +225,20 @@ static int rtl83xx_add_flow(struct rtl838x_switch_priv *priv, struct flow_cls_of
 
 	pr_debug("%s\n", __func__);
 
-	rtl83xx_parse_flow_rule(priv, rule, flow);
+	if (flow_rule_match_has_control_flags(rule, f->common.extack))
+		return -EOPNOTSUPP;
+
+	if (!flow_action_hw_stats_check(&rule->action, f->common.extack,
+					FLOW_ACTION_HW_STATS_IMMEDIATE_BIT))
+		return -EOPNOTSUPP;
+
+	err = rtldsa_validate_flow_actions(rule);
+	if (err)
+		return err;
+
+	err = rtl83xx_parse_flow_rule(priv, rule, flow);
+	if (err)
+		return err;
 
 	flow_action_for_each(i, act, &rule->action) {
 		switch (act->id) {


### PR DESCRIPTION
Two patches split out of #24994 at @plappermaul's request. They apply against
current code and do not depend on the offload series; #24994 will rebase on top
once this lands, dropping its own "patch 1" and "patch 10" (which this squashes).

### `realtek: dsa: rtl930x: mask the PIE action VID/act fields before shifting`

Fixes #25048.

`rtl930x_write_pie_action()` builds the `ivid_act` / `ivid_data` / `ovid_act`
fields with the mask applied *after* the shift:

```c
r[15] |= ((u32)(pr->ivid_data) << 9) & 0xfff;
```

so only the low three bits of a 12-bit assigned VID survive (id 100 -> VID 4,
id 254 -> VID 6) and `ivid_act` / `ovid_act` are masked to zero. `ovid_data` was
already the right way round. Mask each field to its width, then shift. Checked on
an RTL9302C: `ivid_data = 254` now encodes as `r15 = 0x0001fc00` where the old
code produced `0x00000c00`.

The same mask-after-shift pattern is present at `rtl839x.c:1212-1214`. It is left
out here: this issue is rtl930x-scoped, there is no rtl839x hardware on hand to
verify against, and the `ovid_act` line appears to overlap the `ovid_data` split
two lines below, which wants its own analysis. rtl838x and rtl931x are correct.

### `realtek: dsa: rtl83xx: validate and tighten tc flower match parsing`

`rtl83xx_parse_flow_rule()` accepted whatever it was handed: unknown dissector
keys were ignored, partial EtherType / ip_proto / VLAN masks were treated as
exact, `frame_type_l4` was set twice for TCP and never for a UDP-only match, and
the return value was dropped. Reject what the PIE cannot express before
programming it: unknown dissector keys, a mixed IPv4/IPv6 rule, non-exact
EtherType / ip_proto masks, VLAN priority / DEI / TPID / ethertype sub-matches.
Add `rtldsa_validate_flow_actions()`, which accepts only drop / trap / redirect /
mirred - VLAN push/pop included in the rejection, the `ivid` / `ovid` PIE action
path is neither programmed nor tested through this offload - honours control
flags and the hw-stats type, and propagates parse errors out of
`rtl83xx_add_flow()`.

This is the end state of what were two commits in #24994 (add the action
validator, then take VLAN push/pop back out of it), squashed.

### Verification

Both patches touch code that is dormant until #24994 wires the cls_flower -> PIE
offload, so this was tested on `main` + these two + the #24994 offload commits,
on a Zyxel XGS1210-12 (RTL9302C):

- unknown dissector key (`tcp_flags`) -> `-EOPNOTSUPP`, `unsupported TC keys` in dmesg
- `action vlan push id N` / `action vlan pop` with `skip_sw` -> `-EOPNOTSUPP`;
  without `skip_sw` the software path still installs
- multi-action rule (`drop` + `trap`) -> rejected
- plain `drop` / `trap` / `arp trap` -> still install `in_hw`
- `tc qdisc del clsact` teardown clean, no BUG/WARNING

Builds clean for realtek/rtl930x; CI covers all five realtek subtargets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
