### PR TITLE
scripts/package-metadata: drop linux_kernel CPE on kmod SBOM entries

### DIFF
--- a/scripts/package-metadata.pl
+++ b/scripts/package-metadata.pl
@@ -8,6 +8,7 @@ use Time::Piece;
 use JSON::PP;
 
 my %board;
+my $LINUX_KERNEL_CPE = "cpe:/o:linux:linux_kernel";
 
 sub version_to_num($) {
 	my $str = shift;
@@ -710,6 +711,17 @@ sub dump_cyclonedxsbom_json {
 	return encode_json($cyclonedx);
 }
 
+sub cyclonedxsbom_component_cpe($$) {
+	my ($name, $cpe_id) = @_;
+
+	# Kmods inherit PKG_CPE_ID from the kernel Makefile; the SBOM
+	# already lists a 'kernel' component with the same CPE.
+	return undef unless $cpe_id;
+	return undef if $name =~ /^kmod-/
+		and $cpe_id eq $LINUX_KERNEL_CPE;
+	return $cpe_id;
+}
+
 sub gen_image_cyclonedxsbom() {
 	my $pkginfo = shift @ARGV;
 	my $imgmanifest = shift @ARGV;
@@ -722,7 +734,7 @@ sub gen_image_cyclonedxsbom() {
 
 	$package{"kernel"} = {
 		license => "GPL-2.0",
-		cpe_id  => "cpe:/o:linux:linux_kernel",
+		cpe_id  => $LINUX_KERNEL_CPE,
 		name    => "kernel",
 		category  => "operating-system",
 	};
@@ -774,11 +786,13 @@ sub gen_image_cyclonedxsbom() {
 			$version = $1;
 		}
 
+		my $cpe = cyclonedxsbom_component_cpe($pkg->{name}, $pkg->{cpe_id});
+
 		push @components, {
 			name => $pkg->{name},
 			version => $version,
 			@licenses > 0 ? (licenses => [ @licenses ]) : (),
-			$pkg->{cpe_id} ? (cpe => $pkg->{cpe_id}.":".$version) : (),
+			$cpe ? (cpe => $cpe.":".$version) : (),
 			$type ? (type => $type) : (),
 			$version ? (version => $version) : (),
 		};
@@ -827,11 +841,13 @@ sub gen_package_cyclonedxsbom() {
 			$version = $1;
 		}
 
+		my $cpe = cyclonedxsbom_component_cpe($name, $pkg->{cpe_id});
+
 		push @components, {
 			name => $name,
 			version => $version,
 			@licenses > 0 ? (licenses => [ @licenses ]) : (),
-			$pkg->{cpe_id} ? (cpe => $pkg->{cpe_id}.":".$version) : (),
+			$cpe ? (cpe => $cpe.":".$version) : (),
 			$type ? (type => $type) : (),
 			$version ? (version => $version) : (),
 		};


### PR DESCRIPTION
## Problem

Every in-tree `kmod-*` subpackage inherits `PKG_CPE_ID` from `package/kernel/linux/Makefile` (`cpe:/o:linux:linux_kernel`). `gen_image_cyclonedxsbom()` and `gen_package_cyclonedxsbom()` then stamp that same CPE onto every kmod in the emitted CycloneDX SBOM, while also emitting a synthetic top-level `kernel` component carrying the identical CPE.

This causes SCA tools (Dependency Track, Trivy, Grype, GitHub dependency-graph, ...) to match every kernel CVE against every kmod component, producing tens of thousands of duplicate findings from each single kernel CVE.

## Reproducible on official builds

The current OpenWrt snapshot x86/64 image SBOM (https://downloads.openwrt.org/snapshots/targets/x86/64/openwrt-x86-64.bom.cdx.json) shows:

- 103 components total
- 24 `kmod-*` components
- **23 of 24 carry the identical `cpe:/o:linux:linux_kernel:6.18.44` — the same CPE as the top-level `kernel` component**

On a real device image with 100–200 kmods the multiplier is proportionally larger. A recent downstream (WeRT OS) build showed ~60k findings on Dependency Track, of which 90%+ were duplicate kernel-CVE matches.

## Fix

Only in the SBOM generator, suppress the kernel CPE on `kmod-*` components whose `PKG_CPE_ID` equals `cpe:/o:linux:linux_kernel`. The component still appears in the SBOM inventory (with name, version, license) so downstream compliance/inventory reporting is unaffected — only the CPE (and therefore CVE matching) is dropped for the duplicate entries.

`.ipk` / `.apk` package metadata (`CPE-ID:` field in control files) is intentionally left unchanged: at the package-manifest layer a kmod is legitimately part of the Linux kernel product. This is a SBOM-consumer-layer fix only.

kmods that explicitly override `PKG_CPE_ID` (e.g. out-of-tree drivers with their own CPE namespace) keep their CPE untouched.

## Alternative considered

Suppressing at the source (clearing `PKG_CPE_ID` inheritance in `KernelPackage/Package/kmod-*` in `include/kernel.mk`) would also fix the `.ipk`/`.apk` `CPE-ID:` field, but changes the package-manifest layer in a way that other downstream consumers of the metadata (not just SBOMs) would observe. Happy to pivot to that approach if maintainers prefer it.

## Test

```
diff <(gen SBOM without patch) <(gen SBOM with patch)
```
shows the identical `kmod-*` component list, with `cpe:` field removed only from those inheriting the kernel CPE. Synthetic `kernel` component still carries `cpe:/o:linux:linux_kernel:<version>`, so the kernel itself is still matched exactly once.