### PR TITLE
ramips: add support for TP-Link MR600 V1(EU)

### DIFF
--- a/target/linux/ramips/dts/mt7621_tplink_mr600-v1-eu.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_mr600-v1-eu.dts
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "tplink,mr600-v1-eu", "mediatek,mt7621-soc";
+	model = "TP-Link MR600 v1 (EU)";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wlan {
+			label = "wlan";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WLAN>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "network";
+		};
+
+		wan {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		signal1 {
+			function = "signal";
+			function-enumerator = <1>;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		signal2 {
+			function = "signal";
+			function-enumerator = <2>;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		signal3 {
+			function = "signal";
+			function-enumerator = <3>;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		4g {
+			function = LED_FUNCTION_MOBILE;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "network";
+		};
+	};
+
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "uboot";
+				reg = <0x00000 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "openwrt,uimage";
+				openwrt,offset = <512>; /* account for the 512-byte long header */
+				label = "firmware";
+				reg = <0x20000 0xfa0000>;
+			};
+
+			partition@fc0000 {
+				label = "romfile";
+				reg = <0xfc0000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_romfile_f100: romfile@f100 {
+						compatible = "mac-base";
+						reg = <0xf100 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@fd0000 {
+				label = "config";
+				reg = <0xfd0000 0x10000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "radio";
+				reg = <0xff0000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_radio_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_radio_8000: eeprom@8000 {
+						reg = <0x8000 0x200>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_radio_0>, <&macaddr_romfile_f100 0>;
+		nvmem-cell-names = "eeprom", "mac-address";
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_romfile_f100 (-1)>;
+		nvmem-cell-names = "eeprom", "mac-address";
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_romfile_f100 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_romfile_f100 1>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethphy4 {
+	/delete-property/ interrupts;
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -3184,6 +3184,25 @@ define Device/tplink_ex220-v2
 endef
 TARGET_DEVICES += tplink_ex220-v2
 
+define Device/tplink_mr600-v1-eu
+  $(Device/dsa-migration)
+  $(Device/tplink-v2)
+  DEVICE_MODEL := MR600
+  DEVICE_VARIANT := v1 (EU)
+  TPLINK_FLASHLAYOUT := 16Mltq
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 \
+		kmod-usb-net-qmi-wwan uqmi kmod-usb3 \
+		kmod-ledtrig-network -uboot-envtools
+  IMAGE/factory.bin := tplink-v2-image -e -a 0x10000
+  IMAGE/sysupgrade.bin := tplink-v2-image -s -e -a 0x10000 | check-size | \
+	append-metadata
+  KERNEL := $(KERNEL_DTB) | uImage lzma
+  KERNEL_INITRAMFS := $$(KERNEL) | tplink-v2-header
+  TPLINK_BOARD_ID := MR600-V1-EU
+  IMAGE_SIZE := 16384k
+endef
+TARGET_DEVICES += tplink_mr600-v1-eu
+
 define Device/tplink_mr600-v2-eu
   $(Device/dsa-migration)
   $(Device/tplink-v2)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -235,6 +235,10 @@ tplink,re350-v1)
 	ucidef_set_led_netdev "eth_act" "LAN act" "green:eth_act" "lan" "tx rx"
 	ucidef_set_led_netdev "eth_link" "LAN link" "green:eth_link" "lan" "link"
 	;;
+tplink,mr600-v1-eu)
+	ucidef_set_led_netdev "wan" "WAN" "white:wan" "wan"
+	ucidef_set_led_netdev "4g" "4G" "white:mobile" "wwan0"
+	;;
 tplink,mr600-v2-eu)
 	ucidef_set_led_netdev "lan" "LAN" "white:lan" "br-lan"
 	ucidef_set_led_netdev "wan" "WAN" "white:wan" "wan"

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -27,6 +27,7 @@ ramips_setup_interfaces()
 	sim,simax1800t|\
 	sim,simax1800u|\
 	teltonika,rutm11|\
+	tplink,mr600-v1-eu|\
 	tplink,mr600-v2-eu|\
 	xiaomi,mi-router-3-pro|\
 	xiaomi,mi-router-ac2100|\
@@ -285,6 +286,7 @@ ramips_setup_macs()
 		lan_mac=$label_mac
 		wan_mac=$(macaddr_add "$label_mac" 1)
 		;;
+	tplink,mr600-v1-eu|\
 	tplink,mr600-v2-eu)
 		wwan_mac=$(macaddr_add $(cat /sys/class/net/eth0/address) 1)
 		ucidef_set_interface "wwan0" device "/dev/cdc-wdm0" protocol "qmi" macaddr "$wwan_mac"


### PR DESCRIPTION
MR600 V1(EU) is an LTE router with WiFi 5 support.

It is very similar to the V2, only the 5GHz radio
driver and GPIO pins were changed.

# Specs:

* SoC: Mediatek MT7621A 880MHz
* RAM: 128MB DDR3
* Flash: 16MB SPI NOR flash (W25Q128BV)
* LTE Modem: Qualcomm MDM9240
* WiFi 5GHz: Mediatek MT7612E
* WiFi 2.4GHz: Mediatek MT7603E
* Ethernet: MT7530, 4x 1000Base-T.
* UART: Serial console (115200 8n1), J1(GND:3)
* Buttons: Reset, WPS, WiFi Toggle.
* LED: Power, WAN, LTE, WiFi , LAN, Signal1, Signal2, Signal3

# MAC Addresses:

60:32:b1:xx:xx:3b : 5GHz
60:32:b1:xx:xx:3c : LAN / 2.4GHz (Label)
60:32:b1:xx:xx:3d : WAN/LTE

# Installation:

Requirements:

* TFTP server, tftp-hpa was tested
* Initramfs and sysupgrade image
* UART shell access

1. Connect ethernet to router

Set tftp server to listen on 192.168.0.5/24

Put initramfs image renamed to "test.bin" into the root

2. Connect to uboot shell over uart and boot initramfs

Press "t" while the router is booting to get to a prompt

Run "tftpboot" then "bootm"

3. Install sysupgrade image

Transfer sysupgrade image to the router (e.g. with scp) and install it


## Note:
I tested basic functionality of WiFi and ethernet, but as I don't have a spare SIM card I did not test the LTE modem. Though since it's the same modem as in the v2, I assume it should work.