### PR TITLE
   ramips: mt76x8: fix cudy tr1200-v1 switch port leak on boot

### DIFF
--- a/target/linux/ramips/dts/mt7628an_cudy_tr1200-v1.dts
+++ b/target/linux/ramips/dts/mt7628an_cudy_tr1200-v1.dts
@@ -194,5 +194,5 @@
 
 &esw {
 	mediatek,portmap = <0x3d>;
-	mediatek,portdisable = <0x3c>;
+	mediatek,portdisable = <0x3f>;
 };


### PR DESCRIPTION
## Problem

On the Cudy TR1200 v1, port 0 is used as LAN and port 1 as WAN,
isolated via VLANs configured through swconfig. However, during
boot there is a window of a few seconds where both ports are
electrically up and unfiltered, before OpenWrt's preinit script
applies the VLAN configuration.

Traced via kernel boot log timestamps:
- rt3050-esw driver brings ports 0 and 1 link-up at ~6s uptime
  (hardware probe), with no VLAN filtering active yet.
- preinit only resets the switch and applies VLAN isolation via
  swconfig at ~17-21s uptime.

For roughly 12-15 seconds, ports 0 and 1 share the same unfiltered
L2 domain. If a client is powered on in that window, it can reach
a DHCP server on the wrong port and get an IP from the wrong
network segment. On the affected device, this was reproduced with
two separate physical networks connected to LAN and WAN: some
Windows clients ended up with an IP from the wrong network and
would not recover automatically — they kept the wrong lease until
an explicit `ipconfig /renew` was run, since Windows does not
retry DHCP on its own once a lease is (wrongly) obtained.

Confirmed the leak directly in the router's own DHCP log:
a client briefly received an IP from the unintended network,
followed by a DHCPNAK ("wrong network") and a corrected DHCPACK
on the intended subnet moments later.

## Root cause

`target/linux/ramips/dts/mt7628an_cudy_tr1200-v1.dts` sets:

    mediatek,portdisable = <0x3c>;   // ports 2-5 disabled by default

This does not cover ports 0 and 1, the two ports actually used
(LAN/WAN) on this device, so they come up enabled at the hardware
level before any VLAN configuration is applied.

## Fix

Extend `portdisable` to also cover ports 0 and 1, so all
user-facing ports stay disabled at power-on until preinit/netifd
apply VLAN isolation:

    mediatek,portdisable = <0x3f>;   // ports 0-5 disabled by default

Port 6 (CPU port) is unaffected. This mirrors the approach already
used on other rt3050/rt3052-family devices to avoid the same class
of issue (e.g. mt7628an_duzun_dm06.dts, mt7628an_tplink_tl-mr6400-v4.dts).

## Testing

Verified live on hardware via swconfig/devicetree inspection
(`/sys/firmware/devicetree/base/esw@10110000/mediatek,portdisable`)
that the current value matches the dts (`0x3c`), and confirmed the
boot timeline and DHCP leak via `logread`/`dmesg`. I don't currently
have an OpenWrt build environment set up, so this PR has not been
build/boot tested with the new value — happy to test if someone can
point me to a quick way to verify, or if a maintainer can confirm on
CI.
