### PR TITLE
realtek: dsa: rtl83xx: pass priv to the packet counter ops, use dev_dbg

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/l3.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/l3.c
@@ -879,7 +879,7 @@ static int otto_l3_nexthop_update(struct otto_l3_ctrl *ctrl, __be32 ip_addr, u64
 			}
 			priv->r->pie_rule_add(priv, &r->pr);
 		} else {
-			int pkts = priv->r->packet_cntr_read(r->pr.packet_cntr);
+			int pkts = priv->r->packet_cntr_read(priv, r->pr.packet_cntr);
 
 			dev_dbg(ctrl->dev, "total packets: %d\n", pkts);
 

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl-otto.h
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl-otto.h
@@ -1481,8 +1481,8 @@ struct rtldsa_config {
 	int (*pie_rule_add)(struct rtl838x_switch_priv *priv, struct pie_rule *rule);
 	void (*pie_rule_rm)(struct rtl838x_switch_priv *priv, struct pie_rule *rule);
 	void (*l2_learning_setup)(void);
-	u32 (*packet_cntr_read)(int counter);
-	void (*packet_cntr_clear)(int counter);
+	u32 (*packet_cntr_read)(struct rtl838x_switch_priv *priv, int counter);
+	void (*packet_cntr_clear)(struct rtl838x_switch_priv *priv, int counter);
 	void (*set_receive_management_action)(int port, rma_ctrl_t type, action_type_t action);
 	void (*led_init)(struct rtl838x_switch_priv *priv);
 	u32 (*get_egress_rate)(struct rtl838x_switch_priv *priv, int port);

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl838x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl838x.c
@@ -1571,15 +1571,15 @@ static void rtl838x_pie_init(struct rtl838x_switch_priv *priv)
 	sw_w32(0b10101010101, RTL838X_ACL_BLK_GROUP_CTRL);
 }
 
-static u32 rtl838x_packet_cntr_read(int counter)
+static u32 rtl838x_packet_cntr_read(struct rtl838x_switch_priv *priv, int counter)
 {
 	u32 buf[2];
 	u32 v;
 
-	pr_debug("In %s, id %d\n", __func__, counter);
+	dev_dbg(priv->dev, "reading LOG packet counter %d\n", counter);
 	otto_table_read(RTL8380_TBL_LOG, counter / 2, &buf);
 
-	pr_debug("Registers: %08x %08x\n", buf[0], buf[1]);
+	dev_dbg(priv->dev, "LOG entry: %08x %08x\n", buf[0], buf[1]);
 	if (counter % 2)
 		v = buf[0];
 	else
@@ -1588,12 +1588,12 @@ static u32 rtl838x_packet_cntr_read(int counter)
 	return v;
 }
 
-static void rtl838x_packet_cntr_clear(int counter)
+static void rtl838x_packet_cntr_clear(struct rtl838x_switch_priv *priv, int counter)
 {
 	int tbl = otto_table_acquire(RTL8380_TBL_LOG);
 	u32 buf[2];
 
-	pr_debug("In %s, id %d\n", __func__, counter);
+	dev_dbg(priv->dev, "clearing LOG packet counter %d\n", counter);
 
 	/*
 	 * Two counters share one LOG table entry. Read the current entry

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl839x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl839x.c
@@ -1467,12 +1467,12 @@ static void rtl839x_pie_init(struct rtl838x_switch_priv *priv)
 		sw_w32(template_selectors, RTL839X_ACL_BLK_TMPLTE_CTRL(i));
 }
 
-static u32 rtl839x_packet_cntr_read(int counter)
+static u32 rtl839x_packet_cntr_read(struct rtl838x_switch_priv *priv, int counter)
 {
 	u32 buf[2];
 	u32 v;
 
-	pr_debug("In %s, id %d\n", __func__, counter);
+	dev_dbg(priv->dev, "reading LOG packet counter %d\n", counter);
 	otto_table_read(RTL8390_TBL_LOG, counter / 2, &buf);
 
 	if (counter % 2)
@@ -1483,12 +1483,12 @@ static u32 rtl839x_packet_cntr_read(int counter)
 	return v;
 }
 
-static void rtl839x_packet_cntr_clear(int counter)
+static void rtl839x_packet_cntr_clear(struct rtl838x_switch_priv *priv, int counter)
 {
 	int tbl = otto_table_acquire(RTL8390_TBL_LOG);
 	u32 buf[2];
 
-	pr_debug("In %s, id %d\n", __func__, counter);
+	dev_dbg(priv->dev, "clearing LOG packet counter %d\n", counter);
 
 	/*
 	 * Two counters share one LOG table entry. Read the current entry

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -1843,18 +1843,18 @@ static void rtl930x_pie_init(struct rtl838x_switch_priv *priv)
 		sw_w32(template_selectors, RTL930X_PIE_BLK_TMPLTE_CTRL(i));
 }
 
-static u32 rtl930x_packet_cntr_read(int counter)
+static u32 rtl930x_packet_cntr_read(struct rtl838x_switch_priv *priv, int counter)
 {
 	u32 buf[2];
 	u32 v;
 
-	pr_debug("In %s, id %d\n", __func__, counter);
+	dev_dbg(priv->dev, "reading LOG packet counter %d\n", counter);
 	/* Two counters share one entry, so the parity of counter picks which
 	 * half of it to return.
 	 */
 	otto_table_read(RTL9300_TBL_LOG, counter / 2, &buf);
 
-	pr_debug("Registers: %08x %08x\n", buf[0], buf[1]);
+	dev_dbg(priv->dev, "LOG entry: %08x %08x\n", buf[0], buf[1]);
 	if (counter % 2)
 		v = buf[0];
 	else
@@ -1863,13 +1863,13 @@ static u32 rtl930x_packet_cntr_read(int counter)
 	return v;
 }
 
-static void rtl930x_packet_cntr_clear(int counter)
+static void rtl930x_packet_cntr_clear(struct rtl838x_switch_priv *priv, int counter)
 {
 	int tbl = otto_table_acquire(RTL9300_TBL_LOG);
 
 	u32 v[2];
 
-	pr_debug("In %s, id %d\n", __func__, counter);
+	dev_dbg(priv->dev, "clearing LOG packet counter %d\n", counter);
 
 	/* Two counters share one LOG table entry. Read the current entry
 	 * first so clearing one half preserves the adjacent counter.

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
@@ -427,7 +427,7 @@ static int rtl83xx_stats_flower(struct rtl838x_switch_priv *priv,
 		return -1;
 
 	if (flow->rule.packet_cntr >= 0) {
-		total_packets = priv->r->packet_cntr_read(flow->rule.packet_cntr);
+		total_packets = priv->r->packet_cntr_read(priv, flow->rule.packet_cntr);
 		pr_debug("Total packets: %d\n", total_packets);
 		new_packets = total_packets - flow->rule.last_packet_cnt;
 		flow->rule.last_packet_cnt = total_packets;


### PR DESCRIPTION
`rtl83xx_packet_cntr_read()` / `_clear()` only had the raw counter index, so their tracing was `pr_debug("In %s ...", __func__)`. Give both ops a `struct rtl838x_switch_priv *priv` argument (both call sites already have one), drop `__func__` and give `dev_dbg()` a message that says what the call does.

Split out of #24994 at @plappermaul's request. Builds clean for realtek/rtl930x; CI covers all five subtargets.

The `read a PIE rule's LOG packet counter correctly` patch that was here first has moved back into #24994 — its `counter < RTL930X_PIE_RULE_IDS` split is only correct once that series' offload commit biases the packet-counter allocator past the PIE rule ID range, so it can't stand alone on main.
