### PR TITLE
qualcommax: qca_ppe: take the ingress VLAN the flowtable reports

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -1341,6 +1341,7 @@ config KERNEL_DCB
 	bool "Data Center Bridging support"
 	default y if TARGET_armsr_armv8
 	default y if TARGET_microchipsw
+	default y if TARGET_qualcommax
 	default y if TARGET_x86_64
 	help
 	  This enables support for configuring Data Center Bridging (DCB)

--- a/package/kernel/linux/modules/netsupport.mk
+++ b/package/kernel/linux/modules/netsupport.mk
@@ -743,6 +743,22 @@ endef
 $(eval $(call KernelPackage,sched-core))
 
 
+define KernelPackage/sched-act-pedit
+  SUBMENU:=$(NETWORK_SUPPORT_MENU)
+  TITLE:=Traffic Packet Editing
+  DEPENDS:=+kmod-sched-core
+  KCONFIG:=CONFIG_NET_ACT_PEDIT
+  FILES:=$(LINUX_DIR)/net/sched/act_pedit.ko
+  AUTOLOAD:=$(call AutoProbe,act_pedit)
+endef
+
+define KernelPackage/sched-act-pedit/description
+ Allows to configure rules to rewrite header fields, such as the DSCP.
+endef
+
+$(eval $(call KernelPackage,sched-act-pedit))
+
+
 define KernelPackage/sched-act-police
   SUBMENU:=$(NETWORK_SUPPORT_MENU)
   TITLE:=Traffic Policing
@@ -858,6 +874,22 @@ define KernelPackage/sched-drr/description
 endef
 
 $(eval $(call KernelPackage,sched-drr))
+
+
+define KernelPackage/sched-ets
+  SUBMENU:=$(NETWORK_SUPPORT_MENU)
+  TITLE:=Enhanced Transmission Selection scheduler
+  DEPENDS:=+kmod-sched-core
+  KCONFIG:=CONFIG_NET_SCH_ETS
+  FILES:=$(LINUX_DIR)/net/sched/sch_ets.ko
+  AUTOLOAD:=$(call AutoProbe,sch_ets)
+endef
+
+define KernelPackage/sched-ets/description
+ Strict priority and weighted round-robin bands, offloadable to a switch.
+endef
+
+$(eval $(call KernelPackage,sched-ets))
 
 
 define KernelPackage/sched-flower
@@ -1007,13 +1039,14 @@ endef
 $(eval $(call KernelPackage,bpf-test))
 
 
-SCHED_MODULES_EXTRA = sch_codel sch_gred sch_multiq sch_sfq sch_teql sch_fq sch_ets act_pedit act_simple act_skbmod act_csum em_cmp em_nbyte em_meta em_text
+SCHED_MODULES_EXTRA = sch_codel sch_gred sch_multiq sch_sfq sch_teql sch_fq act_simple act_skbmod act_csum em_cmp em_nbyte em_meta em_text
 SCHED_FILES_EXTRA = $(foreach mod,$(SCHED_MODULES_EXTRA),$(LINUX_DIR)/net/sched/$(mod).ko)
 
 define KernelPackage/sched
   SUBMENU:=$(NETWORK_SUPPORT_MENU)
   TITLE:=Extra traffic schedulers
-  DEPENDS:=+kmod-sched-core +LINUX_6_12:kmod-lib-crc32c +kmod-lib-textsearch
+  DEPENDS:=+kmod-sched-core +kmod-sched-ets +kmod-sched-act-pedit \
+	+LINUX_6_12:kmod-lib-crc32c +kmod-lib-textsearch
   KCONFIG:= \
 	CONFIG_NET_SCH_CODEL \
 	CONFIG_NET_SCH_GRED \
@@ -1021,8 +1054,6 @@ define KernelPackage/sched
 	CONFIG_NET_SCH_SFQ \
 	CONFIG_NET_SCH_TEQL \
 	CONFIG_NET_SCH_FQ \
-	CONFIG_NET_SCH_ETS \
-	CONFIG_NET_ACT_PEDIT \
 	CONFIG_NET_ACT_SIMP \
 	CONFIG_NET_ACT_SKBMOD \
 	CONFIG_NET_ACT_CSUM \

--- a/target/linux/airoha/patches-6.18/099-08-v6.19-net-airoha-ppe-Flush-PPE-SRAM-table-during-PPE-setup.patch
+++ b/target/linux/airoha/patches-6.18/099-08-v6.19-net-airoha-ppe-Flush-PPE-SRAM-table-during-PPE-setup.patch
@@ -18,7 +18,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -1304,18 +1304,22 @@ static int airoha_ppe_flow_offload_cmd(s
+@@ -1305,18 +1305,22 @@ static int airoha_ppe_flow_offload_cmd(s
  	return -EOPNOTSUPP;
  }
  
@@ -47,7 +47,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  }
  
  static struct airoha_npu *airoha_ppe_npu_get(struct airoha_eth *eth)
-@@ -1380,10 +1384,6 @@ static int airoha_ppe_offload_setup(stru
+@@ -1381,10 +1385,6 @@ static int airoha_ppe_offload_setup(stru
  	}
  
  	airoha_ppe_hw_init(ppe);
@@ -58,7 +58,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  	airoha_ppe_foe_flow_stats_reset(ppe, npu);
  
  	rcu_assign_pointer(eth->npu, npu);
-@@ -1555,6 +1555,10 @@ int airoha_ppe_init(struct airoha_eth *e
+@@ -1556,6 +1556,10 @@ int airoha_ppe_init(struct airoha_eth *e
  	if (!ppe->foe_check_time)
  		return -ENOMEM;
  

--- a/target/linux/airoha/patches-6.18/134-v7.1-net-airoha-Delay-offloading-until-all-net_devices-ar.patch
+++ b/target/linux/airoha/patches-6.18/134-v7.1-net-airoha-Delay-offloading-until-all-net_devices-ar.patch
@@ -47,7 +47,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  enum {
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -1425,6 +1425,13 @@ int airoha_ppe_setup_tc_block_cb(struct
+@@ -1426,6 +1426,13 @@ int airoha_ppe_setup_tc_block_cb(struct
  	struct airoha_eth *eth = ppe->eth;
  	int err = 0;
  

--- a/target/linux/airoha/patches-6.18/161-01-v7.2-net-airoha-Introduce-airoha_gdm_dev-struct.patch
+++ b/target/linux/airoha/patches-6.18/161-01-v7.2-net-airoha-Introduce-airoha_gdm_dev-struct.patch
@@ -810,7 +810,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  			if (dsa_port >= 0 || eth->ports[1])
  				pse_port = port->id == 4 ? FE_PSE_PORT_GDM4
  							 : port->id;
-@@ -1473,7 +1476,7 @@ void airoha_ppe_check_skb(struct airoha_
+@@ -1474,7 +1477,7 @@ void airoha_ppe_check_skb(struct airoha_
  void airoha_ppe_init_upd_mem(struct airoha_gdm_port *port)
  {
  	struct airoha_eth *eth = port->qdma->eth;

--- a/target/linux/airoha/patches-6.18/161-02-v7.2-net-airoha-Move-airoha_qdma-pointer-in-airoha_gdm_de.patch
+++ b/target/linux/airoha/patches-6.18/161-02-v7.2-net-airoha-Move-airoha_qdma-pointer-in-airoha_gdm_de.patch
@@ -437,7 +437,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		}
  	}
  }
-@@ -1473,11 +1473,12 @@ void airoha_ppe_check_skb(struct airoha_
+@@ -1474,11 +1474,12 @@ void airoha_ppe_check_skb(struct airoha_
  	airoha_ppe_foe_insert_entry(ppe, skb, hash, rx_wlan);
  }
  

--- a/target/linux/airoha/patches-6.18/165-01-v7.2-net-airoha-Remove-private-net_device-pointer-in-airo.patch
+++ b/target/linux/airoha/patches-6.18/165-01-v7.2-net-airoha-Remove-private-net_device-pointer-in-airo.patch
@@ -113,7 +113,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  	DECLARE_BITMAP(qos_sq_bmap, AIROHA_NUM_QOS_CHANNELS);
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -1475,8 +1475,8 @@ void airoha_ppe_check_skb(struct airoha_
+@@ -1476,8 +1476,8 @@ void airoha_ppe_check_skb(struct airoha_
  
  void airoha_ppe_init_upd_mem(struct airoha_gdm_dev *dev)
  {

--- a/target/linux/airoha/patches-6.18/165-05-v7.2-net-airoha-Support-multiple-LAN-WAN-interfaces-for-h.patch
+++ b/target/linux/airoha/patches-6.18/165-05-v7.2-net-airoha-Support-multiple-LAN-WAN-interfaces-for-h.patch
@@ -151,7 +151,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  						  u32 hash);
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -1487,12 +1487,10 @@ void airoha_ppe_check_skb(struct airoha_
+@@ -1488,12 +1488,10 @@ void airoha_ppe_check_skb(struct airoha_
  	airoha_ppe_foe_insert_entry(ppe, skb, hash, rx_wlan);
  }
  

--- a/target/linux/airoha/patches-6.18/915-01-net-netfilter-flowtable-Add-the-capability-to-offloa.patch
+++ b/target/linux/airoha/patches-6.18/915-01-net-netfilter-flowtable-Add-the-capability-to-offloa.patch
@@ -58,7 +58,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	ip_decrease_ttl(iph);
  	skb_clear_tstamp(skb);
  
-@@ -655,6 +662,7 @@ static int nf_flow_offload_ipv6_forward(
+@@ -658,6 +665,7 @@ static int nf_flow_offload_ipv6_forward(
  	struct flow_offload *flow;
  	unsigned int thoff, mtu;
  	struct ipv6hdr *ip6h;
@@ -66,7 +66,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  
  	dir = tuplehash->tuple.dir;
  	flow = container_of(tuplehash, struct flow_offload, tuplehash[dir]);
-@@ -683,6 +691,12 @@ static int nf_flow_offload_ipv6_forward(
+@@ -686,6 +694,12 @@ static int nf_flow_offload_ipv6_forward(
  	ip6h = ipv6_hdr(skb);
  	nf_flow_nat_ipv6(flow, skb, dir, ip6h);
  

--- a/target/linux/airoha/patches-6.18/915-02-net-airoha-Set-hw-QoS-parameter-according-to-the-pac.patch
+++ b/target/linux/airoha/patches-6.18/915-02-net-airoha-Set-hw-QoS-parameter-according-to-the-pac.patch
@@ -83,7 +83,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	switch (addr_type) {
  	case 0:
  		offload_type = PPE_PKT_TYPE_BRIDGE;
-@@ -1160,7 +1172,7 @@ static int airoha_ppe_flow_offload_repla
+@@ -1161,7 +1173,7 @@ static int airoha_ppe_flow_offload_repla
  		return -EINVAL;
  
  	err = airoha_ppe_foe_entry_prepare(eth, &hwe, odev, offload_type,

--- a/target/linux/generic/backport-6.18/782-v7.0-net-dsa-eliminate-local-type-for-tc-policers.patch
+++ b/target/linux/generic/backport-6.18/782-v7.0-net-dsa-eliminate-local-type-for-tc-policers.patch
@@ -1,0 +1,172 @@
+From c22ba07c827f2ac84573ac788383a8e1eafe21bc Mon Sep 17 00:00:00 2001
+From: Vladimir Oltean <vladimir.oltean@nxp.com>
+Date: Fri, 6 Feb 2026 15:54:21 +0800
+Subject: [PATCH] net: dsa: eliminate local type for tc policers
+
+David Yang is saying that struct flow_action_entry in
+include/net/flow_offload.h has gained new fields and DSA's struct
+dsa_mall_policer_tc_entry, derived from that, isn't keeping up.
+This structure is passed to drivers and they are completely oblivious to
+the values of fields they don't see.
+
+This has happened before, and almost always the solution was to make the
+DSA layer thinner and use the upstream data structures. Here, the reason
+why we didn't do that is because struct flow_action_entry :: police is
+an anonymous structure.
+
+That is easily enough fixable, just name those fields "struct
+flow_action_police" and reference them from DSA.
+
+Make the according transformations to the two users (sja1105 and felix):
+"rate_bytes_per_sec" -> "rate_bytes_ps".
+
+Signed-off-by: Vladimir Oltean <vladimir.oltean@nxp.com>
+Co-developed-by: David Yang <mmyangfl@gmail.com>
+Signed-off-by: David Yang <mmyangfl@gmail.com>
+Link: https://patch.msgid.link/20260206075427.44733-1-mmyangfl@gmail.com
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ drivers/net/dsa/ocelot/felix.c         |  4 ++--
+ drivers/net/dsa/sja1105/sja1105_main.c |  4 ++--
+ include/net/dsa.h                      | 10 ++-------
+ include/net/flow_offload.h             | 30 ++++++++++++++------------
+ net/dsa/user.c                         |  5 ++---
+ 5 files changed, 24 insertions(+), 29 deletions(-)
+
+--- a/drivers/net/dsa/ocelot/felix.c
++++ b/drivers/net/dsa/ocelot/felix.c
+@@ -1984,11 +1984,11 @@ static int felix_cls_flower_stats(struct
+ }
+ 
+ static int felix_port_policer_add(struct dsa_switch *ds, int port,
+-				  struct dsa_mall_policer_tc_entry *policer)
++				  const struct flow_action_police *policer)
+ {
+ 	struct ocelot *ocelot = ds->priv;
+ 	struct ocelot_policer pol = {
+-		.rate = div_u64(policer->rate_bytes_per_sec, 1000) * 8,
++		.rate = div_u64(policer->rate_bytes_ps, 1000) * 8,
+ 		.burst = policer->burst,
+ 	};
+ 
+--- a/drivers/net/dsa/sja1105/sja1105_main.c
++++ b/drivers/net/dsa/sja1105/sja1105_main.c
+@@ -2903,7 +2903,7 @@ static void sja1105_mirror_del(struct ds
+ }
+ 
+ static int sja1105_port_policer_add(struct dsa_switch *ds, int port,
+-				    struct dsa_mall_policer_tc_entry *policer)
++				    const struct flow_action_police *policer)
+ {
+ 	struct sja1105_l2_policing_entry *policing;
+ 	struct sja1105_private *priv = ds->priv;
+@@ -2914,7 +2914,7 @@ static int sja1105_port_policer_add(stru
+ 	 * the value of RATE bytes divided by 64, up to a maximum of SMAX
+ 	 * bytes.
+ 	 */
+-	policing[port].rate = div_u64(512 * policer->rate_bytes_per_sec,
++	policing[port].rate = div_u64(512 * policer->rate_bytes_ps,
+ 				      1000000);
+ 	policing[port].smax = policer->burst;
+ 
+--- a/include/net/dsa.h
++++ b/include/net/dsa.h
+@@ -214,12 +214,6 @@ struct dsa_mall_mirror_tc_entry {
+ 	bool ingress;
+ };
+ 
+-/* TC port policer entry */
+-struct dsa_mall_policer_tc_entry {
+-	u32 burst;
+-	u64 rate_bytes_per_sec;
+-};
+-
+ /* TC matchall entry */
+ struct dsa_mall_tc_entry {
+ 	struct list_head list;
+@@ -227,7 +221,7 @@ struct dsa_mall_tc_entry {
+ 	enum dsa_port_mall_action_type type;
+ 	union {
+ 		struct dsa_mall_mirror_tc_entry mirror;
+-		struct dsa_mall_policer_tc_entry policer;
++		struct flow_action_police policer;
+ 	};
+ };
+ 
+@@ -1124,7 +1118,7 @@ struct dsa_switch_ops {
+ 	void	(*port_mirror_del)(struct dsa_switch *ds, int port,
+ 				   struct dsa_mall_mirror_tc_entry *mirror);
+ 	int	(*port_policer_add)(struct dsa_switch *ds, int port,
+-				    struct dsa_mall_policer_tc_entry *policer);
++				    const struct flow_action_police *policer);
+ 	void	(*port_policer_del)(struct dsa_switch *ds, int port);
+ 	int	(*port_setup_tc)(struct dsa_switch *ds, int port,
+ 				 enum tc_setup_type type, void *type_data);
+--- a/include/net/flow_offload.h
++++ b/include/net/flow_offload.h
+@@ -231,6 +231,21 @@ struct flow_action_cookie *flow_action_c
+ 						     gfp_t gfp);
+ void flow_action_cookie_destroy(struct flow_action_cookie *cookie);
+ 
++struct flow_action_police {
++	u32 burst;
++	u64 rate_bytes_ps;
++	u64 peakrate_bytes_ps;
++	u32 avrate;
++	u16 overhead;
++	u64 burst_pkt;
++	u64 rate_pkt_ps;
++	u32 mtu;
++	struct {
++		enum flow_action_id act_id;
++		u32 extval;
++	} exceed, notexceed;
++};
++
+ struct flow_action_entry {
+ 	enum flow_action_id		id;
+ 	u32				hw_index;
+@@ -275,20 +290,7 @@ struct flow_action_entry {
+ 			u32			trunc_size;
+ 			bool			truncate;
+ 		} sample;
+-		struct {				/* FLOW_ACTION_POLICE */
+-			u32			burst;
+-			u64			rate_bytes_ps;
+-			u64			peakrate_bytes_ps;
+-			u32			avrate;
+-			u16			overhead;
+-			u64			burst_pkt;
+-			u64			rate_pkt_ps;
+-			u32			mtu;
+-			struct {
+-				enum flow_action_id	act_id;
+-				u32			extval;
+-			} exceed, notexceed;
+-		} police;
++		struct flow_action_police police;	/* FLOW_ACTION_POLICE */
+ 		struct {				/* FLOW_ACTION_CT */
+ 			int action;
+ 			u16 zone;
+--- a/net/dsa/user.c
++++ b/net/dsa/user.c
+@@ -1459,8 +1459,8 @@ dsa_user_add_cls_matchall_police(struct
+ 	struct netlink_ext_ack *extack = cls->common.extack;
+ 	struct dsa_port *dp = dsa_user_to_port(dev);
+ 	struct dsa_user_priv *p = netdev_priv(dev);
+-	struct dsa_mall_policer_tc_entry *policer;
+ 	struct dsa_mall_tc_entry *mall_tc_entry;
++	struct flow_action_police *policer;
+ 	struct dsa_switch *ds = dp->ds;
+ 	struct flow_action_entry *act;
+ 	int err;
+@@ -1497,8 +1497,7 @@ dsa_user_add_cls_matchall_police(struct
+ 	mall_tc_entry->cookie = cls->cookie;
+ 	mall_tc_entry->type = DSA_PORT_MALL_POLICER;
+ 	policer = &mall_tc_entry->policer;
+-	policer->rate_bytes_per_sec = act->police.rate_bytes_ps;
+-	policer->burst = act->police.burst;
++	*policer = act->police;
+ 
+ 	err = ds->ops->port_policer_add(ds, dp->index, policer);
+ 	if (err) {

--- a/target/linux/generic/backport-6.18/783-v7.2-net-dsa-pass-extack-to-dsa_switch_ops-port_policer_.patch
+++ b/target/linux/generic/backport-6.18/783-v7.2-net-dsa-pass-extack-to-dsa_switch_ops-port_policer_.patch
@@ -1,0 +1,69 @@
+From 09e4d1298b367051b60d9b0a13b22e7d78e61803 Mon Sep 17 00:00:00 2001
+From: David Yang <mmyangfl@gmail.com>
+Date: Thu, 30 Apr 2026 19:45:24 +0800
+Subject: [PATCH] net: dsa: pass extack to dsa_switch_ops :: port_policer_add()
+
+Drivers might have error messages to propagate to user space. Propagate
+the netlink extack so that they can inform user space in a verbal way of
+their limitations.
+
+Make the according transformations to the two users (sja1105 and felix).
+
+Signed-off-by: David Yang <mmyangfl@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Link: https://patch.msgid.link/20260430114529.3536911-2-mmyangfl@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/ocelot/felix.c         | 3 ++-
+ drivers/net/dsa/sja1105/sja1105_main.c | 3 ++-
+ include/net/dsa.h                      | 3 ++-
+ net/dsa/user.c                         | 2 +-
+ 4 files changed, 7 insertions(+), 4 deletions(-)
+
+--- a/drivers/net/dsa/ocelot/felix.c
++++ b/drivers/net/dsa/ocelot/felix.c
+@@ -1984,7 +1984,8 @@ static int felix_cls_flower_stats(struct
+ }
+ 
+ static int felix_port_policer_add(struct dsa_switch *ds, int port,
+-				  const struct flow_action_police *policer)
++				  const struct flow_action_police *policer,
++				  struct netlink_ext_ack *extack)
+ {
+ 	struct ocelot *ocelot = ds->priv;
+ 	struct ocelot_policer pol = {
+--- a/drivers/net/dsa/sja1105/sja1105_main.c
++++ b/drivers/net/dsa/sja1105/sja1105_main.c
+@@ -2903,7 +2903,8 @@ static void sja1105_mirror_del(struct ds
+ }
+ 
+ static int sja1105_port_policer_add(struct dsa_switch *ds, int port,
+-				    const struct flow_action_police *policer)
++				    const struct flow_action_police *policer,
++				    struct netlink_ext_ack *extack)
+ {
+ 	struct sja1105_l2_policing_entry *policing;
+ 	struct sja1105_private *priv = ds->priv;
+--- a/include/net/dsa.h
++++ b/include/net/dsa.h
+@@ -1118,7 +1118,8 @@ struct dsa_switch_ops {
+ 	void	(*port_mirror_del)(struct dsa_switch *ds, int port,
+ 				   struct dsa_mall_mirror_tc_entry *mirror);
+ 	int	(*port_policer_add)(struct dsa_switch *ds, int port,
+-				    const struct flow_action_police *policer);
++				    const struct flow_action_police *policer,
++				    struct netlink_ext_ack *extack);
+ 	void	(*port_policer_del)(struct dsa_switch *ds, int port);
+ 	int	(*port_setup_tc)(struct dsa_switch *ds, int port,
+ 				 enum tc_setup_type type, void *type_data);
+--- a/net/dsa/user.c
++++ b/net/dsa/user.c
+@@ -1499,7 +1499,7 @@ dsa_user_add_cls_matchall_police(struct
+ 	policer = &mall_tc_entry->policer;
+ 	*policer = act->police;
+ 
+-	err = ds->ops->port_policer_add(ds, dp->index, policer);
++	err = ds->ops->port_policer_add(ds, dp->index, policer, extack);
+ 	if (err) {
+ 		kfree(mall_tc_entry);
+ 		return err;

--- a/target/linux/generic/hack-6.18/650-netfilter-add-xt_FLOWOFFLOAD-target.patch
+++ b/target/linux/generic/hack-6.18/650-netfilter-add-xt_FLOWOFFLOAD-target.patch
@@ -798,7 +798,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +#endif /* _XT_FLOWOFFLOAD_H */
 --- a/include/net/netfilter/nf_flow_table.h
 +++ b/include/net/netfilter/nf_flow_table.h
-@@ -301,6 +301,11 @@ void nf_flow_table_free(struct nf_flowta
+@@ -302,6 +302,11 @@ void nf_flow_table_free(struct nf_flowta
  
  void flow_offload_teardown(struct flow_offload *flow);
  

--- a/target/linux/generic/pending-6.18/760-02-dsa-add-devlink-flash_update-callback-to-dsa.patch
+++ b/target/linux/generic/pending-6.18/760-02-dsa-add-devlink-flash_update-callback-to-dsa.patch
@@ -25,7 +25,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/include/net/dsa.h
 +++ b/include/net/dsa.h
-@@ -1169,6 +1169,9 @@ struct dsa_switch_ops {
+@@ -1164,6 +1164,9 @@ struct dsa_switch_ops {
  	int	(*devlink_info_get)(struct dsa_switch *ds,
  				    struct devlink_info_req *req,
  				    struct netlink_ext_ack *extack);

--- a/target/linux/generic/pending-6.18/775-net-sched-sch_tbf-carry-the-queue-limit-into-the-offload.patch
+++ b/target/linux/generic/pending-6.18/775-net-sched-sch_tbf-carry-the-queue-limit-into-the-offload.patch
@@ -1,0 +1,36 @@
+From: Julius Bairaktaris <julius@bairaktaris.de>
+Date: Thu, 20 Aug 2026 21:23:00 +0200
+Subject: [PATCH] net/sched: sch_tbf: carry the queue limit into the offload
+
+A driver offloading tbf is told the rate and the burst, but not how deep the
+queue behind them may get - and on hardware whose shaper drains a real queue
+that is the parameter which decides the latency the shaper adds. Without it a
+driver has to invent a depth, or ask the user to attach a child red qdisc purely
+to carry a number tbf already knows.
+
+Pass q->limit, which is what the user wrote as limit or latency, alongside
+the rate and the burst. A driver that ignores the new field behaves as before.
+
+Assisted-by: Claude:claude-opus-5
+Signed-off-by: Julius Bairaktaris <julius@bairaktaris.de>
+---
+--- a/include/net/pkt_cls.h
++++ b/include/net/pkt_cls.h
+@@ -1042,6 +1042,7 @@ enum tc_tbf_command {
+ struct tc_tbf_qopt_offload_replace_params {
+ 	struct psched_ratecfg rate;
+ 	u32 max_size;
++	u32 limit;
+ 	struct gnet_stats_queue *qstats;
+ };
+ 
+--- a/net/sched/sch_tbf.c
++++ b/net/sched/sch_tbf.c
+@@ -153,6 +153,7 @@ static void tbf_offload_change(struct Qd
+ 	qopt.parent = sch->parent;
+ 	qopt.replace_params.rate = q->rate;
+ 	qopt.replace_params.max_size = q->max_size;
++	qopt.replace_params.limit = q->limit;
+ 	qopt.replace_params.qstats = &sch->qstats;
+ 
+ 	dev->netdev_ops->ndo_setup_tc(dev, TC_SETUP_QDISC_TBF, &qopt);

--- a/target/linux/generic/pending-6.18/776-netfilter-flowtable-carry-a-priority-into-the-offload.patch
+++ b/target/linux/generic/pending-6.18/776-netfilter-flowtable-carry-a-priority-into-the-offload.patch
@@ -1,0 +1,124 @@
+From: Julius Bairaktaris <julius@bairaktaris.de>
+Date: Fri, 21 Aug 2026 08:00:00 +0200
+Subject: [PATCH] netfilter: flowtable: carry a priority into the offload
+
+A flow rule handed to a driver describes NAT, encapsulation and the
+output device, but not how the flow should be treated on the way out,
+so hardware with priority queues can only fall back on the DSCP the
+packet carries.
+
+Carry skb->priority of the packet that created the flow. The hardware
+path emits it as FLOW_ACTION_PRIORITY, the action act_skbedit already
+emits on the tc path; the software fast path applies it to the packets
+it forwards, which bypass the rules that classified the flow. "meta
+priority set" before "flow add" then reaches the hardware and the
+software path alike. A flow without a priority emits no action; mtk
+and airoha, the two in-tree consumers of these rules, ignore the new
+one as they do FLOW_ACTION_CSUM.
+
+The flowtable holds one flow for both directions and the expression
+runs once, so the priority applies to both; per-direction
+classification is not carried.
+
+Assisted-by: Claude:claude-opus-5
+Signed-off-by: Julius Bairaktaris <julius@bairaktaris.de>
+---
+--- a/include/net/netfilter/nf_flow_table.h
++++ b/include/net/netfilter/nf_flow_table.h
+@@ -184,6 +184,7 @@ struct flow_offload {
+ 	unsigned long				flags;
+ 	u16					type;
+ 	u32					timeout;
++	u32					priority;
+ 	struct rcu_head				rcu_head;
+ };
+ 
+--- a/net/netfilter/nf_flow_table_offload.c
++++ b/net/netfilter/nf_flow_table_offload.c
+@@ -694,6 +694,17 @@ nf_flow_rule_route_common(struct net *ne
+ 	    flow_offload_eth_dst(net, flow, dir, flow_rule) < 0)
+ 		return -1;
+ 
++	if (flow->priority) {
++		struct flow_action_entry *entry;
++
++		entry = flow_action_entry_next(flow_rule);
++		if (!entry)
++			return -1;
++
++		entry->id = FLOW_ACTION_PRIORITY;
++		entry->priority = flow->priority;
++	}
++
+ 	tuple = &flow->tuplehash[dir].tuple;
+ 
+ 	for (i = 0; i < tuple->encap_num; i++) {
+--- a/net/netfilter/nft_flow_offload.c
++++ b/net/netfilter/nft_flow_offload.c
+@@ -116,6 +116,11 @@ static void nft_flow_offload_eval(const
+ 	if (tcph)
+ 		flow_offload_ct_tcp(ct);
+ 
++	/* The packets the flow forwards in its place bypass the rules that
++	 * classified this one; carry the result with the flow.
++	 */
++	flow->priority = pkt->skb->priority;
++
+ 	__set_bit(NF_FLOW_HW_BIDIRECTIONAL, &flow->flags);
+ 	ret = flow_offload_add(flowtable, flow);
+ 	if (ret < 0)
+--- a/drivers/net/ethernet/mediatek/mtk_ppe_offload.c
++++ b/drivers/net/ethernet/mediatek/mtk_ppe_offload.c
+@@ -369,6 +369,7 @@ mtk_flow_offload_replace(struct mtk_eth
+ 		case FLOW_ACTION_REDIRECT:
+ 			odev = act->dev;
+ 			break;
++		case FLOW_ACTION_PRIORITY:
+ 		case FLOW_ACTION_CSUM:
+ 			break;
+ 		case FLOW_ACTION_VLAN_PUSH:
+--- a/drivers/net/ethernet/airoha/airoha_ppe.c
++++ b/drivers/net/ethernet/airoha/airoha_ppe.c
+@@ -1073,6 +1073,7 @@ static int airoha_ppe_flow_offload_repla
+ 		case FLOW_ACTION_REDIRECT:
+ 			odev = act->dev;
+ 			break;
++		case FLOW_ACTION_PRIORITY:
+ 		case FLOW_ACTION_CSUM:
+ 			break;
+ 		case FLOW_ACTION_VLAN_PUSH:
+--- a/net/netfilter/nf_flow_table_ip.c
++++ b/net/netfilter/nf_flow_table_ip.c
+@@ -408,6 +408,9 @@ static int nf_flow_offload_forward(struc
+ 	ip_decrease_ttl(iph);
+ 	skb_clear_tstamp(skb);
+ 
++	if (flow->priority)
++		skb->priority = flow->priority;
++
+ 	if (flow_table->flags & NF_FLOWTABLE_COUNTER)
+ 		nf_ct_acct_update(flow->ct, tuplehash->tuple.dir, skb->len);
+ 
+@@ -686,6 +689,9 @@ static int nf_flow_offload_ipv6_forward(
+ 	ip6h->hop_limit--;
+ 	skb_clear_tstamp(skb);
+ 
++	if (flow->priority)
++		skb->priority = flow->priority;
++
+ 	if (flow_table->flags & NF_FLOWTABLE_COUNTER)
+ 		nf_ct_acct_update(flow->ct, tuplehash->tuple.dir, skb->len);
+ 
+--- a/Documentation/networking/nf_flowtable.rst
++++ b/Documentation/networking/nf_flowtable.rst
+@@ -71,7 +71,9 @@ forwarding path including the Netfilter
+ 
+ The flowtable entry also stores the NAT configuration, so all packets are
+ mangled according to the NAT policy that is specified from the classic IP
+-forwarding path. The TTL is decremented before calling neigh_xmit(). Fragmented
++forwarding path. The TTL is decremented before calling neigh_xmit(). The flow
++also stores the priority of the packet that created it, so a priority set before
++``flow add`` applies to the packets that the flowtable forwards. Fragmented
+ traffic is passed up to follow the classic IP forwarding path given that the
+ transport header is missing, in this case, flowtable lookups are not possible.
+ TCP RST and FIN packets are also passed up to the classic IP forwarding path to

--- a/target/linux/generic/pending-6.18/777-netfilter-flowtable-advertise-the-vlan-match-in-used_keys.patch
+++ b/target/linux/generic/pending-6.18/777-netfilter-flowtable-advertise-the-vlan-match-in-used_keys.patch
@@ -1,0 +1,51 @@
+From: Julius Bairaktaris <julius@bairaktaris.de>
+Date: Sun, 6 Sep 2026 15:41:31 +0200
+Subject: [PATCH] netfilter: flowtable: advertise the vlan match in used_keys
+
+nf_flow_rule_match() fills the vlan and cvlan keys and sets their
+dissector offsets, but does not set their bits in used_keys. That bit
+is how a driver learns that a rule has the key: flow_rule_match_key()
+reads used_keys, and a key the rule does not declare cannot be read.
+So no driver sees the vlan match, although the rule carries the vlan
+pop action built from the same encapsulation. mtk_ppe_offload.c reads
+the ingress vlan through flow_rule_match_key() and so never gets it,
+and a driver that checks used_keys against the keys it supports
+installs an entry that ignores the tag.
+
+Set the bits where the keys are filled, like the other keys in this
+function.
+
+Fixes: 3e1b0c168f6c ("netfilter: flowtable: add vlan match offload support")
+Assisted-by: Claude:claude-fable-5-1
+Signed-off-by: Julius Bairaktaris <julius@bairaktaris.de>
+---
+ net/netfilter/nf_flow_table_offload.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+--- a/net/netfilter/nf_flow_table_offload.c
++++ b/net/netfilter/nf_flow_table_offload.c
+@@ -124,6 +124,7 @@ static int nf_flow_rule_match(struct nf_
+ 		nf_flow_rule_vlan_match(&key->vlan, &mask->vlan,
+ 					tuple->encap[0].id,
+ 					tuple->encap[0].proto);
++		match->dissector.used_keys |= BIT_ULL(FLOW_DISSECTOR_KEY_VLAN);
+ 		vlan_encap = true;
+ 	}
+ 
+@@ -135,12 +136,16 @@ static int nf_flow_rule_match(struct nf_
+ 			nf_flow_rule_vlan_match(&key->cvlan, &mask->cvlan,
+ 						tuple->encap[1].id,
+ 						tuple->encap[1].proto);
++			match->dissector.used_keys |=
++				BIT_ULL(FLOW_DISSECTOR_KEY_CVLAN);
+ 		} else {
+ 			NF_FLOW_DISSECTOR(match, FLOW_DISSECTOR_KEY_VLAN,
+ 					  vlan);
+ 			nf_flow_rule_vlan_match(&key->vlan, &mask->vlan,
+ 						tuple->encap[1].id,
+ 						tuple->encap[1].proto);
++			match->dissector.used_keys |=
++				BIT_ULL(FLOW_DISSECTOR_KEY_VLAN);
+ 		}
+ 	}
+ 

--- a/target/linux/generic/pending-6.18/779-net-dsa-offer-a-flowtable-to-the-switch-before-the-conduit.patch
+++ b/target/linux/generic/pending-6.18/779-net-dsa-offer-a-flowtable-to-the-switch-before-the-conduit.patch
@@ -1,0 +1,80 @@
+From: Julius Bairaktaris <julius@bairaktaris.de>
+Date: Tue, 1 Sep 2026 10:30:42 +0200
+Subject: [PATCH] net: dsa: offer a flowtable to the switch before the conduit
+
+A flowtable bound to a DSA user port is forwarded to the conduit netdev
+by dsa_user_setup_ft_block(), for a flow engine that sits on the
+conduit as mtk_eth's does. It does not go through
+ds->ops->port_setup_tc, so a switch that owns its flow engine is never
+offered the flowtable.
+
+Offer TC_SETUP_FT to the switch first and forward it to the conduit
+only when the switch answers -EOPNOTSUPP. The side that takes the bind
+is recorded on the port so that the unbind goes to the same side. Every
+in-tree .port_setup_tc returns -EOPNOTSUPP for TC_SETUP_FT, so a
+conduit-side flow engine is reached as before.
+
+Assisted-by: Claude:claude-fable-5-1
+Signed-off-by: Julius Bairaktaris <julius@bairaktaris.de>
+---
+--- a/include/net/dsa.h
++++ b/include/net/dsa.h
+@@ -289,6 +289,12 @@ struct dsa_port {
+ 
+ 	u8			setup:1;
+ 
++	/* Flowtable blocks on this user port go to the switch, not the
++	 * conduit; decided at bind time. Written without rtnl, so not one of
++	 * the bit fields above.
++	 */
++	bool			ft_on_switch;
++
+ 	struct device_node	*dn;
+ 	unsigned int		ageing_time;
+ 
+--- a/net/dsa/user.c
++++ b/net/dsa/user.c
+@@ -1718,15 +1718,30 @@ static int dsa_user_setup_tc_block(struc
+ 	}
+ }
+ 
+-static int dsa_user_setup_ft_block(struct dsa_switch *ds, int port,
+-				   void *type_data)
++static int dsa_user_setup_ft_block(struct dsa_port *dp,
++				   struct flow_block_offload *bo)
+ {
+-	struct net_device *conduit = dsa_port_to_conduit(dsa_to_port(ds, port));
++	struct net_device *conduit = dsa_port_to_conduit(dp);
++	struct dsa_switch *ds = dp->ds;
++	int err;
++
++	/* The unbind goes to the side that took the bind. */
++	if (bo->command == FLOW_BLOCK_BIND) {
++		err = -EOPNOTSUPP;
++		if (ds->ops->port_setup_tc)
++			err = ds->ops->port_setup_tc(ds, dp->index, TC_SETUP_FT,
++						     bo);
++		dp->ft_on_switch = !err;
++		if (err != -EOPNOTSUPP)
++			return err;
++	} else if (dp->ft_on_switch) {
++		return ds->ops->port_setup_tc(ds, dp->index, TC_SETUP_FT, bo);
++	}
+ 
+ 	if (!conduit->netdev_ops->ndo_setup_tc)
+ 		return -EOPNOTSUPP;
+ 
+-	return conduit->netdev_ops->ndo_setup_tc(conduit, TC_SETUP_FT, type_data);
++	return conduit->netdev_ops->ndo_setup_tc(conduit, TC_SETUP_FT, bo);
+ }
+ 
+ static int dsa_user_setup_tc(struct net_device *dev, enum tc_setup_type type,
+@@ -1739,7 +1754,7 @@ static int dsa_user_setup_tc(struct net_
+ 	case TC_SETUP_BLOCK:
+ 		return dsa_user_setup_tc_block(dev, type_data);
+ 	case TC_SETUP_FT:
+-		return dsa_user_setup_ft_block(ds, dp->index, type_data);
++		return dsa_user_setup_ft_block(dp, type_data);
+ 	default:
+ 		break;
+ 	}

--- a/target/linux/generic/pending-6.18/795-01-net-ethernet-mtk_ppe_offload-use-rhashtable_lookup_f.patch
+++ b/target/linux/generic/pending-6.18/795-01-net-ethernet-mtk_ppe_offload-use-rhashtable_lookup_f.patch
@@ -44,7 +44,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		return -EEXIST;
  
  	if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_META)) {
-@@ -522,8 +523,8 @@ mtk_flow_offload_destroy(struct mtk_eth
+@@ -523,8 +524,8 @@ mtk_flow_offload_destroy(struct mtk_eth
  {
  	struct mtk_flow_entry *entry;
  
@@ -55,7 +55,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	if (!entry)
  		return -ENOENT;
  
-@@ -544,8 +545,8 @@ mtk_flow_offload_stats(struct mtk_eth *e
+@@ -545,8 +546,8 @@ mtk_flow_offload_stats(struct mtk_eth *e
  	u64 packets, bytes;
  	int idle;
  

--- a/target/linux/generic/pending-6.18/795-03-net-ethernet-mtk_ppe_offload-set-output-device-befor.patch
+++ b/target/linux/generic/pending-6.18/795-03-net-ethernet-mtk_ppe_offload-set-output-device-befor.patch
@@ -27,7 +27,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/ethernet/mediatek/mtk_ppe_offload.c
 +++ b/drivers/net/ethernet/mediatek/mtk_ppe_offload.c
-@@ -472,6 +472,14 @@ mtk_flow_offload_replace(struct mtk_eth
+@@ -473,6 +473,14 @@ mtk_flow_offload_replace(struct mtk_eth
  			return err;
  	}
  
@@ -42,7 +42,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	if (offload_type == MTK_PPE_PKT_TYPE_BRIDGE)
  		foe.bridge.vlan = data.vlan_in;
  
-@@ -481,14 +489,6 @@ mtk_flow_offload_replace(struct mtk_eth
+@@ -482,14 +490,6 @@ mtk_flow_offload_replace(struct mtk_eth
  	if (data.pppoe.num == 1)
  		mtk_foe_entry_set_pppoe(eth, &foe, data.pppoe.sid);
  

--- a/target/linux/qualcommax/Makefile
+++ b/target/linux/qualcommax/Makefile
@@ -19,6 +19,6 @@ DEFAULT_PACKAGES += \
 	e2fsprogs kmod-fs-ext4 losetup \
 	tc-tiny kmod-sched-flower kmod-sched-prio \
 	kmod-sched-act-police kmod-sched-act-pedit \
-	kmod-sched-mqprio kmod-sched-ets dcb
+	kmod-sched-mqprio kmod-sched-ets kmod-sched-act-vlan dcb
 
 $(eval $(call BuildTarget))

--- a/target/linux/qualcommax/Makefile
+++ b/target/linux/qualcommax/Makefile
@@ -16,6 +16,9 @@ DEFAULT_PACKAGES += \
 	kmod-leds-gpio kmod-gpio-button-hotplug \
 	kmod-ath11k-ahb \
 	wpad-basic-mbedtls uboot-envtools \
-	e2fsprogs kmod-fs-ext4 losetup
+	e2fsprogs kmod-fs-ext4 losetup \
+	tc-tiny kmod-sched-flower kmod-sched-prio \
+	kmod-sched-act-police kmod-sched-act-pedit \
+	kmod-sched-mqprio kmod-sched-ets dcb
 
 $(eval $(call BuildTarget))

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-ess.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-ess.dtsi
@@ -103,7 +103,7 @@
 
 	switch: ppe@3a000000 {
 		compatible = "qualcomm,ipq6018-ppe";
-		reg = <0x0 0x3a000000 0x0 0x900000>;
+		reg = <0x0 0x3a000000 0x0 0xa00000>;
 		clocks = <&gcc GCC_CMN_12GPLL_AHB_CLK>,
 			 <&gcc GCC_CMN_12GPLL_SYS_CLK>,
 			 <&gcc GCC_PORT1_MAC_CLK>,

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-ess.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-ess.dtsi
@@ -113,7 +113,7 @@
 
 	switch: ppe@3a000000 {
 		compatible = "qualcomm,ipq8074-ppe";
-		reg = <0x3a000000 0x900000>;
+		reg = <0x3a000000 0xa00000>;
 		clocks = <&gcc GCC_CMN_12GPLL_AHB_CLK>,
 			 <&gcc GCC_CMN_12GPLL_SYS_CLK>,
 			 <&gcc GCC_PORT1_MAC_CLK>,

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
@@ -311,8 +311,12 @@ static bool edma_rx_page_take(struct edma_priv *priv, struct page *page,
 	return false;
 }
 
+/* @napi_budget is the NAPI budget the poll was given, or zero when the caller
+ * is not a poll: the skb cache napi_consume_skb() recycles into is per-CPU and
+ * is only safe to touch from softirq context.
+ */
 static u32 edma_clean_tx(struct edma_priv *priv, struct edma_ring *txcmpl_ring,
-			 int budget)
+			 int budget, int napi_budget)
 {
 	const struct edma_soc_data *soc = priv->soc;
 	struct platform_device *pdev = priv->pdev;
@@ -357,7 +361,7 @@ static u32 edma_clean_tx(struct edma_priv *priv, struct edma_ring *txcmpl_ring,
 				 le32_to_cpu(txdesc->buffer_addr),
 				 len, DMA_TO_DEVICE);
 		bytes += len - EDMA_TX_PREHDR_SIZE;
-		napi_consume_skb(skb, budget);
+		napi_consume_skb(skb, napi_budget);
 
 next:
 		if (++cons == txcmpl_ring->count)
@@ -478,7 +482,7 @@ next:
 static int edma_tx_napi(struct napi_struct *napi, int budget)
 {
 	struct edma_priv *priv = container_of(napi, struct edma_priv, tx_napi);
-	int work = edma_clean_tx(priv, &priv->txcmpl_ring, budget);
+	int work = edma_clean_tx(priv, &priv->txcmpl_ring, budget, budget);
 	const struct edma_soc_data *soc = priv->soc;
 	u32 val;
 
@@ -757,7 +761,7 @@ err_txcmpl:
 static void edma_rings_drain(struct edma_priv *priv)
 {
 	edma_txdesc_drain(priv, &priv->txdesc_ring);
-	edma_clean_tx(priv, &priv->txcmpl_ring, INT_MAX);
+	edma_clean_tx(priv, &priv->txcmpl_ring, INT_MAX, 0);
 
 	edma_tx_ring_free(priv, &priv->txdesc_ring, sizeof(struct edma_txdesc));
 	edma_ring_free(priv, &priv->txcmpl_ring, sizeof(struct edma_txcmpl));

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
@@ -590,6 +590,16 @@ static netdev_tx_t edma_ring_xmit(struct edma_priv *priv, struct net_device *net
 		return NETDEV_TX_BUSY;
 	}
 
+	/* Both refusals come before the preheader is pushed: the qdisc requeues
+	 * the frame as it was handed over, and a second push would prefix it
+	 * twice and hand the hardware a length that no longer describes it.
+	 */
+	idx = prod & (txdesc_ring->count - 1);
+	if (unlikely(txdesc_ring->skb_store[idx] != NULL)) {
+		spin_unlock_bh(&priv->tx_lock);
+		return NETDEV_TX_BUSY;
+	}
+
 	buf_len = skb_headlen(skb);
 
 	tag_info = skb_ext_find(skb, SKB_EXT_DSA_OOB);
@@ -603,12 +613,6 @@ static netdev_tx_t edma_ring_xmit(struct edma_priv *priv, struct net_device *net
 	memset((void *)txph, 0, EDMA_TX_PREHDR_SIZE);
 
 	txph->dst_info = dst_info;
-
-	idx = prod & (txdesc_ring->count - 1);
-	if (unlikely(txdesc_ring->skb_store[idx] != NULL)) {
-		spin_unlock_bh(&priv->tx_lock);
-		return NETDEV_TX_BUSY;
-	}
 
 	txdesc_ring->skb_store[idx] = skb;
 	txph->opaque = idx;

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
@@ -8,6 +8,7 @@
 #include <linux/ethtool.h>
 #include <linux/if_vlan.h>
 #include <linux/interrupt.h>
+#include <linux/log2.h>
 #include <linux/module.h>
 #include <linux/of.h>
 #include <linux/of_address.h>
@@ -717,22 +718,22 @@ static int edma_rings_alloc(struct edma_priv *priv)
 {
 	int ret;
 
-	ret = edma_tx_ring_alloc(priv, &priv->txdesc_ring, EDMA_TX_RING_SIZE,
+	ret = edma_tx_ring_alloc(priv, &priv->txdesc_ring, priv->tx_ring_size,
 				 sizeof(struct edma_txdesc));
 	if (ret)
 		return ret;
 
-	ret = edma_ring_alloc(priv, &priv->txcmpl_ring, EDMA_TX_RING_SIZE,
+	ret = edma_ring_alloc(priv, &priv->txcmpl_ring, priv->tx_ring_size,
 			      sizeof(struct edma_txcmpl));
 	if (ret)
 		goto err_txcmpl;
 
-	ret = edma_rx_ring_alloc(priv, &priv->rxfill_ring, EDMA_RX_RING_SIZE,
+	ret = edma_rx_ring_alloc(priv, &priv->rxfill_ring, priv->rx_ring_size,
 				 sizeof(struct edma_rxfill_desc));
 	if (ret)
 		goto err_rxfill;
 
-	ret = edma_ring_alloc(priv, &priv->rxdesc_ring, EDMA_RX_RING_SIZE,
+	ret = edma_ring_alloc(priv, &priv->rxdesc_ring, priv->rx_ring_size,
 			      sizeof(struct edma_rxdesc));
 	if (ret)
 		goto err_rxdesc;
@@ -980,16 +981,69 @@ static void edma_get_ringparam(struct net_device *netdev,
 			       struct kernel_ethtool_ringparam *kernel_ring,
 			       struct netlink_ext_ack *extack)
 {
-	ring->tx_max_pending = EDMA_TX_RING_SIZE;
-	ring->rx_max_pending = EDMA_RX_RING_SIZE;
-	ring->tx_pending = EDMA_TX_RING_SIZE;
-	ring->rx_pending = EDMA_RX_RING_SIZE;
+	struct edma_priv *priv = netdev_priv(netdev);
+
+	ring->tx_max_pending = EDMA_MAX_RING_SIZE;
+	ring->rx_max_pending = EDMA_MAX_RING_SIZE;
+	ring->tx_pending = priv->tx_ring_size;
+	ring->rx_pending = priv->rx_ring_size;
+}
+
+static int edma_reconfigure(struct edma_priv *priv, u8 order, u16 tx_size,
+			    u16 rx_size);
+
+/* The core has already held the request to what get_ringparam calls the
+ * maximum; the floor and the power of two are this driver's, and a transmit
+ * ring shorter than the threshold it stops the queue at would never start it
+ * again.
+ */
+static int edma_set_ringparam(struct net_device *netdev,
+			      struct ethtool_ringparam *ring,
+			      struct kernel_ethtool_ringparam *kernel_ring,
+			      struct netlink_ext_ack *extack)
+{
+	struct edma_priv *priv = netdev_priv(netdev);
+
+	if (!is_power_of_2(ring->tx_pending) ||
+	    !is_power_of_2(ring->rx_pending)) {
+		NL_SET_ERR_MSG_MOD(extack, "a ring index wraps by a mask, so a ring is a power of two");
+		return -EINVAL;
+	}
+
+	if (ring->tx_pending < EDMA_MIN_RING_SIZE ||
+	    ring->rx_pending < EDMA_MIN_RING_SIZE) {
+		NL_SET_ERR_MSG_MOD(extack, "ring shorter than this driver's floor");
+		return -EINVAL;
+	}
+
+	if (ring->tx_pending == priv->tx_ring_size &&
+	    ring->rx_pending == priv->rx_ring_size)
+		return 0;
+
+	return edma_reconfigure(priv, priv->rx_page_order, ring->tx_pending,
+				ring->rx_pending);
+}
+
+/* One ring in each direction with an interrupt and a NAPI of its own, and
+ * which ring of the engine each one is comes from the per-SoC data. Nothing
+ * here can be handed out differently, which is why no set_channels sits
+ * beside this.
+ */
+static void edma_get_channels(struct net_device *netdev,
+			      struct ethtool_channels *ch)
+{
+	ch->max_rx = 1;
+	ch->max_tx = 1;
+	ch->rx_count = 1;
+	ch->tx_count = 1;
 }
 
 static const struct ethtool_ops edma_ethtool_ops = {
 	.get_drvinfo = edma_get_drvinfo,
 	.get_link = ethtool_op_get_link,
 	.get_ringparam = edma_get_ringparam,
+	.set_ringparam = edma_set_ringparam,
+	.get_channels = edma_get_channels,
 };
 
 static int edma_ndo_open(struct net_device *netdev)
@@ -1134,11 +1188,11 @@ static u32 edma_rx_buffer_size(u8 order)
 }
 
 static struct page_pool *edma_page_pool_create(struct edma_priv *priv,
-					       u8 order)
+					       u8 order, u16 size)
 {
 	struct page_pool_params pp = {
 		.order     = order,
-		.pool_size = EDMA_RX_RING_SIZE,
+		.pool_size = size,
 		.nid       = NUMA_NO_NODE,
 		.dev       = &priv->pdev->dev,
 		.dma_dir   = DMA_FROM_DEVICE,
@@ -1150,21 +1204,23 @@ static struct page_pool *edma_page_pool_create(struct edma_priv *priv,
 	return page_pool_create(&pp);
 }
 
-static int edma_ndo_change_mtu(struct net_device *netdev, int new_mtu)
+/* The receive buffer size and the ring counts are both fixed at the moment the
+ * rings are allocated, so either one changing means taking them down and
+ * bringing them back - and putting the old ones back if that fails, rather
+ * than leaving the conduit without a datapath.
+ */
+static int edma_reconfigure(struct edma_priv *priv, u8 order, u16 tx_size,
+			    u16 rx_size)
 {
-	struct edma_priv *priv = netdev_priv(netdev);
+	struct net_device *netdev = priv->netdev;
 	struct page_pool *old_pool, *new_pool;
-	u8 old_order, new_order;
+	u16 old_tx = priv->tx_ring_size;
+	u16 old_rx = priv->rx_ring_size;
+	u8 old_order = priv->rx_page_order;
 	bool running;
 	int ret;
 
-	new_order = edma_rx_page_order(new_mtu);
-	if (new_order == priv->rx_page_order) {
-		WRITE_ONCE(netdev->mtu, new_mtu);
-		return 0;
-	}
-
-	new_pool = edma_page_pool_create(priv, new_order);
+	new_pool = edma_page_pool_create(priv, order, rx_size);
 	if (IS_ERR(new_pool))
 		return PTR_ERR(new_pool);
 
@@ -1178,10 +1234,11 @@ static int edma_ndo_change_mtu(struct net_device *netdev, int new_mtu)
 	edma_rings_drain(priv);
 
 	old_pool = priv->page_pool;
-	old_order = priv->rx_page_order;
 	priv->page_pool = new_pool;
-	priv->rx_page_order = new_order;
-	priv->rx_buffer_size = edma_rx_buffer_size(new_order);
+	priv->rx_page_order = order;
+	priv->rx_buffer_size = edma_rx_buffer_size(order);
+	priv->tx_ring_size = tx_size;
+	priv->rx_ring_size = rx_size;
 
 	ret = edma_hw_init(priv);
 	if (ret) {
@@ -1190,12 +1247,14 @@ static int edma_ndo_change_mtu(struct net_device *netdev, int new_mtu)
 		priv->page_pool = old_pool;
 		priv->rx_page_order = old_order;
 		priv->rx_buffer_size = edma_rx_buffer_size(old_order);
+		priv->tx_ring_size = old_tx;
+		priv->rx_ring_size = old_rx;
 		page_pool_destroy(new_pool);
 
 		restore_ret = edma_hw_init(priv);
 		if (restore_ret) {
 			netdev_err(netdev,
-				   "failed to restore receive buffers after MTU change: %d\n",
+				   "failed to restore the receive rings: %d\n",
 				   restore_ret);
 			if (running) {
 				napi_enable(&priv->tx_napi);
@@ -1206,13 +1265,30 @@ static int edma_ndo_change_mtu(struct net_device *netdev, int new_mtu)
 		}
 	} else {
 		page_pool_destroy(old_pool);
-		WRITE_ONCE(netdev->mtu, new_mtu);
 	}
 
 	if (running)
 		edma_ndo_open(netdev);
 
 	return ret;
+}
+
+static int edma_ndo_change_mtu(struct net_device *netdev, int new_mtu)
+{
+	struct edma_priv *priv = netdev_priv(netdev);
+	u8 order = edma_rx_page_order(new_mtu);
+	int ret;
+
+	if (order != priv->rx_page_order) {
+		ret = edma_reconfigure(priv, order, priv->tx_ring_size,
+				       priv->rx_ring_size);
+		if (ret)
+			return ret;
+	}
+
+	WRITE_ONCE(netdev->mtu, new_mtu);
+
+	return 0;
 }
 
 static const struct regmap_config edma_regmap_cfg = {
@@ -1305,9 +1381,12 @@ static int edma_probe(struct platform_device *pdev)
 	if (ret)
 		eth_hw_addr_random(netdev);
 
+	priv->tx_ring_size = EDMA_TX_RING_SIZE;
+	priv->rx_ring_size = EDMA_RX_RING_SIZE;
 	priv->rx_page_order = edma_rx_page_order(netdev->mtu);
 	priv->rx_buffer_size = edma_rx_buffer_size(priv->rx_page_order);
-	priv->page_pool = edma_page_pool_create(priv, priv->rx_page_order);
+	priv->page_pool = edma_page_pool_create(priv, priv->rx_page_order,
+						priv->rx_ring_size);
 	if (IS_ERR(priv->page_pool))
 		return PTR_ERR(priv->page_pool);
 

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
@@ -916,14 +916,20 @@ static void edma_hw_reset(struct edma_priv *priv)
 static int edma_hw_init(struct edma_priv *priv)
 {
 	const struct edma_soc_data *soc = priv->soc;
-	int ret;
+	int i, ret;
 	u32 val;
 
 	edma_hw_reset(priv);
 	edma_hw_stop(priv);
 
-	regmap_write(priv->regmap, EDMA_QID2RID_TABLE_MEM(0),
-		     soc->rxdesc_ring & 0xF);
+	/* Every queue names the one receive ring this driver enables. The
+	 * vendor writes the first queue alone and leaves the rest pointing at
+	 * ring 0 for its firmware to claim; here that ring stays disabled, so
+	 * a queue other than the first would deliver nowhere.
+	 */
+	val = (soc->rxdesc_ring & EDMA_QID2RID_RING_MASK) * 0x11111111u;
+	for (i = 0; i < EDMA_QID2RID_DEPTH; i++)
+		regmap_write(priv->regmap, EDMA_QID2RID_TABLE_MEM(i), val);
 
 	ret = edma_rings_alloc(priv);
 	if (ret)
@@ -938,7 +944,6 @@ static int edma_hw_init(struct edma_priv *priv)
 
 	if (soc->txcmpl_ring != soc->txdesc_ring) {
 		int map_idx, bit_pos;
-		int i;
 
 		for (i = 0; i < 3; i++)
 			regmap_write(priv->regmap, EDMA_REG_TXDESC2CMPL_MAP(i), 0);

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
@@ -18,6 +18,8 @@
 #include <linux/regmap.h>
 #include <linux/reset.h>
 #include <linux/version.h>
+#include <net/netdev_queues.h>
+
 #include "qca_edma.h"
 
 static void edma_irq_disable_all(struct edma_priv *priv)
@@ -311,6 +313,25 @@ static bool edma_rx_page_take(struct edma_priv *priv, struct page *page,
 	return false;
 }
 
+/* Descriptors the transmit ring has left, taken from the hardware rather than
+ * from a cached index: the stop and its recheck have to see what the engine
+ * has consumed by now, not what it had consumed when the frame arrived.
+ */
+static u16 edma_txdesc_free(struct edma_priv *priv)
+{
+	const struct edma_soc_data *soc = priv->soc;
+	u32 prod, cons;
+
+	regmap_read(priv->regmap, EDMA_REG_TXDESC_PROD_IDX(soc->txdesc_ring),
+		    &prod);
+	regmap_read(priv->regmap, EDMA_REG_TXDESC_CONS_IDX(soc->txdesc_ring),
+		    &cons);
+
+	return ((cons & EDMA_TXDESC_CONS_IDX_MASK) -
+		(prod & EDMA_TXDESC_PROD_IDX_MASK) - 1) &
+	       (priv->txdesc_ring.count - 1);
+}
+
 /* @napi_budget is the NAPI budget the poll was given, or zero when the caller
  * is not a poll: the skb cache napi_consume_skb() recycles into is per-CPU and
  * is only safe to touch from softirq context.
@@ -373,8 +394,12 @@ next:
 	if (cleaned == 0)
 		return 0;
 
-	netdev_tx_completed_queue(netdev_get_tx_queue(priv->netdev, 0), cleaned,
-				  bytes);
+	/* A drain runs with the queue deliberately stopped and the rings about
+	 * to be freed, so only a poll may wake it.
+	 */
+	__netif_txq_completed_wake(netdev_get_tx_queue(priv->netdev, 0),
+				   cleaned, bytes, edma_txdesc_free(priv),
+				   EDMA_TX_RING_THRESH, !napi_budget);
 
 	/* Ensure all TX completions are processed before updating cons idx */
 	wmb();
@@ -486,22 +511,6 @@ static int edma_tx_napi(struct napi_struct *napi, int budget)
 	const struct edma_soc_data *soc = priv->soc;
 	u32 val;
 
-	if (priv->netdev && netif_queue_stopped(priv->netdev) &&
-	    netif_carrier_ok(priv->netdev)) {
-		u16 prod, cons, free;
-
-		regmap_read(priv->regmap,
-			    EDMA_REG_TXDESC_PROD_IDX(soc->txdesc_ring), &val);
-		prod = val & EDMA_TXDESC_PROD_IDX_MASK;
-		regmap_read(priv->regmap,
-			    EDMA_REG_TXDESC_CONS_IDX(soc->txdesc_ring), &val);
-		cons = val & EDMA_TXDESC_CONS_IDX_MASK;
-		free = (cons - prod - 1) & (priv->txdesc_ring.count - 1);
-
-		if (free > EDMA_TX_RING_THRESH)
-			netif_wake_queue(priv->netdev);
-	}
-
 	if (work < budget) {
 		regmap_read(priv->regmap,
 			    EDMA_REG_TX_INT_STAT(soc->tx_int_base,
@@ -588,21 +597,17 @@ static netdev_tx_t edma_ring_xmit(struct edma_priv *priv, struct net_device *net
 	cons = val & EDMA_TXDESC_CONS_IDX_MASK;
 
 	next = (prod + 1) & (txdesc_ring->count - 1);
+	idx = prod & (txdesc_ring->count - 1);
 
-	if (next == cons) {
-		spin_unlock_bh(&priv->tx_lock);
-		return NETDEV_TX_BUSY;
-	}
+	if (next == cons)
+		goto busy;
 
 	/* Both refusals come before the preheader is pushed: the qdisc requeues
 	 * the frame as it was handed over, and a second push would prefix it
 	 * twice and hand the hardware a length that no longer describes it.
 	 */
-	idx = prod & (txdesc_ring->count - 1);
-	if (unlikely(txdesc_ring->skb_store[idx] != NULL)) {
-		spin_unlock_bh(&priv->tx_lock);
-		return NETDEV_TX_BUSY;
-	}
+	if (unlikely(txdesc_ring->skb_store[idx] != NULL))
+		goto busy;
 
 	buf_len = skb_headlen(skb);
 
@@ -649,12 +654,34 @@ static netdev_tx_t edma_ring_xmit(struct edma_priv *priv, struct net_device *net
 		     EDMA_REG_TXDESC_PROD_IDX(soc->txdesc_ring),
 		     prod & EDMA_TXDESC_PROD_IDX_MASK);
 
-	if (((cons - prod - 1) & (txdesc_ring->count - 1)) <
-	    EDMA_TX_RING_THRESH)
-		netif_stop_queue(netdev);
+	/* The queue is rechecked against the hardware once it is stopped: a
+	 * completion that drains the ring between the descriptor going out and
+	 * the stop landing would otherwise find the queue still running and
+	 * leave nothing behind to start it again.
+	 */
+	netif_txq_maybe_stop(netdev_get_tx_queue(netdev, 0),
+			     edma_txdesc_free(priv), EDMA_TX_RING_THRESH,
+			     EDMA_TX_RING_THRESH);
 
 	spin_unlock_bh(&priv->tx_lock);
 	return NETDEV_TX_OK;
+
+busy:
+	/* A refusal stops the queue here rather than in the caller, so that the
+	 * recheck happens against the state this refusal was decided on: a
+	 * completion that drains the ring once the lock is dropped would
+	 * otherwise find the queue still running and leave nothing behind to
+	 * start it again. A taken store slot outlives the descriptor that named
+	 * it, because the engine releases the descriptor as soon as it reads it
+	 * and only the completion clears the slot, so a free descriptor count
+	 * would restart the queue on a resource the refused frame still lacks.
+	 */
+	netif_txq_try_stop(netdev_get_tx_queue(netdev, 0),
+			   txdesc_ring->skb_store[idx] ? 0 :
+			   edma_txdesc_free(priv), EDMA_TX_RING_THRESH);
+
+	spin_unlock_bh(&priv->tx_lock);
+	return NETDEV_TX_BUSY;
 }
 
 static void edma_rx_ring_free(struct edma_priv *priv, struct edma_ring *ring,
@@ -1092,7 +1119,6 @@ static netdev_tx_t edma_ndo_xmit(struct sk_buff *skb, struct net_device *netdev)
 {
 	struct edma_priv *priv = netdev_priv(netdev);
 	const struct edma_soc_data *soc = priv->soc;
-	netdev_tx_t ret;
 	u32 nhead, ntail;
 
 	if (skb->len < ETH_HLEN)
@@ -1119,11 +1145,7 @@ static netdev_tx_t edma_ndo_xmit(struct sk_buff *skb, struct net_device *netdev)
 	    pskb_expand_head(skb, nhead, ntail, GFP_ATOMIC))
 		goto drop;
 
-	ret = edma_ring_xmit(priv, netdev, skb, &priv->txdesc_ring);
-	if (ret == NETDEV_TX_BUSY)
-		netif_stop_queue(netdev);
-
-	return ret;
+	return edma_ring_xmit(priv, netdev, skb, &priv->txdesc_ring);
 
 drop:
 	dev_kfree_skb_any(skb);
@@ -1241,8 +1263,13 @@ static int edma_reconfigure(struct edma_priv *priv, u8 order, u16 tx_size,
 
 	running = netif_running(netdev);
 	if (running) {
-		netif_tx_disable(netdev);
+		/* The poll is the other writer of the queue state and it wakes
+		 * a stopped queue whenever it completes a frame, so it is put
+		 * down first: a wake landing after netif_tx_disable() leaves
+		 * the transmit path running into the rings freed below.
+		 */
 		edma_ndo_stop(netdev);
+		netif_tx_disable(netdev);
 	}
 
 	edma_hw_stop(priv);

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
@@ -1093,12 +1093,14 @@ static netdev_tx_t edma_ndo_xmit(struct sk_buff *skb, struct net_device *netdev)
 	if (skb_is_nonlinear(skb) && skb_linearize(skb))
 		goto drop;
 
-	if (soc->tx_min_size && skb->len < soc->tx_min_size) {
-		if (skb_padto(skb, soc->tx_min_size)) {
-			netdev->stats.tx_dropped++;
-			return NETDEV_TX_OK;
-		}
-		skb->len = soc->tx_min_size;
+	/* skb_padto() zero-fills the tailroom but leaves the tail where it
+	 * was, so advancing the length by hand puts skb->len past the data a
+	 * later head reallocation copies: the pad would be reallocated
+	 * uninitialised and transmitted.
+	 */
+	if (soc->tx_min_size && skb_put_padto(skb, soc->tx_min_size)) {
+		netdev->stats.tx_dropped++;
+		return NETDEV_TX_OK;
 	}
 
 	nhead = netdev->needed_headroom;

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
@@ -151,6 +151,12 @@
 #define EDMA_TX_RING_SIZE 128
 #define EDMA_RX_RING_SIZE 2048
 #define EDMA_TX_RING_THRESH 16
+/* A ring index wraps by masking, so a ring is a power of two. The size
+ * registers are sixteen bits wide, but a fill ring pins a page per entry and
+ * the ceiling below is that, not the field.
+ */
+#define EDMA_MIN_RING_SIZE 64
+#define EDMA_MAX_RING_SIZE 8192
 
 /* Descriptor accessors */
 #define EDMA_GET_DESC(R, i, type) (&(((type *)((R)->desc))[i]))
@@ -248,6 +254,8 @@ struct edma_priv {
 	struct page_pool *page_pool;
 	u32 rx_buffer_size;
 	u8 rx_page_order;
+	u16 tx_ring_size;
+	u16 rx_ring_size;
 
 	struct edma_ring txdesc_ring;
 	struct edma_ring txcmpl_ring;

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
@@ -126,8 +126,10 @@
 #define EDMA_RXDESC_INT_MASK_PKT_INT 0x1
 #define EDMA_RX_MOD_TIMER_INIT 1000
 
-/* QID to ring mapping */
-#define EDMA_QID2RID_TABLE_MEM(q) (0x5a000 + (0x4 * (q)))
+/* PPE queue to receive ring mapping: 64 entries of eight four-bit ring ids */
+#define EDMA_QID2RID_TABLE_MEM(n) (0x5a000 + (0x4 * (n)))
+#define EDMA_QID2RID_DEPTH 0x40
+#define EDMA_QID2RID_RING_MASK 0xf
 
 /* TXDESC to TXCMPL ring mapping */
 #define EDMA_REG_TXDESC2CMPL_MAP(n) (0x0c + 0x4 * (n))

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -197,6 +197,8 @@
 #define PPE_XLT_RULE_TBL(idx)		(PPE_IVLAN_BASE + 0x2000 + (idx) * 0x10)
 #define   PPE_XLT_VALID			BIT(0)
 #define   PPE_XLT_PORT_BMP		GENMASK(8, 1)
+#define   PPE_XLT_SKEY_FMT		GENMASK(11, 9)
+#define   PPE_XLT_SKEY_UNTAGGED		1
 #define   PPE_XLT_CKEY_FMT_0		BIT(31)
 
 #define PPE_XLT_RULE_W1(idx)		(PPE_IVLAN_BASE + 0x2000 + (idx) * 0x10 + 0x4)

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -223,6 +223,25 @@
 
 #define PPE_EG_UNTOUCHED		3
 
+/* Flows of one class spread across this many queues of their egress port by
+ * the packet's RSS hash: fixed-bucket fair queueing in silicon. Two bands
+ * per port - bulk at the bottom, the classified priorities above - each
+ * hash-spread, DRR-fair inside, strict priority between them.
+ */
+#define PPE_FLOW_SPREAD_QUEUES		4
+
+/* --- RSS hash (in the IPO block): unprogrammed, the 5-tuple hash is
+ * degenerate and every flow lands in one bucket.
+ */
+#define PPE_RSS_HASH_MASK		(0x0b0000 + 0x4318)
+#define PPE_RSS_HASH_SEED		(0x0b0000 + 0x431c)
+#define PPE_RSS_HASH_MIX(i)		(0x0b0000 + 0x4320 + (i) * 0x4)
+#define PPE_RSS_HASH_FIN(i)		(0x0b0000 + 0x4350 + (i) * 0x4)
+#define PPE_RSS_HASH_MASK_IPV4		(0x0b0000 + 0x4380)
+#define PPE_RSS_HASH_SEED_IPV4		(0x0b0000 + 0x4384)
+#define PPE_RSS_HASH_MIX_IPV4(i)	(0x0b0000 + 0x4390 + (i) * 0x4)
+#define PPE_RSS_HASH_FIN_IPV4(i)	(0x0b0000 + 0x43b0 + (i) * 0x4)
+
 /* --- L2 (base 0x060000) --- */
 #define PPE_L2_BASE			0x060000
 

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -175,14 +175,6 @@
 #define   PPE_TDM_DIR			BIT(4)
 #define   PPE_TDM_VALID			BIT(5)
 
-#define PPE_PRX_MRU_MTU_W1(p)		(PPE_PRX_BASE + 0x3000 + (p) * 0x10 + 0x4)
-#define   PPE_QOS_PCP_GRP		BIT(4)
-#define   PPE_QOS_DSCP_GRP		BIT(5)
-#define   PPE_QOS_PREHEADER_PREC	GENMASK(10, 8)
-#define   PPE_QOS_PCP_PREC		GENMASK(13, 11)
-#define   PPE_QOS_DSCP_PREC		GENMASK(16, 14)
-#define   PPE_QOS_FLOW_PREC		GENMASK(19, 17)
-#define   PPE_QOS_ACL_PREC		GENMASK(22, 20)
 
 /* --- Ingress VLAN (base 0x00f000) --- */
 #define PPE_IVLAN_BASE			0x00f000
@@ -284,6 +276,13 @@
 #define   PPE_APP_CTRL_STP_BYPASS	BIT(12)
 #define   PPE_APP_CTRL_CMD		GENMASK(16, 15)
 #define   PPE_APP_CTRL_REDIRECT_CPU	3
+
+#define PPE_PORT_QOS_CTRL(p)		(PPE_L2_BASE + 0x900 + (p) * 0x10)
+#define   PPE_QOS_DSCP_PREC		GENMASK(5, 3)
+#define   PPE_QOS_PCP_PREC		GENMASK(8, 6)
+#define   PPE_QOS_PREHEADER_PREC	GENMASK(11, 9)
+#define   PPE_QOS_FLOW_PREC		GENMASK(14, 12)
+#define   PPE_QOS_ACL_PREC		GENMASK(17, 15)
 
 #define PPE_VSI_TBL(vsi)		(PPE_L2_BASE + 0x1800 + (vsi) * 0x10)
 #define   PPE_VSI_TBL_MEMBER		GENMASK(7, 0)

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -301,6 +301,18 @@
  */
 #define   PPE_ACL_RULE_WORDS		4
 #define   PPE_ACL_MAC_HI		GENMASK(15, 0)	/* w1: bytes 1-0 */
+#define   PPE_ACL_CVID			GENMASK(11, 0)	/* w0; range min */
+#define   PPE_ACL_CPCP			GENMASK(18, 16)	/* w0 */
+#define   PPE_ACL_CTAG_FMT		GENMASK(6, 4)	/* w1 */
+#define   PPE_ACL_STAG_FMT		GENMASK(9, 7)	/* w1 */
+/* The tag-format fields hold one frame format, not a bitmap of the formats a
+ * key accepts: a key naming both the tagged and the priority-tagged encoding
+ * matches neither.
+ */
+#define     PPE_ACL_TAG_UNTAGGED	1
+#define     PPE_ACL_TAG_TAGGED		4
+#define   PPE_ACL_L2_PROT		GENMASK(31, 16)	/* w0 */
+#define   PPE_ACL_PPPOE_SID		GENMASK(15, 0)	/* w1 */
 #define   PPE_ACL_IP_PORT		GENMASK(15, 0)	/* w0: L4 or ICMP */
 #define   PPE_ACL_IP_LO			GENMASK(31, 16)	/* w0 */
 #define   PPE_ACL_IP_HI			GENMASK(15, 0)	/* w1 */
@@ -314,6 +326,8 @@
 #define   PPE_ACL_RULE_TYPE		GENMASK(26, 23)	/* w1 */
 #define     PPE_ACL_TYPE_MAC_DA		0
 #define     PPE_ACL_TYPE_MAC_SA		1
+#define     PPE_ACL_TYPE_VLAN		2
+#define     PPE_ACL_TYPE_L2MISC		3
 #define     PPE_ACL_TYPE_IPV4_DIP	4
 #define     PPE_ACL_TYPE_IPV4_SIP	5
 #define     PPE_ACL_TYPE_IPV6_DIP0	6	/* +1, +2 for the rest */
@@ -362,6 +376,21 @@
 #define   PPE_ACL_POLICER_INDEX		GENMASK(20, 12)	/* word 3 */
 #define   PPE_ACL_QID_EN		BIT(21)		/* word 3 */
 #define   PPE_ACL_QID			GENMASK(29, 22)	/* word 3 */
+/* The tag edit spans the action words and the C-tag priority straddles a word
+ * boundary, so these are written by bit offset.
+ */
+#define   PPE_ACL_ACT_CVID_EN_OFF	64
+#define   PPE_ACL_ACT_CTAG_FMT_OFF	65
+#define   PPE_ACL_ACT_CVID_OFF		66
+#define   PPE_ACL_ACT_VID_LEN		12
+#define   PPE_ACL_ACT_CPCP_EN_OFF	93
+#define   PPE_ACL_ACT_CPCP_OFF		94
+#define   PPE_ACL_ACT_PCP_LEN		3
+#define   PPE_ACL_ACT_EN_LEN		1
+/* The one-bit tag format beside each change enable: the frame leaves carrying
+ * the tag, or leaves without it.
+ */
+#define     PPE_ACL_ACT_TAG_KEEP	1
 /* The counters live in the ingress policer block, not the IPO: the vendor
  * reaches them at its 0x100000 base plus the table's own 0x74000. Packets in
  * word 0, the low 32 bits of the byte count in word 1, its top 8 in word 2.

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -725,6 +725,7 @@ u64 ppe_mib_read(struct qca_ppe_priv *priv, int port, unsigned int off);
 
 struct tc_tbf_qopt_offload;
 struct tc_ets_qopt_offload;
+struct tc_prio_qopt_offload;
 struct tc_query_caps_base;
 struct tc_mqprio_qopt_offload;
 
@@ -744,6 +745,8 @@ int qca_ppe_setup_tc_tbf(struct qca_ppe_priv *priv, int port,
 			 struct tc_tbf_qopt_offload *qopt);
 int qca_ppe_setup_tc_ets(struct qca_ppe_priv *priv, int port,
 			 struct tc_ets_qopt_offload *qopt);
+int qca_ppe_setup_tc_prio(struct qca_ppe_priv *priv, int port,
+			  struct tc_prio_qopt_offload *qopt);
 int qca_ppe_tc_query_caps(struct tc_query_caps_base *base);
 int qca_ppe_setup_tc_mqprio(struct qca_ppe_priv *priv, int port,
 			    struct tc_mqprio_qopt_offload *qopt);

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -565,6 +565,10 @@
  * scheduler cannot be told to rotate credit for two queues on one node.
  */
 #define PPE_QOS_MAX_PRI			11
+/* The internal priority of a flow the driver has found sparse: the list a
+ * port's scheduler serves ahead of its download band, on the band's node.
+ */
+#define PPE_QOS_SPARSE_PRI		12
 
 #define PPE_VSI_TBL(vsi)		(PPE_L2_BASE + 0x1800 + (vsi) * 0x10)
 #define   PPE_VSI_TBL_MEMBER		GENMASK(7, 0)
@@ -713,6 +717,7 @@
 #define   PPE_FLOW_E_TYPE_LEN		1
 #define   PPE_FLOW_E_HOST_IDX_OFF	3
 #define   PPE_FLOW_E_HOST_IDX_LEN	13
+#define   PPE_FLOW_E_HOST_IDX_MASK	GENMASK(15, 3)
 #define   PPE_FLOW_E_PROTO_OFF		16
 #define   PPE_FLOW_E_PROTO_LEN		2
 #define   PPE_FLOW_E_AGE_OFF		18
@@ -1277,6 +1282,8 @@ struct qca_ppe_priv {
 	u32 flow_reinstalled;
 	u32 flow_destroy_miss;
 	u32 flow_stale;
+	u32 flow_sparse_promoted;
+	u32 flow_sparse_demoted;
 	/* The VSI, translation-index and bridge-VLAN state is reached from the
 	 * switchdev ops under rtnl and from a workqueue, which holds none.
 	 * Taken after flow_lock wherever both are needed.
@@ -1328,6 +1335,7 @@ struct qca_ppe_priv {
 	 */
 	spinlock_t mib_lock;
 	struct delayed_work mib_work;
+	struct delayed_work sparse_work;
 };
 
 extern const struct psch_tdm_data cppe_psch_tdm_data;

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -354,6 +354,12 @@
 /* --- Ingress policer (base 0x100000) --- */
 #define PPE_POLICER_BASE		0x100000
 
+#define PPE_POLICER_CMPST_LEN(p)	(PPE_POLICER_BASE + (p) * 0x4)
+#define   PPE_CMPST_LENGTH		GENMASK(4, 0)
+
+#define PPE_POLICER_DROP_BYPASS		(PPE_POLICER_BASE + 0x20)
+#define   PPE_DROP_BYPASS_EN		BIT(0)
+
 #define PPE_POLICER_TIME_SLOT		(PPE_POLICER_BASE + 0x40)
 #define   PPE_POLICER_SLOT_TIME		GENMASK(9, 0)
 
@@ -489,6 +495,9 @@
 #define PPE_QM_UCAST_PRI_MAP(i)		(PPE_QM_BASE + 0x42000 + (i) * 0x10)
 #define   PPE_QM_PRI_CLASS		GENMASK(3, 0)
 
+#define PPE_QM_MCAST_PRI_MAP(p, i)	(PPE_QM_BASE + 0x100 + (p) * 0x40 + \
+					 (i) * 0x4)
+
 #define PPE_QM_AC_UNI_W0(i)		(PPE_QM_BASE + 0x48000 + (i) * 0x10)
 #define PPE_QM_AC_UNI_W1(i)		(PPE_QM_BASE + 0x48000 + (i) * 0x10 + 0x4)
 #define PPE_QM_AC_UNI_W2(i)		(PPE_QM_BASE + 0x48000 + (i) * 0x10 + 0x8)
@@ -512,9 +521,7 @@
 #define PPE_QM_AC_MUL_W2(i)		(PPE_QM_BASE + 0x4a000 + (i) * 0x10 + 0x8)
 #define   PPE_AC_MUL_EN			BIT(0)
 #define   PPE_AC_MUL_CEILING		GENMASK(26, 16)
-#define   PPE_AC_MUL_GRN_MAX_LO		GENMASK(31, 27)
-#define   PPE_AC_MUL_GRN_MAX_HI		GENMASK(5, 0)
-#define   PPE_AC_MUL_GRN_RESUME_HI	GENMASK(17, 7)
+#define   PPE_AC_MUL_GRN_RESUME_OFF	GENMASK(17, 7)
 
 #define PPE_QM_AC_GRP_W0(g)		(PPE_QM_BASE + 0x4c000 + (g) * 0x10)
 #define PPE_QM_AC_GRP_W1(g)		(PPE_QM_BASE + 0x4c000 + (g) * 0x10 + 0x4)

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -830,6 +830,7 @@
 #define PPE_FDB_OP_ENTRY_IDX		GENMASK(21, 11)
 
 #define PPE_FDB_RSLT_CMD_ID		GENMASK(3, 0)
+#define PPE_FDB_RSLT_VALID_CNT		GENMASK(8, 5)
 
 #define PPE_FDB_DATA1_VALID		BIT(16)
 #define PPE_FDB_DATA1_LKP_VALID		BIT(17)
@@ -971,6 +972,7 @@ struct qca_ppe_priv {
 	struct clk_bulk_data *clks;
 	int num_clks;
 	spinlock_t fdb_lock;
+	u32 fdb_cmd_id;
 	/* Guards the FDB and the tables the operation engine reaches. */
 	struct mutex flow_lock;
 	/* The VSI, translation-index and bridge-VLAN state is reached from the

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -181,6 +181,17 @@
 /* --- IPR: the ingress parser (base 0x002000; 0x1e0000 only on APPE) --- */
 #define PPE_IPR_BASE			0x002000
 
+/* One register for both trunk groups, and in the parser rather than beside the
+ * trunk member tables in L2.
+ */
+#define PPE_TRUNK_HASH_FIELD		(PPE_IPR_BASE + 0x68)
+#define   PPE_TRUNK_HASH_MAC_DA		BIT(1)
+#define   PPE_TRUNK_HASH_MAC_SA		BIT(2)
+#define   PPE_TRUNK_HASH_SIP		BIT(3)
+#define   PPE_TRUNK_HASH_DIP		BIT(4)
+#define   PPE_TRUNK_HASH_L4_SPORT	BIT(5)
+#define   PPE_TRUNK_HASH_L4_DPORT	BIT(6)
+
 #define PPE_IPR_PKT_CNT(port)		(PPE_IPR_BASE + 0x80 + (port) * 0x4)
 #define PPE_IPR_BYTE_LO(port)		(PPE_IPR_BASE + 0xa0 + (port) * 0x4)
 #define PPE_IPR_BYTE_HI(port)		(PPE_IPR_BASE + 0xc0 + (port) * 0x4)
@@ -403,6 +414,19 @@
 #define   PPE_BRIDGE_STA_MOVE_EN	BIT(3)
 #define   PPE_BRIDGE_PORT_ISOL		GENMASK(15, 8)
 #define   PPE_PORT_BRIDGE_CTRL_TXMAC_EN	BIT(16)
+
+/* The bitmap a frame arriving on a member of this group may not leave by. */
+#define PPE_TRUNK_FILTER(g)		(PPE_L2_BASE + 0x50 + (g) * 0x4)
+#define   PPE_TRUNK_FILTER_MEMBERS	GENMASK(7, 0)
+
+/* Eight hash buckets, each holding the id of the port that bucket sends to. */
+#define PPE_TRUNK_MEMBER(g)		(PPE_L2_BASE + 0x60 + (g) * 0x4)
+#define PPE_TRUNK_MEMBER_SLOTS		8
+#define PPE_TRUNK_MEMBER_SLOT_SHIFT	4
+
+#define PPE_PORT_TRUNK_ID(port)		(PPE_L2_BASE + 0x600 + (port) * 0x4)
+#define   PPE_PORT_TRUNK_EN		BIT(0)
+#define   PPE_PORT_TRUNK_GROUP		BIT(1)
 
 #define PPE_MC_MTU_CTRL(port)		(PPE_L2_BASE + 0xa00 + (port) * 0x4)
 #define   PPE_MC_MTU_CTRL_MTU		GENMASK(13, 0)
@@ -776,8 +800,15 @@
 #define PPE_FDB_OP_GET			2
 #define PPE_FDB_DST_PORT		2
 #define PPE_FDB_DST_PORTMAP		3
+/* A trunk is named in the destination field of an ordinary port entry: the two
+ * trunk ids continue the destination numbering above the physical ports, so the
+ * type stays PPE_FDB_DST_PORT. The base is the encoding's, not a port count.
+ */
+#define PPE_FDB_DST_TRUNK(g)		(32 + (g))
 #define PPE_FDB_AGE_STATIC		3
 #define PPE_FDB_OP_FLUSH		4
+
+#define PPE_TRUNK_GROUPS		2
 
 #define PPE_XLT_TBL_NUM			64
 #define PPE_XLT_MISS_FWD_DROP		3
@@ -907,6 +938,13 @@ struct qca_ppe_priv {
 	u32 vsi_member[PPE_VSI_MAX];
 	unsigned long port_brflags[QCA_PPE_MAX_PORTS];
 	u32 port_isolated;
+	/* Member and transmitting-member masks of each trunk group, and the
+	 * hash fields the one global register is programmed with. Written from
+	 * the LAG ops under rtnl and read wherever a VSI is programmed.
+	 */
+	u8 trunk_members[PPE_TRUNK_GROUPS];
+	u8 trunk_tx[PPE_TRUNK_GROUPS];
+	u32 trunk_hash;
 	struct qca_ppe_bridge_vsi bridges[QCA_PPE_MAX_BRIDGES];
 	struct qca_ppe_vlan_entry vlans[PPE_VSI_MAX];
 	struct net_device *port_br_dev[QCA_PPE_MAX_PORTS];

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -733,6 +733,8 @@ int qca_ppe_vlan_setup(struct dsa_switch *ds);
 int qca_ppe_port_vlan_filtering(struct dsa_switch *ds, int port,
 				bool vlan_filtering,
 				struct netlink_ext_ack *extack);
+struct qca_ppe_vlan_entry *
+ppe_vlan_find(struct qca_ppe_priv *priv, struct net_device *br_dev, u16 vid);
 int qca_ppe_port_vlan_add(struct dsa_switch *ds, int port,
 			  const struct switchdev_obj_port_vlan *vlan,
 			  struct netlink_ext_ack *extack);

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -18,6 +18,9 @@
 
 
 /* --- Global --- */
+#define PPE_CLK_GATING_CTRL		0x8
+#define   PPE_QM_CLK_GATE_EN		BIT(4)
+
 #define PPE_PORT_MUX_CTRL		0x10
 
 /* CPPE (IPQ60xx) PORT_MUX_CTRL bit layout */
@@ -589,6 +592,9 @@
 
 #define PPE_TM_RING_Q_MAP(r)		(PPE_TM_BASE + 0x2a000 + (r) * 0x40)
 
+#define PPE_TM_DEQ_DIS(q)		(PPE_TM_BASE + 0x30000 + (q) * 0x10)
+#define   PPE_DEQ_DIS			BIT(0)
+
 #define PPE_TM_L1_FLOW_MAP(i)		(PPE_TM_BASE + 0x40000 + (i) * 0x10)
 #define   PPE_L1_SP_ID			GENMASK(3, 0)
 #define   PPE_L1_C_PRI			GENMASK(6, 4)
@@ -688,6 +694,20 @@
 
 /* --- Queue Manager (base 0x800000) --- */
 #define PPE_QM_BASE			0x800000
+
+/* Draining a queue: the gate that stops it filling, and the flush that hands
+ * its buffers back to the group. FLUSH_BUSY is written to start the flush and
+ * the hardware clears it; FLUSH_STATUS says whether it worked.
+ */
+#define PPE_QM_FLUSH_CFG		(PPE_QM_BASE + 0x0)
+#define   PPE_FLUSH_QID			GENMASK(8, 0)
+#define   PPE_FLUSH_STATUS		BIT(10)
+#define   PPE_FLUSH_DST_PORT		GENMASK(23, 21)
+#define   PPE_FLUSH_ALL_QUEUES		BIT(24)
+#define   PPE_FLUSH_BUSY		BIT(31)
+
+#define PPE_QM_ENQ_OPR(q)		(PPE_QM_BASE + 0x5c000 + (q) * 0x10)
+#define   PPE_ENQ_DISABLE		BIT(0)
 
 #define PPE_QM_UCAST_MAP(i)		(PPE_QM_BASE + 0x10000 + (i) * 0x10)
 #define   PPE_QM_PROFILE_ID		GENMASK(3, 0)
@@ -1016,6 +1036,7 @@ struct flow_cls_offload;
 #define PPE_DEVLINK_SB		0
 
 void ppe_scheduler_init(struct qca_ppe_priv *priv);
+void ppe_port_queues_enable(struct qca_ppe_priv *priv, int port, bool en);
 int qca_ppe_setup_tc(struct dsa_switch *ds, int port, enum tc_setup_type type,
 		     void *type_data);
 int qca_ppe_devlink_sb_setup(struct dsa_switch *ds);

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -305,6 +305,30 @@
 #define   PPE_L3_VP_VSI_VALID		BIT(9)
 #define   PPE_L3_VP_VSI			GENMASK(14, 10)
 
+/* --- Ingress policer (base 0x100000) --- */
+#define PPE_POLICER_BASE		0x100000
+
+#define PPE_POLICER_TIME_SLOT		(PPE_POLICER_BASE + 0x40)
+#define   PPE_POLICER_SLOT_TIME		GENMASK(9, 0)
+
+#define PPE_PORT_METER_W0(p)		(PPE_POLICER_BASE + 0xc000 + (p) * 0x10)
+#define   PPE_METER_EN			BIT(0)
+#define   PPE_METER_FRAME_TYPE		GENMASK(6, 2)
+#define   PPE_METER_MODE		BIT(8)
+#define   PPE_METER_TOKEN_UNIT		GENMASK(11, 9)
+#define   PPE_METER_UNIT		BIT(12)
+#define   PPE_METER_CBS			GENMASK(28, 13)
+#define   PPE_METER_CIR_LO		GENMASK(31, 29)
+#define PPE_PORT_METER_W1(p)		(PPE_POLICER_BASE + 0xc000 + (p) * 0x10 + 0x4)
+#define   PPE_METER_CIR_HI		GENMASK(14, 0)
+#define PPE_PORT_METER_W2(p)		(PPE_POLICER_BASE + 0xc000 + (p) * 0x10 + 0x8)
+#define PPE_PORT_METER_W3(p)		(PPE_POLICER_BASE + 0xc000 + (p) * 0x10 + 0xc)
+
+#define PPE_PORT_TX_DROP_CNT(p)	(PPE_POLICER_BASE + 0x7d000 + (p) * 0x10)
+
+#define PPE_PORT_METER_CNT(p, c)	(PPE_POLICER_BASE + 0xe000 + \
+					 ((p) * 3 + (c)) * 0x10)
+
 /* --- Traffic Manager (base 0x400000) --- */
 #define PPE_TM_BASE			0x400000
 
@@ -346,6 +370,23 @@
 #define   PPE_PSCH_ENS_PORT		GENMASK(7, 4)
 #define   PPE_PSCH_ENS_PORT_BMP		GENMASK(15, 8)
 
+#define PPE_TM_IPG_PRE_LEN		(PPE_TM_BASE + 0x8)
+#define   PPE_IPG_PRE_LEN		GENMASK(4, 0)
+
+#define PPE_TM_SHP_SLOT_PORT		(PPE_TM_BASE + 0x18)
+#define   PPE_PORT_SHP_SLOT_TIME	GENMASK(11, 0)
+
+#define PPE_TM_PSCH_SHP_SIGN(p)	(PPE_TM_BASE + 0x70000 + (p) * 0x10)
+#define PPE_TM_PSCH_SHP_CREDIT(p)	(PPE_TM_BASE + 0x72000 + (p) * 0x10)
+
+#define PPE_TM_PSCH_SHP_CFG_W0(p)	(PPE_TM_BASE + 0x74000 + (p) * 0x10)
+#define   PPE_PSCH_SHP_CIR		GENMASK(17, 0)
+#define   PPE_PSCH_SHP_CBS		GENMASK(31, 18)
+#define PPE_TM_PSCH_SHP_CFG_W1(p)	(PPE_TM_BASE + 0x74000 + (p) * 0x10 + 0x4)
+#define   PPE_PSCH_SHP_TOKEN_UNIT	GENMASK(2, 0)
+#define   PPE_PSCH_SHP_METER_UNIT	BIT(3)
+#define   PPE_PSCH_SHP_EN		BIT(4)
+
 /* --- Buffer Manager (base 0x600000) --- */
 #define PPE_BM_BASE			0x600000
 
@@ -386,6 +427,13 @@
 #define PPE_QM_AC_UNI_W2(i)		(PPE_QM_BASE + 0x48000 + (i) * 0x10 + 0x8)
 #define PPE_QM_AC_UNI_W3(i)		(PPE_QM_BASE + 0x48000 + (i) * 0x10 + 0xc)
 #define   PPE_AC_EN			BIT(0)
+/* The vendor calls this FORCE_AC_EN and the in-kernel ppe driver calls it
+ * FC_EN; measured, it is what makes the limit bind. A queue held to twelve
+ * buffers under a 20 Mbit/s ceiling passes 5 Mbit/s with this set and the
+ * ceiling's full rate with it clear, so clear means the limit is advisory.
+ * The vendor leaves it clear, and so does this driver until a port is shaped.
+ */
+#define   PPE_AC_FORCE_AC_EN		BIT(2)
 #define   PPE_AC_GRP_ID			GENMASK(5, 4)
 #define   PPE_AC_SHARED_DYNAMIC		BIT(17)
 #define   PPE_AC_SHARED_WEIGHT		GENMASK(20, 18)
@@ -431,6 +479,7 @@
 #define PPE_L0_QUEUES			300
 #define PPE_L0_UCAST_QUEUES		256
 
+#define PPE_BM_BUF_SIZE			256
 #define PPE_BM_PORTS			15
 #define PPE_BM_PHY_START		8
 
@@ -517,6 +566,19 @@ struct qca_ppe_vlan_entry {
 /* Defined beside the MIB table that dimensions it. */
 struct qca_ppe_mib_stats;
 
+/* What a port's offloaded tbf was given, so that a stats read can be a delta and
+ * its queues can be resized without the rate being asked for again.
+ */
+struct ppe_port_shaper {
+	u32 tbf_handle;
+	u32 bands_handle;
+	u32 limit;
+	u64 rate_bps;
+	u64 base_bytes;
+	u32 base_pkts;
+	u32 base_drops;
+};
+
 struct qca_ppe_priv {
 	struct dsa_switch ds;
 	struct regmap *regmap;
@@ -524,6 +586,15 @@ struct qca_ppe_priv {
 	struct clk_bulk_data *clks;
 	int num_clks;
 	spinlock_t fdb_lock;
+	/* Guards the FDB and the tables the operation engine reaches. */
+	struct mutex flow_lock;
+	/* The VSI, translation-index and bridge-VLAN state is reached from the
+	 * switchdev ops under rtnl and from a workqueue, which holds none.
+	 * Taken after flow_lock wherever both are needed.
+	 */
+	struct mutex vlan_lock;
+	struct ppe_port_shaper shaper[QCA_PPE_MAX_PORTS];
+	struct dentry *debugfs;
 	DECLARE_BITMAP(vsi_bitmap, PPE_VSI_MAX);
 	DECLARE_BITMAP(xlt_bitmap, PPE_XLT_TBL_NUM);
 	u32 port_vsi[QCA_PPE_MAX_PORTS];
@@ -556,7 +627,19 @@ static inline struct qca_ppe_priv *ds_to_priv(struct dsa_switch *ds)
 	return container_of(ds, struct qca_ppe_priv, ds);
 }
 
+u64 ppe_mib_read(struct qca_ppe_priv *priv, int port, unsigned int off);
+
+struct tc_tbf_qopt_offload;
+
 void ppe_scheduler_init(struct qca_ppe_priv *priv);
+int qca_ppe_setup_tc(struct dsa_switch *ds, int port, enum tc_setup_type type,
+		     void *type_data);
+int qca_ppe_setup_tc_tbf(struct qca_ppe_priv *priv, int port,
+			 struct tc_tbf_qopt_offload *qopt);
+int qca_ppe_port_policer_add(struct dsa_switch *ds, int port,
+			     const struct flow_action_police *policer,
+			     struct netlink_ext_ack *extack);
+void qca_ppe_port_policer_del(struct dsa_switch *ds, int port);
 
 int ppe_vsi_alloc(struct qca_ppe_priv *priv);
 void ppe_vsi_free(struct qca_ppe_priv *priv, u32 vsi);
@@ -571,5 +654,7 @@ int qca_ppe_port_vlan_add(struct dsa_switch *ds, int port,
 			  struct netlink_ext_ack *extack);
 int qca_ppe_port_vlan_del(struct dsa_switch *ds, int port,
 			  const struct switchdev_obj_port_vlan *vlan);
+
+unsigned long ppe_clk_rate(struct qca_ppe_priv *priv);
 
 #endif

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -399,7 +399,7 @@
 #define   PPE_AC_MUL_CEILING		GENMASK(26, 16)
 #define   PPE_AC_MUL_GRN_MAX_LO		GENMASK(31, 27)
 #define   PPE_AC_MUL_GRN_MAX_HI		GENMASK(5, 0)
-#define   PPE_AC_MUL_GRN_RESUME_HI	GENMASK(17, 11)
+#define   PPE_AC_MUL_GRN_RESUME_HI	GENMASK(17, 7)
 
 #define PPE_QM_AC_GRP_W0(g)		(PPE_QM_BASE + 0x4c000 + (g) * 0x10)
 #define PPE_QM_AC_GRP_W1(g)		(PPE_QM_BASE + 0x4c000 + (g) * 0x10 + 0x4)

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -18,6 +18,10 @@
 
 
 /* --- Global --- */
+#define PPE_SWITCH_ID			0x0
+#define   PPE_SWITCH_ID_REV		GENMASK(7, 0)
+#define   PPE_SWITCH_ID_DEV		GENMASK(15, 8)
+
 #define PPE_CLK_GATING_CTRL		0x8
 #define   PPE_QM_CLK_GATE_EN		BIT(4)
 
@@ -567,6 +571,11 @@
 #define   PPE_METER_CIR_HI		GENMASK(14, 0)
 #define PPE_PORT_METER_W2(p)		(PPE_POLICER_BASE + 0xc000 + (p) * 0x10 + 0x8)
 #define PPE_PORT_METER_W3(p)		(PPE_POLICER_BASE + 0xc000 + (p) * 0x10 + 0xc)
+
+/* The meter's token buckets, committed and excess, one entry per port and two
+ * words wide, the second of which commits it.
+ */
+#define PPE_PORT_METER_CRDT(p)		(PPE_POLICER_BASE + 0xd000 + (p) * 0x10)
 
 #define PPE_PORT_TX_DROP_CNT(p)	(PPE_POLICER_BASE + 0x7d000 + (p) * 0x10)
 #define PPE_VP_TX_DROP_CNT(v)		(PPE_POLICER_BASE + 0x7e000 + (v) * 0x10)

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -734,6 +734,11 @@
 #define   PPE_FLOW_E_SPORT_LEN		16
 #define   PPE_FLOW_E_DPORT_OFF		124
 #define   PPE_FLOW_E_DPORT_LEN		16
+/* A protocol the two-bit field cannot name keys on the IP protocol instead,
+ * in the bits the source port holds for one that can.
+ */
+#define   PPE_FLOW_E_IP_PROTO_OFF	108
+#define   PPE_FLOW_E_IP_PROTO_LEN	8
 #define   PPE_FLOW_E_IPV6_OFF		140
 #define   PPE_FLOW_E_PRI_PROFILE_OFF	63
 #define   PPE_FLOW_E_PRI_PROFILE_LEN	5

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -433,6 +433,7 @@
 
 #define PPE_MC_MTU_CTRL(port)		(PPE_L2_BASE + 0xa00 + (port) * 0x4)
 #define   PPE_MC_MTU_CTRL_MTU		GENMASK(13, 0)
+#define   PPE_MC_MTU_CTRL_MTU_CMD	GENMASK(15, 14)
 #define   PPE_MC_MTU_CTRL_TX_CNT_EN	BIT(16)
 
 #define PPE_RFDB_TBL(idx)		(PPE_L2_BASE + 0x1000 + (idx) * 0x8)
@@ -481,7 +482,10 @@
 
 #define PPE_MRU_MTU_CTRL(port, stride)	(PPE_L2_BASE + 0x3000 + (port) * (stride))
 #define   PPE_MRU_MTU_CTRL_MRU		GENMASK(13, 0)
+#define   PPE_MRU_MTU_CTRL_MRU_CMD	GENMASK(15, 14)
 #define   PPE_MRU_MTU_CTRL_MTU		GENMASK(29, 16)
+#define   PPE_MRU_MTU_CTRL_MTU_CMD	GENMASK(31, 30)
+#define     PPE_MTU_CMD_RDT_TO_CPU	3
 #define   PPE_MRU_MTU_CTRL_RX_CNT_EN	BIT(0)
 #define   PPE_MRU_MTU_CTRL_TX_CNT_EN	BIT(1)
 

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -170,11 +170,20 @@
 #define   PPE_TDM_DEPTH			GENMASK(7, 0)
 #define   PPE_TDM_EN			BIT(31)
 
+#define PPE_PRX_DROP_CNT(port)		(PPE_PRX_BASE + 0x24 + (port) * 0x4)
+
 #define PPE_PRX_TDM_CFG(i)		(PPE_PRX_BASE + 0x1000 + (i) * 0x10)
 #define   PPE_TDM_PORT_NUM		GENMASK(3, 0)
 #define   PPE_TDM_DIR			BIT(4)
 #define   PPE_TDM_VALID			BIT(5)
 
+
+/* --- IPR: the ingress parser (base 0x002000; 0x1e0000 only on APPE) --- */
+#define PPE_IPR_BASE			0x002000
+
+#define PPE_IPR_PKT_CNT(port)		(PPE_IPR_BASE + 0x80 + (port) * 0x4)
+#define PPE_IPR_BYTE_LO(port)		(PPE_IPR_BASE + 0xa0 + (port) * 0x4)
+#define PPE_IPR_BYTE_HI(port)		(PPE_IPR_BASE + 0xc0 + (port) * 0x4)
 
 /* --- Ingress VLAN (base 0x00f000) --- */
 #define PPE_IVLAN_BASE			0x00f000
@@ -211,6 +220,17 @@
 #define PPE_EG_VSI_TAG(vsi)		(PPE_PTX_BASE + (vsi) * 0x4)
 #define   PPE_EG_VSI_TAG_UNMODIFIED	0xaaaa
 
+/* What left the egress editor, per VSI, per physical port and per virtual
+ * port, and what the whole stage took in and put out.
+ */
+#define PPE_EG_VSI_CNT_TBL(v)		(PPE_PTX_BASE + 0x600 + (v) * 0x10)
+#define PPE_PORT_TX_CNT_TBL(p)		(PPE_PTX_BASE + 0x900 + (p) * 0x10)
+#define PPE_VP_TX_CNT_TBL(v)		(PPE_PTX_BASE + 0x1000 + (v) * 0x10)
+#define PPE_EPE_DBG_IN_CNT		(PPE_PTX_BASE + 0x6054)
+#define PPE_EPE_DBG_OUT_CNT		(PPE_PTX_BASE + 0x6070)
+
+#define PPE_QUEUE_TX_CNT_TBL(q)		(PPE_PTX_BASE + 0x4000 + (q) * 0x10)
+
 #define PPE_EG_BRIDGE_CONFIG		(PPE_PTX_BASE + 0x6000)
 #define   PPE_EG_L2_EDIT_EN		BIT(1)
 #define   PPE_EG_QUEUE_CNT_EN		BIT(2)
@@ -241,6 +261,44 @@
 #define PPE_RSS_HASH_SEED_IPV4		(0x0b0000 + 0x4384)
 #define PPE_RSS_HASH_MIX_IPV4(i)	(0x0b0000 + 0x4390 + (i) * 0x4)
 #define PPE_RSS_HASH_FIN_IPV4(i)	(0x0b0000 + 0x43b0 + (i) * 0x4)
+
+/* --- ACL (rules in the IPO block, actions beside the L2 tables) ---
+ * A rule, its mask and its action share one flat index. A rule whose RANGE_EN
+ * is set must sit at an even index. There is no valid bit and no global
+ * enable: a rule with an empty source bitmap matches nothing, one with ports
+ * in it is live.
+ */
+#define PPE_ACL_RULE(i)			(0x0b0000 + (i) * 0x10)
+/* 3 implemented words in a 4-word slot; whole slots are written so the
+ * latch on the slot's last word always fires (same for the mask below).
+ */
+#define   PPE_ACL_RULE_WORDS		4
+#define   PPE_ACL_L3_LEN		GENMASK(15, 0)	/* word 0; range min */
+#define   PPE_ACL_IS_IPV6		BIT(17)		/* word 1 */
+#define   PPE_ACL_RANGE_EN		BIT(21)		/* word 1 */
+#define   PPE_ACL_RULE_TYPE		GENMASK(26, 23)	/* word 1 */
+#define     PPE_ACL_TYPE_IPMISC		12
+#define   PPE_ACL_SRC_LO		GENMASK(31, 29)	/* word 1: ports 0-2 */
+#define   PPE_ACL_SRC_HI		GENMASK(4, 0)	/* word 2: ports 3-7 */
+#define PPE_ACL_MASK(i)			(0x0b2000 + (i) * 0x10)
+#define   PPE_ACL_MASK_WORDS		4	/* 2 implemented; same field layout
+						 * as the rule, and under RANGE_EN
+						 * the length field carries the
+						 * range max
+						 */
+#define PPE_ACL_ACTION(i)		(0x068000 + (i) * 0x20)
+/* 5 implemented words in an 8-word slot; the entry latches on the write to
+ * the slot's last word, so all 8 are written.
+ */
+#define   PPE_ACL_ACTION_WORDS		8
+#define   PPE_ACL_PRI_CHANGE_EN		BIT(3)		/* word 3 */
+#define   PPE_ACL_PRI			GENMASK(7, 4)	/* word 3 */
+#define PPE_ACL_CNT(i)			(0x174000 + (i) * 0x10)
+#define   PPE_ACL_CNT_ENTRIES		512
+/* Read-only, and counting whether or not any rule is installed. */
+#define PPE_ACL_GLB_HIT_CNT		(0x0b0000 + 0x430c)
+#define PPE_ACL_GLB_MISS_CNT		(0x0b0000 + 0x4310)
+#define PPE_ACL_GLB_BYPASS_CNT		(0x0b0000 + 0x4314)
 
 /* --- L2 (base 0x060000) --- */
 #define PPE_L2_BASE			0x060000
@@ -354,11 +412,35 @@
 /* --- Ingress policer (base 0x100000) --- */
 #define PPE_POLICER_BASE		0x100000
 
+/* The counter tables that carry a drop pair are five words: packets and bytes,
+ * then the same pair again for what was dropped.
+ */
+#define PPE_CNT_DROP_WORDS		5
+#define PPE_CNT_DROP_OFF		72
+
+#define PPE_RT_IF_CNT_TBL(i)		(PPE_POLICER_BASE + 0x40000 + (i) * 0x20)
+#define   PPE_RT_IF_CNT_ENTRIES		512
+
 #define PPE_POLICER_CMPST_LEN(p)	(PPE_POLICER_BASE + (p) * 0x4)
 #define   PPE_CMPST_LENGTH		GENMASK(4, 0)
 
 #define PPE_POLICER_DROP_BYPASS		(PPE_POLICER_BASE + 0x20)
 #define   PPE_DROP_BYPASS_EN		BIT(0)
+
+/* One table counts both why a frame was sent to the CPU and why one was
+ * dropped: the first 256 entries are CPU codes, the rest are a drop code per
+ * port, eight ports to a code.
+ */
+#define PPE_DROP_CPU_CNT_TBL(i)		(PPE_POLICER_BASE + 0x60000 + (i) * 0x10)
+#define   PPE_CPU_CODE_ENTRIES		256
+#define   PPE_DROP_CODE_PORTS		8
+#define   PPE_DROP_CPU_ENTRIES		1280
+
+/* One entry per VSI: what the L2 stage saw and what it discarded, and the
+ * VLAN-tagged frames classified into it.
+ */
+#define PPE_VLAN_CNT_TBL(v)		(PPE_POLICER_BASE + 0x78000 + (v) * 0x10)
+#define PPE_PRE_L2_CNT_TBL(v)		(PPE_POLICER_BASE + 0x7c000 + (v) * 0x20)
 
 #define PPE_POLICER_TIME_SLOT		(PPE_POLICER_BASE + 0x40)
 #define   PPE_POLICER_SLOT_TIME		GENMASK(9, 0)
@@ -377,6 +459,7 @@
 #define PPE_PORT_METER_W3(p)		(PPE_POLICER_BASE + 0xc000 + (p) * 0x10 + 0xc)
 
 #define PPE_PORT_TX_DROP_CNT(p)	(PPE_POLICER_BASE + 0x7d000 + (p) * 0x10)
+#define PPE_VP_TX_DROP_CNT(v)		(PPE_POLICER_BASE + 0x7e000 + (v) * 0x10)
 
 #define PPE_PORT_METER_CNT(p, c)	(PPE_POLICER_BASE + 0xe000 + \
 					 ((p) * 3 + (c)) * 0x10)
@@ -471,6 +554,24 @@
 #define PPE_BM_SHARED_GRP(g)		(PPE_BM_BASE + 0x290 + (g) * 0x4)
 #define   PPE_BM_SHARED_LIMIT		GENMASK(10, 0)
 
+/* Live occupancy, in buffers: what a BM port is holding, and what it was
+ * holding after it asked the link to pause.
+ */
+#define PPE_BM_PORT_CNT(i)		(PPE_BM_BASE + 0x1c0 + (i) * 0x4)
+#define   PPE_BM_PORT_CNT_VAL		GENMASK(10, 0)
+#define PPE_BM_PORT_REACT_CNT(i)	(PPE_BM_BASE + 0x240 + (i) * 0x4)
+#define   PPE_BM_PORT_REACT_CNT_VAL	GENMASK(8, 0)
+#define PPE_BM_SHARED_GRP_CNT(g)	(PPE_BM_BASE + 0x280 + (g) * 0x4)
+#define   PPE_BM_SHARED_GRP_CNT_VAL	GENMASK(10, 0)
+/* The buffer manager has four shared groups. */
+#define   PPE_BM_SHARED_GROUPS		4
+
+/* Ingress drops live in the PRX block, not the BM's own: one entry per BM port
+ * for a buffer overload and a second, PPE_BM_PORTS higher, for a drop the flow
+ * control caused.
+ */
+#define PPE_BM_DROP_STAT(i)		(PPE_PRX_BASE + 0x3000 + (i) * 0x10)
+
 #define PPE_BM_PORT_FC_W0(i)		(PPE_BM_BASE + 0x1000 + (i) * 0x10)
 #define PPE_BM_PORT_FC_W1(i)		(PPE_BM_BASE + 0x1000 + (i) * 0x10 + 0x4)
 #define   PPE_BM_REACT_LIMIT		GENMASK(8, 0)
@@ -522,6 +623,32 @@
 #define   PPE_AC_MUL_EN			BIT(0)
 #define   PPE_AC_MUL_CEILING		GENMASK(26, 16)
 #define   PPE_AC_MUL_GRN_RESUME_OFF	GENMASK(17, 7)
+
+/* Live occupancy, in buffers: what a queue is holding right now rather than
+ * what has passed through it.
+ */
+#define PPE_QM_AC_UNI_CNT(q)		(PPE_QM_BASE + 0x4e000 + (q) * 0x10)
+#define   PPE_AC_UNI_PEND_CNT		GENMASK(11, 0)
+#define PPE_QM_AC_MUL_CNT(q)		(PPE_QM_BASE + 0x52000 + (q) * 0x10)
+#define   PPE_AC_MUL_PEND_CNT		GENMASK(12, 0)
+#define PPE_QM_AC_GRP_CNT(g)		(PPE_QM_BASE + 0x54000 + (g) * 0x10)
+#define   PPE_AC_GRP_PEND_CNT		GENMASK(15, 0)
+#define   PPE_AC_GRP_ALLOC_USED		GENMASK(31, 16)
+
+/* Per-queue drops, one entry per drop reason and colour. A unicast queue has
+ * WRED and forced drops for each of the three colours; a multicast queue only
+ * the forced ones, and its table is one block per port.
+ */
+#define PPE_QM_UNI_DROP_CNT(q, t)	(PPE_QM_BASE + 0x1e0000 + \
+					 ((q) * PPE_UNI_DROP_TYPES + (t)) * 0x10)
+#define   PPE_UNI_DROP_TYPES		6
+#define PPE_QM_MUL_DROP_CNT(p, q, t)	(PPE_QM_BASE + 0x1f0000 + \
+					 (p) * 0x1000 + \
+					 ((q) * PPE_MUL_DROP_TYPES + (t)) * 0x10)
+#define   PPE_MUL_DROP_TYPES		3
+/* The CPU port has sixteen multicast queues, every other port four. */
+#define   PPE_MUL_QUEUES_CPU		16
+#define   PPE_MUL_QUEUES_PORT		4
 
 #define PPE_QM_AC_GRP_W0(g)		(PPE_QM_BASE + 0x4c000 + (g) * 0x10)
 #define PPE_QM_AC_GRP_W1(g)		(PPE_QM_BASE + 0x4c000 + (g) * 0x10 + 0x4)
@@ -716,6 +843,35 @@ extern const struct psch_tdm_data hppe_psch_tdm_data;
 extern const struct bm_tdm_data cppe_bm_tdm_data;
 extern const struct bm_tdm_data hppe_bm_tdm_data;
 
+/* Set or read a field of a multi-word hardware table entry. Such a field
+ * straddles 32-bit boundaries, so neither can be expressed with FIELD_PREP.
+ */
+static inline void ppe_entry_set(u32 *words, u32 offset, u32 len, u64 val)
+{
+	u32 word = offset / 32;
+	u32 bit = offset % 32;
+
+	val &= (len >= 64) ? U64_MAX : (1ULL << len) - 1;
+
+	words[word] |= (u32)(val << bit);
+	if (bit + len > 32)
+		words[word + 1] |= (u32)(val >> (32 - bit));
+	if (bit + len > 64)
+		words[word + 2] |= (u32)(val >> (64 - bit));
+}
+
+static inline u64 ppe_entry_get(const u32 *words, u32 offset, u32 len)
+{
+	u32 word = offset / 32;
+	u32 bit = offset % 32;
+	u64 val = words[word] >> bit;
+
+	if (bit + len > 32)
+		val |= (u64)words[word + 1] << (32 - bit);
+
+	return len >= 64 ? val : val & ((1ULL << len) - 1);
+}
+
 static inline struct qca_ppe_priv *ds_to_priv(struct dsa_switch *ds)
 {
 	return container_of(ds, struct qca_ppe_priv, ds);
@@ -777,5 +933,7 @@ int qca_ppe_port_vlan_del(struct dsa_switch *ds, int port,
 			  const struct switchdev_obj_port_vlan *vlan);
 
 unsigned long ppe_clk_rate(struct qca_ppe_priv *priv);
+void ppe_debugfs_init(struct qca_ppe_priv *priv);
+void ppe_debugfs_exit(struct qca_ppe_priv *priv);
 
 #endif

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -1049,6 +1049,9 @@ struct flow_cls_offload;
 #define PPE_DEVLINK_SB		0
 
 void ppe_scheduler_init(struct qca_ppe_priv *priv);
+void ppe_scheduler_ready(struct qca_ppe_priv *priv);
+void ppe_scheduler_unready(void);
+void ppe_scheduler_exit(struct qca_ppe_priv *priv);
 void ppe_port_queues_enable(struct qca_ppe_priv *priv, int port, bool en);
 int qca_ppe_setup_tc(struct dsa_switch *ds, int port, enum tc_setup_type type,
 		     void *type_data);

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -732,6 +732,7 @@
 #define PPE_QM_AC_GRP_W0(g)		(PPE_QM_BASE + 0x4c000 + (g) * 0x10)
 #define PPE_QM_AC_GRP_W1(g)		(PPE_QM_BASE + 0x4c000 + (g) * 0x10 + 0x4)
 #define PPE_QM_AC_GRP_W2(g)		(PPE_QM_BASE + 0x4c000 + (g) * 0x10 + 0x8)
+#define   PPE_AC_GRP_WORDS		3
 #define   PPE_AC_GRP_LIMIT		GENMASK(14, 4)
 #define   PPE_AC_GRP_PALLOC		GENMASK(26, 16)
 
@@ -973,9 +974,20 @@ struct tc_query_caps_base;
 struct tc_mqprio_qopt_offload;
 struct flow_cls_offload;
 
+/* The PPE has one buffer memory, so one devlink shared buffer describes it. */
+#define PPE_DEVLINK_SB		0
+
 void ppe_scheduler_init(struct qca_ppe_priv *priv);
 int qca_ppe_setup_tc(struct dsa_switch *ds, int port, enum tc_setup_type type,
 		     void *type_data);
+int qca_ppe_devlink_sb_setup(struct dsa_switch *ds);
+int qca_ppe_devlink_sb_pool_get(struct dsa_switch *ds, unsigned int sb_index,
+				u16 pool_index,
+				struct devlink_sb_pool_info *pool_info);
+int qca_ppe_devlink_sb_pool_set(struct dsa_switch *ds, unsigned int sb_index,
+				u16 pool_index, u32 size,
+				enum devlink_sb_threshold_type threshold_type,
+				struct netlink_ext_ack *extack);
 int qca_ppe_port_get_dscp_prio(struct dsa_switch *ds, int port, u8 dscp);
 int qca_ppe_port_add_dscp_prio(struct dsa_switch *ds, int port, u8 dscp,
 			       u8 prio);

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -257,6 +257,14 @@
 #define PPE_FDB_RD_OP_DATA1		(PPE_L2_BASE + 0x264)
 #define PPE_FDB_RD_OP_DATA2		(PPE_L2_BASE + 0x268)
 
+#define PPE_MIRROR_ANALYZER		(PPE_L2_BASE + 0x40)
+#define   PPE_MIRROR_IN_ANALYZER	GENMASK(5, 0)
+#define   PPE_MIRROR_EG_ANALYZER	GENMASK(13, 8)
+
+#define PPE_PORT_MIRROR(port)		(PPE_L2_BASE + 0x800 + (port) * 0x4)
+#define   PPE_PORT_MIRROR_IN_EN		BIT(0)
+#define   PPE_PORT_MIRROR_EG_EN		BIT(1)
+
 #define PPE_PORT_BRIDGE_CTRL(port)	(PPE_L2_BASE + 0x300 + (port) * 0x4)
 #define   PPE_BRIDGE_NEW_LRN_EN		BIT(0)
 #define   PPE_BRIDGE_STA_MOVE_EN	BIT(3)
@@ -610,6 +618,9 @@ struct qca_ppe_priv {
 	 * Taken after flow_lock wherever both are needed.
 	 */
 	struct mutex vlan_lock;
+	s8 mirror_port;
+	u16 mirror_ref;
+	u8 mirror_dir_ref[QCA_PPE_MAX_PORTS][2];
 	struct ppe_port_shaper shaper[QCA_PPE_MAX_PORTS];
 	struct dentry *debugfs;
 	DECLARE_BITMAP(vsi_bitmap, PPE_VSI_MAX);
@@ -665,6 +676,11 @@ int qca_ppe_setup_tc_tbf(struct qca_ppe_priv *priv, int port,
 			 struct tc_tbf_qopt_offload *qopt);
 int qca_ppe_setup_tc_ets(struct qca_ppe_priv *priv, int port,
 			 struct tc_ets_qopt_offload *qopt);
+int qca_ppe_port_mirror_add(struct dsa_switch *ds, int port,
+			    struct dsa_mall_mirror_tc_entry *mirror,
+			    bool ingress, struct netlink_ext_ack *extack);
+void qca_ppe_port_mirror_del(struct dsa_switch *ds, int port,
+			     struct dsa_mall_mirror_tc_entry *mirror);
 int qca_ppe_port_policer_add(struct dsa_switch *ds, int port,
 			     const struct flow_action_police *policer,
 			     struct netlink_ext_ack *extack);

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -295,6 +295,8 @@
 #define PPE_PCP_QOS_GROUP(g, pcp)	(PPE_L2_BASE + 0xb00 + (g) * 0x100 + \
 					 (pcp) * 0x4)
 #define PPE_PCP_QOS_ENTRIES		16
+#define PPE_FLOW_QOS_GROUP(g, prof)	(PPE_L2_BASE + 0xd00 + (g) * 0x100 + \
+					 (prof) * 0x4)
 #define PPE_DSCP_QOS_GROUP(g, dscp)	(PPE_L2_BASE + 0x2000 + (g) * 0x800 + \
 					 (dscp) * 0x10)
 #define   PPE_QOS_INFO_PCP		GENMASK(2, 0)
@@ -400,6 +402,27 @@
 
 #define PPE_TM_SHP_SLOT_PORT		(PPE_TM_BASE + 0x18)
 #define   PPE_PORT_SHP_SLOT_TIME	GENMASK(11, 0)
+
+#define PPE_TM_SHP_SLOT_L0		(PPE_TM_BASE + 0x10)
+#define PPE_TM_SHP_SLOT_L1		(PPE_TM_BASE + 0x14)
+#define   PPE_SHP_SLOT_TIME		GENMASK(11, 0)
+
+/* A scheduler node's shaper is two token buckets in one entry, committed and
+ * excess, one per input the node offers its parent, and each has its own
+ * enable. W0 is the committed rate and depth, W1 the excess pair in the same
+ * two fields, W2 the units and the enables. The credit entry is one bucket per
+ * input as well, which is why clearing it takes both of its words.
+ */
+#define PPE_TM_L0_SHP_CREDIT(q)		(PPE_TM_BASE + 0x1a000 + (q) * 0x10)
+#define PPE_TM_L0_SHP_CFG(q)		(PPE_TM_BASE + 0x1c000 + (q) * 0x10)
+#define PPE_TM_L1_SHP_CREDIT(n)		(PPE_TM_BASE + 0x5c000 + (n) * 0x10)
+#define PPE_TM_L1_SHP_CFG(n)		(PPE_TM_BASE + 0x5e000 + (n) * 0x10)
+#define   PPE_SHP_CIR			GENMASK(17, 0)
+#define   PPE_SHP_CBS			GENMASK(31, 18)
+#define   PPE_SHP_TOKEN_UNIT		GENMASK(2, 0)
+#define   PPE_SHP_METER_UNIT		BIT(3)
+#define   PPE_SHP_C_EN			BIT(4)
+#define   PPE_SHP_E_EN			BIT(5)
 
 #define PPE_TM_PSCH_SHP_SIGN(p)	(PPE_TM_BASE + 0x70000 + (p) * 0x10)
 #define PPE_TM_PSCH_SHP_CREDIT(p)	(PPE_TM_BASE + 0x72000 + (p) * 0x10)
@@ -591,6 +614,16 @@ struct qca_ppe_vlan_entry {
 /* Defined beside the MIB table that dimensions it. */
 struct qca_ppe_mib_stats;
 
+/* A traffic class's rate and the scheduler node that will carry it, worked out
+ * before any of it is programmed.
+ */
+struct ppe_class_shaper {
+	u32 cfg;
+	u32 credit;
+	u32 slot;
+	u64 rate_bps;
+};
+
 /* What a port's offloaded tbf was given, so that a stats read can be a delta and
  * its queues can be resized without the rate being asked for again.
  */
@@ -599,6 +632,7 @@ struct ppe_port_shaper {
 	u32 bands_handle;
 	u32 limit;
 	u64 rate_bps;
+	u64 queue_rate[PPE_QOS_MAX_PRI + 1];
 	u64 base_bytes;
 	u32 base_pkts;
 	u32 base_drops;
@@ -659,6 +693,8 @@ u64 ppe_mib_read(struct qca_ppe_priv *priv, int port, unsigned int off);
 
 struct tc_tbf_qopt_offload;
 struct tc_ets_qopt_offload;
+struct tc_query_caps_base;
+struct tc_mqprio_qopt_offload;
 
 void ppe_scheduler_init(struct qca_ppe_priv *priv);
 int qca_ppe_setup_tc(struct dsa_switch *ds, int port, enum tc_setup_type type,
@@ -676,6 +712,9 @@ int qca_ppe_setup_tc_tbf(struct qca_ppe_priv *priv, int port,
 			 struct tc_tbf_qopt_offload *qopt);
 int qca_ppe_setup_tc_ets(struct qca_ppe_priv *priv, int port,
 			 struct tc_ets_qopt_offload *qopt);
+int qca_ppe_tc_query_caps(struct tc_query_caps_base *base);
+int qca_ppe_setup_tc_mqprio(struct qca_ppe_priv *priv, int port,
+			    struct tc_mqprio_qopt_offload *qopt);
 int qca_ppe_port_mirror_add(struct dsa_switch *ds, int port,
 			    struct dsa_mall_mirror_tc_entry *mirror,
 			    bool ingress, struct netlink_ext_ack *extack);

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -5,7 +5,11 @@
 
 #include <linux/bitfield.h>
 #include <linux/bitmap.h>
+#include <linux/cleanup.h>
+#include <linux/mutex.h>
+#include <linux/units.h>
 #include <linux/regmap.h>
+#include <linux/rhashtable.h>
 #include <linux/spinlock.h>
 #include <linux/workqueue.h>
 #include <linux/types.h>
@@ -15,6 +19,45 @@
 #define QCA_PPE_MAX_PORTS		8
 #define QCA_PPE_CPU_PORT		0
 #define QCA_PPE_MAX_BRIDGES		8
+
+/* Flow table op engine */
+#define PPE_TBL_OP_ADD		0
+#define PPE_TBL_OP_DEL		1
+#define PPE_TBL_OP_GET		2
+#define PPE_TBL_OP_FLUSH	3
+#define PPE_FLOW_HASH_BLOCKS	3
+
+#define PPE_FLOW_ENTRY_WORDS_V4	5
+#define PPE_FLOW_ENTRY_WORDS_V6	9
+#define PPE_HOST_ENTRY_WORDS_V4	3
+#define PPE_HOST_ENTRY_WORDS_V6	5
+
+/* The two-bit age field is loaded at its maximum and counts down. */
+#define PPE_FLOW_AGE_MAX	3
+
+/* Flow control is configured per packet type and per direction. */
+#define PPE_FLOW_PKT_TYPES	3
+#define PPE_FLOW_MISS_FORWARD	0
+
+/* Age unit 0 counts seconds, which the hardware derives from the clock rate
+ * programmed into PPE_FLOW_CLK_FREQ_MHZ.
+ */
+#define PPE_FLOW_AGE_UNIT_SEC	0
+#define PPE_FLOW_AGE_SECS	60
+
+/* Forward types of a flow entry, as the hardware numbers them. */
+#define PPE_FLOW_FWD_FORWARD	0
+#define PPE_FLOW_FWD_SNAT	1
+#define PPE_FLOW_FWD_DNAT	2
+#define PPE_FLOW_FWD_ROUTE	3
+#define PPE_FLOW_FWD_BRIDGE	4
+#define PPE_FLOW_FWD_DROP	5
+#define PPE_FLOW_FWD_TO_CPU	6
+
+/* Protocol encoding of a flow entry's two-bit protocol field. */
+#define PPE_FLOW_PROTO_OTHER	0
+#define PPE_FLOW_PROTO_TCP	1
+#define PPE_FLOW_PROTO_UDP	2
 
 
 /* --- Global --- */
@@ -529,8 +572,174 @@
 #define   PPE_L3_VP_VSI_VALID		BIT(9)
 #define   PPE_L3_VP_VSI			GENMASK(14, 10)
 
+#define PPE_MY_MAC_TBL(i)		(PPE_L3_BASE + (i) * 0x8)
+#define   PPE_MY_MAC_ENTRIES		8
+#define   PPE_MY_MAC_WORDS		2
+#define   PPE_MY_MAC_ADDR_OFF		0
+#define   PPE_MY_MAC_ADDR_LEN		48
+#define   PPE_MY_MAC_VALID_OFF		48
+#define   PPE_MY_MAC_VALID_LEN		1
+
+#define PPE_L3_VSI_TBL(vsi)		(PPE_L3_BASE + 0x40 + (vsi) * 0x4)
+#define   PPE_L3_VSI_IF_VALID		BIT(0)
+#define   PPE_L3_VSI_IF_INDEX		GENMASK(8, 1)
+
+#define PPE_FLOW_CTRL0			(PPE_L3_BASE + 0x368)
+#define   PPE_FLOW_EN			BIT(0)
+#define   PPE_FLOW_HASH_MODE0		GENMASK(2, 1)
+#define   PPE_FLOW_HASH_MODE1		GENMASK(4, 3)
+#define   PPE_FLOW_AGE_TIMER		GENMASK(20, 5)
+#define   PPE_FLOW_AGE_TIMER_UNIT	GENMASK(22, 21)
+#define   PPE_FLOW_CLK_FREQ_MHZ		GENMASK(31, 23)
+
+/* One register per packet type, five six-bit direction groups per register. */
+#define PPE_FLOW_CTRL1(type)		(PPE_L3_BASE + 0x36c + (type) * 0x4)
+#define   PPE_FLOW_CTRL1_DIRS		5
+#define   PPE_FLOW_CTRL1_DIR_BITS	6
+#define   PPE_FLOW_MISS_ACTION		GENMASK(1, 0)
+#define   PPE_FLOW_FRAG_BYPASS		BIT(2)
+#define   PPE_FLOW_TCP_SPECIAL		BIT(3)
+#define   PPE_FLOW_ALL_BYPASS		BIT(4)
+#define   PPE_FLOW_KEY_SEL		BIT(5)
+
+#define PPE_PUB_IP_TBL(i)		(PPE_L3_BASE + 0x378 + (i) * 0x4)
+#define   PPE_PUB_IP_ENTRIES		16
+
+#define PPE_FLOW_TBL_OP			(PPE_L3_BASE + 0x3b8)
+#define   PPE_FLOW_OP_CMD_ID		GENMASK(3, 0)
+#define   PPE_FLOW_OP_TYPE		GENMASK(7, 5)
+#define   PPE_FLOW_OP_HASH_BLOCK	GENMASK(9, 8)
+#define   PPE_FLOW_OP_INDEX_MODE	BIT(10)
+#define   PPE_FLOW_OP_HOST_EN		BIT(11)
+#define   PPE_FLOW_OP_ENTRY_IDX		GENMASK(23, 12)
+
+#define PPE_FLOW_HOST_TBL_OP		(PPE_L3_BASE + 0x3bc)
+#define   PPE_FLOW_HOST_OP_HASH_BLOCK	GENMASK(1, 0)
+#define   PPE_FLOW_HOST_OP_ENTRY_IDX	GENMASK(14, 2)
+
+#define PPE_FLOW_TBL_OP_DATA(i)		(PPE_L3_BASE + 0x3c0 + (i) * 0x4)
+#define PPE_FLOW_HOST_TBL_OP_DATA(i)	(PPE_L3_BASE + 0x3e4 + (i) * 0x4)
+
+/* Reading the result register consumes it: read once, keep the value. */
+#define PPE_FLOW_TBL_OP_RSLT		(PPE_L3_BASE + 0x40c)
+#define   PPE_FLOW_RSLT_CMD_ID		GENMASK(3, 0)
+#define   PPE_FLOW_RSLT_FAIL		BIT(4)
+#define   PPE_FLOW_RSLT_ENTRY_IDX	GENMASK(16, 5)
+#define   PPE_FLOW_RSLT_VALID_CNT	GENMASK(20, 17)
+
+#define PPE_FLOW_HOST_TBL_OP_RSLT	(PPE_L3_BASE + 0x410)
+#define   PPE_FLOW_HOST_RSLT_ENTRY_IDX	GENMASK(12, 0)
+
+#define PPE_FLOW_TBL_RD_OP		(PPE_L3_BASE + 0x414)
+#define PPE_FLOW_HOST_TBL_RD_OP		(PPE_L3_BASE + 0x418)
+#define PPE_FLOW_TBL_RD_OP_DATA(i)	(PPE_L3_BASE + 0x41c + (i) * 0x4)
+#define PPE_FLOW_HOST_TBL_RD_OP_DATA(i)	(PPE_L3_BASE + 0x440 + (i) * 0x4)
+#define PPE_FLOW_TBL_RD_OP_RSLT		(PPE_L3_BASE + 0x468)
+#define PPE_FLOW_HOST_TBL_RD_OP_RSLT	(PPE_L3_BASE + 0x46c)
+#define PPE_FLOW_TBL_RD_RSLT_DATA(i)	(PPE_L3_BASE + 0x470 + (i) * 0x4)
+
+#define PPE_HOST_TBL_OP			(PPE_L3_BASE + 0x4bc)
+#define   PPE_HOST_OP_CMD_ID		GENMASK(3, 0)
+#define   PPE_HOST_OP_TYPE		GENMASK(7, 5)
+#define   PPE_HOST_OP_HASH_BLOCK	GENMASK(9, 8)
+#define   PPE_HOST_OP_INDEX_MODE	BIT(10)
+#define   PPE_HOST_OP_ENTRY_IDX		GENMASK(23, 11)
+#define PPE_HOST_TBL_OP_DATA(i)		(PPE_L3_BASE + 0x4c0 + (i) * 0x4)
+#define PPE_HOST_TBL_OP_RSLT		(PPE_L3_BASE + 0x4e8)
+#define   PPE_HOST_RSLT_CMD_ID		GENMASK(3, 0)
+#define   PPE_HOST_RSLT_FAIL		BIT(4)
+#define   PPE_HOST_RSLT_ENTRY_IDX	GENMASK(17, 5)
+#define   PPE_HOST_RSLT_VALID_CNT	GENMASK(21, 18)
+
+#define PPE_IN_L3_IF_TBL(i)		(PPE_L3_BASE + 0x2000 + (i) * 0x8)
+#define   PPE_L3_IF_MRU			GENMASK(13, 0)
+#define   PPE_L3_IF_MTU			GENMASK(27, 14)
+#define   PPE_L3_IF_TTL_DEC_BYPASS	BIT(28)
+#define   PPE_L3_IF_IPV4_ROUTE_EN	BIT(29)
+#define   PPE_L3_IF_IPV6_ROUTE_EN	BIT(30)
+#define   PPE_L3_IF_ICMP_TRIGGER_EN	BIT(31)
+#define   PPE_L3_IF_TTL_EXCEED_CMD	GENMASK(1, 0)
+#define   PPE_L3_IF_TTL_EXCEED_DEACCEL	BIT(2)
+#define   PPE_L3_IF_MAC_BITMAP		GENMASK(10, 3)
+#define   PPE_L3_IF_PPPOE_EN		BIT(11)
+
+#define PPE_HOST_TBL(i)			(PPE_L3_BASE + 0x20000 + (i) * 0x10)
+#define   PPE_HOST_E_VALID_OFF		0
+#define   PPE_HOST_E_VALID_LEN		1
+#define   PPE_HOST_E_KEY_TYPE_OFF	1
+#define   PPE_HOST_E_KEY_TYPE_LEN	2
+#define   PPE_HOST_E_IPV6_OFF		22
+#define   PPE_HOST_E_IPV4_OFF		32
+#define   PPE_HOST_E_IPV4_LEN		32
+#define   PPE_HOST_KEY_IPV4		0
+#define   PPE_HOST_KEY_IPV6		2
+#define PPE_IN_FLOW_TBL(i)		(PPE_L3_BASE + 0x40000 + (i) * 0x20)
+/* Flow entry fields, as bit offset and width within the entry's words. The
+ * IPv4 and IPv6 forms agree up to the address: the ports sit at the same place
+ * and only the address offset differs.
+ */
+#define   PPE_FLOW_E_VALID_OFF		0
+#define   PPE_FLOW_E_VALID_LEN		1
+#define   PPE_FLOW_E_TYPE_OFF		1
+#define   PPE_FLOW_E_TYPE_LEN		1
+#define   PPE_FLOW_E_HOST_IDX_OFF	3
+#define   PPE_FLOW_E_HOST_IDX_LEN	13
+#define   PPE_FLOW_E_PROTO_OFF		16
+#define   PPE_FLOW_E_PROTO_LEN		2
+#define   PPE_FLOW_E_AGE_OFF		18
+#define   PPE_FLOW_E_AGE_LEN		2
+#define   PPE_FLOW_E_AGE_MASK		GENMASK(19, 18)
+#define   PPE_FLOW_E_FWD_TYPE_OFF	29
+#define   PPE_FLOW_E_FWD_TYPE_LEN	3
+#define   PPE_FLOW_E_NEXTHOP_OFF	32
+#define   PPE_FLOW_E_NEXTHOP_LEN	12
+#define   PPE_FLOW_E_NEW_PORT_OFF	44
+#define   PPE_FLOW_E_NEW_PORT_LEN	16
+#define   PPE_FLOW_E_IPV4_OFF		76
+#define   PPE_FLOW_E_IPV4_LEN		32
+#define   PPE_FLOW_E_SPORT_OFF		108
+#define   PPE_FLOW_E_SPORT_LEN		16
+#define   PPE_FLOW_E_DPORT_OFF		124
+#define   PPE_FLOW_E_DPORT_LEN		16
+#define   PPE_FLOW_E_IPV6_OFF		140
+#define   PPE_FLOW_E_PRI_PROFILE_OFF	63
+#define   PPE_FLOW_E_PRI_PROFILE_LEN	5
+
+#define   PPE_FLOW_E_TYPE_IPV6		BIT(1)
+#define PPE_IN_NEXTHOP_TBL(i)		(PPE_L3_BASE + 0x60000 + (i) * 0x10)
+#define   PPE_NEXTHOP_WORDS		4
+#define   PPE_NEXTHOP_PORT_OFF		1
+#define   PPE_NEXTHOP_PORT_LEN		8
+#define   PPE_NEXTHOP_POST_L3_IF_OFF	9
+#define   PPE_NEXTHOP_POST_L3_IF_LEN	8
+#define   PPE_NEXTHOP_CTAG_FMT_OFF	31
+#define   PPE_NEXTHOP_CTAG_FMT_LEN	1
+#define   PPE_NEXTHOP_CVID_OFF		32
+#define   PPE_NEXTHOP_CVID_LEN		12
+#define   PPE_NEXTHOP_PUB_IP_IDX_OFF	44
+#define   PPE_NEXTHOP_PUB_IP_IDX_LEN	4
+#define   PPE_NEXTHOP_MAC_OFF		48
+#define   PPE_NEXTHOP_MAC_LEN		48
+#define   PPE_NEXTHOP_DNAT_IP_OFF	96
+#define   PPE_NEXTHOP_DNAT_IP_LEN	32
+
+/* Egress L3 interface: source MAC and PPPoE session, in the PTX block. */
+#define PPE_EG_L3_IF_TBL(i)		(PPE_PTX_BASE + 0xe000 + (i) * 0x10)
+#define   PPE_EG_L3_IF_ENTRIES		256
+#define   PPE_EG_L3_IF_WORDS		3
+#define   PPE_EG_L3_IF_MAC_OFF		0
+#define   PPE_EG_L3_IF_MAC_LEN		48
+#define   PPE_EG_L3_IF_SESSION_OFF	48
+#define   PPE_EG_L3_IF_SESSION_LEN	16
+#define   PPE_EG_L3_IF_PPPOE_EN_OFF	64
+#define   PPE_EG_L3_IF_PPPOE_EN_LEN	1
+
 /* --- Ingress policer (base 0x100000) --- */
 #define PPE_POLICER_BASE		0x100000
+
+#define PPE_IN_FLOW_CNT_TBL(i)		(PPE_POLICER_BASE + 0x20000 + (i) * 0x10)
+#define   PPE_FLOW_CNT_WORDS		3
+#define   PPE_FLOW_CNT_BYTES_HI		GENMASK(7, 0)
 
 /* The counter tables that carry a drop pair are five words: packets and bytes,
  * then the same pair again for what was dropped.
@@ -918,6 +1127,9 @@ struct ppe_data {
 	u16 qm_total_buf;
 	u16 qm_ceiling;
 	u16 qm_green_max;
+	u16 num_flow_entries;
+	u16 num_host_entries;
+	u16 num_nexthop_entries;
 	const struct psch_tdm_data *psch_tdm;
 	const struct bm_tdm_data *bm_tdm;
 };
@@ -975,6 +1187,7 @@ struct qca_ppe_priv {
 	u32 fdb_cmd_id;
 	/* Guards the FDB and the tables the operation engine reaches. */
 	struct mutex flow_lock;
+	u32 flow_cmd_id;
 	/* The VSI, translation-index and bridge-VLAN state is reached from the
 	 * switchdev ops under rtnl and from a workqueue, which holds none.
 	 * Taken after flow_lock wherever both are needed.
@@ -1139,6 +1352,20 @@ int qca_ppe_port_vlan_add(struct dsa_switch *ds, int port,
 			  struct netlink_ext_ack *extack);
 int qca_ppe_port_vlan_del(struct dsa_switch *ds, int port,
 			  const struct switchdev_obj_port_vlan *vlan);
+
+void ppe_flow_init(struct qca_ppe_priv *priv);
+int ppe_flow_op(struct qca_ppe_priv *priv, u32 op_type,
+		const u32 *entry, int nentry, const u32 *host, int nhost,
+		u32 *index, u32 *host_index);
+int ppe_host_del(struct qca_ppe_priv *priv, u32 index);
+int ppe_flow_entry_read(struct qca_ppe_priv *priv, u32 index, u32 *words,
+			int nwords);
+void ppe_flow_counter_read(struct qca_ppe_priv *priv, u32 index, u64 *packets,
+			   u64 *bytes);
+void ppe_flow_counter_clear(struct qca_ppe_priv *priv, u32 index);
+int ppe_flow_entry_delete(struct qca_ppe_priv *priv, u32 index);
+void ppe_flow_debugfs_init(struct qca_ppe_priv *priv);
+
 
 unsigned long ppe_clk_rate(struct qca_ppe_priv *priv);
 void ppe_debugfs_init(struct qca_ppe_priv *priv);

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -679,6 +679,12 @@ struct qca_ppe_priv {
 	DECLARE_BITMAP(vsi_bitmap, PPE_VSI_MAX);
 	DECLARE_BITMAP(xlt_bitmap, PPE_XLT_TBL_NUM);
 	u32 port_vsi[QCA_PPE_MAX_PORTS];
+	/* The member mask each VSI was last programmed with, so a bridge flag
+	 * that narrows a flood class can reprogram every VSI it reaches.
+	 */
+	u32 vsi_member[PPE_VSI_MAX];
+	unsigned long port_brflags[QCA_PPE_MAX_PORTS];
+	u32 port_isolated;
 	struct qca_ppe_bridge_vsi bridges[QCA_PPE_MAX_BRIDGES];
 	struct qca_ppe_vlan_entry vlans[PPE_VSI_MAX];
 	struct net_device *port_br_dev[QCA_PPE_MAX_PORTS];

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -262,39 +262,95 @@
 #define PPE_RSS_HASH_MIX_IPV4(i)	(0x0b0000 + 0x4390 + (i) * 0x4)
 #define PPE_RSS_HASH_FIN_IPV4(i)	(0x0b0000 + 0x43b0 + (i) * 0x4)
 
-/* --- ACL (rules in the IPO block, actions beside the L2 tables) ---
- * A rule, its mask and its action share one flat index. A rule whose RANGE_EN
- * is set must sit at an even index. There is no valid bit and no global
- * enable: a rule with an empty source bitmap matches nothing, one with ports
- * in it is live.
+/* --- ACL: rules and masks in the IPO block, actions beside the L2 tables,
+ * hit counters in the ingress policer ---
+ * A rule, its mask and its action share one flat index. The 512 indices are
+ * 64 hardware lists of eight: a rule whose key is wider than one entry takes
+ * several entries of one list and the list's RULE_EXT bits merge them into a
+ * single match. A rule whose RANGE_EN is set compares one of its fields
+ * against a range - that field's mask slot carries the maximum, the rest of
+ * the mask stays a mask - and must sit at an even index. There is no valid
+ * bit and no global enable: a rule with an empty source bitmap matches
+ * nothing, one with ports in it is live.
  */
+#define PPE_ACL_LISTS			64
+#define PPE_ACL_LIST_ENTRIES		8
+
 #define PPE_ACL_RULE(i)			(0x0b0000 + (i) * 0x10)
 /* 3 implemented words in a 4-word slot; whole slots are written so the
  * latch on the slot's last word always fires (same for the mask below).
+ * Words 0 and 1 carry a 53-bit key whose fields belong to the rule type.
  */
 #define   PPE_ACL_RULE_WORDS		4
-#define   PPE_ACL_L3_LEN		GENMASK(15, 0)	/* word 0; range min */
-#define   PPE_ACL_IS_IPV6		BIT(17)		/* word 1 */
-#define   PPE_ACL_RANGE_EN		BIT(21)		/* word 1 */
-#define   PPE_ACL_RULE_TYPE		GENMASK(26, 23)	/* word 1 */
+#define   PPE_ACL_MAC_HI		GENMASK(15, 0)	/* w1: bytes 1-0 */
+#define   PPE_ACL_IP_PORT		GENMASK(15, 0)	/* w0: L4 or ICMP */
+#define   PPE_ACL_IP_LO			GENMASK(31, 16)	/* w0 */
+#define   PPE_ACL_IP_HI			GENMASK(15, 0)	/* w1 */
+#define   PPE_ACL_L3_LEN		GENMASK(15, 0)	/* w0; range min */
+#define   PPE_ACL_L3_PROT		GENMASK(23, 16)	/* w0 */
+#define   PPE_ACL_L3_DSCP		GENMASK(31, 24)	/* w0 */
+#define   PPE_ACL_TCP_FLAGS		GENMASK(6, 1)	/* w1 */
+#define   PPE_ACL_L3_FRAG		BIT(16)		/* w1 */
+#define   PPE_ACL_IS_IPV6		BIT(17)		/* w1 */
+#define   PPE_ACL_RANGE_EN		BIT(21)		/* w1 */
+#define   PPE_ACL_RULE_TYPE		GENMASK(26, 23)	/* w1 */
+#define     PPE_ACL_TYPE_MAC_DA		0
+#define     PPE_ACL_TYPE_MAC_SA		1
+#define     PPE_ACL_TYPE_IPV4_DIP	4
+#define     PPE_ACL_TYPE_IPV4_SIP	5
+#define     PPE_ACL_TYPE_IPV6_DIP0	6	/* +1, +2 for the rest */
+#define     PPE_ACL_TYPE_IPV6_SIP0	9
 #define     PPE_ACL_TYPE_IPMISC		12
-#define   PPE_ACL_SRC_LO		GENMASK(31, 29)	/* word 1: ports 0-2 */
-#define   PPE_ACL_SRC_HI		GENMASK(4, 0)	/* word 2: ports 3-7 */
+#define   PPE_ACL_SRC_TYPE		GENMASK(28, 27)	/* w1 */
+#define     PPE_ACL_SRC_PORT_BMP	0
+#define   PPE_ACL_SRC_LO		GENMASK(31, 29)	/* w1: ports 0-2 */
+#define   PPE_ACL_SRC_HI		GENMASK(4, 0)	/* w2: ports 3-7 */
+#define   PPE_ACL_RULE_PRI		GENMASK(13, 5)	/* w2 */
 #define PPE_ACL_MASK(i)			(0x0b2000 + (i) * 0x10)
 #define   PPE_ACL_MASK_WORDS		4	/* 2 implemented; same field layout
 						 * as the rule, and under RANGE_EN
-						 * the length field carries the
-						 * range max
+						 * the ranged field's slot carries
+						 * its maximum
 						 */
+/* One register per hardware list, one bit per mergeable pair of its entries:
+ * EXT1 merges (0,1) (2,3) (4,5) (6,7), EXT2 merges (0,2) (4,6), EXT4 (0,4).
+ * No other pairing exists, which is what limits a wide rule's placement.
+ */
+#define PPE_ACL_RULE_EXT1(l)		(0x0b4000 + (l) * 0x4)
+#define PPE_ACL_RULE_EXT2(l)		(0x0b4100 + (l) * 0x4)
+#define PPE_ACL_RULE_EXT4(l)		(0x0b4200 + (l) * 0x4)
 #define PPE_ACL_ACTION(i)		(0x068000 + (i) * 0x20)
 /* 5 implemented words in an 8-word slot; the entry latches on the write to
  * the slot's last word, so all 8 are written.
  */
 #define   PPE_ACL_ACTION_WORDS		8
+#define   PPE_ACL_DEST_CHANGE_EN	BIT(0)		/* word 0 */
+#define   PPE_ACL_FWD_CMD		GENMASK(2, 1)	/* word 0 */
+#define     PPE_ACL_FWD_FORWARD		0
+#define     PPE_ACL_FWD_DROP		1
+#define     PPE_ACL_FWD_RDT_CPU		3
+/* The destination that replaces the one the lookup found: a twelve-bit
+ * value under a two-bit type.
+ */
+#define   PPE_ACL_DEST_VALUE		GENMASK(14, 3)	/* word 0 */
+#define   PPE_ACL_DEST_TYPE		GENMASK(16, 15)	/* word 0 */
+#define     PPE_ACL_DEST_PORT_BMP	3
+#define   PPE_ACL_MIRROR_EN		BIT(17)		/* word 0 */
+#define   PPE_ACL_DSCP_TC_CHANGE_EN	BIT(14)		/* word 2 */
+#define   PPE_ACL_DSCP_TC		GENMASK(22, 15)	/* word 2 */
 #define   PPE_ACL_PRI_CHANGE_EN		BIT(3)		/* word 3 */
 #define   PPE_ACL_PRI			GENMASK(7, 4)	/* word 3 */
+#define   PPE_ACL_POLICER_EN		BIT(11)		/* word 3 */
+#define   PPE_ACL_POLICER_INDEX		GENMASK(20, 12)	/* word 3 */
+#define   PPE_ACL_QID_EN		BIT(21)		/* word 3 */
+#define   PPE_ACL_QID			GENMASK(29, 22)	/* word 3 */
+/* The counters live in the ingress policer block, not the IPO: the vendor
+ * reaches them at its 0x100000 base plus the table's own 0x74000. Packets in
+ * word 0, the low 32 bits of the byte count in word 1, its top 8 in word 2.
+ */
 #define PPE_ACL_CNT(i)			(0x174000 + (i) * 0x10)
 #define   PPE_ACL_CNT_ENTRIES		512
+#define   PPE_ACL_CNT_WORDS		3
 /* Read-only, and counting whether or not any rule is installed. */
 #define PPE_ACL_GLB_HIT_CNT		(0x0b0000 + 0x430c)
 #define PPE_ACL_GLB_MISS_CNT		(0x0b0000 + 0x4310)
@@ -444,6 +500,29 @@
 
 #define PPE_POLICER_TIME_SLOT		(PPE_POLICER_BASE + 0x40)
 #define   PPE_POLICER_SLOT_TIME		GENMASK(9, 0)
+/* The refresh period every meter in the block shares, in units of 8 PPE
+ * clocks, as ppe_rate_limit_init programs it.
+ */
+#define PPE_POLICER_SLOT		600
+
+/* One meter per classifier rule, bound by the rule's action. The fields are
+ * the port meter's in a different order and without its frame-type filter,
+ * and the two words past the rate carry the exceed and violate actions: left
+ * at zero, a violation drops.
+ */
+#define PPE_ACL_METER(i)		(PPE_POLICER_BASE + 0x4000 + (i) * 0x10)
+#define   PPE_ACL_METER_ENTRIES		512
+#define   PPE_ACL_METER_EN		BIT(0)		/* word 0 */
+#define   PPE_ACL_METER_MODE		BIT(3)		/* word 0 */
+#define   PPE_ACL_METER_TOKEN_UNIT	GENMASK(6, 4)	/* word 0 */
+#define   PPE_ACL_METER_CBS		GENMASK(23, 8)	/* word 0 */
+#define   PPE_ACL_METER_CIR_LO		GENMASK(31, 24)	/* word 0 */
+#define   PPE_ACL_METER_CIR_HI		GENMASK(9, 0)	/* word 1 */
+
+/* The meter's token buckets, committed and excess, two words that commit on
+ * the second - the port meter's table one block over, per meter index.
+ */
+#define PPE_ACL_METER_CRDT(i)		(PPE_POLICER_BASE + 0x8000 + (i) * 0x10)
 
 #define PPE_PORT_METER_W0(p)		(PPE_POLICER_BASE + 0xc000 + (p) * 0x10)
 #define   PPE_METER_EN			BIT(0)
@@ -805,6 +884,14 @@ struct qca_ppe_priv {
 	 * Taken after flow_lock wherever both are needed.
 	 */
 	struct mutex vlan_lock;
+	/* Free entries of every ACL hardware list. Guarded by its own lock
+	 * because the small-packet module parameters reach the table from a
+	 * writer that holds no rtnl.
+	 */
+	u8 acl_free[PPE_ACL_LISTS];
+	DECLARE_BITMAP(acl_meter_used, PPE_ACL_METER_ENTRIES);
+	struct list_head acl_rules;
+	struct mutex acl_lock;
 	s8 mirror_port;
 	u16 mirror_ref;
 	u8 mirror_dir_ref[QCA_PPE_MAX_PORTS][2];
@@ -884,6 +971,7 @@ struct tc_ets_qopt_offload;
 struct tc_prio_qopt_offload;
 struct tc_query_caps_base;
 struct tc_mqprio_qopt_offload;
+struct flow_cls_offload;
 
 void ppe_scheduler_init(struct qca_ppe_priv *priv);
 int qca_ppe_setup_tc(struct dsa_switch *ds, int port, enum tc_setup_type type,
@@ -915,6 +1003,8 @@ int qca_ppe_port_policer_add(struct dsa_switch *ds, int port,
 			     const struct flow_action_police *policer,
 			     struct netlink_ext_ack *extack);
 void qca_ppe_port_policer_del(struct dsa_switch *ds, int port);
+int ppe_token_bucket(unsigned long clk, u32 slot, u64 rate_bps, u32 burst,
+		     u32 cir_max, u32 cbs_max, u32 *cir, u32 *cbs);
 
 int ppe_vsi_alloc(struct qca_ppe_priv *priv);
 void ppe_vsi_free(struct qca_ppe_priv *priv, u32 vsi);
@@ -935,5 +1025,18 @@ int qca_ppe_port_vlan_del(struct dsa_switch *ds, int port,
 unsigned long ppe_clk_rate(struct qca_ppe_priv *priv);
 void ppe_debugfs_init(struct qca_ppe_priv *priv);
 void ppe_debugfs_exit(struct qca_ppe_priv *priv);
+
+void ppe_acl_init(struct qca_ppe_priv *priv);
+void ppe_acl_exit(struct qca_ppe_priv *priv);
+int qca_ppe_cls_flower_add(struct dsa_switch *ds, int port,
+			   struct flow_cls_offload *cls, bool ingress);
+int qca_ppe_cls_flower_del(struct dsa_switch *ds, int port,
+			   struct flow_cls_offload *cls, bool ingress);
+int qca_ppe_set_rxnfc(struct dsa_switch *ds, int port,
+		      struct ethtool_rxnfc *nfc);
+int qca_ppe_get_rxnfc(struct dsa_switch *ds, int port,
+		      struct ethtool_rxnfc *nfc, u32 *rule_locs);
+int ppe_mirror_analyzer_get(struct qca_ppe_priv *priv, int to_port);
+void ppe_mirror_analyzer_put(struct qca_ppe_priv *priv);
 
 #endif

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -284,6 +284,23 @@
 #define   PPE_QOS_FLOW_PREC		GENMASK(14, 12)
 #define   PPE_QOS_ACL_PREC		GENMASK(17, 15)
 
+#define PPE_PCP_QOS_GROUP(g, pcp)	(PPE_L2_BASE + 0xb00 + (g) * 0x100 + \
+					 (pcp) * 0x4)
+#define PPE_PCP_QOS_ENTRIES		16
+#define PPE_DSCP_QOS_GROUP(g, dscp)	(PPE_L2_BASE + 0x2000 + (g) * 0x800 + \
+					 (dscp) * 0x10)
+#define   PPE_QOS_INFO_PCP		GENMASK(2, 0)
+#define   PPE_QOS_INFO_DEI		BIT(3)
+#define   PPE_QOS_INFO_PRI		GENMASK(7, 4)
+#define   PPE_QOS_INFO_DSCP		GENMASK(13, 8)
+#define   PPE_QOS_INFO_DP		GENMASK(15, 14)
+
+/* The highest priority a packet may be given. The port's top four unicast
+ * queues share an L0 node and a DRR node with its multicast queues, and the
+ * scheduler cannot be told to rotate credit for two queues on one node.
+ */
+#define PPE_QOS_MAX_PRI			11
+
 #define PPE_VSI_TBL(vsi)		(PPE_L2_BASE + 0x1800 + (vsi) * 0x10)
 #define   PPE_VSI_TBL_MEMBER		GENMASK(7, 0)
 #define   PPE_VSI_TBL_UUC		GENMASK(15, 8)
@@ -630,12 +647,24 @@ static inline struct qca_ppe_priv *ds_to_priv(struct dsa_switch *ds)
 u64 ppe_mib_read(struct qca_ppe_priv *priv, int port, unsigned int off);
 
 struct tc_tbf_qopt_offload;
+struct tc_ets_qopt_offload;
 
 void ppe_scheduler_init(struct qca_ppe_priv *priv);
 int qca_ppe_setup_tc(struct dsa_switch *ds, int port, enum tc_setup_type type,
 		     void *type_data);
+int qca_ppe_port_get_dscp_prio(struct dsa_switch *ds, int port, u8 dscp);
+int qca_ppe_port_add_dscp_prio(struct dsa_switch *ds, int port, u8 dscp,
+			       u8 prio);
+int qca_ppe_port_del_dscp_prio(struct dsa_switch *ds, int port, u8 dscp,
+			       u8 prio);
+int qca_ppe_port_get_apptrust(struct dsa_switch *ds, int port, u8 *sel,
+			      int *nsel);
+int qca_ppe_port_set_apptrust(struct dsa_switch *ds, int port, const u8 *sel,
+			      int nsel);
 int qca_ppe_setup_tc_tbf(struct qca_ppe_priv *priv, int port,
 			 struct tc_tbf_qopt_offload *qopt);
+int qca_ppe_setup_tc_ets(struct qca_ppe_priv *priv, int port,
+			 struct tc_ets_qopt_offload *qopt);
 int qca_ppe_port_policer_add(struct dsa_switch *ds, int port,
 			     const struct flow_action_police *policer,
 			     struct netlink_ext_ack *extack);

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe.h
@@ -281,6 +281,24 @@
 #define PPE_EG_VSI_TAG(vsi)		(PPE_PTX_BASE + (vsi) * 0x4)
 #define   PPE_EG_VSI_TAG_UNMODIFIED	0xaaaa
 
+#define PPE_EG_XLT_RULE(idx)		(PPE_PTX_BASE + 0x200 + (idx) * 0x8)
+#define   PPE_EG_XLT_VALID		BIT(0)
+#define   PPE_EG_XLT_PORT_BMP		GENMASK(8, 1)
+#define   PPE_EG_XLT_VSI_INCL		BIT(9)
+#define   PPE_EG_XLT_VSI		GENMASK(14, 10)
+#define   PPE_EG_XLT_VSI_VALID		BIT(15)
+#define   PPE_EG_XLT_SKEY_FMT		GENMASK(18, 16)
+
+#define PPE_EG_XLT_RULE_W1(idx)		(PPE_PTX_BASE + 0x200 + (idx) * 0x8 + 0x4)
+#define   PPE_EG_XLT_CKEY_FMT		GENMASK(8, 6)
+
+#define PPE_EG_XLT_ACTION(idx)		(PPE_PTX_BASE + 0xd000 + (idx) * 0x8)
+#define   PPE_EG_XLT_CVID_CMD		GENMASK(16, 15)
+#define   PPE_EG_XLT_CVID		GENMASK(28, 17)
+#define   PPE_EG_XLT_CVID_ADD		1
+
+#define PPE_EG_XLT_ACTION_W1(idx)	(PPE_PTX_BASE + 0xd000 + (idx) * 0x8 + 0x4)
+
 /* What left the egress editor, per VSI, per physical port and per virtual
  * port, and what the whole stage took in and put out.
  */
@@ -572,6 +590,14 @@
 #define   PPE_L3_VP_VSI_VALID		BIT(9)
 #define   PPE_L3_VP_VSI			GENMASK(14, 10)
 
+#define PPE_PPPOE_SESSION(i)		(PPE_L3_BASE + 0xc20 + (i) * 0x4)
+#define   PPE_PPPOE_SESSION_ID		GENMASK(15, 0)
+#define   PPE_PPPOE_SESSION_PORT_BMP	GENMASK(23, 16)
+#define   PPE_PPPOE_SESSION_L3_IF	GENMASK(31, 24)
+#define PPE_PPPOE_SESSION_EXT(i)	(PPE_L3_BASE + 0xc60 + (i) * 0x4)
+#define   PPE_PPPOE_EXT_L3_IF_VALID	BIT(0)
+#define   PPE_PPPOE_EXT_UC_VALID	BIT(2)
+
 #define PPE_MY_MAC_TBL(i)		(PPE_L3_BASE + (i) * 0x8)
 #define   PPE_MY_MAC_ENTRIES		8
 #define   PPE_MY_MAC_WORDS		2
@@ -597,8 +623,8 @@
 #define   PPE_FLOW_CTRL1_DIRS		5
 #define   PPE_FLOW_CTRL1_DIR_BITS	6
 #define   PPE_FLOW_MISS_ACTION		GENMASK(1, 0)
+#define   PPE_FLOW_DIR_WAN_TO_LAN	2
 #define   PPE_FLOW_FRAG_BYPASS		BIT(2)
-#define   PPE_FLOW_TCP_SPECIAL		BIT(3)
 #define   PPE_FLOW_ALL_BYPASS		BIT(4)
 #define   PPE_FLOW_KEY_SEL		BIT(5)
 
@@ -652,13 +678,16 @@
 #define   PPE_HOST_RSLT_VALID_CNT	GENMASK(21, 18)
 
 #define PPE_IN_L3_IF_TBL(i)		(PPE_L3_BASE + 0x2000 + (i) * 0x8)
+#define   PPE_L3_IF_WORDS		2
 #define   PPE_L3_IF_MRU			GENMASK(13, 0)
 #define   PPE_L3_IF_MTU			GENMASK(27, 14)
 #define   PPE_L3_IF_TTL_DEC_BYPASS	BIT(28)
 #define   PPE_L3_IF_IPV4_ROUTE_EN	BIT(29)
 #define   PPE_L3_IF_IPV6_ROUTE_EN	BIT(30)
 #define   PPE_L3_IF_ICMP_TRIGGER_EN	BIT(31)
+/* Second word of the entry. */
 #define   PPE_L3_IF_TTL_EXCEED_CMD	GENMASK(1, 0)
+#define     PPE_L3_IF_TTL_EXCEED_TO_CPU	3
 #define   PPE_L3_IF_TTL_EXCEED_DEACCEL	BIT(2)
 #define   PPE_L3_IF_MAC_BITMAP		GENMASK(10, 3)
 #define   PPE_L3_IF_PPPOE_EN		BIT(11)
@@ -689,6 +718,10 @@
 #define   PPE_FLOW_E_AGE_OFF		18
 #define   PPE_FLOW_E_AGE_LEN		2
 #define   PPE_FLOW_E_AGE_MASK		GENMASK(19, 18)
+#define   PPE_FLOW_E_SRC_IF_VALID_OFF	20
+#define   PPE_FLOW_E_SRC_IF_VALID_LEN	1
+#define   PPE_FLOW_E_SRC_IF_OFF		21
+#define   PPE_FLOW_E_SRC_IF_LEN		8
 #define   PPE_FLOW_E_FWD_TYPE_OFF	29
 #define   PPE_FLOW_E_FWD_TYPE_LEN	3
 #define   PPE_FLOW_E_NEXTHOP_OFF	32
@@ -708,6 +741,9 @@
 #define   PPE_FLOW_E_TYPE_IPV6		BIT(1)
 #define PPE_IN_NEXTHOP_TBL(i)		(PPE_L3_BASE + 0x60000 + (i) * 0x10)
 #define   PPE_NEXTHOP_WORDS		4
+#define   PPE_NEXTHOP_TYPE_OFF		0
+#define   PPE_NEXTHOP_TYPE_LEN		1
+#define   PPE_NEXTHOP_TYPE_PORT		1
 #define   PPE_NEXTHOP_PORT_OFF		1
 #define   PPE_NEXTHOP_PORT_LEN		8
 #define   PPE_NEXTHOP_POST_L3_IF_OFF	9
@@ -740,6 +776,7 @@
 #define PPE_IN_FLOW_CNT_TBL(i)		(PPE_POLICER_BASE + 0x20000 + (i) * 0x10)
 #define   PPE_FLOW_CNT_WORDS		3
 #define   PPE_FLOW_CNT_BYTES_HI		GENMASK(7, 0)
+#define   PPE_FLOW_CNT_BYTES		GENMASK_ULL(39, 0)
 
 /* The counter tables that carry a drop pair are five words: packets and bytes,
  * then the same pair again for what was dropped.
@@ -1134,6 +1171,31 @@ struct ppe_data {
 	const struct bm_tdm_data *bm_tdm;
 };
 
+/* Why a flow was not offloaded. Counted so that "it stayed in software" can be
+ * answered without a kernel rebuild.
+ */
+enum ppe_flow_reject {
+	PPE_REJECT_INGRESS_PORT,
+	PPE_REJECT_INGRESS_VLAN,
+	PPE_REJECT_KEY,
+	PPE_REJECT_PROTO,
+	PPE_REJECT_ACTION,
+	PPE_REJECT_L2,
+	PPE_REJECT_EGRESS_PORT,
+	PPE_REJECT_HAIRPIN,
+	PPE_REJECT_NAT_BOTH,
+	PPE_REJECT_NAT_IPV6,
+	PPE_REJECT_RESOURCE,
+	PPE_REJECT_HW_OP,
+	PPE_REJECT_MAX,
+};
+
+/* One slot of a reference-counted hardware side table. */
+struct ppe_res {
+	u32 words[PPE_NEXTHOP_WORDS];
+	int refcount;
+};
+
 struct qca_ppe_bridge_vsi {
 	struct net_device *br_dev;
 	u32 vsi;
@@ -1188,6 +1250,28 @@ struct qca_ppe_priv {
 	/* Guards the FDB and the tables the operation engine reaches. */
 	struct mutex flow_lock;
 	u32 flow_cmd_id;
+	struct rhashtable flow_table;
+	struct list_head flow_list;
+	struct ppe_res *eg_l3_if;
+	struct ppe_res *pub_ip;
+	struct ppe_res *nexthop;
+	struct ppe_res *my_mac;
+	u16 *host_ref;
+	u16 l3_if_ref[PPE_VSI_MAX];
+	/* A tagged PPPoE WAN port routes on its own VSI, separate from the L2
+	 * bridge, so its download direction reaches the flow lookup. Allocated
+	 * with the first offloaded flow on the port and shared by the rest.
+	 */
+	s8 wan_vsi[QCA_PPE_MAX_PORTS];
+	s8 wan_mymac[QCA_PPE_MAX_PORTS];
+	u16 wan_ref[QCA_PPE_MAX_PORTS];
+	int wan_xlt[QCA_PPE_MAX_PORTS];
+	u16 wan_vid[QCA_PPE_MAX_PORTS];
+	u32 flow_reject[PPE_REJECT_MAX];
+	u32 flow_offloaded;
+	u32 flow_reinstalled;
+	u32 flow_destroy_miss;
+	u32 flow_stale;
 	/* The VSI, translation-index and bridge-VLAN state is reached from the
 	 * switchdev ops under rtnl and from a workqueue, which holds none.
 	 * Taken after flow_lock wherever both are needed.
@@ -1225,6 +1309,7 @@ struct qca_ppe_priv {
 	struct qca_ppe_bridge_vsi bridges[QCA_PPE_MAX_BRIDGES];
 	struct qca_ppe_vlan_entry vlans[PPE_VSI_MAX];
 	struct net_device *port_br_dev[QCA_PPE_MAX_PORTS];
+	struct notifier_block netdev_nb;
 	u16 port_pvid[QCA_PPE_MAX_PORTS];
 	struct clk *port_rx_clk[QCA_PPE_MAX_PORTS];
 	struct clk *port_tx_clk[QCA_PPE_MAX_PORTS];
@@ -1341,6 +1426,11 @@ int ppe_vsi_alloc(struct qca_ppe_priv *priv);
 void ppe_vsi_free(struct qca_ppe_priv *priv, u32 vsi);
 void ppe_vsi_member_set(struct qca_ppe_priv *priv, u32 vsi, u32 portmask);
 
+int ppe_xlt_idx_alloc(struct qca_ppe_priv *priv);
+void ppe_xlt_idx_free(struct qca_ppe_priv *priv, int *idx);
+struct qca_ppe_vlan_entry *ppe_vlan_find(struct qca_ppe_priv *priv,
+					 struct net_device *br_dev, u16 vid);
+
 int qca_ppe_vlan_setup(struct dsa_switch *ds);
 int qca_ppe_port_vlan_filtering(struct dsa_switch *ds, int port,
 				bool vlan_filtering,
@@ -1383,5 +1473,14 @@ int qca_ppe_get_rxnfc(struct dsa_switch *ds, int port,
 		      struct ethtool_rxnfc *nfc, u32 *rule_locs);
 int ppe_mirror_analyzer_get(struct qca_ppe_priv *priv, int to_port);
 void ppe_mirror_analyzer_put(struct qca_ppe_priv *priv);
+int qca_ppe_setup_tc(struct dsa_switch *ds, int port, enum tc_setup_type type,
+		     void *type_data);
+struct flow_block_offload;
+
+int ppe_setup_ft_block(struct qca_ppe_priv *priv,
+		       struct flow_block_offload *f);
+int ppe_flow_offload_init(struct qca_ppe_priv *priv);
+void ppe_flow_purge_vsi(struct qca_ppe_priv *priv, u32 vsi);
+void ppe_flow_offload_exit(struct qca_ppe_priv *priv);
 
 #endif

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_acl.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_acl.c
@@ -1,0 +1,1281 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/* Copyright (c) 2026 Julius Bairaktaris <julius@bairaktaris.de> */
+/* Hardware classifier (ACL/IPO) for the Qualcomm PPE.
+ *
+ * The engine holds 512 entries as 64 lists of eight. One entry carries a
+ * 53-bit key, a mask and an action, and a rule needing more key than that
+ * takes several entries of one list which the list's RULE_EXT bits merge into
+ * a single match. Only the pairs (0,1) (2,3) (4,5) (6,7), (0,2) (4,6) and
+ * (0,4) can be merged, so a rule of n entries has to land on one of the shapes
+ * those pairings build - which is what the allocator here is for.
+ */
+
+#include <linux/bitfield.h>
+#include <linux/bitops.h>
+#include <linux/etherdevice.h>
+#include <linux/ethtool.h>
+#include <linux/module.h>
+#include <net/flow_offload.h>
+#include <net/ipv6.h>
+
+#include "qca_ppe.h"
+
+/* One entry of a rule: the key, its mask, and the rule type that tells the
+ * engine which bits of the packet the key is compared against. A range
+ * compare takes the mask slot of the field it names for the range maximum,
+ * leaving the entry's other masks alone, and the entry it lands on has to be
+ * an even one.
+ */
+struct ppe_acl_slice {
+	u8 type;
+	bool range;
+	u32 key[2];
+	u32 mask[2];
+};
+
+/* The entries of one list a rule may occupy, and the RULE_EXT bits that chain
+ * them. Taken from the vendor's table in its order: the single-entry shapes
+ * name the odd entries first, which leaves the even ones - the only place a
+ * range compare may sit - free for longer.
+ */
+static const struct {
+	u8 num;
+	u8 ext1;
+	u8 ext2;
+	u8 ext4;
+	u8 entries;
+} ppe_acl_shape[] = {
+	{ 1, 0x0, 0x0, 0x0, 0x02 },
+	{ 1, 0x0, 0x0, 0x0, 0x08 },
+	{ 1, 0x0, 0x0, 0x0, 0x20 },
+	{ 1, 0x0, 0x0, 0x0, 0x80 },
+	{ 1, 0x0, 0x0, 0x0, 0x01 },
+	{ 1, 0x0, 0x0, 0x0, 0x04 },
+	{ 1, 0x0, 0x0, 0x0, 0x10 },
+	{ 1, 0x0, 0x0, 0x0, 0x40 },
+	{ 2, 0x1, 0x0, 0x0, 0x03 },
+	{ 2, 0x2, 0x0, 0x0, 0x0c },
+	{ 2, 0x4, 0x0, 0x0, 0x30 },
+	{ 2, 0x8, 0x0, 0x0, 0xc0 },
+	{ 2, 0x0, 0x1, 0x0, 0x05 },
+	{ 2, 0x0, 0x2, 0x0, 0x50 },
+	{ 2, 0x0, 0x0, 0x1, 0x11 },
+	{ 3, 0x1, 0x1, 0x0, 0x07 },
+	{ 3, 0x1, 0x0, 0x1, 0x13 },
+	{ 3, 0x2, 0x1, 0x0, 0x0d },
+	{ 3, 0x4, 0x2, 0x0, 0x70 },
+	{ 3, 0x4, 0x0, 0x1, 0x31 },
+	{ 3, 0x8, 0x2, 0x0, 0xd0 },
+	{ 3, 0x0, 0x1, 0x1, 0x15 },
+	{ 3, 0x0, 0x2, 0x1, 0x51 },
+	{ 4, 0x3, 0x1, 0x0, 0x0f },
+	{ 4, 0x5, 0x0, 0x1, 0x33 },
+	{ 4, 0x2, 0x1, 0x1, 0x1d },
+	{ 4, 0xc, 0x2, 0x0, 0xf0 },
+	{ 4, 0x4, 0x1, 0x1, 0x35 },
+	{ 4, 0x8, 0x2, 0x1, 0xd1 },
+	{ 4, 0x0, 0x3, 0x1, 0x55 },
+	{ 5, 0x3, 0x1, 0x1, 0x1f },
+	{ 5, 0x6, 0x1, 0x1, 0x3d },
+	{ 5, 0xc, 0x2, 0x1, 0xf1 },
+	{ 5, 0x8, 0x3, 0x1, 0xd5 },
+	{ 6, 0x7, 0x1, 0x1, 0x3f },
+	{ 6, 0x6, 0x3, 0x1, 0x7d },
+	{ 6, 0xc, 0x3, 0x1, 0xf5 },
+	{ 7, 0x7, 0x3, 0x1, 0x7f },
+	{ 7, 0xe, 0x3, 0x1, 0xfd },
+	{ 8, 0xf, 0x3, 0x1, 0xff },
+};
+
+/* Entries of a list a range compare may sit on. */
+#define PPE_ACL_EVEN_ENTRIES	0x55
+
+/* One rule's placement: which list, which of its entries, and the RULE_EXT
+ * bits this rule set in that list.
+ */
+struct ppe_acl_group {
+	u8 list;
+	u8 entries;
+	u8 ext1;
+	u8 ext2;
+	u8 ext4;
+	u8 index[PPE_ACL_LIST_ENTRIES];
+	u8 nslices;
+};
+
+static void ppe_acl_ext_write(struct qca_ppe_priv *priv,
+			      const struct ppe_acl_group *g, bool set)
+{
+	regmap_update_bits(priv->regmap, PPE_ACL_RULE_EXT1(g->list), g->ext1,
+			   set ? g->ext1 : 0);
+	regmap_update_bits(priv->regmap, PPE_ACL_RULE_EXT2(g->list), g->ext2,
+			   set ? g->ext2 : 0);
+	regmap_update_bits(priv->regmap, PPE_ACL_RULE_EXT4(g->list), g->ext4,
+			   set ? g->ext4 : 0);
+}
+
+/* Hand one entry of the shape to a slice. A range compare has to have an even
+ * entry; everything else takes an odd one first, which leaves the even ones to
+ * the ranges of the same rule - the shape was picked with enough of them, and
+ * with exactly one entry per slice, so there is always something to hand out.
+ */
+static u8 ppe_acl_entry_take(u8 *avail, bool range)
+{
+	u8 want = range ? PPE_ACL_EVEN_ENTRIES : ~PPE_ACL_EVEN_ENTRIES;
+	u8 pick = *avail & want ? *avail & want : *avail;
+
+	pick &= -pick;
+	*avail &= ~pick;
+
+	return __ffs(pick);
+}
+
+/* Place a rule on the first list carrying a free shape of the right width with
+ * an even entry left for each of the rule's range compares.
+ */
+static int ppe_acl_alloc(struct qca_ppe_priv *priv,
+			 const struct ppe_acl_slice *slice, int nslices,
+			 struct ppe_acl_group *g)
+{
+	int i, l, n, nranges = 0;
+	u8 avail;
+
+	for (i = 0; i < nslices; i++)
+		nranges += slice[i].range;
+
+	for (l = 0; l < PPE_ACL_LISTS; l++) {
+		for (i = 0; i < ARRAY_SIZE(ppe_acl_shape); i++) {
+			u8 e = ppe_acl_shape[i].entries;
+
+			if (ppe_acl_shape[i].num != nslices ||
+			    (priv->acl_free[l] & e) != e ||
+			    hweight8(e & PPE_ACL_EVEN_ENTRIES) < nranges)
+				continue;
+
+			priv->acl_free[l] &= ~e;
+			g->list = l;
+			g->entries = e;
+			g->ext1 = ppe_acl_shape[i].ext1;
+			g->ext2 = ppe_acl_shape[i].ext2;
+			g->ext4 = ppe_acl_shape[i].ext4;
+			g->nslices = nslices;
+
+			avail = e;
+			for (n = 0; n < nslices; n++)
+				g->index[n] = l * PPE_ACL_LIST_ENTRIES +
+					      ppe_acl_entry_take(&avail,
+							slice[n].range);
+
+			/* The chain has to exist before any of its entries
+			 * goes live: an armed entry whose RULE_EXT bit is
+			 * still clear is a rule of its own, matching far more
+			 * than what was asked for and carrying the action.
+			 */
+			ppe_acl_ext_write(priv, g, true);
+
+			return 0;
+		}
+	}
+
+	return -ENOSPC;
+}
+
+/* Zeroing the rule words clears the source bitmap, which is the only thing
+ * that makes an entry live; the chain goes last for the same reason it was
+ * built first.
+ */
+static void ppe_acl_free(struct qca_ppe_priv *priv, struct ppe_acl_group *g)
+{
+	int i, j;
+
+	for (i = 0; i < g->nslices; i++)
+		for (j = 0; j < PPE_ACL_RULE_WORDS; j++)
+			regmap_write(priv->regmap,
+				     PPE_ACL_RULE(g->index[i]) + j * 4, 0);
+
+	ppe_acl_ext_write(priv, g, false);
+	priv->acl_free[g->list] |= g->entries;
+	g->nslices = 0;
+}
+
+/* Arm one entry. The engine commits an entry on the write to its last word, so
+ * the action and the mask are in place before the rule word that carries the
+ * source bitmap lands, and the rule is disarmed first in case it was live.
+ */
+static void ppe_acl_slice_write(struct qca_ppe_priv *priv, u32 index,
+				const struct ppe_acl_slice *s, const u32 *act,
+				u32 ports, u16 pri)
+{
+	u32 w[PPE_ACL_ACTION_WORDS];
+	int i;
+
+	for (i = 0; i < PPE_ACL_RULE_WORDS; i++)
+		regmap_write(priv->regmap, PPE_ACL_RULE(index) + i * 4, 0);
+
+	for (i = 0; i < PPE_ACL_ACTION_WORDS; i++)
+		regmap_write(priv->regmap, PPE_ACL_ACTION(index) + i * 4,
+			     act[i]);
+
+	memset(w, 0, sizeof(w));
+	w[0] = s->mask[0];
+	w[1] = s->mask[1];
+	for (i = 0; i < PPE_ACL_MASK_WORDS; i++)
+		regmap_write(priv->regmap, PPE_ACL_MASK(index) + i * 4, w[i]);
+
+	memset(w, 0, sizeof(w));
+	w[0] = s->key[0];
+	w[1] = s->key[1] |
+	       FIELD_PREP(PPE_ACL_RULE_TYPE, s->type) |
+	       (s->range ? PPE_ACL_RANGE_EN : 0) |
+	       FIELD_PREP(PPE_ACL_SRC_TYPE, PPE_ACL_SRC_PORT_BMP) |
+	       FIELD_PREP(PPE_ACL_SRC_LO, ports & 0x7);
+	w[2] = FIELD_PREP(PPE_ACL_SRC_HI, ports >> 3) |
+	       FIELD_PREP(PPE_ACL_RULE_PRI, pri);
+	for (i = 0; i < PPE_ACL_RULE_WORDS; i++)
+		regmap_write(priv->regmap, PPE_ACL_RULE(index) + i * 4, w[i]);
+}
+
+/* The keys the rule types below cover. A filter carrying anything else is
+ * declined rather than offloaded without it: a key the driver drops makes the
+ * rule match a superset of what was asked for, and the action goes with it.
+ */
+#define PPE_ACL_MATCH_KEYS					\
+	(BIT_ULL(FLOW_DISSECTOR_KEY_CONTROL) |			\
+	 BIT_ULL(FLOW_DISSECTOR_KEY_BASIC) |			\
+	 BIT_ULL(FLOW_DISSECTOR_KEY_ETH_ADDRS) |		\
+	 BIT_ULL(FLOW_DISSECTOR_KEY_IPV4_ADDRS) |		\
+	 BIT_ULL(FLOW_DISSECTOR_KEY_IPV6_ADDRS) |		\
+	 BIT_ULL(FLOW_DISSECTOR_KEY_PORTS) |			\
+	 BIT_ULL(FLOW_DISSECTOR_KEY_PORTS_RANGE) |		\
+	 BIT_ULL(FLOW_DISSECTOR_KEY_ICMP) |			\
+	 BIT_ULL(FLOW_DISSECTOR_KEY_IP) |			\
+	 BIT_ULL(FLOW_DISSECTOR_KEY_TCP))
+
+/* TCP flags as the header carries them, FIN first. */
+#define PPE_ACL_TCP_FLAGS_MAX	GENMASK(5, 0)
+
+/* A filter needs at most one entry per rule type, which is more than one
+ * hardware list holds; the width is checked once the whole filter is parsed.
+ */
+#define PPE_ACL_MAX_SLICES	(PPE_ACL_TYPE_IPMISC + 1)
+
+struct ppe_acl_rule {
+	struct list_head list;
+	unsigned long cookie;
+	/* The ethtool location this rule was inserted at, or -1 for one that
+	 * came from tc. ethtool has to hand the whole spec back on a get, so
+	 * the rules it owns keep theirs.
+	 */
+	int loc;
+	struct ethtool_rx_flow_spec *fs;
+	int port;
+	int meter;
+	bool mirror;
+	struct ppe_acl_group group;
+	u32 act[PPE_ACL_ACTION_WORDS];
+};
+
+/* One entry per rule type, reused as more of the filter is parsed into it. */
+static struct ppe_acl_slice *ppe_acl_slice_get(struct ppe_acl_slice *slice,
+					       int *n, u8 type)
+{
+	int i;
+
+	for (i = 0; i < *n; i++)
+		if (slice[i].type == type)
+			return &slice[i];
+
+	slice[*n].type = type;
+
+	return &slice[(*n)++];
+}
+
+/* A MAC address sits low byte first: bytes 5 to 2 in word 0, bytes 1 and 0 in
+ * word 1.
+ */
+static void ppe_acl_mac_words(u32 *w, const u8 *mac)
+{
+	w[0] = mac[5] | mac[4] << 8 | mac[3] << 16 | mac[2] << 24;
+	w[1] = FIELD_PREP(PPE_ACL_MAC_HI, mac[1] | mac[0] << 8);
+}
+
+/* An IPv6 address needs three entries: its low 32 bits and the 16 above them
+ * in the first, the next 48 in the second, the top 32 in the third - which
+ * leaves the third entry's port field free for the L4 port.
+ */
+static void ppe_acl_ip6_words(u32 w[3][2], const __be32 *addr)
+{
+	u32 v[4];
+	int i;
+
+	for (i = 0; i < 4; i++)
+		v[i] = ntohl(addr[i]);
+
+	w[0][0] = FIELD_PREP(PPE_ACL_IP_PORT, v[3]) |
+		  FIELD_PREP(PPE_ACL_IP_LO, v[3] >> 16);
+	w[0][1] = FIELD_PREP(PPE_ACL_IP_HI, v[2]);
+	w[1][0] = FIELD_PREP(PPE_ACL_IP_PORT, v[2] >> 16) |
+		  FIELD_PREP(PPE_ACL_IP_LO, v[1]);
+	w[1][1] = FIELD_PREP(PPE_ACL_IP_HI, v[1] >> 16);
+	w[2][0] = FIELD_PREP(PPE_ACL_IP_LO, v[0]);
+	w[2][1] = FIELD_PREP(PPE_ACL_IP_HI, v[0] >> 16);
+}
+
+static void ppe_acl_key_ip6(struct ppe_acl_slice *slice, int *n, u8 type,
+			    const struct in6_addr *key,
+			    const struct in6_addr *mask)
+{
+	u32 kw[3][2], mw[3][2];
+	int i;
+
+	ppe_acl_ip6_words(kw, key->s6_addr32);
+	ppe_acl_ip6_words(mw, mask->s6_addr32);
+
+	for (i = 0; i < 3; i++) {
+		struct ppe_acl_slice *s;
+
+		/* A prefix shorter than the address leaves whole entries with
+		 * nothing to compare, and an entry that compares nothing still
+		 * costs one of the list's eight. The vendor gates each rule
+		 * type on its own half of the mask; so does this.
+		 */
+		if (!mw[i][0] && !mw[i][1])
+			continue;
+
+		s = ppe_acl_slice_get(slice, n, type + i);
+		s->key[0] |= kw[i][0];
+		s->key[1] |= kw[i][1];
+		s->mask[0] |= mw[i][0];
+		s->mask[1] |= mw[i][1];
+	}
+}
+
+/* Turn the filter into entries: one per rule type it needs, each carrying the
+ * part of the key that rule type compares. Returns how many.
+ */
+static int ppe_acl_parse_key(struct flow_rule *rule,
+			     struct netlink_ext_ack *extack,
+			     struct ppe_acl_slice *slice, __be16 *family)
+{
+	struct ppe_acl_slice *s;
+	u8 sip_type, dip_type;
+	u16 addr_type = 0;
+	__be16 proto = 0;
+	int n = 0;
+
+	if (rule->match.dissector->used_keys & ~PPE_ACL_MATCH_KEYS) {
+		NL_SET_ERR_MSG_MOD(extack, "match key the classifier has no field for");
+		return -EOPNOTSUPP;
+	}
+
+	if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_CONTROL)) {
+		struct flow_match_control match;
+
+		flow_rule_match_control(rule, &match);
+		addr_type = match.key->addr_type;
+		if (!flow_rule_is_supp_control_flags(FLOW_DIS_IS_FRAGMENT,
+						     match.mask->flags, extack))
+			return -EOPNOTSUPP;
+
+		if (match.mask->flags & FLOW_DIS_IS_FRAGMENT) {
+			s = ppe_acl_slice_get(slice, &n, PPE_ACL_TYPE_IPMISC);
+			if (match.key->flags & FLOW_DIS_IS_FRAGMENT)
+				s->key[1] |= PPE_ACL_L3_FRAG;
+			s->mask[1] |= PPE_ACL_L3_FRAG;
+		}
+	}
+
+	/* The engine tells the families apart by one bit rather than by the
+	 * ethertype, which is also what picks the IPv4 or IPv6 rule types for
+	 * everything below, so an L3 or L4 match needs the family named.
+	 */
+	if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_BASIC)) {
+		struct flow_match_basic match;
+
+		flow_rule_match_basic(rule, &match);
+		if (match.mask->n_proto) {
+			if (match.mask->n_proto != htons(0xffff)) {
+				NL_SET_ERR_MSG_MOD(extack, "the protocol is matched whole or not at all");
+				return -EOPNOTSUPP;
+			}
+			proto = match.key->n_proto;
+			if (proto != htons(ETH_P_IP) &&
+			    proto != htons(ETH_P_IPV6)) {
+				NL_SET_ERR_MSG_MOD(extack, "only IPv4 and IPv6 are matched by protocol");
+				return -EOPNOTSUPP;
+			}
+			s = ppe_acl_slice_get(slice, &n, PPE_ACL_TYPE_IPMISC);
+			if (proto == htons(ETH_P_IPV6))
+				s->key[1] |= PPE_ACL_IS_IPV6;
+			s->mask[1] |= PPE_ACL_IS_IPV6;
+		}
+		if (match.mask->ip_proto) {
+			s = ppe_acl_slice_get(slice, &n, PPE_ACL_TYPE_IPMISC);
+			s->key[0] |= FIELD_PREP(PPE_ACL_L3_PROT,
+						match.key->ip_proto);
+			s->mask[0] |= FIELD_PREP(PPE_ACL_L3_PROT,
+						 match.mask->ip_proto);
+		}
+	}
+
+	if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_IP)) {
+		struct flow_match_ip match;
+
+		flow_rule_match_ip(rule, &match);
+		if (match.mask->ttl) {
+			NL_SET_ERR_MSG_MOD(extack, "the TTL field is two encoded bits, not a value");
+			return -EOPNOTSUPP;
+		}
+		if (match.mask->tos) {
+			s = ppe_acl_slice_get(slice, &n, PPE_ACL_TYPE_IPMISC);
+			s->key[0] |= FIELD_PREP(PPE_ACL_L3_DSCP,
+						match.key->tos);
+			s->mask[0] |= FIELD_PREP(PPE_ACL_L3_DSCP,
+						 match.mask->tos);
+		}
+	}
+
+	if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_TCP)) {
+		struct flow_match_tcp match;
+		u16 flags, mask;
+
+		flow_rule_match_tcp(rule, &match);
+		flags = ntohs(match.key->flags);
+		mask = ntohs(match.mask->flags);
+		if (mask & ~PPE_ACL_TCP_FLAGS_MAX) {
+			NL_SET_ERR_MSG_MOD(extack, "the classifier stops at the URG flag");
+			return -EOPNOTSUPP;
+		}
+		if (mask) {
+			s = ppe_acl_slice_get(slice, &n, PPE_ACL_TYPE_IPMISC);
+			s->key[1] |= FIELD_PREP(PPE_ACL_TCP_FLAGS, flags);
+			s->mask[1] |= FIELD_PREP(PPE_ACL_TCP_FLAGS, mask);
+		}
+	}
+
+	if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_ETH_ADDRS)) {
+		struct flow_match_eth_addrs match;
+		u32 kw[2], mw[2];
+
+		flow_rule_match_eth_addrs(rule, &match);
+		if (!is_zero_ether_addr(match.mask->dst)) {
+			s = ppe_acl_slice_get(slice, &n, PPE_ACL_TYPE_MAC_DA);
+			ppe_acl_mac_words(kw, match.key->dst);
+			ppe_acl_mac_words(mw, match.mask->dst);
+			s->key[0] |= kw[0];
+			s->key[1] |= kw[1];
+			s->mask[0] |= mw[0];
+			s->mask[1] |= mw[1];
+		}
+		if (!is_zero_ether_addr(match.mask->src)) {
+			s = ppe_acl_slice_get(slice, &n, PPE_ACL_TYPE_MAC_SA);
+			ppe_acl_mac_words(kw, match.key->src);
+			ppe_acl_mac_words(mw, match.mask->src);
+			s->key[0] |= kw[0];
+			s->key[1] |= kw[1];
+			s->mask[0] |= mw[0];
+			s->mask[1] |= mw[1];
+		}
+	}
+
+	if (proto == htons(ETH_P_IPV6)) {
+		sip_type = PPE_ACL_TYPE_IPV6_SIP0 + 2;
+		dip_type = PPE_ACL_TYPE_IPV6_DIP0 + 2;
+	} else {
+		sip_type = PPE_ACL_TYPE_IPV4_SIP;
+		dip_type = PPE_ACL_TYPE_IPV4_DIP;
+	}
+
+	/* Which of the two address keys carries the filter's addresses is the
+	 * control key's to say. cls_flower keeps both families in one union
+	 * and registers a key for either whenever the bytes it covers are
+	 * masked, so a family chosen by the dissector alone reads the other
+	 * one's addresses out of the same memory, and the entries that come
+	 * back match no frame of either family.
+	 */
+	if (addr_type == FLOW_DISSECTOR_KEY_IPV4_ADDRS &&
+	    flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_IPV4_ADDRS)) {
+		struct flow_match_ipv4_addrs match;
+
+		flow_rule_match_ipv4_addrs(rule, &match);
+		if (match.mask->src) {
+			s = ppe_acl_slice_get(slice, &n, PPE_ACL_TYPE_IPV4_SIP);
+			s->key[0] |= FIELD_PREP(PPE_ACL_IP_LO,
+						ntohl(match.key->src));
+			s->key[1] |= FIELD_PREP(PPE_ACL_IP_HI,
+						ntohl(match.key->src) >> 16);
+			s->mask[0] |= FIELD_PREP(PPE_ACL_IP_LO,
+						 ntohl(match.mask->src));
+			s->mask[1] |= FIELD_PREP(PPE_ACL_IP_HI,
+						 ntohl(match.mask->src) >> 16);
+		}
+		if (match.mask->dst) {
+			s = ppe_acl_slice_get(slice, &n, PPE_ACL_TYPE_IPV4_DIP);
+			s->key[0] |= FIELD_PREP(PPE_ACL_IP_LO,
+						ntohl(match.key->dst));
+			s->key[1] |= FIELD_PREP(PPE_ACL_IP_HI,
+						ntohl(match.key->dst) >> 16);
+			s->mask[0] |= FIELD_PREP(PPE_ACL_IP_LO,
+						 ntohl(match.mask->dst));
+			s->mask[1] |= FIELD_PREP(PPE_ACL_IP_HI,
+						 ntohl(match.mask->dst) >> 16);
+		}
+	}
+
+	if (addr_type == FLOW_DISSECTOR_KEY_IPV6_ADDRS &&
+	    flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_IPV6_ADDRS)) {
+		struct flow_match_ipv6_addrs match;
+
+		flow_rule_match_ipv6_addrs(rule, &match);
+		if (!ipv6_addr_any(&match.mask->src))
+			ppe_acl_key_ip6(slice, &n, PPE_ACL_TYPE_IPV6_SIP0,
+					&match.key->src, &match.mask->src);
+		if (!ipv6_addr_any(&match.mask->dst))
+			ppe_acl_key_ip6(slice, &n, PPE_ACL_TYPE_IPV6_DIP0,
+					&match.key->dst, &match.mask->dst);
+	}
+
+	/* The port and the ICMP type/code share one field of the address
+	 * entry, which is why a filter may not ask for both.
+	 */
+	if ((flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_PORTS) ||
+	     flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_PORTS_RANGE)) &&
+	    flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_ICMP)) {
+		NL_SET_ERR_MSG_MOD(extack, "ports and ICMP share one field");
+		return -EOPNOTSUPP;
+	}
+
+	if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_PORTS)) {
+		struct flow_match_ports match;
+
+		if (!proto) {
+			NL_SET_ERR_MSG_MOD(extack, "a port match needs the IP version named");
+			return -EOPNOTSUPP;
+		}
+		flow_rule_match_ports(rule, &match);
+		if (match.mask->src) {
+			s = ppe_acl_slice_get(slice, &n, sip_type);
+			s->key[0] |= FIELD_PREP(PPE_ACL_IP_PORT,
+						ntohs(match.key->src));
+			s->mask[0] |= FIELD_PREP(PPE_ACL_IP_PORT,
+						 ntohs(match.mask->src));
+		}
+		if (match.mask->dst) {
+			s = ppe_acl_slice_get(slice, &n, dip_type);
+			s->key[0] |= FIELD_PREP(PPE_ACL_IP_PORT,
+						ntohs(match.key->dst));
+			s->mask[0] |= FIELD_PREP(PPE_ACL_IP_PORT,
+						 ntohs(match.mask->dst));
+		}
+	}
+
+	/* A range compare turns the same field's mask slot into the maximum,
+	 * so the entry carrying it has no mask left for the port and cannot
+	 * also match one exactly. The address the entry carries keeps its own
+	 * mask - only the field the range names is repurposed - and the
+	 * allocator gives a ranged entry an even slot.
+	 */
+	if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_PORTS_RANGE)) {
+		struct flow_match_ports_range match;
+
+		if (!proto) {
+			NL_SET_ERR_MSG_MOD(extack, "a port match needs the IP version named");
+			return -EOPNOTSUPP;
+		}
+		flow_rule_match_ports_range(rule, &match);
+		if (match.mask->tp_min.src) {
+			s = ppe_acl_slice_get(slice, &n, sip_type);
+			if (s->mask[0] & PPE_ACL_IP_PORT)
+				goto both;
+			s->range = true;
+			s->key[0] |= FIELD_PREP(PPE_ACL_IP_PORT,
+						ntohs(match.key->tp_min.src));
+			s->mask[0] |= FIELD_PREP(PPE_ACL_IP_PORT,
+						 ntohs(match.key->tp_max.src));
+		}
+		if (match.mask->tp_min.dst) {
+			s = ppe_acl_slice_get(slice, &n, dip_type);
+			if (s->mask[0] & PPE_ACL_IP_PORT)
+				goto both;
+			s->range = true;
+			s->key[0] |= FIELD_PREP(PPE_ACL_IP_PORT,
+						ntohs(match.key->tp_min.dst));
+			s->mask[0] |= FIELD_PREP(PPE_ACL_IP_PORT,
+						 ntohs(match.key->tp_max.dst));
+		}
+	}
+
+	if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_ICMP)) {
+		struct flow_match_icmp match;
+
+		if (!proto) {
+			NL_SET_ERR_MSG_MOD(extack, "an ICMP match needs the IP version named");
+			return -EOPNOTSUPP;
+		}
+		flow_rule_match_icmp(rule, &match);
+		if (match.mask->type || match.mask->code) {
+			s = ppe_acl_slice_get(slice, &n, dip_type);
+			s->key[0] |= FIELD_PREP(PPE_ACL_IP_PORT,
+						match.key->type << 8 |
+						match.key->code);
+			s->mask[0] |= FIELD_PREP(PPE_ACL_IP_PORT,
+						 match.mask->type << 8 |
+						 match.mask->code);
+		}
+	}
+
+	*family = proto;
+
+	return n;
+
+both:
+	NL_SET_ERR_MSG_MOD(extack, "a port is matched exactly or as a range, not both");
+
+	return -EOPNOTSUPP;
+}
+
+/* One of the 512 ingress meters. The rate maths is the port policer's - same
+ * block, same refresh period - and metering mode 1 is RFC 2697: one rate, one
+ * bucket, everything the committed burst cannot hold is red. The two words
+ * past the rate leave the excess bucket empty and the violate command at zero,
+ * which is drop, so red means "over the rate" and is dropped.
+ */
+static int ppe_acl_meter_set(struct qca_ppe_priv *priv, u32 index,
+			     u64 rate_bps, u32 burst)
+{
+	u32 cir = 0, cbs = 0;
+	unsigned long clk;
+	int sel = 0;
+
+	if (rate_bps) {
+		clk = ppe_clk_rate(priv);
+		if (!clk)
+			return -ENODEV;
+
+		sel = ppe_token_bucket(clk, PPE_POLICER_SLOT, rate_bps, burst,
+				       FIELD_MAX(PPE_ACL_METER_CIR_HI) << 8 |
+				       FIELD_MAX(PPE_ACL_METER_CIR_LO),
+				       FIELD_MAX(PPE_ACL_METER_CBS),
+				       &cir, &cbs);
+		if (sel < 0)
+			return sel;
+	}
+
+	/* Four words, latching on the last, like every other PPE table. */
+	regmap_write(priv->regmap, PPE_ACL_METER(index),
+		     (rate_bps ? PPE_ACL_METER_EN : 0) |
+		     PPE_ACL_METER_MODE |
+		     FIELD_PREP(PPE_ACL_METER_TOKEN_UNIT, sel) |
+		     FIELD_PREP(PPE_ACL_METER_CBS, cbs) |
+		     FIELD_PREP(PPE_ACL_METER_CIR_LO, cir));
+	regmap_write(priv->regmap, PPE_ACL_METER(index) + 0x4,
+		     FIELD_PREP(PPE_ACL_METER_CIR_HI, cir >> 8));
+	regmap_write(priv->regmap, PPE_ACL_METER(index) + 0x8, 0);
+	regmap_write(priv->regmap, PPE_ACL_METER(index) + 0xc, 0);
+
+	/* A meter index outlives the rule that held it, so the bucket goes back
+	 * with it: tokens the old rule bought at its own rate would otherwise
+	 * be the first thing the next rule to take this index spends.
+	 */
+	if (!rate_bps) {
+		regmap_write(priv->regmap, PPE_ACL_METER_CRDT(index), 0);
+		regmap_write(priv->regmap, PPE_ACL_METER_CRDT(index) + 0x4, 0);
+	}
+
+	return 0;
+}
+
+/* The resources a rule holds outside its own entries. */
+static void ppe_acl_rule_free(struct qca_ppe_priv *priv,
+			      struct ppe_acl_rule *r)
+{
+	if (r->mirror)
+		ppe_mirror_analyzer_put(priv);
+	if (r->meter >= 0) {
+		ppe_acl_meter_set(priv, r->meter, 0, 0);
+		clear_bit(r->meter, priv->acl_meter_used);
+	}
+	kfree(r->fs);
+	kfree(r);
+}
+
+static int ppe_acl_parse_action(struct qca_ppe_priv *priv,
+				struct flow_rule *rule,
+				struct netlink_ext_ack *extack, __be16 family,
+				struct ppe_acl_rule *r)
+{
+	const struct flow_action_entry *a;
+	u32 *act = r->act;
+	bool fwd = false;
+	int i, ret;
+
+	flow_action_for_each(i, a, &rule->action) {
+		switch (a->id) {
+		case FLOW_ACTION_ACCEPT:
+		case FLOW_ACTION_DROP:
+		case FLOW_ACTION_TRAP:
+			if (fwd) {
+				NL_SET_ERR_MSG_MOD(extack, "one forward command per rule");
+				return -EOPNOTSUPP;
+			}
+			fwd = true;
+			act[0] |= PPE_ACL_DEST_CHANGE_EN |
+				  FIELD_PREP(PPE_ACL_FWD_CMD,
+					     a->id == FLOW_ACTION_DROP ?
+					     PPE_ACL_FWD_DROP :
+					     a->id == FLOW_ACTION_TRAP ?
+					     PPE_ACL_FWD_RDT_CPU :
+					     PPE_ACL_FWD_FORWARD);
+			break;
+		case FLOW_ACTION_REDIRECT: {
+			struct dsa_port *to = dsa_port_from_netdev(a->dev);
+
+			if (IS_ERR(to) || to->ds != &priv->ds) {
+				NL_SET_ERR_MSG_MOD(extack, "the destination has to name a port of this switch");
+				return -EOPNOTSUPP;
+			}
+			if (fwd) {
+				NL_SET_ERR_MSG_MOD(extack, "one forward command per rule");
+				return -EOPNOTSUPP;
+			}
+			fwd = true;
+			/* The forward command stays at pass: what changes is
+			 * the destination it passes the frame to.
+			 */
+			act[0] |= PPE_ACL_DEST_CHANGE_EN |
+				  FIELD_PREP(PPE_ACL_DEST_TYPE,
+					     PPE_ACL_DEST_PORT_BMP) |
+				  FIELD_PREP(PPE_ACL_DEST_VALUE,
+					     BIT(to->index));
+			break;
+		}
+		case FLOW_ACTION_PRIORITY:
+			if (a->priority > FIELD_MAX(PPE_ACL_PRI)) {
+				NL_SET_ERR_MSG_MOD(extack, "internal priority is four bits");
+				return -EOPNOTSUPP;
+			}
+			act[3] |= PPE_ACL_PRI_CHANGE_EN |
+				  FIELD_PREP(PPE_ACL_PRI, a->priority);
+			break;
+		case FLOW_ACTION_QUEUE:
+			/* The index is a hardware queue of the whole switch:
+			 * which port it drains is the queue's business, not
+			 * the classifier's.
+			 */
+			if (a->queue.index > FIELD_MAX(PPE_ACL_QID)) {
+				NL_SET_ERR_MSG_MOD(extack, "no such hardware queue");
+				return -EOPNOTSUPP;
+			}
+			act[3] |= PPE_ACL_QID_EN |
+				  FIELD_PREP(PPE_ACL_QID, a->queue.index);
+			break;
+		case FLOW_ACTION_MANGLE: {
+			enum flow_action_mangle_base htype = a->mangle.htype;
+			u32 mask = ntohl(a->mangle.mask);
+			u32 val = ntohl(a->mangle.val);
+			int shift;
+
+			/* Where the byte sits in the header's first word,
+			 * and which family that header is: pedit resolves
+			 * IPv4, IPv6 and unspecified alike to the network
+			 * header, so only the filter's own protocol tells the
+			 * two apart, and the engine rewrites per family.
+			 */
+			if (family == htons(ETH_P_IP) &&
+			    htype == FLOW_ACT_MANGLE_HDR_TYPE_IP4) {
+				shift = 16;
+			} else if (family == htons(ETH_P_IPV6) &&
+				   htype == FLOW_ACT_MANGLE_HDR_TYPE_IP6) {
+				shift = 20;
+			} else {
+				NL_SET_ERR_MSG_MOD(extack, "only the traffic class of the IP version the filter names is rewritten");
+				return -EOPNOTSUPP;
+			}
+			/* The field has no mask on this generation, so the
+			 * rewrite has to be the whole byte and nothing else -
+			 * and what the kernel keeps of the word is what the
+			 * value is xored into, so it may not reach outside.
+			 */
+			if (a->mangle.offset || ~mask != (u32)0xff << shift ||
+			    val & mask) {
+				NL_SET_ERR_MSG_MOD(extack, "the traffic class is rewritten whole or not at all");
+				return -EOPNOTSUPP;
+			}
+			act[2] |= PPE_ACL_DSCP_TC_CHANGE_EN |
+				  FIELD_PREP(PPE_ACL_DSCP_TC, val >> shift);
+			break;
+		}
+		case FLOW_ACTION_POLICE: {
+			unsigned long index;
+
+			/* One byte rate whose excess is dropped: the meter
+			 * has no second bucket to hand a peak rate to, counts
+			 * bytes rather than packets, compensates frame length
+			 * by the block's own constant rather than by a per
+			 * frame overhead, and the colour a lesser exceed
+			 * action would set is read by nothing here.
+			 */
+			if (!a->police.rate_bytes_ps ||
+			    a->police.peakrate_bytes_ps || a->police.avrate ||
+			    a->police.rate_pkt_ps || a->police.overhead ||
+			    a->police.exceed.act_id != FLOW_ACTION_DROP ||
+			    (a->police.notexceed.act_id != FLOW_ACTION_ACCEPT &&
+			     a->police.notexceed.act_id != FLOW_ACTION_PIPE)) {
+				NL_SET_ERR_MSG_MOD(extack, "the meter is one byte rate and drops what exceeds it");
+				return -EOPNOTSUPP;
+			}
+			/* Accepting what conforms ends the filter, so a later
+			 * action would run in the hardware and nowhere else.
+			 */
+			if (a->police.notexceed.act_id == FLOW_ACTION_ACCEPT &&
+			    !flow_action_is_last_entry(&rule->action, a)) {
+				NL_SET_ERR_MSG_MOD(extack, "nothing may follow an action that accepts what conforms");
+				return -EOPNOTSUPP;
+			}
+			if (r->meter >= 0) {
+				NL_SET_ERR_MSG_MOD(extack, "one meter per rule");
+				return -EOPNOTSUPP;
+			}
+			index = find_first_zero_bit(priv->acl_meter_used,
+						    PPE_ACL_METER_ENTRIES);
+			if (index >= PPE_ACL_METER_ENTRIES) {
+				NL_SET_ERR_MSG_MOD(extack, "every meter is taken");
+				return -ENOSPC;
+			}
+			ret = ppe_acl_meter_set(priv, index,
+						a->police.rate_bytes_ps *
+						BITS_PER_BYTE,
+						a->police.burst);
+			if (ret) {
+				NL_SET_ERR_MSG_MOD(extack, "the rate and burst are outside the meter's range");
+				return ret;
+			}
+			set_bit(index, priv->acl_meter_used);
+			r->meter = index;
+			act[3] |= PPE_ACL_POLICER_EN |
+				  FIELD_PREP(PPE_ACL_POLICER_INDEX, index);
+			break;
+		}
+		case FLOW_ACTION_MIRRED: {
+			struct dsa_port *to = dsa_port_from_netdev(a->dev);
+
+			if (IS_ERR(to) || to->ds != &priv->ds) {
+				NL_SET_ERR_MSG_MOD(extack, "the mirror has to name a port of this switch");
+				return -EOPNOTSUPP;
+			}
+			if (r->mirror) {
+				NL_SET_ERR_MSG_MOD(extack, "one mirror per rule");
+				return -EOPNOTSUPP;
+			}
+			ret = ppe_mirror_analyzer_get(priv, to->index);
+			if (ret) {
+				NL_SET_ERR_MSG_MOD(extack, "another port is already mirrored elsewhere");
+				return ret;
+			}
+			r->mirror = true;
+			act[0] |= PPE_ACL_MIRROR_EN;
+			break;
+		}
+		default:
+			NL_SET_ERR_MSG_MOD(extack, "action the classifier cannot take");
+			return -EOPNOTSUPP;
+		}
+	}
+
+	return 0;
+}
+
+static struct ppe_acl_rule *ppe_acl_rule_find(struct qca_ppe_priv *priv,
+					      unsigned long cookie, int port)
+{
+	struct ppe_acl_rule *r;
+
+	list_for_each_entry(r, &priv->acl_rules, list)
+		if (r->cookie == cookie && r->port == port)
+			return r;
+
+	return NULL;
+}
+
+/* Place one parsed rule in the engine. Both uAPIs land here: the preference
+ * is tc's for a filter and the location for an ethtool entry, and in each the
+ * lower number is the stronger rule, which the engine expresses as the higher
+ * priority.
+ */
+static int ppe_acl_rule_add(struct qca_ppe_priv *priv, int port,
+			    struct flow_rule *rule, unsigned long cookie,
+			    int loc, const struct ethtool_rx_flow_spec *fs,
+			    u16 prio, struct netlink_ext_ack *extack)
+{
+	struct ppe_acl_slice slice[PPE_ACL_MAX_SLICES] = {};
+	struct ppe_acl_rule *r;
+	int nslices, ret, i;
+	__be16 family;
+	u16 pri;
+
+	nslices = ppe_acl_parse_key(rule, extack, slice, &family);
+	if (nslices < 0)
+		return nslices;
+	if (!nslices) {
+		NL_SET_ERR_MSG_MOD(extack, "a rule with no key would match every frame");
+		return -EOPNOTSUPP;
+	}
+	if (nslices > PPE_ACL_LIST_ENTRIES) {
+		NL_SET_ERR_MSG_MOD(extack, "the key needs more entries than one list holds");
+		return -EOPNOTSUPP;
+	}
+
+	r = kzalloc(sizeof(*r), GFP_KERNEL);
+	if (!r)
+		return -ENOMEM;
+	r->meter = -1;
+	r->loc = loc;
+	if (fs) {
+		r->fs = kmemdup(fs, sizeof(*fs), GFP_KERNEL);
+		if (!r->fs) {
+			kfree(r);
+			return -ENOMEM;
+		}
+	}
+
+	/* The meter index comes out of the same lock the entries do: the
+	 * small-packet parameters reach the table without rtnl, and so does
+	 * ethtool's n-tuple insert.
+	 */
+	mutex_lock(&priv->acl_lock);
+	ret = ppe_acl_parse_action(priv, rule, extack, family, r);
+	if (ret)
+		goto err;
+
+	ret = ppe_acl_alloc(priv, slice, nslices, &r->group);
+	if (ret) {
+		NL_SET_ERR_MSG_MOD(extack, "no room left in the classifier");
+		goto err;
+	}
+
+	/* Every entry of one rule carries the rule's priority. */
+	pri = FIELD_MAX(PPE_ACL_RULE_PRI) - prio;
+	for (i = 0; i < nslices; i++)
+		ppe_acl_slice_write(priv, r->group.index[i], &slice[i], r->act,
+				    BIT(port), pri);
+
+	r->cookie = cookie;
+	r->port = port;
+	list_add_tail(&r->list, &priv->acl_rules);
+	mutex_unlock(&priv->acl_lock);
+
+	return 0;
+
+err:
+	ppe_acl_rule_free(priv, r);
+	mutex_unlock(&priv->acl_lock);
+
+	return ret;
+}
+
+int qca_ppe_cls_flower_add(struct dsa_switch *ds, int port,
+			   struct flow_cls_offload *cls, bool ingress)
+{
+	struct flow_rule *rule = flow_cls_offload_flow_rule(cls);
+	struct netlink_ext_ack *extack = cls->common.extack;
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+
+	if (!ingress) {
+		NL_SET_ERR_MSG_MOD(extack, "the classifier only sees ingress");
+		return -EOPNOTSUPP;
+	}
+	if (cls->common.chain_index) {
+		NL_SET_ERR_MSG_MOD(extack, "only chain 0 reaches the classifier");
+		return -EOPNOTSUPP;
+	}
+	/* The engine matches the highest priority it holds, where tc gives
+	 * precedence to the lowest preference, so the rule's standing is the
+	 * field's span less the preference. Nine bits carry it, and a
+	 * preference past that is refused rather than tied to another rule's:
+	 * the filter tc reports as offloaded has to be the one that wins.
+	 */
+	if (cls->common.prio > FIELD_MAX(PPE_ACL_RULE_PRI)) {
+		NL_SET_ERR_MSG_MOD(extack, "filter preference is above what the classifier can order; use one below 512");
+		return -EOPNOTSUPP;
+	}
+
+	return ppe_acl_rule_add(priv, port, rule, cls->cookie, -1, NULL,
+				cls->common.prio, extack);
+}
+
+int qca_ppe_cls_flower_del(struct dsa_switch *ds, int port,
+			   struct flow_cls_offload *cls, bool ingress)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	struct ppe_acl_rule *r;
+
+	mutex_lock(&priv->acl_lock);
+	r = ppe_acl_rule_find(priv, cls->cookie, port);
+	if (r) {
+		ppe_acl_free(priv, &r->group);
+		list_del(&r->list);
+		ppe_acl_rule_free(priv, r);
+	}
+	mutex_unlock(&priv->acl_lock);
+
+	return 0;
+}
+
+/* Small packets jump the bulk queue. One rule per IP family classifies every
+ * frame whose L3 length is at most small_pkt_len into internal priority
+ * small_pkt_prio, whose queue the scheduler serves past a standing bulk queue
+ * on a shaped port. Length is the one property the silicon can read that
+ * separates acks, handshakes, DNS, VoIP and game traffic from full-size bulk
+ * without any marking on the packet; the deep queue a shaper wants for
+ * throughput then costs its latency only to the bulk traffic inside it.
+ * The default takes the 200-byte G.711 voice frame, the largest of the
+ * common voice codecs on the wire, with room for its tunnelled forms;
+ * every bulk protocol's data rides at the MTU.
+ *
+ * The priority is capped at 7: the slots above sit on the port's second SP
+ * beside the multicast queues.
+ */
+static ushort ppe_small_pkt_len = 256;
+static ushort ppe_small_pkt_prio = 5;
+
+/* One PPE per SoC; the parameter store needs the instance back. */
+static struct qca_ppe_priv *ppe_acl_priv;
+
+static struct ppe_acl_group ppe_small_pkt_group[2];
+
+/* ethtool's n-tuple table is the second way into the same engine, and the only
+ * one that reaches the queue action: its ring cookie names a queue of the whole
+ * switch, where tc can ask for a priority class and leave the hash to pick
+ * which of that class's queues the flow lands in.
+ */
+static struct ppe_acl_rule *ppe_acl_rule_at(struct qca_ppe_priv *priv,
+					    int port, u32 loc)
+{
+	struct ppe_acl_rule *r;
+
+	lockdep_assert_held(&priv->acl_lock);
+
+	/* Only a rule ethtool inserted has a location. Without the sign test
+	 * the -1 of a tc rule promotes to 0xffffffff and a delete at that
+	 * location takes the tc rule's hardware entry away under it.
+	 */
+	list_for_each_entry(r, &priv->acl_rules, list)
+		if (r->port == port && r->loc >= 0 && r->loc == loc)
+			return r;
+
+	return NULL;
+}
+
+static int ppe_acl_rxnfc_ins(struct qca_ppe_priv *priv, int port,
+			     struct ethtool_rx_flow_spec *fs)
+{
+	struct ethtool_rx_flow_spec_input input = { .fs = fs };
+	struct ethtool_rx_flow_rule *flow;
+	bool taken;
+	int ret;
+
+	/* The location names the rule and orders it, so it shares the span the
+	 * priority field has.
+	 */
+	if (fs->location > FIELD_MAX(PPE_ACL_RULE_PRI))
+		return -EINVAL;
+
+	mutex_lock(&priv->acl_lock);
+	taken = ppe_acl_rule_at(priv, port, fs->location);
+	mutex_unlock(&priv->acl_lock);
+	if (taken)
+		return -EEXIST;
+
+	flow = ethtool_rx_flow_rule_create(&input);
+	if (IS_ERR(flow))
+		return PTR_ERR(flow);
+
+	ret = ppe_acl_rule_add(priv, port, flow->rule, 0, fs->location, fs,
+			       fs->location, NULL);
+	ethtool_rx_flow_rule_destroy(flow);
+
+	return ret;
+}
+
+int qca_ppe_set_rxnfc(struct dsa_switch *ds, int port,
+		      struct ethtool_rxnfc *nfc)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	struct ppe_acl_rule *r;
+
+	if (nfc->cmd == ETHTOOL_SRXCLSRLINS)
+		return ppe_acl_rxnfc_ins(priv, port, &nfc->fs);
+	if (nfc->cmd != ETHTOOL_SRXCLSRLDEL)
+		return -EOPNOTSUPP;
+
+	guard(mutex)(&priv->acl_lock);
+
+	r = ppe_acl_rule_at(priv, port, nfc->fs.location);
+	if (!r)
+		return -ENOENT;
+
+	ppe_acl_free(priv, &r->group);
+	list_del(&r->list);
+	ppe_acl_rule_free(priv, r);
+
+	return 0;
+}
+
+int qca_ppe_get_rxnfc(struct dsa_switch *ds, int port,
+		      struct ethtool_rxnfc *nfc, u32 *rule_locs)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	struct ppe_acl_rule *r;
+	u32 cnt = 0;
+
+	guard(mutex)(&priv->acl_lock);
+
+	switch (nfc->cmd) {
+	case ETHTOOL_GRXRINGS:
+		/* What the action may name: a queue of the whole switch, not a
+		 * receive ring of this port.
+		 */
+		nfc->data = FIELD_MAX(PPE_ACL_QID) + 1;
+		return 0;
+	case ETHTOOL_GRXCLSRLCNT:
+		list_for_each_entry(r, &priv->acl_rules, list)
+			if (r->port == port && r->loc >= 0)
+				cnt++;
+		nfc->rule_cnt = cnt;
+		nfc->data = FIELD_MAX(PPE_ACL_RULE_PRI) + 1;
+		return 0;
+	case ETHTOOL_GRXCLSRULE:
+		r = ppe_acl_rule_at(priv, port, nfc->fs.location);
+		if (!r || !r->fs)
+			return -ENOENT;
+
+		nfc->fs = *r->fs;
+		return 0;
+	case ETHTOOL_GRXCLSRLALL:
+		list_for_each_entry(r, &priv->acl_rules, list) {
+			if (r->port != port || r->loc < 0)
+				continue;
+			if (cnt >= nfc->rule_cnt)
+				return -EMSGSIZE;
+
+			rule_locs[cnt++] = r->loc;
+		}
+		nfc->rule_cnt = cnt;
+		nfc->data = FIELD_MAX(PPE_ACL_RULE_PRI) + 1;
+		return 0;
+	default:
+		return -EOPNOTSUPP;
+	}
+}
+
+static void ppe_acl_small_pkt_apply(struct qca_ppe_priv *priv)
+{
+	u32 ports = GENMASK(priv->data->num_ports - 1, 0);
+	u32 act[PPE_ACL_ACTION_WORDS] = {};
+	struct ppe_acl_slice s = {};
+	int i;
+
+	act[3] = PPE_ACL_PRI_CHANGE_EN |
+		 FIELD_PREP(PPE_ACL_PRI, ppe_small_pkt_prio);
+
+	s.type = PPE_ACL_TYPE_IPMISC;
+	s.range = true;
+	/* Range compare: minimum in the rule, maximum in the mask slot. */
+	s.mask[0] = FIELD_PREP(PPE_ACL_L3_LEN, ppe_small_pkt_len);
+	s.mask[1] = PPE_ACL_IS_IPV6;
+
+	/* Length 0 disarms by handing the rule an empty source bitmap, which
+	 * keeps its entry so the parameter can be turned back on.
+	 *
+	 * Priority 1, not the floor: a tc filter at the last preference
+	 * lands on priority 0, which is the one place a rule that has to
+	 * lose to this promotion for a small frame can stand.
+	 */
+	for (i = 0; i < ARRAY_SIZE(ppe_small_pkt_group); i++) {
+		struct ppe_acl_group *g = &ppe_small_pkt_group[i];
+
+		if (!g->nslices && ppe_acl_alloc(priv, &s, 1, g))
+			continue;
+
+		s.key[1] = i ? PPE_ACL_IS_IPV6 : 0;
+		ppe_acl_slice_write(priv, g->index[0], &s, act,
+				    ppe_small_pkt_len ? ports : 0, 1);
+	}
+}
+
+static int ppe_small_pkt_param_set(const char *val,
+				   const struct kernel_param *kp)
+{
+	struct qca_ppe_priv *priv = ppe_acl_priv;
+	int ret = param_set_ushort(val, kp);
+
+	if (ret)
+		return ret;
+	if (ppe_small_pkt_prio > 7)
+		ppe_small_pkt_prio = 7;
+	if (!priv)
+		return 0;
+
+	mutex_lock(&priv->acl_lock);
+	ppe_acl_small_pkt_apply(priv);
+	mutex_unlock(&priv->acl_lock);
+
+	return 0;
+}
+
+static const struct kernel_param_ops ppe_small_pkt_param_ops = {
+	.set = ppe_small_pkt_param_set,
+	.get = param_get_ushort,
+};
+
+module_param_cb(small_pkt_len, &ppe_small_pkt_param_ops,
+		&ppe_small_pkt_len, 0644);
+MODULE_PARM_DESC(small_pkt_len,
+		 "Classify frames up to this L3 length into small_pkt_prio (0 disables)");
+module_param_cb(small_pkt_prio, &ppe_small_pkt_param_ops,
+		&ppe_small_pkt_prio, 0644);
+MODULE_PARM_DESC(small_pkt_prio,
+		 "Internal priority for small frames (0-7)");
+
+void ppe_acl_init(struct qca_ppe_priv *priv)
+{
+	int i;
+
+	mutex_init(&priv->acl_lock);
+	INIT_LIST_HEAD(&priv->acl_rules);
+	for (i = 0; i < PPE_ACL_LISTS; i++)
+		priv->acl_free[i] = GENMASK(PPE_ACL_LIST_ENTRIES - 1, 0);
+
+	mutex_lock(&priv->acl_lock);
+	ppe_acl_priv = priv;
+	ppe_acl_small_pkt_apply(priv);
+	mutex_unlock(&priv->acl_lock);
+}
+
+void ppe_acl_exit(struct qca_ppe_priv *priv)
+{
+	struct ppe_acl_rule *r, *tmp;
+	int i;
+
+	/* The parameter writer finds this driver through the global and then
+	 * takes the lock that lives inside it, so the lock cannot be what
+	 * guards the pointer. param_attr_store() holds the parameter lock
+	 * across the whole set, so clearing the global under it lets any
+	 * writer already inside finish before this teardown frees what it is
+	 * writing through.
+	 */
+	kernel_param_lock(THIS_MODULE);
+	ppe_acl_priv = NULL;
+	kernel_param_unlock(THIS_MODULE);
+
+	mutex_lock(&priv->acl_lock);
+	list_for_each_entry_safe(r, tmp, &priv->acl_rules, list) {
+		ppe_acl_free(priv, &r->group);
+		list_del(&r->list);
+		ppe_acl_rule_free(priv, r);
+	}
+	for (i = 0; i < ARRAY_SIZE(ppe_small_pkt_group); i++)
+		if (ppe_small_pkt_group[i].nslices)
+			ppe_acl_free(priv, &ppe_small_pkt_group[i]);
+	mutex_unlock(&priv->acl_lock);
+}

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_acl.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_acl.c
@@ -242,6 +242,9 @@ static void ppe_acl_slice_write(struct qca_ppe_priv *priv, u32 index,
 #define PPE_ACL_MATCH_KEYS					\
 	(BIT_ULL(FLOW_DISSECTOR_KEY_CONTROL) |			\
 	 BIT_ULL(FLOW_DISSECTOR_KEY_BASIC) |			\
+	 BIT_ULL(FLOW_DISSECTOR_KEY_VLAN) |			\
+	 BIT_ULL(FLOW_DISSECTOR_KEY_CVLAN) |			\
+	 BIT_ULL(FLOW_DISSECTOR_KEY_PPPOE) |			\
 	 BIT_ULL(FLOW_DISSECTOR_KEY_ETH_ADDRS) |		\
 	 BIT_ULL(FLOW_DISSECTOR_KEY_IPV4_ADDRS) |		\
 	 BIT_ULL(FLOW_DISSECTOR_KEY_IPV6_ADDRS) |		\
@@ -398,16 +401,25 @@ static int ppe_acl_parse_key(struct flow_rule *rule,
 				NL_SET_ERR_MSG_MOD(extack, "the protocol is matched whole or not at all");
 				return -EOPNOTSUPP;
 			}
-			proto = match.key->n_proto;
-			if (proto != htons(ETH_P_IP) &&
-			    proto != htons(ETH_P_IPV6)) {
-				NL_SET_ERR_MSG_MOD(extack, "only IPv4 and IPv6 are matched by protocol");
-				return -EOPNOTSUPP;
+			/* One bit tells the two IP versions apart, and the
+			 * rule type that carries an ethertype names anything
+			 * else.
+			 */
+			if (match.key->n_proto == htons(ETH_P_IP) ||
+			    match.key->n_proto == htons(ETH_P_IPV6)) {
+				proto = match.key->n_proto;
+				s = ppe_acl_slice_get(slice, &n,
+						      PPE_ACL_TYPE_IPMISC);
+				if (proto == htons(ETH_P_IPV6))
+					s->key[1] |= PPE_ACL_IS_IPV6;
+				s->mask[1] |= PPE_ACL_IS_IPV6;
+			} else {
+				s = ppe_acl_slice_get(slice, &n,
+						      PPE_ACL_TYPE_L2MISC);
+				s->key[0] |= FIELD_PREP(PPE_ACL_L2_PROT,
+						ntohs(match.key->n_proto));
+				s->mask[0] |= PPE_ACL_L2_PROT;
 			}
-			s = ppe_acl_slice_get(slice, &n, PPE_ACL_TYPE_IPMISC);
-			if (proto == htons(ETH_P_IPV6))
-				s->key[1] |= PPE_ACL_IS_IPV6;
-			s->mask[1] |= PPE_ACL_IS_IPV6;
 		}
 		if (match.mask->ip_proto) {
 			s = ppe_acl_slice_get(slice, &n, PPE_ACL_TYPE_IPMISC);
@@ -415,6 +427,81 @@ static int ppe_acl_parse_key(struct flow_rule *rule,
 						match.key->ip_proto);
 			s->mask[0] |= FIELD_PREP(PPE_ACL_L3_PROT,
 						 match.mask->ip_proto);
+		}
+	}
+
+	/* A lone 802.1Q tag classifies into the C slot, which is where the
+	 * bridge's own translation rules key it, and these ports carry no
+	 * service tag: a second tag or an 802.1ad one is never classified, so
+	 * a filter naming either has nothing to match. The format field holds
+	 * one frame format rather than a bitmap of accepted ones.
+	 */
+	if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_VLAN)) {
+		struct flow_match_vlan match;
+
+		if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_CVLAN)) {
+			NL_SET_ERR_MSG_MOD(extack, "the ports classify one tag, not two");
+			return -EOPNOTSUPP;
+		}
+
+		flow_rule_match_vlan(rule, &match);
+		/* ethtool registers the key on the tci alone and leaves the
+		 * tpid unset, which is a tag it did not name rather than one
+		 * this classifier has no slot for.
+		 */
+		if (match.mask->vlan_tpid &&
+		    match.key->vlan_tpid != htons(ETH_P_8021Q)) {
+			NL_SET_ERR_MSG_MOD(extack, "only an 802.1Q tag is classified");
+			return -EOPNOTSUPP;
+		}
+
+		/* The slice compares the id and the priority; the tag's
+		 * drop-eligible bit has no compare of its own. Only ethtool
+		 * presents a mask for it, and it does so by masking the whole
+		 * tci rather than by naming the bit, so a filter is not
+		 * refused for one.
+		 */
+		s = ppe_acl_slice_get(slice, &n, PPE_ACL_TYPE_VLAN);
+		if (match.mask->vlan_id) {
+			s->key[0] |= FIELD_PREP(PPE_ACL_CVID,
+						match.key->vlan_id);
+			s->mask[0] |= FIELD_PREP(PPE_ACL_CVID,
+						 match.mask->vlan_id);
+		}
+		if (match.mask->vlan_priority) {
+			s->key[0] |= FIELD_PREP(PPE_ACL_CPCP,
+						match.key->vlan_priority);
+			s->mask[0] |= FIELD_PREP(PPE_ACL_CPCP,
+						 match.mask->vlan_priority);
+		}
+		s->key[1] |= FIELD_PREP(PPE_ACL_CTAG_FMT, PPE_ACL_TAG_TAGGED) |
+			     FIELD_PREP(PPE_ACL_STAG_FMT, PPE_ACL_TAG_UNTAGGED);
+		s->mask[1] |= PPE_ACL_CTAG_FMT | PPE_ACL_STAG_FMT;
+	}
+
+	/* The classifier has one ethertype field and PPPoE needs it for the
+	 * session, so a rule that also names the protocol the session carries -
+	 * which tc hands over in place of the frame's own - is declined rather
+	 * than installed matching only the half the field holds.
+	 */
+	if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_PPPOE)) {
+		struct flow_match_pppoe match;
+
+		flow_rule_match_pppoe(rule, &match);
+		if (match.mask->ppp_proto) {
+			NL_SET_ERR_MSG_MOD(extack, "the session is matched, not what it carries");
+			return -EOPNOTSUPP;
+		}
+		s = ppe_acl_slice_get(slice, &n, PPE_ACL_TYPE_L2MISC);
+		s->key[0] |= FIELD_PREP(PPE_ACL_L2_PROT,
+					ntohs(match.key->type));
+		s->mask[0] |= FIELD_PREP(PPE_ACL_L2_PROT,
+					 ntohs(match.mask->type));
+		if (match.mask->session_id) {
+			s->key[1] |= FIELD_PREP(PPE_ACL_PPPOE_SID,
+						ntohs(match.key->session_id));
+			s->mask[1] |= FIELD_PREP(PPE_ACL_PPPOE_SID,
+						 ntohs(match.mask->session_id));
 		}
 	}
 
@@ -487,11 +574,9 @@ static int ppe_acl_parse_key(struct flow_rule *rule,
 	}
 
 	/* Which of the two address keys carries the filter's addresses is the
-	 * control key's to say. cls_flower keeps both families in one union
-	 * and registers a key for either whenever the bytes it covers are
-	 * masked, so a family chosen by the dissector alone reads the other
-	 * one's addresses out of the same memory, and the entries that come
-	 * back match no frame of either family.
+	 * control key's to say. A dissector that offers both answers for the
+	 * one it does not hold out of the memory the other occupies, and the
+	 * entries that come back match no frame of either family.
 	 */
 	if (addr_type == FLOW_DISSECTOR_KEY_IPV4_ADDRS &&
 	    flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_IPV4_ADDRS)) {
@@ -768,6 +853,36 @@ static int ppe_acl_parse_action(struct qca_ppe_priv *priv,
 			}
 			act[3] |= PPE_ACL_QID_EN |
 				  FIELD_PREP(PPE_ACL_QID, a->queue.index);
+			break;
+		case FLOW_ACTION_VLAN_POP:
+			/* The format bit beside the change enable is the whole
+			 * choice: the frame leaves without the tag.
+			 */
+			ppe_entry_set(act, PPE_ACL_ACT_CVID_EN_OFF,
+				      PPE_ACL_ACT_EN_LEN, 1);
+			break;
+		case FLOW_ACTION_VLAN_PUSH:
+		case FLOW_ACTION_VLAN_MANGLE:
+			/* A push and a replace are the same write: whether a
+			 * tag was already there is the frame's business, not
+			 * the rule's. tc carries a priority with either,
+			 * named by the filter or defaulted, so both fields of
+			 * the tag are rewritten together.
+			 */
+			if (a->vlan.proto != htons(ETH_P_8021Q)) {
+				NL_SET_ERR_MSG_MOD(extack, "only an 802.1Q tag is edited");
+				return -EOPNOTSUPP;
+			}
+			ppe_entry_set(act, PPE_ACL_ACT_CVID_EN_OFF,
+				      PPE_ACL_ACT_EN_LEN, 1);
+			ppe_entry_set(act, PPE_ACL_ACT_CTAG_FMT_OFF,
+				      PPE_ACL_ACT_EN_LEN, PPE_ACL_ACT_TAG_KEEP);
+			ppe_entry_set(act, PPE_ACL_ACT_CVID_OFF,
+				      PPE_ACL_ACT_VID_LEN, a->vlan.vid);
+			ppe_entry_set(act, PPE_ACL_ACT_CPCP_EN_OFF,
+				      PPE_ACL_ACT_EN_LEN, 1);
+			ppe_entry_set(act, PPE_ACL_ACT_CPCP_OFF,
+				      PPE_ACL_ACT_PCP_LEN, a->vlan.prio);
 			break;
 		case FLOW_ACTION_MANGLE: {
 			enum flow_action_mangle_base htype = a->mangle.htype;

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_debugfs.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_debugfs.c
@@ -1,0 +1,462 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/* Copyright (c) 2026 Julius Bairaktaris <julius@bairaktaris.de> */
+/* Read-only dumps of the PPE's hardware counters.
+ *
+ * The driver switches most of these on at probe and reads none of them back,
+ * so every question about where a frame stopped has so far been answered with
+ * devmem. Nothing here writes hardware, not even the tables the hardware lets
+ * a host clear.
+ */
+
+#include <linux/bitfield.h>
+#include <linux/debugfs.h>
+#include <linux/regmap.h>
+#include <linux/seq_file.h>
+
+#include "qca_ppe.h"
+
+/* Every packet-and-byte counter table below is three words wide. */
+#define PPE_CNT_WORDS		3
+
+/* The counter tables share one shape: a 32-bit packet count followed by a
+ * 40-bit byte count, both straddling word boundaries.
+ */
+static void ppe_cnt_get(const u32 *w, u32 off, u64 *pkts, u64 *bytes)
+{
+	*pkts = ppe_entry_get(w, off, 32);
+	*bytes = ppe_entry_get(w, off + 32, 40);
+}
+
+/* Frames that reached the L3 stage, per ingress L3 interface. This is what
+ * separates "the flow entry never matched" from "the frame never got as far as
+ * the lookup", which no other counter answers.
+ */
+static int ppe_l3_interface_show(struct seq_file *s, void *data)
+{
+	struct qca_ppe_priv *priv = s->private;
+	u64 pkts, bytes, drop_pkts, drop_bytes;
+	u32 w[PPE_CNT_DROP_WORDS];
+	u32 i;
+
+	seq_puts(s, "l3_if packets bytes drop_packets drop_bytes\n");
+
+	for (i = 0; i < PPE_RT_IF_CNT_ENTRIES; i++) {
+		if (regmap_bulk_read(priv->regmap, PPE_RT_IF_CNT_TBL(i), w,
+				     ARRAY_SIZE(w)))
+			return -EIO;
+
+		ppe_cnt_get(w, 0, &pkts, &bytes);
+		ppe_cnt_get(w, PPE_CNT_DROP_OFF, &drop_pkts,
+			    &drop_bytes);
+		if (!pkts && !drop_pkts)
+			continue;
+
+		seq_printf(s, "%-5u %llu %llu %llu %llu\n", i, pkts, bytes,
+			   drop_pkts, drop_bytes);
+	}
+
+	return 0;
+}
+DEFINE_SHOW_ATTRIBUTE(ppe_l3_interface);
+
+/* The ingress policer's own view of what it did to a port's traffic. Red is the
+ * colour a token-bucket overrun is painted and the packets counted there are
+ * the ones it dropped, which until now was inferred from the throughput that
+ * came out the other side.
+ */
+static int ppe_policer_show(struct seq_file *s, void *data)
+{
+	static const char * const colour[] = { "green", "yellow", "red" };
+	struct qca_ppe_priv *priv = s->private;
+	u32 w[PPE_CNT_WORDS];
+	u64 pkts, bytes;
+	int port, c;
+
+	seq_puts(s, "port colour packets bytes\n");
+
+	for (port = 0; port < priv->ds.num_ports; port++) {
+		for (c = 0; c < ARRAY_SIZE(colour); c++) {
+			if (regmap_bulk_read(priv->regmap,
+					     PPE_PORT_METER_CNT(port, c), w,
+					     ARRAY_SIZE(w)))
+				return -EIO;
+
+			ppe_cnt_get(w, 0, &pkts, &bytes);
+			seq_printf(s, "%-4d %-6s %llu %llu\n", port,
+				   colour[c], pkts, bytes);
+		}
+	}
+
+	return 0;
+}
+DEFINE_SHOW_ATTRIBUTE(ppe_policer);
+
+/* Why frames left the datapath. A CPU code says which exception handed the
+ * frame to the host; a drop code says which stage discarded it, and is the
+ * only counter that names the stage.
+ */
+static int ppe_drop_code_show(struct seq_file *s, void *data)
+{
+	struct qca_ppe_priv *priv = s->private;
+	u32 w[PPE_CNT_WORDS];
+	u64 pkts, bytes;
+	u32 i;
+
+	seq_puts(s, "kind code port packets bytes\n");
+
+	for (i = 0; i < PPE_DROP_CPU_ENTRIES; i++) {
+		if (regmap_bulk_read(priv->regmap, PPE_DROP_CPU_CNT_TBL(i), w,
+				     ARRAY_SIZE(w)))
+			return -EIO;
+
+		ppe_cnt_get(w, 0, &pkts, &bytes);
+		if (!pkts)
+			continue;
+
+		if (i < PPE_CPU_CODE_ENTRIES)
+			seq_printf(s, "cpu  %-4u -    %llu %llu\n", i, pkts,
+				   bytes);
+		else
+			seq_printf(s, "drop %-4u %-4u %llu %llu\n",
+				   (i - PPE_CPU_CODE_ENTRIES) /
+				   PPE_DROP_CODE_PORTS,
+				   (i - PPE_CPU_CODE_ENTRIES) %
+				   PPE_DROP_CODE_PORTS, pkts, bytes);
+	}
+
+	return 0;
+}
+DEFINE_SHOW_ATTRIBUTE(ppe_drop_code);
+
+/* What each egress queue has transmitted and what it is holding right now.
+ * Depth in buffers is the direct readout of standing queue occupancy, which
+ * has so far only been inferred from the latency it causes.
+ */
+static int ppe_queues_show(struct seq_file *s, void *data)
+{
+	struct qca_ppe_priv *priv = s->private;
+	u32 w[PPE_CNT_WORDS], val;
+	u64 pkts, bytes;
+	u32 i;
+
+	seq_puts(s, "queue packets bytes buffers\n");
+
+	for (i = 0; i < PPE_L0_QUEUES; i++) {
+		if (regmap_bulk_read(priv->regmap, PPE_QUEUE_TX_CNT_TBL(i), w,
+				     ARRAY_SIZE(w)))
+			return -EIO;
+
+		if (i < PPE_L0_UCAST_QUEUES) {
+			regmap_read(priv->regmap, PPE_QM_AC_UNI_CNT(i), &val);
+			val = FIELD_GET(PPE_AC_UNI_PEND_CNT, val);
+		} else {
+			regmap_read(priv->regmap,
+				    PPE_QM_AC_MUL_CNT(i - PPE_L0_UCAST_QUEUES),
+				    &val);
+			val = FIELD_GET(PPE_AC_MUL_PEND_CNT, val);
+		}
+
+		ppe_cnt_get(w, 0, &pkts, &bytes);
+		if (!pkts && !val)
+			continue;
+
+		seq_printf(s, "%-5u %llu %llu %u\n", i, pkts, bytes, val);
+	}
+
+	/* One buffer group per value the queues' group field can hold. */
+	seq_puts(s, "group buffers prealloc_used\n");
+	for (i = 0; i <= FIELD_MAX(PPE_AC_GRP_ID); i++) {
+		regmap_read(priv->regmap, PPE_QM_AC_GRP_CNT(i), &val);
+		seq_printf(s, "%-5u %lu %lu\n", i,
+			   FIELD_GET(PPE_AC_GRP_PEND_CNT, val),
+			   FIELD_GET(PPE_AC_GRP_ALLOC_USED, val));
+	}
+
+	return 0;
+}
+DEFINE_SHOW_ATTRIBUTE(ppe_queues);
+
+/* Why a queue discarded a frame, split the way the hardware counts it: WRED
+ * against the queue's own limit, or a forced drop when the buffer pool behind
+ * it ran out, each per colour.
+ */
+static int ppe_queue_drops_show(struct seq_file *s, void *data)
+{
+	static const char * const reason[PPE_UNI_DROP_TYPES] = {
+		"wred_green", "wred_yellow", "wred_red",
+		"force_green", "force_yellow", "force_red",
+	};
+	const u32 force = PPE_UNI_DROP_TYPES - PPE_MUL_DROP_TYPES;
+	struct qca_ppe_priv *priv = s->private;
+	u32 w[PPE_CNT_WORDS];
+	u64 pkts, bytes;
+	u32 i, t, reg;
+
+	seq_puts(s, "queue reason packets bytes\n");
+
+	for (i = 0; i < PPE_L0_QUEUES; i++) {
+		for (t = 0; t < PPE_UNI_DROP_TYPES; t++) {
+			if (i < PPE_L0_UCAST_QUEUES) {
+				reg = PPE_QM_UNI_DROP_CNT(i, t);
+			} else {
+				u32 mq = i - PPE_L0_UCAST_QUEUES;
+				u32 port = 0;
+
+				/* A multicast queue only has the forced
+				 * drops, in a block per port.
+				 */
+				if (t < force)
+					continue;
+
+				if (mq >= PPE_MUL_QUEUES_CPU) {
+					mq -= PPE_MUL_QUEUES_CPU;
+					port = 1 + mq / PPE_MUL_QUEUES_PORT;
+					mq %= PPE_MUL_QUEUES_PORT;
+				}
+
+				reg = PPE_QM_MUL_DROP_CNT(port, mq, t - force);
+			}
+
+			if (regmap_bulk_read(priv->regmap, reg, w,
+					     ARRAY_SIZE(w)))
+				return -EIO;
+
+			ppe_cnt_get(w, 0, &pkts, &bytes);
+			if (!pkts)
+				continue;
+
+			seq_printf(s, "%-5u %-12s %llu %llu\n", i, reason[t],
+				   pkts, bytes);
+		}
+	}
+
+	return 0;
+}
+DEFINE_SHOW_ATTRIBUTE(ppe_queue_drops);
+
+/* What the buffer manager did to ingress: the buffers each of its ports holds,
+ * and the frames it turned away, separated into a plain overload and a drop
+ * the flow control caused.
+ */
+static int ppe_bm_show(struct seq_file *s, void *data)
+{
+	struct qca_ppe_priv *priv = s->private;
+	u64 pkts, bytes, fc_pkts, fc_bytes;
+	u32 w[PPE_CNT_WORDS], used, react;
+	u32 i;
+
+	seq_puts(s, "port used react drop_packets drop_bytes fc_packets fc_bytes\n");
+
+	for (i = 0; i < PPE_BM_PORTS; i++) {
+		regmap_read(priv->regmap, PPE_BM_PORT_CNT(i), &used);
+		regmap_read(priv->regmap, PPE_BM_PORT_REACT_CNT(i), &react);
+
+		if (regmap_bulk_read(priv->regmap, PPE_BM_DROP_STAT(i), w,
+				     ARRAY_SIZE(w)))
+			return -EIO;
+		ppe_cnt_get(w, 0, &pkts, &bytes);
+
+		if (regmap_bulk_read(priv->regmap,
+				     PPE_BM_DROP_STAT(i + PPE_BM_PORTS), w,
+				     ARRAY_SIZE(w)))
+			return -EIO;
+		ppe_cnt_get(w, 0, &fc_pkts, &fc_bytes);
+
+		seq_printf(s, "%-4u %lu %lu %llu %llu %llu %llu\n", i,
+			   FIELD_GET(PPE_BM_PORT_CNT_VAL, used),
+			   FIELD_GET(PPE_BM_PORT_REACT_CNT_VAL, react),
+			   pkts, bytes, fc_pkts, fc_bytes);
+	}
+
+	seq_puts(s, "group buffers\n");
+	for (i = 0; i < PPE_BM_SHARED_GROUPS; i++) {
+		regmap_read(priv->regmap, PPE_BM_SHARED_GRP_CNT(i), &used);
+		seq_printf(s, "%-5u %lu\n", i,
+			   FIELD_GET(PPE_BM_SHARED_GRP_CNT_VAL, used));
+	}
+
+	return 0;
+}
+DEFINE_SHOW_ATTRIBUTE(ppe_bm);
+
+/* Where an ingress frame stopped before the lookup: the port receiver's own
+ * drop count, the parser's per-port totals, and the L2 stage's per-VSI view.
+ */
+static int ppe_ingress_show(struct seq_file *s, void *data)
+{
+	u64 pkts, bytes, vlan_pkts, drop_pkts, drop_bytes;
+	struct qca_ppe_priv *priv = s->private;
+	u32 w[PPE_CNT_DROP_WORDS];
+	u32 drops, parsed, lo, hi;
+	int i;
+
+	seq_puts(s, "port prx_drops parsed_packets parsed_bytes\n");
+
+	for (i = 0; i < priv->ds.num_ports; i++) {
+		regmap_read(priv->regmap, PPE_PRX_DROP_CNT(i), &drops);
+		regmap_read(priv->regmap, PPE_IPR_PKT_CNT(i), &parsed);
+		regmap_read(priv->regmap, PPE_IPR_BYTE_LO(i), &lo);
+		regmap_read(priv->regmap, PPE_IPR_BYTE_HI(i), &hi);
+
+		seq_printf(s, "%-4d %u %u %llu\n", i, drops, parsed,
+			   lo | ((u64)hi << 32));
+	}
+
+	seq_puts(s, "vsi vlan_packets l2_packets l2_bytes l2_drops l2_drop_bytes\n");
+
+	for (i = 0; i < PPE_VSI_MAX; i++) {
+		if (regmap_bulk_read(priv->regmap, PPE_VLAN_CNT_TBL(i), w,
+				     PPE_CNT_WORDS))
+			return -EIO;
+		ppe_cnt_get(w, 0, &vlan_pkts, &bytes);
+
+		if (regmap_bulk_read(priv->regmap, PPE_PRE_L2_CNT_TBL(i), w,
+				     ARRAY_SIZE(w)))
+			return -EIO;
+		ppe_cnt_get(w, 0, &pkts, &bytes);
+		ppe_cnt_get(w, PPE_CNT_DROP_OFF, &drop_pkts, &drop_bytes);
+
+		if (!vlan_pkts && !pkts && !drop_pkts)
+			continue;
+
+		seq_printf(s, "%-3d %llu %llu %llu %llu %llu\n", i, vlan_pkts,
+			   pkts, bytes, drop_pkts, drop_bytes);
+	}
+
+	return 0;
+}
+DEFINE_SHOW_ATTRIBUTE(ppe_ingress);
+
+/* What the egress editor put out, and what the transmit stage dropped on the
+ * way. The stage totals bracket the per-port rows: a frame counted in but not
+ * out never reached a port at all.
+ */
+static int ppe_egress_show(struct seq_file *s, void *data)
+{
+	struct qca_ppe_priv *priv = s->private;
+	u64 pkts, bytes, drop_pkts, drop_bytes;
+	u32 w[PPE_CNT_WORDS], val;
+	int i;
+
+	regmap_read(priv->regmap, PPE_EPE_DBG_IN_CNT, &val);
+	seq_printf(s, "epe_in %u\n", val);
+	regmap_read(priv->regmap, PPE_EPE_DBG_OUT_CNT, &val);
+	seq_printf(s, "epe_out %u\n", val);
+
+	seq_puts(s, "port packets bytes drop_packets drop_bytes\n");
+
+	for (i = 0; i < priv->ds.num_ports; i++) {
+		if (regmap_bulk_read(priv->regmap, PPE_PORT_TX_CNT_TBL(i), w,
+				     ARRAY_SIZE(w)))
+			return -EIO;
+		ppe_cnt_get(w, 0, &pkts, &bytes);
+
+		if (regmap_bulk_read(priv->regmap, PPE_PORT_TX_DROP_CNT(i), w,
+				     ARRAY_SIZE(w)))
+			return -EIO;
+		ppe_cnt_get(w, 0, &drop_pkts, &drop_bytes);
+
+		seq_printf(s, "%-4d %llu %llu %llu %llu\n", i, pkts, bytes,
+			   drop_pkts, drop_bytes);
+	}
+
+	seq_puts(s, "vsi packets bytes\n");
+
+	for (i = 0; i < PPE_VSI_MAX; i++) {
+		if (regmap_bulk_read(priv->regmap, PPE_EG_VSI_CNT_TBL(i), w,
+				     ARRAY_SIZE(w)))
+			return -EIO;
+
+		ppe_cnt_get(w, 0, &pkts, &bytes);
+		if (!pkts)
+			continue;
+
+		seq_printf(s, "%-3d %llu %llu\n", i, pkts, bytes);
+	}
+
+	seq_puts(s, "vport packets bytes drop_packets drop_bytes\n");
+
+	for (i = 0; i < PPE_MAX_VPORT; i++) {
+		if (regmap_bulk_read(priv->regmap, PPE_VP_TX_CNT_TBL(i), w,
+				     ARRAY_SIZE(w)))
+			return -EIO;
+		ppe_cnt_get(w, 0, &pkts, &bytes);
+
+		if (regmap_bulk_read(priv->regmap, PPE_VP_TX_DROP_CNT(i), w,
+				     ARRAY_SIZE(w)))
+			return -EIO;
+		ppe_cnt_get(w, 0, &drop_pkts, &drop_bytes);
+
+		if (!pkts && !drop_pkts)
+			continue;
+
+		seq_printf(s, "%-5d %llu %llu %llu %llu\n", i, pkts, bytes,
+			   drop_pkts, drop_bytes);
+	}
+
+	return 0;
+}
+DEFINE_SHOW_ATTRIBUTE(ppe_egress);
+
+/* Whether the ACL is doing anything, and which rule. The three global counters
+ * run with no enable bit, so a rule that classifies nothing shows up as a miss
+ * count that keeps climbing while its own row stays at zero.
+ */
+static int ppe_acl_show(struct seq_file *s, void *data)
+{
+	struct qca_ppe_priv *priv = s->private;
+	u32 w[PPE_CNT_WORDS], val;
+	u64 pkts, bytes;
+	int i;
+
+	regmap_read(priv->regmap, PPE_ACL_GLB_HIT_CNT, &val);
+	seq_printf(s, "hit %u\n", val);
+	regmap_read(priv->regmap, PPE_ACL_GLB_MISS_CNT, &val);
+	seq_printf(s, "miss %u\n", val);
+	regmap_read(priv->regmap, PPE_ACL_GLB_BYPASS_CNT, &val);
+	seq_printf(s, "bypass %u\n", val);
+
+	seq_puts(s, "rule packets bytes\n");
+
+	for (i = 0; i < PPE_ACL_CNT_ENTRIES; i++) {
+		if (regmap_bulk_read(priv->regmap, PPE_ACL_CNT(i), w,
+				     ARRAY_SIZE(w)))
+			return -EIO;
+
+		ppe_cnt_get(w, 0, &pkts, &bytes);
+		if (!pkts)
+			continue;
+
+		seq_printf(s, "%-4d %llu %llu\n", i, pkts, bytes);
+	}
+
+	return 0;
+}
+DEFINE_SHOW_ATTRIBUTE(ppe_acl);
+
+void ppe_debugfs_init(struct qca_ppe_priv *priv)
+{
+	priv->debugfs = debugfs_create_dir(dev_name(priv->ds.dev), NULL);
+
+	debugfs_create_file("l3_interface", 0400, priv->debugfs, priv,
+			    &ppe_l3_interface_fops);
+	debugfs_create_file("policer", 0400, priv->debugfs, priv,
+			    &ppe_policer_fops);
+	debugfs_create_file("drop_code", 0400, priv->debugfs, priv,
+			    &ppe_drop_code_fops);
+	debugfs_create_file("queues", 0400, priv->debugfs, priv,
+			    &ppe_queues_fops);
+	debugfs_create_file("queue_drops", 0400, priv->debugfs, priv,
+			    &ppe_queue_drops_fops);
+	debugfs_create_file("bm", 0400, priv->debugfs, priv, &ppe_bm_fops);
+	debugfs_create_file("ingress", 0400, priv->debugfs, priv,
+			    &ppe_ingress_fops);
+	debugfs_create_file("egress", 0400, priv->debugfs, priv,
+			    &ppe_egress_fops);
+	debugfs_create_file("acl", 0400, priv->debugfs, priv, &ppe_acl_fops);
+}
+
+void ppe_debugfs_exit(struct qca_ppe_priv *priv)
+{
+	debugfs_remove_recursive(priv->debugfs);
+}

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_flow.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_flow.c
@@ -239,7 +239,7 @@ static int ppe_flows_show(struct seq_file *s, void *data)
 	u64 packets, bytes;
 	u32 i;
 
-	seq_puts(s, "index type proto fwd age host  packets bytes\n");
+	seq_puts(s, "index type proto fwd age host  pri packets bytes\n");
 
 	guard(mutex)(&priv->flow_lock);
 
@@ -252,7 +252,7 @@ static int ppe_flows_show(struct seq_file *s, void *data)
 
 		ppe_flow_counter_read(priv, i, &packets, &bytes);
 
-		seq_printf(s, "%-5u %-4s %-5llu %-3llu %-3llu %-5llu %llu %llu\n",
+		seq_printf(s, "%-5u %-4s %-5llu %-3llu %-3llu %-5llu %-3llu %llu %llu\n",
 			   i, (w[0] & PPE_FLOW_E_TYPE_IPV6) ? "ipv6" : "ipv4",
 			   ppe_entry_get(w, PPE_FLOW_E_PROTO_OFF,
 					 PPE_FLOW_E_PROTO_LEN),
@@ -262,6 +262,8 @@ static int ppe_flows_show(struct seq_file *s, void *data)
 					 PPE_FLOW_E_AGE_LEN),
 			   ppe_entry_get(w, PPE_FLOW_E_HOST_IDX_OFF,
 					 PPE_FLOW_E_HOST_IDX_LEN),
+			   ppe_entry_get(w, PPE_FLOW_E_PRI_PROFILE_OFF,
+					 PPE_FLOW_E_PRI_PROFILE_LEN),
 			   packets, bytes);
 
 		/* An IPv6 entry occupies two slots and reads back identically
@@ -301,6 +303,10 @@ static int ppe_offload_show(struct seq_file *s, void *data)
 	seq_printf(s, "%-24s %u\n", "reinstalled", priv->flow_reinstalled);
 	seq_printf(s, "%-24s %u\n", "destroy_miss", priv->flow_destroy_miss);
 	seq_printf(s, "%-24s %u\n", "stale", priv->flow_stale);
+	seq_printf(s, "%-24s %u\n", "sparse_promoted",
+		   priv->flow_sparse_promoted);
+	seq_printf(s, "%-24s %u\n", "sparse_demoted",
+		   priv->flow_sparse_demoted);
 	seq_printf(s, "%-24s %u\n", "live_entries",
 		   atomic_read(&priv->flow_table.nelems));
 	for (i = 0; i < PPE_REJECT_MAX; i++)

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_flow.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_flow.c
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/* Routed and NAT flow offload for the Qualcomm PPE.
+ *
+ * The PPE matches a packet's 5-tuple against a hashed flow table and, on a hit,
+ * forwards it in hardware. The key is split across two tables: the flow entry
+ * carries the destination address, the L4 ports and the protocol, while the
+ * source address lives in the host table and the flow entry only references its
+ * index. Which of the two addresses goes where is a per-direction hardware
+ * choice (PPE_FLOW_KEY_SEL); both directions are programmed the same way here,
+ * so the driver never has to agree with the hardware's direction classifier.
+ *
+ * Entries are placed by the hardware hash rather than by the driver: an add
+ * stages the entry in the op registers, and the hardware picks the slot, writes
+ * the host index into the entry itself, and reports both back.
+ */
+
+#include <linux/bitfield.h>
+#include <linux/clk.h>
+#include <linux/debugfs.h>
+#include <linux/regmap.h>
+#include <linux/seq_file.h>
+
+#include "qca_ppe.h"
+
+#define PPE_FLOW_OP_RETRIES	1000
+
+/* The result register reports how many results are queued and a read pops one,
+ * so the value has to be captured on the poll that sees it, not re-read after.
+ */
+static int ppe_flow_op_wait(struct qca_ppe_priv *priv, u32 rslt_reg,
+			    u32 cmd_id, u32 *rslt)
+{
+	u32 val;
+	int i;
+
+	for (i = 0; i < PPE_FLOW_OP_RETRIES; i++) {
+		regmap_read(priv->regmap, rslt_reg, &val);
+		if (FIELD_GET(PPE_FLOW_RSLT_VALID_CNT, val) &&
+		    FIELD_GET(PPE_FLOW_RSLT_CMD_ID, val) == cmd_id) {
+			*rslt = val;
+			return 0;
+		}
+		udelay(1);
+	}
+
+	return -ETIMEDOUT;
+}
+
+static u32 ppe_flow_next_cmd_id(struct qca_ppe_priv *priv)
+{
+	priv->flow_cmd_id = (priv->flow_cmd_id + 1) & PPE_FLOW_RSLT_CMD_ID;
+
+	return priv->flow_cmd_id;
+}
+
+/* Add, delete or look up one flow entry by key. @host carries the source
+ * address half of the key and is staged alongside, so that an add creates both
+ * halves and binds them in one command. On success @index and @host_index name
+ * the slots the hardware chose.
+ */
+int ppe_flow_op(struct qca_ppe_priv *priv, u32 op_type,
+		const u32 *entry, int nentry, const u32 *host, int nhost,
+		u32 *index, u32 *host_index)
+{
+	u32 cmd_id, rslt, val;
+	int ret, i;
+
+	lockdep_assert_held(&priv->flow_lock);
+
+	for (i = 0; i < nhost; i++)
+		regmap_write(priv->regmap, PPE_FLOW_HOST_TBL_OP_DATA(i),
+			     host[i]);
+	regmap_write(priv->regmap, PPE_FLOW_HOST_TBL_OP,
+		     FIELD_PREP(PPE_FLOW_HOST_OP_HASH_BLOCK,
+				PPE_FLOW_HASH_BLOCKS));
+
+	for (i = 0; i < nentry; i++)
+		regmap_write(priv->regmap, PPE_FLOW_TBL_OP_DATA(i), entry[i]);
+
+	cmd_id = ppe_flow_next_cmd_id(priv);
+	regmap_write(priv->regmap, PPE_FLOW_TBL_OP,
+		     FIELD_PREP(PPE_FLOW_OP_CMD_ID, cmd_id) |
+		     FIELD_PREP(PPE_FLOW_OP_TYPE, op_type) |
+		     FIELD_PREP(PPE_FLOW_OP_HASH_BLOCK, PPE_FLOW_HASH_BLOCKS) |
+		     PPE_FLOW_OP_HOST_EN);
+
+	ret = ppe_flow_op_wait(priv, PPE_FLOW_TBL_OP_RSLT, cmd_id, &rslt);
+	if (ret)
+		return ret;
+
+	if (rslt & PPE_FLOW_RSLT_FAIL)
+		return -ENOENT;
+
+	if (index)
+		*index = FIELD_GET(PPE_FLOW_RSLT_ENTRY_IDX, rslt);
+
+	if (host_index) {
+		regmap_read(priv->regmap, PPE_FLOW_HOST_TBL_OP_RSLT, &val);
+		*host_index = FIELD_GET(PPE_FLOW_HOST_RSLT_ENTRY_IDX, val);
+	}
+
+	return 0;
+}
+
+/* Read one entry back by index. An IPv6 entry spans two of the flat table's
+ * slots and the hardware distributes its words across them, so the flat mapping
+ * cannot be used to read an entry of either family with one layout — the op
+ * engine returns the words as they were staged.
+ */
+int ppe_flow_entry_read(struct qca_ppe_priv *priv, u32 index, u32 *words,
+			int nwords)
+{
+	u32 cmd_id, rslt;
+	int ret, i;
+
+	lockdep_assert_held(&priv->flow_lock);
+
+	cmd_id = ppe_flow_next_cmd_id(priv);
+	regmap_write(priv->regmap, PPE_FLOW_TBL_RD_OP,
+		     FIELD_PREP(PPE_FLOW_OP_CMD_ID, cmd_id) |
+		     FIELD_PREP(PPE_FLOW_OP_TYPE, PPE_TBL_OP_GET) |
+		     FIELD_PREP(PPE_FLOW_OP_HASH_BLOCK, PPE_FLOW_HASH_BLOCKS) |
+		     PPE_FLOW_OP_INDEX_MODE |
+		     FIELD_PREP(PPE_FLOW_OP_ENTRY_IDX, index));
+
+	ret = ppe_flow_op_wait(priv, PPE_FLOW_TBL_RD_OP_RSLT, cmd_id, &rslt);
+	if (ret)
+		return ret;
+
+	if (rslt & PPE_FLOW_RSLT_FAIL)
+		return -ENOENT;
+
+	for (i = 0; i < nwords; i++)
+		regmap_read(priv->regmap, PPE_FLOW_TBL_RD_RSLT_DATA(i),
+			    &words[i]);
+
+	return 0;
+}
+
+/* Delete one flow entry by the index the hardware assigned it, so the key does
+ * not have to be kept and restaged just to remove it.
+ */
+int ppe_flow_entry_delete(struct qca_ppe_priv *priv, u32 index)
+{
+	u32 cmd_id, rslt;
+	int ret;
+
+	lockdep_assert_held(&priv->flow_lock);
+
+	cmd_id = ppe_flow_next_cmd_id(priv);
+	regmap_write(priv->regmap, PPE_FLOW_TBL_OP,
+		     FIELD_PREP(PPE_FLOW_OP_CMD_ID, cmd_id) |
+		     FIELD_PREP(PPE_FLOW_OP_TYPE, PPE_TBL_OP_DEL) |
+		     FIELD_PREP(PPE_FLOW_OP_HASH_BLOCK, PPE_FLOW_HASH_BLOCKS) |
+		     PPE_FLOW_OP_INDEX_MODE |
+		     FIELD_PREP(PPE_FLOW_OP_ENTRY_IDX, index));
+
+	ret = ppe_flow_op_wait(priv, PPE_FLOW_TBL_OP_RSLT, cmd_id, &rslt);
+	if (ret)
+		return ret;
+
+	return (rslt & PPE_FLOW_RSLT_FAIL) ? -ENOENT : 0;
+}
+
+/* A host entry is visible in the flat mapping but a valid one cannot be cleared
+ * by writing zeroes there, so removal goes through the host op engine.
+ */
+int ppe_host_del(struct qca_ppe_priv *priv, u32 index)
+{
+	u32 cmd_id, val;
+	int i;
+
+	lockdep_assert_held(&priv->flow_lock);
+
+	cmd_id = ppe_flow_next_cmd_id(priv);
+	regmap_write(priv->regmap, PPE_HOST_TBL_OP,
+		     FIELD_PREP(PPE_HOST_OP_CMD_ID, cmd_id) |
+		     FIELD_PREP(PPE_HOST_OP_TYPE, PPE_TBL_OP_DEL) |
+		     FIELD_PREP(PPE_HOST_OP_HASH_BLOCK, PPE_FLOW_HASH_BLOCKS) |
+		     PPE_HOST_OP_INDEX_MODE |
+		     FIELD_PREP(PPE_HOST_OP_ENTRY_IDX, index));
+
+	for (i = 0; i < PPE_FLOW_OP_RETRIES; i++) {
+		regmap_read(priv->regmap, PPE_HOST_TBL_OP_RSLT, &val);
+		if (FIELD_GET(PPE_HOST_RSLT_VALID_CNT, val) &&
+		    FIELD_GET(PPE_HOST_RSLT_CMD_ID, val) == cmd_id)
+			return (val & PPE_HOST_RSLT_FAIL) ? -ENOENT : 0;
+		udelay(1);
+	}
+
+	return -ETIMEDOUT;
+}
+
+void ppe_flow_counter_read(struct qca_ppe_priv *priv, u32 index, u64 *packets,
+			   u64 *bytes)
+{
+	u32 lo, hi;
+
+	regmap_read(priv->regmap, PPE_IN_FLOW_CNT_TBL(index), &lo);
+	*packets = lo;
+
+	/* 40-bit byte counter. The halves are read in separate statements
+	 * because the order of evaluation within one is unspecified.
+	 */
+	regmap_read(priv->regmap, PPE_IN_FLOW_CNT_TBL(index) + 4, &lo);
+	regmap_read(priv->regmap, PPE_IN_FLOW_CNT_TBL(index) + 8, &hi);
+	*bytes = lo | ((u64)FIELD_GET(PPE_FLOW_CNT_BYTES_HI, hi) << 32);
+}
+
+/* Deleting an entry does not reset its counter, so a slot has to be cleared
+ * when it is handed to a new flow rather than when the old one goes away.
+ */
+void ppe_flow_counter_clear(struct qca_ppe_priv *priv, u32 index)
+{
+	int i;
+
+	for (i = 0; i < PPE_FLOW_CNT_WORDS; i++)
+		regmap_write(priv->regmap, PPE_IN_FLOW_CNT_TBL(index) + i * 4,
+			     0);
+}
+
+static int ppe_flows_show(struct seq_file *s, void *data)
+{
+	struct qca_ppe_priv *priv = s->private;
+	u32 w[PPE_FLOW_ENTRY_WORDS_V6];
+	u64 packets, bytes;
+	u32 i;
+
+	seq_puts(s, "index type proto fwd age host  packets bytes\n");
+
+	guard(mutex)(&priv->flow_lock);
+
+	for (i = 0; i < priv->data->num_flow_entries; i++) {
+		if (ppe_flow_entry_read(priv, i, w, ARRAY_SIZE(w)))
+			continue;
+		if (!ppe_entry_get(w, PPE_FLOW_E_VALID_OFF,
+				   PPE_FLOW_E_VALID_LEN))
+			continue;
+
+		ppe_flow_counter_read(priv, i, &packets, &bytes);
+
+		seq_printf(s, "%-5u %-4s %-5llu %-3llu %-3llu %-5llu %llu %llu\n",
+			   i, (w[0] & PPE_FLOW_E_TYPE_IPV6) ? "ipv6" : "ipv4",
+			   ppe_entry_get(w, PPE_FLOW_E_PROTO_OFF,
+					 PPE_FLOW_E_PROTO_LEN),
+			   ppe_entry_get(w, PPE_FLOW_E_FWD_TYPE_OFF,
+					 PPE_FLOW_E_FWD_TYPE_LEN),
+			   ppe_entry_get(w, PPE_FLOW_E_AGE_OFF,
+					 PPE_FLOW_E_AGE_LEN),
+			   ppe_entry_get(w, PPE_FLOW_E_HOST_IDX_OFF,
+					 PPE_FLOW_E_HOST_IDX_LEN),
+			   packets, bytes);
+
+		/* An IPv6 entry occupies two slots and reads back identically
+		 * through either, so it would otherwise be listed twice.
+		 */
+		if (w[0] & PPE_FLOW_E_TYPE_IPV6)
+			i++;
+	}
+
+	return 0;
+}
+DEFINE_SHOW_ATTRIBUTE(ppe_flows);
+
+static const char * const ppe_flow_reject_name[] = {
+	[PPE_REJECT_INGRESS_PORT]	= "ingress_not_switch_port",
+	[PPE_REJECT_KEY]		= "unsupported_match",
+	[PPE_REJECT_PROTO]		= "unsupported_protocol",
+	[PPE_REJECT_ACTION]		= "unsupported_action",
+	[PPE_REJECT_L2]			= "no_egress_l2_header",
+	[PPE_REJECT_EGRESS_PORT]	= "egress_not_switch_port",
+	[PPE_REJECT_HAIRPIN]		= "egress_is_ingress",
+	[PPE_REJECT_NAT_BOTH]		= "snat_and_dnat",
+	[PPE_REJECT_NAT_IPV6]		= "ipv6_nat",
+	[PPE_REJECT_RESOURCE]		= "table_full",
+	[PPE_REJECT_HW_OP]		= "hardware_op_failed",
+};
+
+static int ppe_offload_show(struct seq_file *s, void *data)
+{
+	struct qca_ppe_priv *priv = s->private;
+	int i;
+
+	guard(mutex)(&priv->flow_lock);
+
+	seq_printf(s, "%-24s %u\n", "offloaded", priv->flow_offloaded);
+	for (i = 0; i < PPE_REJECT_MAX; i++)
+		seq_printf(s, "%-24s %u\n", ppe_flow_reject_name[i],
+			   priv->flow_reject[i]);
+
+	return 0;
+}
+DEFINE_SHOW_ATTRIBUTE(ppe_offload);
+
+void ppe_flow_debugfs_init(struct qca_ppe_priv *priv)
+{
+	debugfs_create_file("flows", 0400, priv->debugfs, priv,
+			    &ppe_flows_fops);
+	debugfs_create_file("offload", 0400, priv->debugfs, priv,
+			    &ppe_offload_fops);
+}
+
+/* The entry's two-bit age field counts down one step per age period, so an
+ * untouched entry survives two to three periods. The hardware turns its own
+ * clock into that period using the rate it is told about here, so read the rate
+ * from the clock the board actually runs instead of assuming one.
+ */
+static void ppe_flow_age_timer_set(struct qca_ppe_priv *priv, u32 *ctrl)
+{
+	unsigned long rate = ppe_clk_rate(priv);
+
+	if (!rate)
+		return;
+
+	*ctrl |= FIELD_PREP(PPE_FLOW_CLK_FREQ_MHZ, rate / HZ_PER_MHZ) |
+		 FIELD_PREP(PPE_FLOW_AGE_TIMER, PPE_FLOW_AGE_SECS) |
+		 FIELD_PREP(PPE_FLOW_AGE_TIMER_UNIT, PPE_FLOW_AGE_UNIT_SEC);
+}
+
+void ppe_flow_init(struct qca_ppe_priv *priv)
+{
+	u32 ctrl;
+	int type, dir;
+
+	mutex_init(&priv->flow_lock);
+
+	/* A miss has to forward: with the lookup enabled and no entry matching,
+	 * any other action would black-hole traffic the driver never saw.
+	 */
+	for (type = 0; type < PPE_FLOW_PKT_TYPES; type++) {
+		u32 val = 0;
+
+		for (dir = 0; dir < PPE_FLOW_CTRL1_DIRS; dir++)
+			val |= FIELD_PREP(PPE_FLOW_MISS_ACTION,
+					  PPE_FLOW_MISS_FORWARD)
+			       << (dir * PPE_FLOW_CTRL1_DIR_BITS);
+
+		regmap_write(priv->regmap, PPE_FLOW_CTRL1(type), val);
+	}
+
+	/* Both hash blocks are searched on every op, so both bucket functions
+	 * place the entries here and both are set explicitly rather than
+	 * inherited from whatever ran before.
+	 */
+	ctrl = PPE_FLOW_EN | FIELD_PREP(PPE_FLOW_HASH_MODE0, 1) |
+	       FIELD_PREP(PPE_FLOW_HASH_MODE1, 1);
+	ppe_flow_age_timer_set(priv, &ctrl);
+	regmap_write(priv->regmap, PPE_FLOW_CTRL0, ctrl);
+}

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_flow.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_flow.c
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/* Copyright (c) 2026 Julius Bairaktaris <julius@bairaktaris.de> */
 /* Routed and NAT flow offload for the Qualcomm PPE.
  *
  * The PPE matches a packet's 5-tuple against a hashed flow table and, on a hit,
  * forwards it in hardware. The key is split across two tables: the flow entry
  * carries the destination address, the L4 ports and the protocol, while the
  * source address lives in the host table and the flow entry only references its
- * index. Which of the two addresses goes where is a per-direction hardware
- * choice (PPE_FLOW_KEY_SEL); both directions are programmed the same way here,
- * so the driver never has to agree with the hardware's direction classifier.
+ * index. Which of the two addresses goes where when a packet is looked up is
+ * a per-direction hardware choice (PPE_FLOW_KEY_SEL); every entry is staged
+ * the same way here, and the one direction group that looks up with the
+ * opposite orientation - WAN-to-LAN, where tunnel-terminated ingress lands -
+ * gets its KEY_SEL flipped to match in ppe_flow_init().
  *
  * Entries are placed by the hardware hash rather than by the driver: an add
  * stages the entry in the op registers, and the hardware picks the slot, writes
@@ -94,9 +97,15 @@ int ppe_flow_op(struct qca_ppe_priv *priv, u32 op_type,
 	if (index)
 		*index = FIELD_GET(PPE_FLOW_RSLT_ENTRY_IDX, rslt);
 
-	if (host_index) {
-		regmap_read(priv->regmap, PPE_FLOW_HOST_TBL_OP_RSLT, &val);
-		*host_index = FIELD_GET(PPE_FLOW_HOST_RSLT_ENTRY_IDX, val);
+	/* The host result register is a queue that fills on its own schedule,
+	 * so it may not yet - or no longer - hold this command's result. What
+	 * binds the flow to its host entry is the host index the hardware
+	 * wrote into the flow entry itself; read it from there.
+	 */
+	if (index && host_index) {
+		regmap_read(priv->regmap, PPE_IN_FLOW_TBL(*index), &val);
+		*host_index = ppe_entry_get(&val, PPE_FLOW_E_HOST_IDX_OFF,
+					    PPE_FLOW_E_HOST_IDX_LEN);
 	}
 
 	return 0;
@@ -194,16 +203,20 @@ int ppe_host_del(struct qca_ppe_priv *priv, u32 index)
 void ppe_flow_counter_read(struct qca_ppe_priv *priv, u32 index, u64 *packets,
 			   u64 *bytes)
 {
-	u32 lo, hi;
+	u32 lo, hi, hi2;
 
 	regmap_read(priv->regmap, PPE_IN_FLOW_CNT_TBL(index), &lo);
 	*packets = lo;
 
-	/* 40-bit byte counter. The halves are read in separate statements
-	 * because the order of evaluation within one is unspecified.
+	/* 40-bit byte counter. Re-read on a carry between the two halves so a
+	 * count crossing the low word's boundary is not torn by 1 << 32.
 	 */
-	regmap_read(priv->regmap, PPE_IN_FLOW_CNT_TBL(index) + 4, &lo);
 	regmap_read(priv->regmap, PPE_IN_FLOW_CNT_TBL(index) + 8, &hi);
+	do {
+		hi2 = hi;
+		regmap_read(priv->regmap, PPE_IN_FLOW_CNT_TBL(index) + 4, &lo);
+		regmap_read(priv->regmap, PPE_IN_FLOW_CNT_TBL(index) + 8, &hi);
+	} while (hi != hi2);
 	*bytes = lo | ((u64)FIELD_GET(PPE_FLOW_CNT_BYTES_HI, hi) << 32);
 }
 
@@ -264,6 +277,7 @@ DEFINE_SHOW_ATTRIBUTE(ppe_flows);
 
 static const char * const ppe_flow_reject_name[] = {
 	[PPE_REJECT_INGRESS_PORT]	= "ingress_not_switch_port",
+	[PPE_REJECT_INGRESS_VLAN]	= "ingress_vlan_domain",
 	[PPE_REJECT_KEY]		= "unsupported_match",
 	[PPE_REJECT_PROTO]		= "unsupported_protocol",
 	[PPE_REJECT_ACTION]		= "unsupported_action",
@@ -284,6 +298,11 @@ static int ppe_offload_show(struct seq_file *s, void *data)
 	guard(mutex)(&priv->flow_lock);
 
 	seq_printf(s, "%-24s %u\n", "offloaded", priv->flow_offloaded);
+	seq_printf(s, "%-24s %u\n", "reinstalled", priv->flow_reinstalled);
+	seq_printf(s, "%-24s %u\n", "destroy_miss", priv->flow_destroy_miss);
+	seq_printf(s, "%-24s %u\n", "stale", priv->flow_stale);
+	seq_printf(s, "%-24s %u\n", "live_entries",
+		   atomic_read(&priv->flow_table.nelems));
 	for (i = 0; i < PPE_REJECT_MAX; i++)
 		seq_printf(s, "%-24s %u\n", ppe_flow_reject_name[i],
 			   priv->flow_reject[i]);
@@ -323,17 +342,39 @@ void ppe_flow_init(struct qca_ppe_priv *priv)
 	int type, dir;
 
 	mutex_init(&priv->flow_lock);
+	mutex_init(&priv->vlan_lock);
 
 	/* A miss has to forward: with the lookup enabled and no entry matching,
 	 * any other action would black-hole traffic the driver never saw.
+	 *
+	 * Fragments bypass the lookup: only the first fragment carries the L4
+	 * ports, so matching it in hardware while the rest miss to the CPU
+	 * would leave conntrack's reassembly waiting forever.
+	 *
+	 * The neighbouring TCP_SPECIAL bypass stays off: on this generation it
+	 * takes every TCP packet out of the lookup, not just the flagged ones.
+	 * A connection's FIN and RST are therefore forwarded in hardware and its
+	 * entry goes on the flowtable's idle timeout, as it does on every driver
+	 * whose hardware never shows it the teardown.
 	 */
 	for (type = 0; type < PPE_FLOW_PKT_TYPES; type++) {
 		u32 val = 0;
 
 		for (dir = 0; dir < PPE_FLOW_CTRL1_DIRS; dir++)
-			val |= FIELD_PREP(PPE_FLOW_MISS_ACTION,
-					  PPE_FLOW_MISS_FORWARD)
+			val |= (FIELD_PREP(PPE_FLOW_MISS_ACTION,
+					   PPE_FLOW_MISS_FORWARD) |
+				PPE_FLOW_FRAG_BYPASS)
 			       << (dir * PPE_FLOW_CTRL1_DIR_BITS);
+
+		/* Tunnel-terminated ingress (a de-encapsulated PPPoE frame)
+		 * classifies as WAN-to-LAN regardless of the host entries,
+		 * and that direction group builds its lookup key with the
+		 * opposite orientation: without its KEY_SEL flipped, such
+		 * frames never find the entries this driver installs. All
+		 * other groups match the orientation entries are staged in.
+		 */
+		val |= PPE_FLOW_KEY_SEL
+		       << (PPE_FLOW_DIR_WAN_TO_LAN * PPE_FLOW_CTRL1_DIR_BITS);
 
 		regmap_write(priv->regmap, PPE_FLOW_CTRL1(type), val);
 	}

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_flow_offload.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_flow_offload.c
@@ -39,6 +39,7 @@ struct ppe_flow_data {
 
 	u16 vlan_id;
 	bool vlan_valid;
+	u16 ivid;
 	u16 pppoe_sid;
 	bool pppoe_valid;
 
@@ -549,7 +550,7 @@ static void ppe_wan_ingress_put(struct qca_ppe_priv *priv, int port)
  * can carry. A domain that cannot be named is declined rather than encoded as
  * the bare tuple, which would let the flow forward traffic from another VLAN.
  */
-static int ppe_flow_ingress_vsi(struct qca_ppe_priv *priv, int iport)
+static int ppe_flow_ingress_vsi(struct qca_ppe_priv *priv, int iport, u16 vid)
 {
 	struct qca_ppe_vlan_entry *vlan;
 
@@ -559,18 +560,21 @@ static int ppe_flow_ingress_vsi(struct qca_ppe_priv *priv, int iport)
 	 * VLAN and session id that classification names reach it.
 	 */
 	if (priv->wan_ref[iport])
-		return priv->wan_vsi[iport];
+		return vid && vid != priv->wan_vid[iport] ? -EOPNOTSUPP :
+							    priv->wan_vsi[iport];
 
-	/* A VLAN-filtering bridge reclassifies an untagged frame into the VSI
-	 * of the port's PVID, so the port's own VSI answers only without one.
+	/* A VLAN-filtering bridge classifies a tagged frame into its VLAN's
+	 * VSI and an untagged one into the PVID's, so the port's own VSI
+	 * answers only without either.
 	 */
-	if (!priv->port_pvid[iport])
+	if (!vid)
+		vid = priv->port_pvid[iport];
+	if (!vid)
 		return ppe_port_l3_vsi(priv, iport);
 
-	vlan = ppe_vlan_find(priv, priv->port_br_dev[iport],
-			     priv->port_pvid[iport]);
+	vlan = ppe_vlan_find(priv, priv->port_br_dev[iport], vid);
 
-	return vlan ? (int)vlan->vsi : -EOPNOTSUPP;
+	return vlan && (vlan->ports & BIT(iport)) ? (int)vlan->vsi : -EOPNOTSUPP;
 }
 
 /* The flow lookup only runs on packets the L3 stage accepted, and nothing in
@@ -583,7 +587,7 @@ static int ppe_flow_ingress_vsi(struct qca_ppe_priv *priv, int iport)
  * index keeps the two in step without a second allocator.
  */
 static int ppe_flow_alloc_ingress(struct qca_ppe_priv *priv, int iport,
-				  struct ppe_flow_entry *entry)
+				  u16 vid, struct ppe_flow_entry *entry)
 {
 	struct dsa_port *dp = dsa_to_port(&priv->ds, iport);
 	u32 words[PPE_NEXTHOP_WORDS] = {};
@@ -593,13 +597,13 @@ static int ppe_flow_alloc_ingress(struct qca_ppe_priv *priv, int iport,
 
 	lockdep_assert_held(&priv->vlan_lock);
 
-	vsi = ppe_flow_ingress_vsi(priv, iport);
+	vsi = ppe_flow_ingress_vsi(priv, iport, vid);
 	if (vsi < 0)
 		return vsi;
 
 	entry->src_if = vsi;
 	entry->ivid = priv->wan_ref[iport] ? priv->wan_vid[iport] :
-					     priv->port_pvid[iport];
+		      vid ? vid : priv->port_pvid[iport];
 
 	/* A PPPoE uplink's ingress interface belongs to the uplink, so take a
 	 * reference rather than programming anything: a sibling flow going away
@@ -1263,16 +1267,22 @@ static int ppe_flow_offload_replace(struct ppe_flow_block *fb,
 			return ppe_flow_reject(priv, PPE_REJECT_INGRESS_PORT);
 	}
 
-	/* An ingress VLAN cannot be part of the hardware key. Where a bridge
-	 * classifies the tag in hardware the kernel marks it as such and does
-	 * not offer it as a match at all, so a tag that does arrive here is one
-	 * this driver has no classification for and no L3 interface to stand in
-	 * for it; the flow stays in software. A second tag has no expression
-	 * either.
+	/* An ingress tag is matched by the VSI it is classified into - the
+	 * uplink's tag on a PPPoE port, a bridge VLAN the port is a member
+	 * of - never by the tag itself, which the hardware key cannot hold.
+	 * A tag this driver has no classification for, and a second tag,
+	 * stay in software.
 	 */
-	if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_VLAN) ||
-	    flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_CVLAN))
+	if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_CVLAN))
 		return ppe_flow_reject(priv, PPE_REJECT_INGRESS_VLAN);
+	if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_VLAN)) {
+		struct flow_match_vlan match;
+
+		flow_rule_match_vlan(rule, &match);
+		if (match.key->vlan_tpid != htons(ETH_P_8021Q))
+			return ppe_flow_reject(priv, PPE_REJECT_INGRESS_VLAN);
+		data.ivid = match.key->vlan_id;
+	}
 
 	{
 		struct flow_match_control match;
@@ -1434,7 +1444,7 @@ static int ppe_flow_offload_replace(struct ppe_flow_block *fb,
 	entry->wan_iport = -1;
 	entry->iport = iport;
 
-	ret = ppe_flow_alloc_ingress(priv, iport, entry);
+	ret = ppe_flow_alloc_ingress(priv, iport, data.ivid, entry);
 	if (ret) {
 		priv->flow_reject[ret == -EOPNOTSUPP ? PPE_REJECT_INGRESS_VLAN :
 				  PPE_REJECT_RESOURCE]++;

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_flow_offload.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_flow_offload.c
@@ -1,0 +1,1695 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/* Copyright (c) 2026 Julius Bairaktaris <julius@bairaktaris.de> */
+/* netfilter flowtable offload for the Qualcomm PPE.
+ *
+ * The kernel hands us one rule per direction of a connection; each becomes one
+ * PPE flow entry, and the two are unrelated as far as this driver is concerned.
+ * A rule that rewrites the source address is an SNAT entry, one that rewrites
+ * the destination is a DNAT entry, and one that rewrites neither is a plain
+ * route. The hardware overlays the SNAT and DNAT fields on the same bits, so a
+ * rule that rewrites both is declined and stays in software.
+ *
+ * Three side tables carry what does not fit in the flow entry: the egress L3
+ * interface holds the source MAC and the PPPoE session, the nexthop holds the
+ * destination MAC, the egress port, the VLAN tag and the DNAT address, and the
+ * public-address table holds the SNAT address. All three are shared between
+ * flows that need the same contents and are reference counted.
+ */
+
+#include <linux/bitfield.h>
+#include <linux/if_pppox.h>
+#include <linux/if_vlan.h>
+#include <linux/netdevice.h>
+#include <linux/rhashtable.h>
+#include <net/dsa.h>
+#include <net/flow_offload.h>
+#include <net/netfilter/nf_flow_table.h>
+#include <net/pkt_cls.h>
+
+#include "qca_ppe.h"
+
+struct ppe_flow_data {
+	struct ethhdr eth;
+	u16 addr_type;
+	u8 l4proto;
+
+	__be32 v4_src, v4_dst, v4_src_new, v4_dst_new;
+	struct in6_addr v6_src, v6_dst;
+	__be16 sport, dport, sport_new, dport_new;
+
+	u16 vlan_id;
+	bool vlan_valid;
+	u16 pppoe_sid;
+	bool pppoe_valid;
+
+	struct net_device *odev;
+	/* The profile the entry is given; filled only where the flowtable
+	 * reports a priority, and zero means DSCP still decides.
+	 */
+	u8 priority;
+};
+
+struct ppe_flow_entry {
+	struct rhash_head node;
+	struct list_head list;
+	struct flow_block *block;
+	unsigned long cookie;
+	u32 index;
+	u32 words[PPE_FLOW_ENTRY_WORDS_V6];
+	u8 nwords;
+	u8 src_if;
+	u32 host_index;
+	int nexthop;
+	int my_mac;
+	int l3_if;
+	int eg_l3_if;
+	int pub_ip;
+	int wan_port;
+	int wan_iport;
+	u8 iport;
+	u8 oport;
+	u16 ivid;
+	u16 ovid;
+	u64 packets;
+	u64 bytes;
+	unsigned long last_used;
+};
+
+/* One bound flowtable block. Entries remember which block installed them,
+ * because a dying flowtable unbinds from every port before the core flushes
+ * its flows - the FLOW_CLS_DESTROY commands never arrive, and the block
+ * callback's release, which the core invokes after the last unbind, is the
+ * one point where that block's flows are known dead.
+ */
+struct ppe_flow_block {
+	struct qca_ppe_priv *priv;
+	struct flow_block *block;
+};
+
+static const struct rhashtable_params ppe_flow_ht_params = {
+	.head_offset = offsetof(struct ppe_flow_entry, node),
+	.key_offset = offsetof(struct ppe_flow_entry, cookie),
+	.key_len = sizeof(unsigned long),
+	.automatic_shrinking = true,
+};
+
+/* Reference-counted allocation over one hardware side table. Entries are
+ * compared by content so that every flow leaving by the same nexthop, or
+ * sourced from the same MAC, shares one slot — without that, the 2560 nexthops
+ * would run out long before the 4096 flow entries do.
+ */
+static int ppe_res_get(struct ppe_res *tbl, u32 count, const u32 *words,
+		       int nwords)
+{
+	int free_idx = -1;
+	u32 i;
+
+	for (i = 0; i < count; i++) {
+		if (!tbl[i].refcount) {
+			if (free_idx < 0)
+				free_idx = i;
+			continue;
+		}
+		if (!memcmp(tbl[i].words, words, nwords * sizeof(*words))) {
+			tbl[i].refcount++;
+			return i;
+		}
+	}
+
+	if (free_idx < 0)
+		return -ENOSPC;
+
+	memcpy(tbl[free_idx].words, words, nwords * sizeof(*words));
+	tbl[free_idx].refcount = 1;
+
+	return free_idx;
+}
+
+static bool ppe_res_put(struct ppe_res *tbl, int idx)
+{
+	if (idx < 0)
+		return false;
+
+	return --tbl[idx].refcount == 0;
+}
+
+/* The hardware find-or-creates a host entry from the source address, so every
+ * flow from one host lands on the same slot and the slot outlives any single
+ * flow that referenced it.
+ */
+static void ppe_host_ref_get(struct qca_ppe_priv *priv, u32 index)
+{
+	priv->host_ref[index]++;
+}
+
+static void ppe_host_ref_put(struct qca_ppe_priv *priv, u32 index)
+{
+	if (!--priv->host_ref[index])
+		ppe_host_del(priv, index);
+}
+
+/* The age of the entry in @index, or -ENOENT if the slot no longer holds this
+ * flow. Word 0 on its own is not an identity - its host index, protocol and
+ * forwarding type are shared by every flow of one client - so a slot the
+ * hardware aged out and handed to a sibling would read back as still ours.
+ */
+static int ppe_flow_entry_age(struct qca_ppe_priv *priv,
+			      struct ppe_flow_entry *entry)
+{
+	u32 w[PPE_FLOW_ENTRY_WORDS_V6];
+	u32 age;
+	int ret;
+
+	/* Only a read that says the slot is empty means the flow is gone; any
+	 * other failure leaves it unknown, and reporting "gone" would strand a
+	 * live entry pointing at side-table slots about to be handed on.
+	 */
+	ret = ppe_flow_entry_read(priv, entry->index, w, entry->nwords);
+	if (ret)
+		return ret;
+
+	age = FIELD_GET(PPE_FLOW_E_AGE_MASK, w[0]);
+	w[0] &= ~PPE_FLOW_E_AGE_MASK;
+
+	if (memcmp(w, entry->words, entry->nwords * sizeof(*w)))
+		return -ENOENT;
+
+	return age;
+}
+
+static void ppe_tbl_write(struct qca_ppe_priv *priv, u32 reg, const u32 *words,
+			  int nwords)
+{
+	int i;
+
+	for (i = 0; i < nwords; i++)
+		regmap_write(priv->regmap, reg + i * 4, words[i]);
+}
+
+static void ppe_tbl_clear(struct qca_ppe_priv *priv, u32 reg, int nwords)
+{
+	int i;
+
+	for (i = 0; i < nwords; i++)
+		regmap_write(priv->regmap, reg + i * 4, 0);
+}
+
+/* An entry of a multi-word table takes the write to its last word as the
+ * commit: a word 0 written on its own is staged and reads back unchanged.
+ *
+ * MRU is also how an interface is retired: teardown clears the entry, leaving
+ * MRU 0, so a frame still matching a flow whose interface is gone fails the
+ * MRU check and L3_ROUTE_CTRL decides what happens to it. The driver never
+ * writes that register and depends on its reset, which redirects to the CPU;
+ * writing it is how teardown would become a black hole.
+ */
+static void ppe_l3_if_mtu_set(struct qca_ppe_priv *priv, u32 vsi, u32 mtu)
+{
+	u32 words[PPE_L3_IF_WORDS];
+	int i;
+
+	/* A bridge takes an mtu wider than the field holds, and the value that
+	 * survives the truncation reads back as a retired interface.
+	 */
+	mtu = min_t(u32, mtu, FIELD_MAX(PPE_L3_IF_MRU));
+
+	for (i = 0; i < PPE_L3_IF_WORDS; i++)
+		regmap_read(priv->regmap, PPE_IN_L3_IF_TBL(vsi) + i * 4,
+			    &words[i]);
+
+	words[0] &= ~(PPE_L3_IF_MRU | PPE_L3_IF_MTU);
+	words[0] |= FIELD_PREP(PPE_L3_IF_MRU, mtu) |
+		    FIELD_PREP(PPE_L3_IF_MTU, mtu);
+
+	ppe_tbl_write(priv, PPE_IN_L3_IF_TBL(vsi), words, PPE_L3_IF_WORDS);
+}
+
+/* The egress half of an L3 interface answers the mtu check and nothing else:
+ * no route enables and no my-mac bitmap, because no VSI resolves to it.
+ */
+static void ppe_eg_l3_if_mtu_set(struct qca_ppe_priv *priv, u32 idx, u32 mtu)
+{
+	u32 words[PPE_L3_IF_WORDS] = {};
+
+	words[0] = FIELD_PREP(PPE_L3_IF_MRU, mtu) |
+		   FIELD_PREP(PPE_L3_IF_MTU, mtu);
+
+	ppe_tbl_write(priv, PPE_IN_L3_IF_TBL(idx), words, PPE_L3_IF_WORDS);
+}
+
+/* Ports outside a bridge sit on VSI 0 since setup. */
+static u32 ppe_port_l3_vsi(struct qca_ppe_priv *priv, int port)
+{
+	return priv->port_vsi[port] == PPE_VSI_INVALID ? 0 :
+	       priv->port_vsi[port];
+}
+
+static void ppe_entry_set_addr6(u32 *words, u32 offset,
+				const struct in6_addr *addr)
+{
+	int i;
+
+	/* The hardware stores the address least significant word first. */
+	for (i = 3; i >= 0; i--)
+		ppe_entry_set(words, offset + (3 - i) * 32, 32,
+			      ntohl(addr->s6_addr32[i]));
+}
+
+static int ppe_flow_proto(u8 l4proto)
+{
+	switch (l4proto) {
+	case IPPROTO_TCP:
+		return PPE_FLOW_PROTO_TCP;
+	case IPPROTO_UDP:
+		return PPE_FLOW_PROTO_UDP;
+	default:
+		return -EOPNOTSUPP;
+	}
+}
+
+static int ppe_flow_mangle_eth(const struct flow_action_entry *act,
+			       struct ethhdr *eth)
+{
+	void *dest = (void *)eth + act->mangle.offset;
+	const void *src = &act->mangle.val;
+
+	/* The core writes the egress header as mangles at byte offsets into
+	 * struct ethhdr, so the destination follows from the offset alone.
+	 */
+	if (act->mangle.offset > 8)
+		return -EOPNOTSUPP;
+
+	if (act->mangle.mask == 0xffff) {
+		src += 2;
+		dest += 2;
+	}
+
+	memcpy(dest, src, act->mangle.mask ? 2 : 4);
+
+	return 0;
+}
+
+static int ppe_flow_mangle_ports(const struct flow_action_entry *act,
+				 struct ppe_flow_data *data)
+{
+	u32 val = ntohl(act->mangle.val);
+
+	switch (act->mangle.offset) {
+	case 0:
+		if (act->mangle.mask == ~htonl(0xffff))
+			data->dport_new = cpu_to_be16(val);
+		else
+			data->sport_new = cpu_to_be16(val >> 16);
+		break;
+	case 2:
+		data->dport_new = cpu_to_be16(val);
+		break;
+	default:
+		return -EOPNOTSUPP;
+	}
+
+	return 0;
+}
+
+static int ppe_flow_mangle_ipv4(const struct flow_action_entry *act,
+				struct ppe_flow_data *data)
+{
+	__be32 *dest;
+
+	switch (act->mangle.offset) {
+	case offsetof(struct iphdr, saddr):
+		dest = &data->v4_src_new;
+		break;
+	case offsetof(struct iphdr, daddr):
+		dest = &data->v4_dst_new;
+		break;
+	default:
+		return -EOPNOTSUPP;
+	}
+
+	memcpy(dest, &act->mangle.val, sizeof(u32));
+
+	return 0;
+}
+
+static int ppe_flow_port_by_ifindex(struct qca_ppe_priv *priv, int ifindex)
+{
+	struct dsa_port *dp;
+
+	dsa_switch_for_each_user_port(dp, &priv->ds)
+		if (dp->user && dp->user->ifindex == ifindex)
+			return dp->index;
+
+	return -EOPNOTSUPP;
+}
+
+/* Make a tagged PPPoE WAN port route its ingress traffic in hardware, so the
+ * download direction of an offloaded connection reaches the flow lookup on its
+ * inner tuple.
+ *
+ * A dedicated VSI keeps the uplink out of any L2 domain: the ingress VLAN is
+ * classified into it with the 802.1Q tag stripped, the VSI carries a route-
+ * and PPPoE-terminating L3 interface holding the router's MAC, and the PPPoE
+ * session id is recognised so the header is parsed through to the inner IP.
+ * Everything is shared by every flow on the port and torn down with the last
+ * of them. A frame that misses the flow table is still forwarded to the CPU,
+ * with the tag the hardware stripped re-added on that path, so the software
+ * PPPoE stack sees on-wire frames throughout.
+ */
+static int ppe_wan_ingress_get(struct qca_ppe_priv *priv, int port, u16 sid,
+			       bool vlan_valid, u16 vlan_id, const u8 *mac,
+			       u32 mtu)
+{
+	u32 words[PPE_MY_MAC_WORDS] = {};
+	int vsi, xlt = -1, ret;
+
+	if (priv->wan_ref[port]++) {
+		/* A re-dialled session has a new id, and an ingress still
+		 * keyed to the dead one silently un-offloads every download on
+		 * this uplink: the entries stay valid and correct, the frame
+		 * is never parsed through to the tuple they key on, and the
+		 * flow lookup is never reached. It is cheaper to write the
+		 * session on every install than to keep a copy of it that
+		 * could be wrong.
+		 */
+		regmap_write(priv->regmap, PPE_PPPOE_SESSION(port),
+			     FIELD_PREP(PPE_PPPOE_SESSION_ID, sid) |
+			     FIELD_PREP(PPE_PPPOE_SESSION_PORT_BMP, BIT(port)) |
+			     FIELD_PREP(PPE_PPPOE_SESSION_L3_IF,
+					priv->wan_vsi[port]));
+		return 0;
+	}
+
+	/* The translation rule shares one table with the bridge VLANs, so its
+	 * index comes from the allocator they share.
+	 */
+	if (vlan_valid) {
+		xlt = ppe_xlt_idx_alloc(priv);
+		if (xlt < 0) {
+			priv->wan_ref[port]--;
+			return xlt;
+		}
+	}
+
+	vsi = ppe_vsi_alloc(priv);
+	if (vsi < 0) {
+		ret = vsi;
+		goto err_xlt;
+	}
+	priv->wan_vsi[port] = vsi;
+	priv->wan_vid[port] = vlan_valid ? vlan_id : 0;
+	ppe_vsi_member_set(priv, vsi, BIT(port) | BIT(QCA_PPE_CPU_PORT));
+
+	ppe_entry_set(words, PPE_MY_MAC_ADDR_OFF, PPE_MY_MAC_ADDR_LEN,
+		      ether_addr_to_u64(mac));
+	ppe_entry_set(words, PPE_MY_MAC_VALID_OFF, PPE_MY_MAC_VALID_LEN, 1);
+	ret = ppe_res_get(priv->my_mac, PPE_MY_MAC_ENTRIES, words,
+			  PPE_MY_MAC_WORDS);
+	if (ret < 0)
+		goto err_vsi;
+	priv->wan_mymac[port] = ret;
+	if (priv->my_mac[ret].refcount == 1)
+		ppe_tbl_write(priv, PPE_MY_MAC_TBL(ret), words, PPE_MY_MAC_WORDS);
+
+	regmap_write(priv->regmap, PPE_IN_L3_IF_TBL(vsi),
+		     PPE_L3_IF_IPV4_ROUTE_EN | PPE_L3_IF_IPV6_ROUTE_EN);
+	regmap_write(priv->regmap, PPE_IN_L3_IF_TBL(vsi) + 4,
+		     FIELD_PREP(PPE_L3_IF_TTL_EXCEED_CMD,
+				PPE_L3_IF_TTL_EXCEED_TO_CPU) |
+		     PPE_L3_IF_TTL_EXCEED_DEACCEL |
+		     FIELD_PREP(PPE_L3_IF_MAC_BITMAP, GENMASK(7, 0)) |
+		     PPE_L3_IF_PPPOE_EN);
+	ppe_l3_if_mtu_set(priv, vsi, mtu);
+	regmap_write(priv->regmap, PPE_L3_VSI_TBL(vsi),
+		     PPE_L3_VSI_IF_VALID | FIELD_PREP(PPE_L3_VSI_IF_INDEX, vsi));
+
+	regmap_write(priv->regmap, PPE_PPPOE_SESSION(port),
+		     FIELD_PREP(PPE_PPPOE_SESSION_ID, sid) |
+		     FIELD_PREP(PPE_PPPOE_SESSION_PORT_BMP, BIT(port)) |
+		     FIELD_PREP(PPE_PPPOE_SESSION_L3_IF, vsi));
+	regmap_write(priv->regmap, PPE_PPPOE_SESSION_EXT(port),
+		     PPE_PPPOE_EXT_L3_IF_VALID | PPE_PPPOE_EXT_UC_VALID);
+
+	if (vlan_valid) {
+		priv->wan_xlt[port] = xlt;
+
+		/* The L3 stage does not parse through a residual 802.1Q tag:
+		 * the PPPoE session is only recognised, and the inner tuple
+		 * only reaches the flow lookup, once the rule also strips the
+		 * tag. The hardware re-adds it toward the CPU (below), so a
+		 * frame that misses the flow table still reaches the software
+		 * PPPoE stack in its on-wire form. Action and re-tag are in
+		 * place before the rule goes live.
+		 */
+		regmap_write(priv->regmap, PPE_XLT_ACTION_TBL(xlt),
+			     FIELD_PREP(PPE_XLT_CVID_CMD, PPE_XLT_CVID_DEL));
+		regmap_write(priv->regmap, PPE_XLT_ACTION_W1(xlt),
+			     PPE_XLT_VSI_CMD | FIELD_PREP(PPE_XLT_VSI, vsi));
+
+		/* An egress translation rule, keyed on the VSI, puts the tag
+		 * back on everything leaving toward the CPU port. Nothing else
+		 * uses the egress table, so the ingress index names its entry
+		 * too rather than needing a second allocator.
+		 */
+		regmap_write(priv->regmap, PPE_EG_XLT_ACTION(xlt),
+			     FIELD_PREP(PPE_EG_XLT_CVID_CMD,
+					PPE_EG_XLT_CVID_ADD) |
+			     FIELD_PREP(PPE_EG_XLT_CVID, vlan_id));
+		regmap_write(priv->regmap, PPE_EG_XLT_ACTION_W1(xlt), 0);
+		regmap_write(priv->regmap, PPE_EG_XLT_RULE(xlt),
+			     PPE_EG_XLT_VALID |
+			     FIELD_PREP(PPE_EG_XLT_PORT_BMP,
+					BIT(QCA_PPE_CPU_PORT)) |
+			     PPE_EG_XLT_VSI_INCL |
+			     FIELD_PREP(PPE_EG_XLT_VSI, vsi) |
+			     PPE_EG_XLT_VSI_VALID |
+			     FIELD_PREP(PPE_EG_XLT_SKEY_FMT,
+					PPE_XLT_SKEY_UNTAGGED));
+		regmap_write(priv->regmap, PPE_EG_XLT_RULE_W1(xlt),
+			     FIELD_PREP(PPE_EG_XLT_CKEY_FMT,
+					PPE_XLT_SKEY_UNTAGGED));
+
+		/* The frame-format fields are match bitmaps: a zero matches no
+		 * frame at all. The uplink is single (C-)tagged, so the S-tag
+		 * side must accept the untagged format for the rule to hit.
+		 */
+		regmap_write(priv->regmap, PPE_XLT_RULE_TBL(xlt),
+			     PPE_XLT_VALID |
+			     FIELD_PREP(PPE_XLT_PORT_BMP, BIT(port)) |
+			     FIELD_PREP(PPE_XLT_SKEY_FMT,
+					PPE_XLT_SKEY_UNTAGGED));
+		regmap_write(priv->regmap, PPE_XLT_RULE_W1(xlt),
+			     FIELD_PREP(PPE_XLT_CKEY_FMT_1,
+					PPE_XLT_CKEY_TAGGED >> 1) |
+			     PPE_XLT_CKEY_VID_INCL |
+			     FIELD_PREP(PPE_XLT_CKEY_VID, vlan_id));
+		regmap_write(priv->regmap, PPE_XLT_RULE_TBL(xlt) + 8, 0);
+	}
+
+	return 1;
+
+err_vsi:
+	ppe_vsi_free(priv, vsi);
+	priv->wan_vsi[port] = -1;
+err_xlt:
+	if (xlt >= 0)
+		ppe_xlt_idx_free(priv, &xlt);
+	priv->wan_ref[port]--;
+	return ret;
+}
+
+static void ppe_wan_ingress_put(struct qca_ppe_priv *priv, int port)
+{
+	int xlt = priv->wan_xlt[port];
+	u32 vsi = priv->wan_vsi[port];
+
+	if (--priv->wan_ref[port])
+		return;
+
+	if (xlt >= 0) {
+		/* Ingress first: the egress rule is what puts the tag back on
+		 * a frame the ingress rule stripped, so taking it down first
+		 * would surface stripped frames on the port device. Within the
+		 * ingress rule the allocator clears the three key words before
+		 * the action's, since a key left live over a zeroed action
+		 * blackholes every frame it matches.
+		 */
+		ppe_xlt_idx_free(priv, &priv->wan_xlt[port]);
+		regmap_write(priv->regmap, PPE_EG_XLT_RULE(xlt), 0);
+		regmap_write(priv->regmap, PPE_EG_XLT_RULE_W1(xlt), 0);
+		regmap_write(priv->regmap, PPE_EG_XLT_ACTION(xlt), 0);
+		regmap_write(priv->regmap, PPE_EG_XLT_ACTION_W1(xlt), 0);
+	}
+	regmap_write(priv->regmap, PPE_PPPOE_SESSION(port), 0);
+	regmap_write(priv->regmap, PPE_PPPOE_SESSION_EXT(port), 0);
+	regmap_write(priv->regmap, PPE_L3_VSI_TBL(vsi), 0);
+	ppe_tbl_clear(priv, PPE_IN_L3_IF_TBL(vsi), PPE_L3_IF_WORDS);
+	if (ppe_res_put(priv->my_mac, priv->wan_mymac[port]))
+		ppe_tbl_clear(priv, PPE_MY_MAC_TBL(priv->wan_mymac[port]),
+			      PPE_MY_MAC_WORDS);
+	ppe_vsi_free(priv, vsi);
+	priv->wan_vsi[port] = -1;
+}
+
+/* The VSI the ingress classification puts this rule's packets in - the routing
+ * domain the flow belongs to, and the one ingress identifier its hardware entry
+ * can carry. A domain that cannot be named is declined rather than encoded as
+ * the bare tuple, which would let the flow forward traffic from another VLAN.
+ */
+static int ppe_flow_ingress_vsi(struct qca_ppe_priv *priv, int iport)
+{
+	struct qca_ppe_vlan_entry *vlan;
+
+	lockdep_assert_held(&priv->vlan_lock);
+
+	/* A PPPoE uplink is classified into a VSI of its own, and only the
+	 * VLAN and session id that classification names reach it.
+	 */
+	if (priv->wan_ref[iport])
+		return priv->wan_vsi[iport];
+
+	/* A VLAN-filtering bridge reclassifies an untagged frame into the VSI
+	 * of the port's PVID, so the port's own VSI answers only without one.
+	 */
+	if (!priv->port_pvid[iport])
+		return ppe_port_l3_vsi(priv, iport);
+
+	vlan = ppe_vlan_find(priv, priv->port_br_dev[iport],
+			     priv->port_pvid[iport]);
+
+	return vlan ? (int)vlan->vsi : -EOPNOTSUPP;
+}
+
+/* The flow lookup only runs on packets the L3 stage accepted, and nothing in
+ * the L2 half of this driver sets that up: the ingress interface has to route,
+ * and the frame's destination address has to match a MY_MAC entry. Both are
+ * built here from the ports the flow actually uses, and torn down with the last
+ * flow that needed them.
+ *
+ * One ingress L3 interface per VSI is enough, and using the VSI number as its
+ * index keeps the two in step without a second allocator.
+ */
+static int ppe_flow_alloc_ingress(struct qca_ppe_priv *priv, int iport,
+				  struct ppe_flow_entry *entry)
+{
+	struct dsa_port *dp = dsa_to_port(&priv->ds, iport);
+	u32 words[PPE_NEXTHOP_WORDS] = {};
+	struct net_device *l3dev;
+	u32 mtu;
+	int vsi, ret;
+
+	lockdep_assert_held(&priv->vlan_lock);
+
+	vsi = ppe_flow_ingress_vsi(priv, iport);
+	if (vsi < 0)
+		return vsi;
+
+	entry->src_if = vsi;
+	entry->ivid = priv->wan_ref[iport] ? priv->wan_vid[iport] :
+					     priv->port_pvid[iport];
+
+	/* A PPPoE uplink's ingress interface belongs to the uplink, so take a
+	 * reference rather than programming anything: a sibling flow going away
+	 * must not pull the classification out from under this one.
+	 */
+	if (priv->wan_ref[iport]) {
+		priv->wan_ref[iport]++;
+		entry->wan_iport = iport;
+		return 0;
+	}
+
+	/* The address the packet is sent to is the address of the device that
+	 * routes for this port, which is the bridge when there is one. That
+	 * pointer is this driver's own, kept in step under this lock; DSA's is
+	 * only safe to follow under rtnl, which the flowtable does not hold.
+	 */
+	l3dev = priv->port_br_dev[iport];
+	if (!l3dev)
+		l3dev = dp->user;
+
+	ppe_entry_set(words, PPE_MY_MAC_ADDR_OFF, PPE_MY_MAC_ADDR_LEN,
+		      ether_addr_to_u64(l3dev->dev_addr));
+	ppe_entry_set(words, PPE_MY_MAC_VALID_OFF, PPE_MY_MAC_VALID_LEN, 1);
+
+	ret = ppe_res_get(priv->my_mac, PPE_MY_MAC_ENTRIES, words,
+			  PPE_MY_MAC_WORDS);
+	if (ret < 0)
+		return ret;
+	entry->my_mac = ret;
+	if (priv->my_mac[ret].refcount == 1)
+		ppe_tbl_write(priv, PPE_MY_MAC_TBL(ret), words,
+			      PPE_MY_MAC_WORDS);
+
+	entry->l3_if = vsi;
+	if (priv->l3_if_ref[vsi]++)
+		return 0;
+
+	mtu = l3dev->mtu + ETH_HLEN;
+
+	/* Accept any of our addresses rather than tracking which MY_MAC entry
+	 * belongs to which interface: the table only holds our own addresses.
+	 */
+	regmap_write(priv->regmap, PPE_IN_L3_IF_TBL(vsi),
+		     PPE_L3_IF_IPV4_ROUTE_EN | PPE_L3_IF_IPV6_ROUTE_EN);
+	regmap_write(priv->regmap, PPE_IN_L3_IF_TBL(vsi) + 4,
+		     FIELD_PREP(PPE_L3_IF_TTL_EXCEED_CMD,
+				PPE_L3_IF_TTL_EXCEED_TO_CPU) |
+		     PPE_L3_IF_TTL_EXCEED_DEACCEL |
+		     FIELD_PREP(PPE_L3_IF_MAC_BITMAP, GENMASK(7, 0)));
+	ppe_l3_if_mtu_set(priv, vsi, mtu);
+	regmap_write(priv->regmap, PPE_L3_VSI_TBL(vsi),
+		     PPE_L3_VSI_IF_VALID | FIELD_PREP(PPE_L3_VSI_IF_INDEX, vsi));
+
+	return 0;
+}
+
+static void ppe_flow_entry_destroy(struct qca_ppe_priv *priv,
+				   struct ppe_flow_entry *entry);
+
+static void ppe_flow_drop(struct qca_ppe_priv *priv,
+			  struct ppe_flow_entry *entry)
+{
+	priv->flow_stale++;
+	rhashtable_remove_fast(&priv->flow_table, &entry->node,
+			       ppe_flow_ht_params);
+	list_del(&entry->list);
+	ppe_flow_entry_destroy(priv, entry);
+	kfree(entry);
+}
+
+/* The ingress L3 interface holds its own MTU and is programmed with the first
+ * flow that needs it, so a routing domain whose MTU changes while flows are
+ * live keeps being forwarded to the old limit unless the change reaches it.
+ */
+static void ppe_flow_l3_mtu_set(struct qca_ppe_priv *priv, int port, int mtu)
+{
+	u32 vsi;
+	int i;
+
+	lockdep_assert_held(&priv->vlan_lock);
+
+	if (priv->wan_ref[port])
+		ppe_l3_if_mtu_set(priv, priv->wan_vsi[port],
+				  mtu + VLAN_ETH_HLEN + PPPOE_SES_HLEN);
+
+	vsi = ppe_port_l3_vsi(priv, port);
+	if (priv->l3_if_ref[vsi])
+		ppe_l3_if_mtu_set(priv, vsi, mtu + ETH_HLEN);
+
+	for (i = 0; i < PPE_VSI_MAX; i++) {
+		struct qca_ppe_vlan_entry *vlan = &priv->vlans[i];
+
+		if (vlan->br_dev && vlan->ports & BIT(port) &&
+		    priv->l3_if_ref[vlan->vsi])
+			ppe_l3_if_mtu_set(priv, vlan->vsi, mtu + ETH_HLEN);
+	}
+}
+
+/* A MAC the entries were built against is changing: it is the address the
+ * ingress accepts and the source the egress writes, so neither half can match
+ * any more. Drop them and let the flowtable rebuild against the new one.
+ */
+static void ppe_flow_drop_port(struct qca_ppe_priv *priv, int port)
+{
+	struct ppe_flow_entry *entry, *tmp;
+
+	list_for_each_entry_safe(entry, tmp, &priv->flow_list, list)
+		if (entry->iport == port || entry->oport == port)
+			ppe_flow_drop(priv, entry);
+}
+
+/* Each half of the size check follows the device that owns it: the routing
+ * domain's MRU follows the device that routes for the port, and the egress size
+ * a flow was built with follows the port itself.
+ *
+ * Neither can be taken from DSA's port_change_mtu. That runs before the bridge
+ * recomputes its own MTU, so a bridged port reads the previous one there, and
+ * `ip link set br-lan mtu N` never reaches it at all. By the NETDEV_CHANGEMTU
+ * of the device the value belongs to, both have settled - whichever of the two
+ * the user set, and however the bridge chose to answer it.
+ *
+ * The egress size is part of the key that picks the interface entry, and that
+ * slot is shared by every flow leaving the same way at the old size, so a live
+ * flow cannot be moved to the new one. Drop those and let the flowtable rebuild
+ * them against the size it has now.
+ */
+static int ppe_flow_netdev_event(struct notifier_block *nb, unsigned long event,
+				 void *ptr)
+{
+	struct qca_ppe_priv *priv = container_of(nb, struct qca_ppe_priv,
+						 netdev_nb);
+	struct net_device *dev = netdev_notifier_info_to_dev(ptr);
+	struct ppe_flow_entry *entry, *tmp;
+	struct dsa_port *dp;
+	int i;
+
+	if (event != NETDEV_CHANGEMTU && event != NETDEV_CHANGEADDR)
+		return NOTIFY_DONE;
+
+	guard(mutex)(&priv->flow_lock);
+	guard(mutex)(&priv->vlan_lock);
+
+	/* Reached through the netdev itself rather than by walking the switch:
+	 * this notifier is live before the switch is registered, and every
+	 * netdev in the system passes through it.
+	 */
+	dp = dsa_port_from_netdev(dev);
+	if (!IS_ERR(dp) && dp->ds == &priv->ds) {
+		if (event == NETDEV_CHANGEADDR) {
+			ppe_flow_drop_port(priv, dp->index);
+		} else {
+			list_for_each_entry_safe(entry, tmp, &priv->flow_list,
+						 list)
+				if (entry->oport == dp->index)
+					ppe_flow_drop(priv, entry);
+
+			if (!priv->port_br_dev[dp->index])
+				ppe_flow_l3_mtu_set(priv, dp->index, dev->mtu);
+		}
+	}
+
+	for (i = 0; i < QCA_PPE_MAX_PORTS; i++) {
+		if (priv->port_br_dev[i] != dev)
+			continue;
+
+		if (event == NETDEV_CHANGEADDR)
+			ppe_flow_drop_port(priv, i);
+		else
+			ppe_flow_l3_mtu_set(priv, i, dev->mtu);
+	}
+
+	return NOTIFY_DONE;
+}
+
+static void ppe_flow_free_ingress(struct qca_ppe_priv *priv,
+				  struct ppe_flow_entry *entry)
+{
+	lockdep_assert_held(&priv->vlan_lock);
+
+	if (entry->wan_iport >= 0) {
+		ppe_wan_ingress_put(priv, entry->wan_iport);
+		return;
+	}
+
+	if (entry->l3_if >= 0 && !--priv->l3_if_ref[entry->l3_if]) {
+		regmap_write(priv->regmap, PPE_L3_VSI_TBL(entry->l3_if), 0);
+		ppe_tbl_clear(priv, PPE_IN_L3_IF_TBL(entry->l3_if),
+			      PPE_L3_IF_WORDS);
+	}
+
+	if (ppe_res_put(priv->my_mac, entry->my_mac))
+		ppe_tbl_clear(priv, PPE_MY_MAC_TBL(entry->my_mac),
+			      PPE_MY_MAC_WORDS);
+}
+
+/* The routing domain a set of flows was built for is going away. Their entries
+ * name its VSI as the ingress they match on, and that number is about to be
+ * handed to another domain, so they cannot be left behind: they would match the
+ * new domain's traffic, and their own teardown would later clear the new
+ * owner's L3 interface out from under it. The flowtable reinstalls whatever is
+ * still live, against whatever domain it belongs to then.
+ */
+void ppe_flow_purge_vsi(struct qca_ppe_priv *priv, u32 vsi)
+{
+	struct ppe_flow_entry *entry, *tmp;
+
+	lockdep_assert_held(&priv->flow_lock);
+
+	list_for_each_entry_safe(entry, tmp, &priv->flow_list, list) {
+		if (entry->src_if != vsi)
+			continue;
+
+		ppe_flow_drop(priv, entry);
+	}
+}
+
+/* A flow that ingresses on this port and was installed before the uplink had a
+ * classification named the port's plain VSI, and can never match now that one
+ * exists. Drop those entries: the flowtable reinstalls whatever is still live.
+ */
+static void ppe_flow_purge_ingress(struct qca_ppe_priv *priv, int iport,
+				   u8 wan_vsi)
+{
+	struct ppe_flow_entry *entry, *tmp;
+
+	list_for_each_entry_safe(entry, tmp, &priv->flow_list, list) {
+		if (entry->iport != iport || entry->src_if == wan_vsi)
+			continue;
+
+		ppe_flow_drop(priv, entry);
+	}
+}
+
+/* Build the egress L3 interface, nexthop and public-address entries this rule
+ * needs, and program any that were not already in use by another flow.
+ */
+static int ppe_flow_alloc_egress(struct qca_ppe_priv *priv,
+				 struct ppe_flow_data *data, bool snat,
+				 bool dnat, int iport,
+				 struct ppe_flow_entry *entry)
+{
+	u32 words[PPE_NEXTHOP_WORDS] = {};
+	struct dsa_port *odp;
+	u32 eg_mtu;
+	u64 mac;
+	int port, ret;
+
+	port = ppe_flow_port_by_ifindex(priv, data->odev->ifindex);
+	if (port < 0)
+		return port;
+
+	/* A frame sent back out the port it arrived on is discarded by source
+	 * port filtering, so offloading it would black-hole what the CPU would
+	 * otherwise have forwarded.
+	 */
+	if (port == iport)
+		return -EBUSY;
+
+	entry->oport = port;
+	/* An untagged egress is credited to the port's PVID VLAN, the one an
+	 * untagged frame on that port belongs to.
+	 */
+	entry->ovid = data->vlan_valid ? data->vlan_id : priv->port_pvid[port];
+
+	mac = ether_addr_to_u64(data->eth.h_source);
+	ppe_entry_set(words, PPE_EG_L3_IF_MAC_OFF, PPE_EG_L3_IF_MAC_LEN, mac);
+	if (data->pppoe_valid) {
+		ppe_entry_set(words, PPE_EG_L3_IF_SESSION_OFF,
+			      PPE_EG_L3_IF_SESSION_LEN, data->pppoe_sid);
+		ppe_entry_set(words, PPE_EG_L3_IF_PPPOE_EN_OFF,
+			      PPE_EG_L3_IF_PPPOE_EN_LEN, 1);
+	}
+	/* The size a routed frame leaves at, which the hardware compares before
+	 * it egresses and sends the frame to the CPU when it does not fit. The
+	 * port's mtu carries one mac header and the vlan tag the nexthop pushes;
+	 * a pppoe session header rides inside that mtu rather than on top of it.
+	 * It joins the key because two interfaces sharing a source address need
+	 * separate entries when they do not share a size.
+	 */
+	odp = dsa_to_port(&priv->ds, port);
+	eg_mtu = odp->user->mtu + ETH_HLEN + (data->vlan_valid ? VLAN_HLEN : 0);
+	words[PPE_EG_L3_IF_WORDS] = eg_mtu;
+
+	/* An L3 interface is one index with an ingress half and an egress half.
+	 * ppe_flow_alloc_ingress() keys the ingress half by VSI, so an egress
+	 * interface allocated below PPE_VSI_MAX would answer the size check out
+	 * of some VSI's ingress mtu, or overwrite it. Allocating above that
+	 * range is what keeps the two halves from sharing an entry.
+	 */
+	ret = ppe_res_get(priv->eg_l3_if + PPE_VSI_MAX,
+			  PPE_EG_L3_IF_ENTRIES - PPE_VSI_MAX, words,
+			  PPE_EG_L3_IF_WORDS + 1);
+	if (ret < 0)
+		return ret;
+	entry->eg_l3_if = ret + PPE_VSI_MAX;
+	if (priv->eg_l3_if[entry->eg_l3_if].refcount == 1) {
+		ppe_tbl_write(priv, PPE_EG_L3_IF_TBL(entry->eg_l3_if), words,
+			      PPE_EG_L3_IF_WORDS);
+		ppe_eg_l3_if_mtu_set(priv, entry->eg_l3_if, eg_mtu);
+	}
+
+	if (snat) {
+		u32 pub = ntohl(data->v4_src_new);
+
+		ret = ppe_res_get(priv->pub_ip, PPE_PUB_IP_ENTRIES, &pub, 1);
+		if (ret < 0)
+			goto err_eg_l3_if;
+		entry->pub_ip = ret;
+		if (priv->pub_ip[ret].refcount == 1)
+			regmap_write(priv->regmap, PPE_PUB_IP_TBL(ret), pub);
+	}
+
+	memset(words, 0, sizeof(words));
+	/* Type selects how the port field is read: as a physical port (1) or,
+	 * left at 0, as a VSI whose FDB resolves the port. The egress port is
+	 * known exactly here, so name it directly; left at 0 the port number
+	 * would be read as a VSI.
+	 */
+	ppe_entry_set(words, PPE_NEXTHOP_TYPE_OFF, PPE_NEXTHOP_TYPE_LEN,
+		      PPE_NEXTHOP_TYPE_PORT);
+	ppe_entry_set(words, PPE_NEXTHOP_PORT_OFF, PPE_NEXTHOP_PORT_LEN, port);
+	ppe_entry_set(words, PPE_NEXTHOP_POST_L3_IF_OFF,
+		      PPE_NEXTHOP_POST_L3_IF_LEN, entry->eg_l3_if);
+	if (data->vlan_valid) {
+		ppe_entry_set(words, PPE_NEXTHOP_CTAG_FMT_OFF,
+			      PPE_NEXTHOP_CTAG_FMT_LEN, 1);
+		ppe_entry_set(words, PPE_NEXTHOP_CVID_OFF,
+			      PPE_NEXTHOP_CVID_LEN, data->vlan_id);
+	}
+	if (snat)
+		ppe_entry_set(words, PPE_NEXTHOP_PUB_IP_IDX_OFF,
+			      PPE_NEXTHOP_PUB_IP_IDX_LEN, entry->pub_ip);
+	ppe_entry_set(words, PPE_NEXTHOP_MAC_OFF, PPE_NEXTHOP_MAC_LEN,
+		      ether_addr_to_u64(data->eth.h_dest));
+	if (dnat)
+		ppe_entry_set(words, PPE_NEXTHOP_DNAT_IP_OFF,
+			      PPE_NEXTHOP_DNAT_IP_LEN, ntohl(data->v4_dst_new));
+
+	ret = ppe_res_get(priv->nexthop, priv->data->num_nexthop_entries, words,
+			  PPE_NEXTHOP_WORDS);
+	if (ret < 0)
+		goto err_pub_ip;
+	entry->nexthop = ret;
+	if (priv->nexthop[ret].refcount == 1)
+		ppe_tbl_write(priv, PPE_IN_NEXTHOP_TBL(ret), words,
+			      PPE_NEXTHOP_WORDS);
+
+	/* The reverse of a flow that egresses PPPoE arrives PPPoE-encapsulated
+	 * on this same port; set the port up to route it so that direction
+	 * offloads too.
+	 */
+	if (data->pppoe_valid) {
+		struct dsa_port *odp = dsa_to_port(&priv->ds, port);
+		u8 wan_vsi;
+
+		ret = ppe_wan_ingress_get(priv, port, data->pppoe_sid,
+					  data->vlan_valid, data->vlan_id,
+					  odp->user->dev_addr,
+					  odp->user->mtu + VLAN_ETH_HLEN +
+					  PPPOE_SES_HLEN);
+		wan_vsi = priv->wan_vsi[port];
+		if (ret < 0)
+			goto err_nexthop;
+		entry->wan_port = port;
+
+		if (ret == 1)
+			ppe_flow_purge_ingress(priv, port, wan_vsi);
+	}
+
+	return 0;
+
+err_nexthop:
+	if (ppe_res_put(priv->nexthop, entry->nexthop))
+		ppe_tbl_clear(priv, PPE_IN_NEXTHOP_TBL(entry->nexthop),
+			      PPE_NEXTHOP_WORDS);
+err_pub_ip:
+	if (ppe_res_put(priv->pub_ip, entry->pub_ip))
+		regmap_write(priv->regmap, PPE_PUB_IP_TBL(entry->pub_ip), 0);
+err_eg_l3_if:
+	if (ppe_res_put(priv->eg_l3_if, entry->eg_l3_if)) {
+		ppe_tbl_clear(priv, PPE_EG_L3_IF_TBL(entry->eg_l3_if),
+			      PPE_EG_L3_IF_WORDS);
+		ppe_tbl_clear(priv, PPE_IN_L3_IF_TBL(entry->eg_l3_if),
+			      PPE_L3_IF_WORDS);
+	}
+
+	return ret;
+}
+
+static void ppe_flow_free_egress(struct qca_ppe_priv *priv,
+				 struct ppe_flow_entry *entry)
+{
+	if (ppe_res_put(priv->nexthop, entry->nexthop))
+		ppe_tbl_clear(priv, PPE_IN_NEXTHOP_TBL(entry->nexthop),
+			      PPE_NEXTHOP_WORDS);
+	if (ppe_res_put(priv->pub_ip, entry->pub_ip))
+		regmap_write(priv->regmap, PPE_PUB_IP_TBL(entry->pub_ip), 0);
+	if (ppe_res_put(priv->eg_l3_if, entry->eg_l3_if)) {
+		ppe_tbl_clear(priv, PPE_EG_L3_IF_TBL(entry->eg_l3_if),
+			      PPE_EG_L3_IF_WORDS);
+		ppe_tbl_clear(priv, PPE_IN_L3_IF_TBL(entry->eg_l3_if),
+			      PPE_L3_IF_WORDS);
+	}
+
+	if (entry->wan_port >= 0)
+		ppe_wan_ingress_put(priv, entry->wan_port);
+}
+
+/* The counters are cumulative and narrower than u64 - 32-bit packets, 40-bit
+ * bytes - so the deltas are computed in the counters' own widths to survive
+ * wraparound.
+ */
+static u32 ppe_flow_counter_delta(struct qca_ppe_priv *priv,
+				  struct ppe_flow_entry *entry, u64 *bytes)
+{
+	u64 packets, total;
+	u32 pkts;
+
+	ppe_flow_counter_read(priv, entry->index, &packets, &total);
+	pkts = (u32)(packets - entry->packets);
+	*bytes = (total - entry->bytes) & PPE_FLOW_CNT_BYTES;
+	entry->packets = packets;
+	entry->bytes = total;
+
+	return pkts;
+}
+
+static void ppe_flow_dev_add(struct net_device *dev, bool rx, u32 pkts,
+			     u64 bytes)
+{
+	local_bh_disable();
+	if (is_vlan_dev(dev)) {
+		struct vlan_pcpu_stats *s;
+
+		s = this_cpu_ptr(vlan_dev_priv(dev)->vlan_pcpu_stats);
+		u64_stats_update_begin(&s->syncp);
+		u64_stats_add(rx ? &s->rx_packets : &s->tx_packets, pkts);
+		u64_stats_add(rx ? &s->rx_bytes : &s->tx_bytes, bytes);
+		u64_stats_update_end(&s->syncp);
+	} else if (netif_is_bridge_master(dev)) {
+		struct pcpu_sw_netstats *s = this_cpu_ptr(dev->tstats);
+
+		u64_stats_update_begin(&s->syncp);
+		u64_stats_add(rx ? &s->rx_packets : &s->tx_packets, pkts);
+		u64_stats_add(rx ? &s->rx_bytes : &s->tx_bytes, bytes);
+		u64_stats_update_end(&s->syncp);
+	}
+	local_bh_enable();
+}
+
+static void ppe_flow_account_side(struct qca_ppe_priv *priv, int port,
+				  u16 vid, bool rx, u32 pkts, u64 bytes)
+{
+	struct net_device *dev = priv->port_br_dev[port];
+
+	if (dev)
+		ppe_flow_dev_add(dev, rx, pkts, bytes);
+	else
+		dev = dsa_to_port(&priv->ds, port)->user;
+
+	if (dev && vid) {
+		dev = __vlan_find_dev_deep_rcu(dev, htons(ETH_P_8021Q), vid);
+		if (dev)
+			ppe_flow_dev_add(dev, rx, pkts, bytes);
+	}
+}
+
+/* What the hardware forwarded never crossed the software interfaces on the
+ * way: the bridge a port is in and the VLAN interface of the VLAN the frame
+ * carries, received on the ingress side and sent on the egress side. Their
+ * counters get the flow's deltas so they read as without offload. The port
+ * itself is left alone; its MIB already counts the frames.
+ *
+ * The bridge pointer is written under the flow lock by the bridge join and
+ * leave ops, and a VLAN interface is found under RCU rather than held.
+ */
+static void ppe_flow_account(struct qca_ppe_priv *priv,
+			     struct ppe_flow_entry *entry, u32 pkts, u64 bytes)
+{
+	lockdep_assert_held(&priv->flow_lock);
+
+	if (!pkts)
+		return;
+
+	rcu_read_lock();
+	ppe_flow_account_side(priv, entry->iport, entry->ivid, true, pkts,
+			      bytes);
+	ppe_flow_account_side(priv, entry->oport, entry->ovid, false, pkts,
+			      bytes);
+	rcu_read_unlock();
+}
+
+/* Both locks: the release below reaches the VLAN side, and a routing domain
+ * going away destroys flows with that lock already held, so taking it here
+ * would be the same task asking for it twice.
+ */
+static void ppe_flow_entry_destroy(struct qca_ppe_priv *priv,
+				   struct ppe_flow_entry *entry)
+{
+	u64 bytes;
+	int age;
+
+	lockdep_assert_held(&priv->flow_lock);
+	lockdep_assert_held(&priv->vlan_lock);
+
+	/* Delete by index - the key does not have to be restaged. Only a read
+	 * that says the slot belongs to another flow is a reason not to: the
+	 * hardware removes an idle entry on its own and may have handed the
+	 * slot on, but a read that failed leaves it unknown, and leaving a live
+	 * entry pointing at side tables about to be reused is the worse half of
+	 * that trade.
+	 */
+	age = ppe_flow_entry_age(priv, entry);
+	if (age >= 0) {
+		u32 pkts = ppe_flow_counter_delta(priv, entry, &bytes);
+
+		ppe_flow_account(priv, entry, pkts, bytes);
+	}
+	if (age != -ENOENT)
+		ppe_flow_entry_delete(priv, entry->index);
+	ppe_host_ref_put(priv, entry->host_index);
+	ppe_flow_free_egress(priv, entry);
+	ppe_flow_free_ingress(priv, entry);
+}
+
+/* Encode the flow entry and its host half. The key is always the tuple as the
+ * packet arrives: the destination address in the flow entry, the source address
+ * in the host entry.
+ */
+static void ppe_flow_encode(struct ppe_flow_data *data, bool v6, bool snat,
+			    bool dnat, u32 nexthop, u32 src_if, u32 *fw,
+			    u32 *hw)
+{
+	u32 fwd;
+
+	ppe_entry_set(fw, PPE_FLOW_E_VALID_OFF, PPE_FLOW_E_VALID_LEN, 1);
+
+	/* The key is a bare 5-tuple otherwise, so the same addresses on two
+	 * VLANs - or on two ports that route separately - would alias. The
+	 * ingress L3 interface is the one ingress identifier the entry can
+	 * hold; a packet that resolves another one misses to the CPU.
+	 */
+	ppe_entry_set(fw, PPE_FLOW_E_SRC_IF_VALID_OFF,
+		      PPE_FLOW_E_SRC_IF_VALID_LEN, 1);
+	ppe_entry_set(fw, PPE_FLOW_E_SRC_IF_OFF, PPE_FLOW_E_SRC_IF_LEN, src_if);
+	ppe_entry_set(fw, PPE_FLOW_E_TYPE_OFF, PPE_FLOW_E_TYPE_LEN, v6);
+	ppe_entry_set(fw, PPE_FLOW_E_PROTO_OFF, PPE_FLOW_E_PROTO_LEN,
+		      ppe_flow_proto(data->l4proto));
+	ppe_entry_set(fw, PPE_FLOW_E_AGE_OFF, PPE_FLOW_E_AGE_LEN,
+		      PPE_FLOW_AGE_MAX);
+
+	fwd = snat ? PPE_FLOW_FWD_SNAT : dnat ? PPE_FLOW_FWD_DNAT :
+						PPE_FLOW_FWD_ROUTE;
+	ppe_entry_set(fw, PPE_FLOW_E_FWD_TYPE_OFF, PPE_FLOW_E_FWD_TYPE_LEN, fwd);
+	ppe_entry_set(fw, PPE_FLOW_E_NEXTHOP_OFF, PPE_FLOW_E_NEXTHOP_LEN,
+		      nexthop);
+	if (snat)
+		ppe_entry_set(fw, PPE_FLOW_E_NEW_PORT_OFF,
+			      PPE_FLOW_E_NEW_PORT_LEN, ntohs(data->sport_new));
+	else if (dnat)
+		ppe_entry_set(fw, PPE_FLOW_E_NEW_PORT_OFF,
+			      PPE_FLOW_E_NEW_PORT_LEN, ntohs(data->dport_new));
+
+	ppe_entry_set(fw, PPE_FLOW_E_SPORT_OFF, PPE_FLOW_E_SPORT_LEN,
+		      ntohs(data->sport));
+	ppe_entry_set(fw, PPE_FLOW_E_DPORT_OFF, PPE_FLOW_E_DPORT_LEN,
+		      ntohs(data->dport));
+
+	ppe_entry_set(hw, PPE_HOST_E_VALID_OFF, PPE_HOST_E_VALID_LEN, 1);
+
+	if (v6) {
+		ppe_entry_set_addr6(fw, PPE_FLOW_E_IPV6_OFF, &data->v6_dst);
+		ppe_entry_set(hw, PPE_HOST_E_KEY_TYPE_OFF,
+			      PPE_HOST_E_KEY_TYPE_LEN, PPE_HOST_KEY_IPV6);
+		ppe_entry_set_addr6(hw, PPE_HOST_E_IPV6_OFF, &data->v6_src);
+	} else {
+		ppe_entry_set(fw, PPE_FLOW_E_IPV4_OFF, PPE_FLOW_E_IPV4_LEN,
+			      ntohl(data->v4_dst));
+		ppe_entry_set(hw, PPE_HOST_E_KEY_TYPE_OFF,
+			      PPE_HOST_E_KEY_TYPE_LEN, PPE_HOST_KEY_IPV4);
+		ppe_entry_set(hw, PPE_HOST_E_IPV4_OFF, PPE_HOST_E_IPV4_LEN,
+			      ntohl(data->v4_src));
+	}
+}
+
+static int ppe_flow_reject(struct qca_ppe_priv *priv, enum ppe_flow_reject why)
+{
+	priv->flow_reject[why]++;
+
+	return -EOPNOTSUPP;
+}
+
+static int ppe_flow_offload_replace(struct ppe_flow_block *fb,
+				    struct flow_cls_offload *f)
+{
+	struct flow_rule *rule = flow_cls_offload_flow_rule(f);
+	struct qca_ppe_priv *priv = fb->priv;
+	u32 fw[PPE_FLOW_ENTRY_WORDS_V6] = {};
+	u32 hw[PPE_HOST_ENTRY_WORDS_V6] = {};
+	struct ppe_flow_entry *entry;
+	struct ppe_flow_data data = {};
+	struct flow_action_entry *act;
+	bool snat, dnat, v6;
+	int i, ret, nfw, nhw, iport;
+
+	guard(mutex)(&priv->flow_lock);
+	guard(mutex)(&priv->vlan_lock);
+
+	/* A replace for a cookie already held is the kernel refreshing a flow
+	 * whose packets it saw in the software path. If the hardware entry is
+	 * intact the refresh is a no-op; if the hardware has lost it - however
+	 * that happened - this is the moment to reinstall, or the flow would
+	 * stay in software for the rest of its life.
+	 */
+	entry = rhashtable_lookup_fast(&priv->flow_table, &f->cookie,
+				       ppe_flow_ht_params);
+	if (entry) {
+		if (ppe_flow_entry_age(priv, entry) >= 0)
+			return 0;
+
+		priv->flow_reinstalled++;
+		rhashtable_remove_fast(&priv->flow_table, &entry->node,
+				       ppe_flow_ht_params);
+		list_del(&entry->list);
+		ppe_flow_entry_destroy(priv, entry);
+		kfree(entry);
+	}
+
+	if (!flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_META) ||
+	    !flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_CONTROL) ||
+	    !flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_BASIC))
+		return ppe_flow_reject(priv, PPE_REJECT_KEY);
+
+	{
+		struct flow_match_meta match;
+
+		flow_rule_match_meta(rule, &match);
+		/* Compare against our own ports rather than looking the index
+		 * up, which keeps this correct without knowing the namespace
+		 * the flowtable belongs to. A flow that did not arrive on a
+		 * switch port cannot be matched anyway: Wi-Fi reaches the CPU
+		 * port, and this silicon has no virtual ports to give it a
+		 * flow-table identity.
+		 */
+		iport = ppe_flow_port_by_ifindex(priv,
+						 match.key->ingress_ifindex);
+		if (iport < 0)
+			return ppe_flow_reject(priv, PPE_REJECT_INGRESS_PORT);
+	}
+
+	/* An ingress VLAN cannot be part of the hardware key. Where a bridge
+	 * classifies the tag in hardware the kernel marks it as such and does
+	 * not offer it as a match at all, so a tag that does arrive here is one
+	 * this driver has no classification for and no L3 interface to stand in
+	 * for it; the flow stays in software. A second tag has no expression
+	 * either.
+	 */
+	if (flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_VLAN) ||
+	    flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_CVLAN))
+		return ppe_flow_reject(priv, PPE_REJECT_INGRESS_VLAN);
+
+	{
+		struct flow_match_control match;
+
+		flow_rule_match_control(rule, &match);
+		if (flow_rule_has_control_flags(match.mask->flags,
+						f->common.extack))
+			return ppe_flow_reject(priv, PPE_REJECT_KEY);
+		data.addr_type = match.key->addr_type;
+	}
+
+	{
+		struct flow_match_basic match;
+
+		flow_rule_match_basic(rule, &match);
+		data.l4proto = match.key->ip_proto;
+	}
+
+	if (ppe_flow_proto(data.l4proto) < 0)
+		return ppe_flow_reject(priv, PPE_REJECT_PROTO);
+
+	flow_action_for_each(i, act, &rule->action) {
+		switch (act->id) {
+		case FLOW_ACTION_MANGLE:
+			if (act->mangle.htype == FLOW_ACT_MANGLE_HDR_TYPE_ETH)
+				ret = ppe_flow_mangle_eth(act, &data.eth);
+			else
+				ret = 0;
+			if (ret)
+				return ppe_flow_reject(priv, PPE_REJECT_ACTION);
+			break;
+		case FLOW_ACTION_REDIRECT:
+			data.odev = act->dev;
+			break;
+		case FLOW_ACTION_CSUM:
+			break;
+		case FLOW_ACTION_VLAN_PUSH:
+			if (data.vlan_valid ||
+			    act->vlan.proto != htons(ETH_P_8021Q))
+				return ppe_flow_reject(priv, PPE_REJECT_ACTION);
+			data.vlan_id = act->vlan.vid;
+			data.vlan_valid = true;
+			break;
+		case FLOW_ACTION_VLAN_POP:
+			/* Routed egress rebuilds the L2 header from the
+			 * nexthop, which sheds the ingress encapsulation on
+			 * its own.
+			 */
+			break;
+		case FLOW_ACTION_PPPOE_PUSH:
+			if (data.pppoe_valid)
+				return ppe_flow_reject(priv, PPE_REJECT_ACTION);
+			data.pppoe_sid = act->pppoe.sid;
+			data.pppoe_valid = true;
+			break;
+		default:
+			return ppe_flow_reject(priv, PPE_REJECT_ACTION);
+		}
+	}
+
+	if (!data.odev || !is_valid_ether_addr(data.eth.h_source) ||
+	    !is_valid_ether_addr(data.eth.h_dest))
+		return ppe_flow_reject(priv, PPE_REJECT_L2);
+
+	switch (data.addr_type) {
+	case FLOW_DISSECTOR_KEY_IPV4_ADDRS: {
+		struct flow_match_ipv4_addrs match;
+
+		flow_rule_match_ipv4_addrs(rule, &match);
+		data.v4_src = match.key->src;
+		data.v4_dst = match.key->dst;
+		v6 = false;
+		break;
+	}
+	case FLOW_DISSECTOR_KEY_IPV6_ADDRS: {
+		struct flow_match_ipv6_addrs match;
+
+		flow_rule_match_ipv6_addrs(rule, &match);
+		data.v6_src = match.key->src;
+		data.v6_dst = match.key->dst;
+		v6 = true;
+		break;
+	}
+	default:
+		return ppe_flow_reject(priv, PPE_REJECT_KEY);
+	}
+
+	if (!flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_PORTS))
+		return ppe_flow_reject(priv, PPE_REJECT_KEY);
+	{
+		struct flow_match_ports match;
+
+		flow_rule_match_ports(rule, &match);
+		data.sport = match.key->src;
+		data.dport = match.key->dst;
+	}
+
+	data.v4_src_new = data.v4_src;
+	data.v4_dst_new = data.v4_dst;
+	data.sport_new = data.sport;
+	data.dport_new = data.dport;
+
+	flow_action_for_each(i, act, &rule->action) {
+		if (act->id != FLOW_ACTION_MANGLE)
+			continue;
+
+		switch (act->mangle.htype) {
+		case FLOW_ACT_MANGLE_HDR_TYPE_IP4:
+			ret = ppe_flow_mangle_ipv4(act, &data);
+			break;
+		case FLOW_ACT_MANGLE_HDR_TYPE_TCP:
+		case FLOW_ACT_MANGLE_HDR_TYPE_UDP:
+			ret = ppe_flow_mangle_ports(act, &data);
+			break;
+		case FLOW_ACT_MANGLE_HDR_TYPE_IP6:
+			/* The IPv6 flow entry has no L4 port rewrite fields and
+			 * the nexthop's NAT address is 32 bits wide, so IPv6
+			 * address translation cannot be expressed at all.
+			 */
+			return ppe_flow_reject(priv, PPE_REJECT_NAT_IPV6);
+		default:
+			ret = 0;
+			break;
+		}
+		if (ret)
+			return ppe_flow_reject(priv, PPE_REJECT_ACTION);
+	}
+
+	snat = data.v4_src_new != data.v4_src || data.sport_new != data.sport;
+	dnat = data.v4_dst_new != data.v4_dst || data.dport_new != data.dport;
+
+	/* SNAT and DNAT share the same bits of the flow entry, so a rule that
+	 * needs both - a hairpinned connection - has no hardware expression.
+	 */
+	if (snat && dnat)
+		return ppe_flow_reject(priv, PPE_REJECT_NAT_BOTH);
+
+	if (v6 && (snat || dnat))
+		return ppe_flow_reject(priv, PPE_REJECT_NAT_IPV6);
+
+	entry = kzalloc(sizeof(*entry), GFP_KERNEL);
+	if (!entry)
+		return -ENOMEM;
+
+	entry->cookie = f->cookie;
+	entry->block = fb->block;
+	entry->nexthop = -1;
+	entry->eg_l3_if = -1;
+	entry->pub_ip = -1;
+	entry->my_mac = -1;
+	entry->l3_if = -1;
+	entry->wan_port = -1;
+	entry->wan_iport = -1;
+	entry->iport = iport;
+
+	ret = ppe_flow_alloc_ingress(priv, iport, entry);
+	if (ret) {
+		priv->flow_reject[ret == -EOPNOTSUPP ? PPE_REJECT_INGRESS_VLAN :
+				  PPE_REJECT_RESOURCE]++;
+		goto err_free;
+	}
+
+	ret = ppe_flow_alloc_egress(priv, &data, snat, dnat, iport, entry);
+	if (ret) {
+		priv->flow_reject[ret == -ENOSPC ? PPE_REJECT_RESOURCE :
+				  ret == -EBUSY ? PPE_REJECT_HAIRPIN :
+				  PPE_REJECT_EGRESS_PORT]++;
+		goto err_ingress;
+	}
+
+	ppe_flow_encode(&data, v6, snat, dnat, entry->nexthop, entry->src_if,
+			fw, hw);
+
+	nfw = v6 ? PPE_FLOW_ENTRY_WORDS_V6 : PPE_FLOW_ENTRY_WORDS_V4;
+	nhw = v6 ? PPE_HOST_ENTRY_WORDS_V6 : PPE_HOST_ENTRY_WORDS_V4;
+
+	ret = ppe_flow_op(priv, PPE_TBL_OP_ADD, fw, nfw, hw, nhw, &entry->index,
+			  &entry->host_index);
+	if (ret) {
+		priv->flow_reject[PPE_REJECT_HW_OP]++;
+		goto err_egress;
+	}
+
+	ppe_host_ref_get(priv, entry->host_index);
+
+	/* The hardware writes the host index it resolved into the entry and
+	 * counts the age down from there, so the stored image carries the one
+	 * and drops the other for readbacks to compare equal.
+	 */
+	memcpy(entry->words, fw, nfw * sizeof(*fw));
+	entry->nwords = nfw;
+	entry->words[0] = (fw[0] | entry->host_index << PPE_FLOW_E_HOST_IDX_OFF) &
+			  ~PPE_FLOW_E_AGE_MASK;
+
+	/* The counter survives the entry that filled it, so a recycled slot has
+	 * to start from zero rather than from the previous flow's total.
+	 */
+	ppe_flow_counter_clear(priv, entry->index);
+	entry->last_used = jiffies;
+
+	ret = rhashtable_insert_fast(&priv->flow_table, &entry->node,
+				     ppe_flow_ht_params);
+	if (ret)
+		goto err_hw;
+
+	list_add_tail(&entry->list, &priv->flow_list);
+	priv->flow_offloaded++;
+
+	return 0;
+
+err_hw:
+	ppe_flow_entry_delete(priv, entry->index);
+	ppe_host_ref_put(priv, entry->host_index);
+err_egress:
+	ppe_flow_free_egress(priv, entry);
+err_ingress:
+	ppe_flow_free_ingress(priv, entry);
+err_free:
+	kfree(entry);
+
+	return ret;
+}
+
+static int ppe_flow_offload_destroy(struct qca_ppe_priv *priv,
+				    struct flow_cls_offload *f)
+{
+	struct ppe_flow_entry *entry;
+
+	guard(mutex)(&priv->flow_lock);
+	guard(mutex)(&priv->vlan_lock);
+
+	entry = rhashtable_lookup_fast(&priv->flow_table, &f->cookie,
+				       ppe_flow_ht_params);
+	if (!entry) {
+		priv->flow_destroy_miss++;
+		return -ENOENT;
+	}
+
+	rhashtable_remove_fast(&priv->flow_table, &entry->node,
+			       ppe_flow_ht_params);
+	list_del(&entry->list);
+	ppe_flow_entry_destroy(priv, entry);
+	kfree(entry);
+
+	return 0;
+}
+
+static int ppe_flow_offload_stats(struct qca_ppe_priv *priv,
+				  struct flow_cls_offload *f)
+{
+	struct ppe_flow_entry *entry;
+	u64 bytes = 0;
+	u32 pkts = 0;
+	int age;
+
+	guard(mutex)(&priv->flow_lock);
+
+	entry = rhashtable_lookup_fast(&priv->flow_table, &f->cookie,
+				       ppe_flow_ht_params);
+	if (!entry)
+		return -ENOENT;
+
+	/* The hit counter does not advance for every forwarding type, but any
+	 * hit rewinds the entry's age to its maximum while the hardware
+	 * decrements it once per aging period - so an entry still at maximum
+	 * age was used within the last period, which is all the flowtable's
+	 * idle detection needs. The comparison excludes an entry whose slot
+	 * the hardware has aged out and handed to another flow.
+	 */
+	age = ppe_flow_entry_age(priv, entry);
+	if (age >= 0) {
+		pkts = ppe_flow_counter_delta(priv, entry, &bytes);
+		if (pkts || age == PPE_FLOW_AGE_MAX)
+			entry->last_used = jiffies;
+		ppe_flow_account(priv, entry, pkts, bytes);
+	}
+
+	flow_stats_update(&f->stats, bytes, pkts, 0, entry->last_used,
+			  FLOW_ACTION_HW_STATS_DELAYED);
+
+	return 0;
+}
+
+static int ppe_flow_block_cb(enum tc_setup_type type, void *type_data,
+			     void *cb_priv)
+{
+	struct flow_cls_offload *cls = type_data;
+	struct ppe_flow_block *fb = cb_priv;
+	struct qca_ppe_priv *priv = fb->priv;
+
+	if (type != TC_SETUP_CLSFLOWER)
+		return -EOPNOTSUPP;
+
+	switch (cls->command) {
+	case FLOW_CLS_REPLACE:
+		return ppe_flow_offload_replace(fb, cls);
+	case FLOW_CLS_DESTROY:
+		return ppe_flow_offload_destroy(priv, cls);
+	case FLOW_CLS_STATS:
+		return ppe_flow_offload_stats(priv, cls);
+	default:
+		return -EOPNOTSUPP;
+	}
+}
+
+static LIST_HEAD(ppe_block_cb_list);
+
+static void ppe_flow_block_release(void *cb_priv)
+{
+	struct ppe_flow_block *fb = cb_priv;
+	struct qca_ppe_priv *priv = fb->priv;
+	struct ppe_flow_entry *entry, *tmp;
+
+	mutex_lock(&priv->flow_lock);
+	mutex_lock(&priv->vlan_lock);
+	list_for_each_entry_safe(entry, tmp, &priv->flow_list, list) {
+		if (entry->block != fb->block)
+			continue;
+
+		rhashtable_remove_fast(&priv->flow_table, &entry->node,
+				       ppe_flow_ht_params);
+		list_del(&entry->list);
+		ppe_flow_entry_destroy(priv, entry);
+		kfree(entry);
+	}
+	mutex_unlock(&priv->vlan_lock);
+	mutex_unlock(&priv->flow_lock);
+
+	kfree(fb);
+}
+
+/* Every user port of the switch binds the same flowtable block, so it is shared
+ * and reference counted rather than refused as busy.
+ */
+int ppe_setup_ft_block(struct qca_ppe_priv *priv,
+		       struct flow_block_offload *f)
+{
+	struct flow_block_cb *block_cb;
+	struct ppe_flow_block *fb;
+
+	if (f->binder_type != FLOW_BLOCK_BINDER_TYPE_CLSACT_INGRESS)
+		return -EOPNOTSUPP;
+
+	f->driver_block_list = &ppe_block_cb_list;
+
+	switch (f->command) {
+	case FLOW_BLOCK_BIND:
+		block_cb = flow_block_cb_lookup(f->block, ppe_flow_block_cb,
+						priv);
+		if (block_cb) {
+			flow_block_cb_incref(block_cb);
+			return 0;
+		}
+
+		fb = kzalloc(sizeof(*fb), GFP_KERNEL);
+		if (!fb)
+			return -ENOMEM;
+		fb->priv = priv;
+		fb->block = f->block;
+
+		block_cb = flow_block_cb_alloc(ppe_flow_block_cb, priv, fb,
+					       ppe_flow_block_release);
+		if (IS_ERR(block_cb)) {
+			kfree(fb);
+			return PTR_ERR(block_cb);
+		}
+
+		flow_block_cb_incref(block_cb);
+		flow_block_cb_add(block_cb, f);
+		list_add_tail(&block_cb->driver_list, &ppe_block_cb_list);
+		return 0;
+	case FLOW_BLOCK_UNBIND:
+		block_cb = flow_block_cb_lookup(f->block, ppe_flow_block_cb,
+						priv);
+		if (!block_cb)
+			return -ENOENT;
+
+		if (!flow_block_cb_decref(block_cb)) {
+			flow_block_cb_remove(block_cb, f);
+			list_del(&block_cb->driver_list);
+		}
+		return 0;
+	default:
+		return -EOPNOTSUPP;
+	}
+}
+
+int ppe_flow_offload_init(struct qca_ppe_priv *priv)
+{
+	struct device *dev = priv->ds.dev;
+	int i, ret;
+
+	priv->eg_l3_if = devm_kcalloc(dev, PPE_EG_L3_IF_ENTRIES,
+				      sizeof(*priv->eg_l3_if), GFP_KERNEL);
+	priv->pub_ip = devm_kcalloc(dev, PPE_PUB_IP_ENTRIES,
+				    sizeof(*priv->pub_ip), GFP_KERNEL);
+	priv->nexthop = devm_kcalloc(dev, priv->data->num_nexthop_entries,
+				     sizeof(*priv->nexthop), GFP_KERNEL);
+	priv->host_ref = devm_kcalloc(dev, priv->data->num_host_entries,
+				      sizeof(*priv->host_ref), GFP_KERNEL);
+	priv->my_mac = devm_kcalloc(dev, PPE_MY_MAC_ENTRIES,
+				    sizeof(*priv->my_mac), GFP_KERNEL);
+	if (!priv->eg_l3_if || !priv->pub_ip || !priv->nexthop ||
+	    !priv->host_ref || !priv->my_mac)
+		return -ENOMEM;
+
+	for (i = 0; i < QCA_PPE_MAX_PORTS; i++) {
+		priv->wan_vsi[i] = -1;
+		priv->wan_mymac[i] = -1;
+		priv->wan_xlt[i] = -1;
+	}
+
+	INIT_LIST_HEAD(&priv->flow_list);
+
+	ret = rhashtable_init(&priv->flow_table, &ppe_flow_ht_params);
+	if (ret)
+		return ret;
+
+	priv->netdev_nb.notifier_call = ppe_flow_netdev_event;
+	ret = register_netdevice_notifier(&priv->netdev_nb);
+	if (ret)
+		rhashtable_destroy(&priv->flow_table);
+
+	return ret;
+}
+
+void ppe_flow_offload_exit(struct qca_ppe_priv *priv)
+{
+	struct ppe_flow_entry *entry, *tmp;
+
+	unregister_netdevice_notifier(&priv->netdev_nb);
+
+	mutex_lock(&priv->flow_lock);
+	mutex_lock(&priv->vlan_lock);
+	list_for_each_entry_safe(entry, tmp, &priv->flow_list, list) {
+		rhashtable_remove_fast(&priv->flow_table, &entry->node,
+				       ppe_flow_ht_params);
+		list_del(&entry->list);
+		ppe_flow_entry_destroy(priv, entry);
+		kfree(entry);
+	}
+	mutex_unlock(&priv->vlan_lock);
+	mutex_unlock(&priv->flow_lock);
+
+	rhashtable_destroy(&priv->flow_table);
+}

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_flow_offload.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_flow_offload.c
@@ -255,6 +255,10 @@ static void ppe_entry_set_addr6(u32 *words, u32 offset,
 			      ntohl(addr->s6_addr32[i]));
 }
 
+/* GRE is the one protocol the flowtable offers whose tuple has no ports: the
+ * entry keys on the IP protocol instead, which the hardware selects by naming
+ * no L4 protocol at all.
+ */
 static int ppe_flow_proto(u8 l4proto)
 {
 	switch (l4proto) {
@@ -262,6 +266,8 @@ static int ppe_flow_proto(u8 l4proto)
 		return PPE_FLOW_PROTO_TCP;
 	case IPPROTO_UDP:
 		return PPE_FLOW_PROTO_UDP;
+	case IPPROTO_GRE:
+		return PPE_FLOW_PROTO_OTHER;
 	default:
 		return -EOPNOTSUPP;
 	}
@@ -1150,10 +1156,15 @@ static void ppe_flow_encode(struct ppe_flow_data *data, bool v6, bool snat,
 		ppe_entry_set(fw, PPE_FLOW_E_NEW_PORT_OFF,
 			      PPE_FLOW_E_NEW_PORT_LEN, ntohs(data->dport_new));
 
-	ppe_entry_set(fw, PPE_FLOW_E_SPORT_OFF, PPE_FLOW_E_SPORT_LEN,
-		      ntohs(data->sport));
-	ppe_entry_set(fw, PPE_FLOW_E_DPORT_OFF, PPE_FLOW_E_DPORT_LEN,
-		      ntohs(data->dport));
+	if (ppe_flow_proto(data->l4proto) == PPE_FLOW_PROTO_OTHER) {
+		ppe_entry_set(fw, PPE_FLOW_E_IP_PROTO_OFF,
+			      PPE_FLOW_E_IP_PROTO_LEN, data->l4proto);
+	} else {
+		ppe_entry_set(fw, PPE_FLOW_E_SPORT_OFF, PPE_FLOW_E_SPORT_LEN,
+			      ntohs(data->sport));
+		ppe_entry_set(fw, PPE_FLOW_E_DPORT_OFF, PPE_FLOW_E_DPORT_LEN,
+			      ntohs(data->dport));
+	}
 
 	ppe_entry_set(hw, PPE_HOST_E_VALID_OFF, PPE_HOST_E_VALID_LEN, 1);
 
@@ -1334,10 +1345,11 @@ static int ppe_flow_offload_replace(struct ppe_flow_block *fb,
 		return ppe_flow_reject(priv, PPE_REJECT_KEY);
 	}
 
-	if (!flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_PORTS))
-		return ppe_flow_reject(priv, PPE_REJECT_KEY);
-	{
+	if (ppe_flow_proto(data.l4proto) != PPE_FLOW_PROTO_OTHER) {
 		struct flow_match_ports match;
+
+		if (!flow_rule_match_key(rule, FLOW_DISSECTOR_KEY_PORTS))
+			return ppe_flow_reject(priv, PPE_REJECT_KEY);
 
 		flow_rule_match_ports(rule, &match);
 		data.sport = match.key->src;

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_flow_offload.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_flow_offload.c
@@ -1156,6 +1156,8 @@ static void ppe_flow_encode(struct ppe_flow_data *data, bool v6, bool snat,
 		      ppe_flow_proto(data->l4proto));
 	ppe_entry_set(fw, PPE_FLOW_E_AGE_OFF, PPE_FLOW_E_AGE_LEN,
 		      PPE_FLOW_AGE_MAX);
+	ppe_entry_set(fw, PPE_FLOW_E_PRI_PROFILE_OFF,
+		      PPE_FLOW_E_PRI_PROFILE_LEN, data->priority);
 
 	fwd = snat ? PPE_FLOW_FWD_SNAT : dnat ? PPE_FLOW_FWD_DNAT :
 						PPE_FLOW_FWD_ROUTE;
@@ -1319,6 +1321,11 @@ static int ppe_flow_offload_replace(struct ppe_flow_block *fb,
 			 * nexthop, which sheds the ingress encapsulation on
 			 * its own.
 			 */
+			break;
+		case FLOW_ACTION_PRIORITY:
+			if (act->priority > PPE_QOS_MAX_PRI)
+				return ppe_flow_reject(priv, PPE_REJECT_ACTION);
+			data.priority = act->priority;
 			break;
 		case FLOW_ACTION_PPPOE_PUSH:
 			if (data.pppoe_valid)

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_flow_offload.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_flow_offload.c
@@ -57,6 +57,11 @@ struct ppe_flow_entry {
 	u32 index;
 	u32 words[PPE_FLOW_ENTRY_WORDS_V6];
 	u8 nwords;
+	u32 hwords[PPE_HOST_ENTRY_WORDS_V6];
+	u8 nhwords;
+	u8 profile;
+	u8 quiet;
+	bool sparse;
 	u8 src_if;
 	u32 host_index;
 	int nexthop;
@@ -72,6 +77,8 @@ struct ppe_flow_entry {
 	u16 ovid;
 	u64 packets;
 	u64 bytes;
+	u64 unread_packets;
+	u64 unread_bytes;
 	unsigned long last_used;
 };
 
@@ -1066,6 +1073,9 @@ static void ppe_flow_account_side(struct qca_ppe_priv *priv, int port,
  * counters get the flow's deltas so they read as without offload. The port
  * itself is left alone; its MIB already counts the frames.
  *
+ * A delta can be read only once, because the read moves the baseline, so the
+ * flowtable is answered from what this banks rather than from the counter.
+ *
  * The bridge pointer is written under the flow lock by the bridge join and
  * leave ops, and a VLAN interface is found under RCU rather than held.
  */
@@ -1076,6 +1086,9 @@ static void ppe_flow_account(struct qca_ppe_priv *priv,
 
 	if (!pkts)
 		return;
+
+	entry->unread_packets += pkts;
+	entry->unread_bytes += bytes;
 
 	rcu_read_lock();
 	ppe_flow_account_side(priv, entry->iport, entry->ivid, true, pkts,
@@ -1450,6 +1463,9 @@ static int ppe_flow_offload_replace(struct ppe_flow_block *fb,
 	 */
 	memcpy(entry->words, fw, nfw * sizeof(*fw));
 	entry->nwords = nfw;
+	memcpy(entry->hwords, hw, nhw * sizeof(*hw));
+	entry->nhwords = nhw;
+	entry->profile = data.priority;
 	entry->words[0] = (fw[0] | entry->host_index << PPE_FLOW_E_HOST_IDX_OFF) &
 			  ~PPE_FLOW_E_AGE_MASK;
 
@@ -1510,8 +1526,6 @@ static int ppe_flow_offload_stats(struct qca_ppe_priv *priv,
 				  struct flow_cls_offload *f)
 {
 	struct ppe_flow_entry *entry;
-	u64 bytes = 0;
-	u32 pkts = 0;
 	int age;
 
 	guard(mutex)(&priv->flow_lock);
@@ -1529,15 +1543,13 @@ static int ppe_flow_offload_stats(struct qca_ppe_priv *priv,
 	 * the hardware has aged out and handed to another flow.
 	 */
 	age = ppe_flow_entry_age(priv, entry);
-	if (age >= 0) {
-		pkts = ppe_flow_counter_delta(priv, entry, &bytes);
-		if (pkts || age == PPE_FLOW_AGE_MAX)
-			entry->last_used = jiffies;
-		ppe_flow_account(priv, entry, pkts, bytes);
-	}
+	if (age >= 0 && (entry->unread_packets || age == PPE_FLOW_AGE_MAX))
+		entry->last_used = jiffies;
 
-	flow_stats_update(&f->stats, bytes, pkts, 0, entry->last_used,
-			  FLOW_ACTION_HW_STATS_DELAYED);
+	flow_stats_update(&f->stats, entry->unread_bytes, entry->unread_packets,
+			  0, entry->last_used, FLOW_ACTION_HW_STATS_DELAYED);
+	entry->unread_packets = 0;
+	entry->unread_bytes = 0;
 
 	return 0;
 }
@@ -1646,6 +1658,142 @@ int ppe_setup_ft_block(struct qca_ppe_priv *priv,
 	}
 }
 
+/* A shared queue gives a sparse flow the loss rate the bulk imposes on it,
+ * and a flow that sends a few packets a second recovers a lost one by a
+ * retransmission timer, not by the next packet: a speed test's latency
+ * probe stalls for hundreds of milliseconds while the download it measures
+ * is unharmed. The hardware has no queue per flow, but a flow entry names a
+ * priority profile the classifier ranks above every other source, so a flow
+ * the counters show to be sparse is moved to the list the scheduler serves
+ * ahead of the band, inside the band's shaper, and back the moment it is
+ * not. A flow is sparse after ten periods under the packet count, one
+ * second, which a TCP flow that is ramping never spends; a promoted flow
+ * that bursts is demoted at the end of the period it burst in.
+ */
+#define PPE_SPARSE_PERIOD_MS	100
+#define PPE_SPARSE_PKTS		8
+#define PPE_SPARSE_QUIET	10
+
+static bool ppe_sparse_flows = true;
+module_param_named(sparse_flows, ppe_sparse_flows, bool, 0644);
+MODULE_PARM_DESC(sparse_flows,
+		 "Serve flows of under 80 packets a second ahead of a shaped port's bulk queue");
+
+/* The entry is replaced rather than rewritten in place: an IPv6 entry's
+ * words are spread over two slots in a layout only the op engine holds. The
+ * host entry is the same one, found again by its key; the counter starts
+ * over with the new slot, and so does everything derived from it.
+ */
+static int ppe_flow_profile_set(struct qca_ppe_priv *priv,
+				struct ppe_flow_entry *entry, u8 profile)
+{
+	u32 w[PPE_FLOW_ENTRY_WORDS_V6];
+	u32 index, host_index, pkts;
+	u64 bytes;
+	int ret;
+
+	lockdep_assert_held(&priv->flow_lock);
+
+	/* The hardware ages an idle entry out and hands its slot on, and a
+	 * flow under the count is the likeliest to have been; a delete by
+	 * index would then take the sibling's entry.
+	 */
+	ret = ppe_flow_entry_age(priv, entry);
+	if (ret < 0)
+		return ret;
+
+	pkts = ppe_flow_counter_delta(priv, entry, &bytes);
+	ppe_flow_account(priv, entry, pkts, bytes);
+
+	/* The stored image carries the host index and no age; an add is
+	 * staged the way the encoder stages it, at full age and with no host
+	 * index, for the hardware to write the one it resolves.
+	 */
+	memcpy(w, entry->words, entry->nwords * sizeof(*w));
+	w[0] = (w[0] & ~PPE_FLOW_E_HOST_IDX_MASK) |
+	       FIELD_PREP(PPE_FLOW_E_AGE_MASK, PPE_FLOW_AGE_MAX);
+	w[1] &= ~BIT(PPE_FLOW_E_PRI_PROFILE_OFF % 32);
+	w[2] &= ~GENMASK(PPE_FLOW_E_PRI_PROFILE_LEN - 2, 0);
+	ppe_entry_set(w, PPE_FLOW_E_PRI_PROFILE_OFF, PPE_FLOW_E_PRI_PROFILE_LEN,
+		      profile);
+
+	ret = ppe_flow_entry_delete(priv, entry->index);
+	if (ret)
+		return ret;
+
+	ret = ppe_flow_op(priv, PPE_TBL_OP_ADD, w, entry->nwords,
+			  entry->hwords, entry->nhwords, &index, &host_index);
+	if (ret)
+		return ret;
+
+	if (host_index != entry->host_index) {
+		ppe_host_ref_get(priv, host_index);
+		ppe_host_ref_put(priv, entry->host_index);
+		entry->host_index = host_index;
+	}
+	memcpy(entry->words, w, entry->nwords * sizeof(*w));
+	entry->words[0] = (w[0] | host_index << PPE_FLOW_E_HOST_IDX_OFF) &
+			  ~PPE_FLOW_E_AGE_MASK;
+	entry->index = index;
+	ppe_flow_counter_clear(priv, index);
+	entry->packets = 0;
+	entry->bytes = 0;
+
+	return 0;
+}
+
+static void ppe_sparse_work(struct work_struct *work)
+{
+	struct qca_ppe_priv *priv = container_of(work, struct qca_ppe_priv,
+						 sparse_work.work);
+	struct ppe_flow_entry *entry;
+	u32 pkts, delta;
+
+	mutex_lock(&priv->flow_lock);
+	list_for_each_entry(entry, &priv->flow_list, list) {
+		u64 bytes;
+
+		regmap_read(priv->regmap, PPE_IN_FLOW_CNT_TBL(entry->index),
+			    &pkts);
+		delta = pkts - (u32)entry->packets;
+
+		/* The age read costs the entry's words and only a flow that
+		 * moved has anything to attribute, so it is taken on the
+		 * delta rather than every period.
+		 */
+		if (delta && ppe_flow_entry_age(priv, entry) >= 0) {
+			u32 acct = ppe_flow_counter_delta(priv, entry, &bytes);
+
+			ppe_flow_account(priv, entry, acct, bytes);
+		}
+
+		if (delta > PPE_SPARSE_PKTS || !ppe_sparse_flows) {
+			entry->quiet = 0;
+			if (entry->sparse &&
+			    !ppe_flow_profile_set(priv, entry, entry->profile)) {
+				entry->sparse = false;
+				priv->flow_sparse_demoted++;
+			}
+			continue;
+		}
+
+		if (entry->sparse)
+			continue;
+		if (entry->quiet < PPE_SPARSE_QUIET) {
+			entry->quiet++;
+			continue;
+		}
+		if (!ppe_flow_profile_set(priv, entry, PPE_QOS_SPARSE_PRI)) {
+			entry->sparse = true;
+			priv->flow_sparse_promoted++;
+		}
+	}
+	mutex_unlock(&priv->flow_lock);
+
+	schedule_delayed_work(&priv->sparse_work,
+			      msecs_to_jiffies(PPE_SPARSE_PERIOD_MS));
+}
+
 int ppe_flow_offload_init(struct qca_ppe_priv *priv)
 {
 	struct device *dev = priv->ds.dev;
@@ -1679,10 +1827,16 @@ int ppe_flow_offload_init(struct qca_ppe_priv *priv)
 
 	priv->netdev_nb.notifier_call = ppe_flow_netdev_event;
 	ret = register_netdevice_notifier(&priv->netdev_nb);
-	if (ret)
+	if (ret) {
 		rhashtable_destroy(&priv->flow_table);
+		return ret;
+	}
 
-	return ret;
+	INIT_DELAYED_WORK(&priv->sparse_work, ppe_sparse_work);
+	schedule_delayed_work(&priv->sparse_work,
+			      msecs_to_jiffies(PPE_SPARSE_PERIOD_MS));
+
+	return 0;
 }
 
 void ppe_flow_offload_exit(struct qca_ppe_priv *priv)
@@ -1690,6 +1844,7 @@ void ppe_flow_offload_exit(struct qca_ppe_priv *priv)
 	struct ppe_flow_entry *entry, *tmp;
 
 	unregister_netdevice_notifier(&priv->netdev_nb);
+	cancel_delayed_work_sync(&priv->sparse_work);
 
 	mutex_lock(&priv->flow_lock);
 	mutex_lock(&priv->vlan_lock);

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -1901,6 +1901,8 @@ static int qca_ppe_probe(struct platform_device *pdev)
 	 * so every port shares one and DSA replicates an entry to all of them.
 	 */
 	ds->dscp_prio_mapping_is_global = true;
+	/* mqprio carves these into traffic classes, one per hardware queue. */
+	ds->num_tx_queues = PPE_QOS_MAX_PRI + 1;
 	priv->mirror_port = -1;
 	ds->phylink_mac_ops = &qca_ppe_phylink_mac_ops;
 

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -618,6 +618,39 @@ static int ppe_devlink_setup(struct dsa_switch *ds)
 	return ret;
 }
 
+/* The part names itself in the first register of the global block. The vendor's
+ * named accessor for it is compiled out; what proves the field split is its init
+ * path reading the same word raw (ssdk_init.c chip_ver_get): device 0x15 is this
+ * switch generation, revision 0 IPQ807x and 1 IPQ6018.
+ */
+static int qca_ppe_devlink_info_get(struct dsa_switch *ds,
+				    struct devlink_info_req *req,
+				    struct netlink_ext_ack *extack)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	u32 id, dev, rev;
+	char buf[8];
+	int ret;
+
+	ret = regmap_read(priv->regmap, PPE_SWITCH_ID, &id);
+	if (ret)
+		return ret;
+
+	dev = FIELD_GET(PPE_SWITCH_ID_DEV, id);
+	rev = FIELD_GET(PPE_SWITCH_ID_REV, id);
+
+	snprintf(buf, sizeof(buf), "0x%02x", dev);
+	ret = devlink_info_version_fixed_put(req,
+					     DEVLINK_INFO_VERSION_GENERIC_ASIC_ID,
+					     buf);
+	if (ret)
+		return ret;
+
+	snprintf(buf, sizeof(buf), "0x%02x", rev);
+
+	return devlink_info_version_fixed_put(req,
+					      DEVLINK_INFO_VERSION_GENERIC_ASIC_REV,
+					      buf);
 }
 
 static int qca_ppe_setup(struct dsa_switch *ds)
@@ -2352,6 +2385,7 @@ static const struct dsa_switch_ops qca_ppe_ops = {
 	.get_stats64		= qca_ppe_get_stats64,
 	.get_regs_len		= qca_ppe_get_regs_len,
 	.get_regs		= qca_ppe_get_regs,
+	.devlink_info_get	= qca_ppe_devlink_info_get,
 	.devlink_sb_pool_get	= qca_ppe_devlink_sb_pool_get,
 	.devlink_sb_pool_set	= qca_ppe_devlink_sb_pool_set,
 };

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -248,14 +248,14 @@ static int ppe_fdb_op_wait(struct qca_ppe_priv *priv, u32 rslt_reg,
 	return -ETIMEDOUT;
 }
 
-static void ppe_fdb_encode(const unsigned char *addr, int port, u16 vid,
+static void ppe_fdb_encode(const unsigned char *addr, int port, u32 vsi,
 			   bool is_static, u32 *data0, u32 *data1, u32 *data2)
 {
 	*data0 = (addr[2] << 24) | (addr[3] << 16) | (addr[4] << 8) | addr[5];
 
 	*data1 = (addr[0] << 8) | addr[1];
 	*data1 |= PPE_FDB_DATA1_VALID | PPE_FDB_DATA1_LKP_VALID;
-	*data1 |= FIELD_PREP(PPE_FDB_DATA1_VSI, vid);
+	*data1 |= FIELD_PREP(PPE_FDB_DATA1_VSI, vsi);
 	*data1 |= FIELD_PREP(PPE_FDB_DATA1_DST_LO, port);
 
 	*data2 = FIELD_PREP(PPE_FDB_DATA2_DST_TYPE, PPE_FDB_DST_PORT) |
@@ -264,12 +264,12 @@ static void ppe_fdb_encode(const unsigned char *addr, int port, u16 vid,
 }
 
 static int ppe_fdb_op(struct qca_ppe_priv *priv, const unsigned char *addr,
-		      int port, u16 vid, u32 op_type)
+		      int port, u32 vsi, u32 op_type)
 {
 	u32 data0, data1, data2;
 	int ret;
 
-	ppe_fdb_encode(addr, port, vid, op_type == PPE_FDB_OP_ADD,
+	ppe_fdb_encode(addr, port, vsi, op_type == PPE_FDB_OP_ADD,
 		       &data0, &data1, &data2);
 
 	spin_lock_bh(&priv->fdb_lock);
@@ -289,7 +289,7 @@ static int ppe_fdb_op(struct qca_ppe_priv *priv, const unsigned char *addr,
 }
 
 static int ppe_fdb_read_entry(struct qca_ppe_priv *priv, u32 index,
-			      unsigned char *addr, u16 *vid, int *port,
+			      unsigned char *addr, u32 *vsi, int *port,
 			      bool *is_static)
 {
 	u32 data0, data1, data2, cmd_id, val;
@@ -337,7 +337,7 @@ unlock:
 	addr[0] = (data1 >> 8) & 0xff;
 	addr[1] = data1 & 0xff;
 
-	*vid = FIELD_GET(PPE_FDB_DATA1_VSI, data1);
+	*vsi = FIELD_GET(PPE_FDB_DATA1_VSI, data1);
 	*port = FIELD_GET(PPE_FDB_DATA1_DST_LO, data1) |
 		(FIELD_GET(PPE_FDB_DATA2_DST_HI, data2) << 9);
 	*is_static = FIELD_GET(PPE_FDB_DATA2_HIT_AGE, data2) == PPE_FDB_AGE_STATIC;
@@ -362,13 +362,13 @@ static int ppe_fdb_flush(struct qca_ppe_priv *priv)
 }
 
 static void ppe_fdb_encode_mcast(const unsigned char *addr, u32 portmap,
-				 u16 vid, u32 *data0, u32 *data1, u32 *data2)
+				 u32 vsi, u32 *data0, u32 *data1, u32 *data2)
 {
 	*data0 = (addr[2] << 24) | (addr[3] << 16) | (addr[4] << 8) | addr[5];
 
 	*data1 = (addr[0] << 8) | addr[1];
 	*data1 |= PPE_FDB_DATA1_VALID | PPE_FDB_DATA1_LKP_VALID;
-	*data1 |= FIELD_PREP(PPE_FDB_DATA1_VSI, vid);
+	*data1 |= FIELD_PREP(PPE_FDB_DATA1_VSI, vsi);
 	*data1 |= FIELD_PREP(PPE_FDB_DATA1_DST_LO, portmap);
 
 	*data2 = FIELD_PREP(PPE_FDB_DATA2_DST_HI, portmap >> 9) |
@@ -377,7 +377,7 @@ static void ppe_fdb_encode_mcast(const unsigned char *addr, u32 portmap,
 }
 
 static int ppe_fdb_lookup(struct qca_ppe_priv *priv,
-			  const unsigned char *addr, u16 vid, u32 *portmap)
+			  const unsigned char *addr, u32 vsi, u32 *portmap)
 {
 	u32 data1, data2;
 	int ret;
@@ -388,7 +388,7 @@ static int ppe_fdb_lookup(struct qca_ppe_priv *priv,
 		     (addr[2] << 24) | (addr[3] << 16) | (addr[4] << 8) | addr[5]);
 	regmap_write(priv->regmap, PPE_FDB_RD_OP_DATA1,
 		     ((addr[0] << 8) | addr[1]) |
-		     FIELD_PREP(PPE_FDB_DATA1_VSI, vid));
+		     FIELD_PREP(PPE_FDB_DATA1_VSI, vsi));
 	regmap_write(priv->regmap, PPE_FDB_RD_OP_DATA2, 0);
 
 	regmap_write(priv->regmap, PPE_FDB_RD_OP,
@@ -417,12 +417,12 @@ out:
 
 static int ppe_fdb_mcast_op(struct qca_ppe_priv *priv,
 			    const unsigned char *addr, u32 portmap,
-			    u16 vid, u32 op_type)
+			    u32 vsi, u32 op_type)
 {
 	u32 data0, data1, data2;
 	int ret;
 
-	ppe_fdb_encode_mcast(addr, portmap, vid, &data0, &data1, &data2);
+	ppe_fdb_encode_mcast(addr, portmap, vsi, &data0, &data1, &data2);
 
 	spin_lock_bh(&priv->fdb_lock);
 
@@ -694,13 +694,58 @@ static void qca_ppe_port_bridge_leave(struct dsa_switch *ds, int port,
 	bridge_vsi_put(priv, bvsi);
 }
 
+/* The entry is keyed on the VSI the frame will carry, which is the bridge's
+ * own VSI while it does not filter - a VLAN it does not enforce classifies
+ * nothing - and the VLAN's VSI once it does.
+ */
+static u32 ppe_fdb_vsi(struct qca_ppe_priv *priv, u16 vid, struct dsa_db db)
+{
+	struct qca_ppe_vlan_entry *vlan;
+	struct qca_ppe_bridge_vsi *bvsi;
+
+	if (db.type != DSA_DB_BRIDGE)
+		return PPE_VSI_INVALID;
+
+	if (vid) {
+		vlan = ppe_vlan_find(priv, db.bridge.dev, vid);
+		if (vlan)
+			return vlan->vsi;
+	}
+
+	bvsi = bridge_vsi_find(priv, db.bridge.dev);
+
+	return bvsi ? bvsi->vsi : PPE_VSI_INVALID;
+}
+
+/* The reverse, for the dump: only a VLAN's VSI has a vid of its own, and a
+ * bridge that does not filter has none to report.
+ */
+static u16 ppe_fdb_vid(struct qca_ppe_priv *priv, u32 vsi)
+{
+	int i;
+
+	for (i = 0; i < PPE_VSI_MAX; i++)
+		if (priv->vlans[i].br_dev && priv->vlans[i].vsi == vsi)
+			return priv->vlans[i].vid;
+
+	return 0;
+}
+
 static int qca_ppe_port_fdb_add(struct dsa_switch *ds, int port,
 				    const unsigned char *addr, u16 vid,
 				    struct dsa_db db)
 {
 	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	u32 vsi;
 
-	return ppe_fdb_op(priv, addr, port, vid, PPE_FDB_OP_ADD);
+	guard(mutex)(&priv->flow_lock);
+	guard(mutex)(&priv->vlan_lock);
+
+	vsi = ppe_fdb_vsi(priv, vid, db);
+	if (vsi == PPE_VSI_INVALID)
+		return -EOPNOTSUPP;
+
+	return ppe_fdb_op(priv, addr, port, vsi, PPE_FDB_OP_ADD);
 }
 
 static int qca_ppe_port_fdb_del(struct dsa_switch *ds, int port,
@@ -708,8 +753,16 @@ static int qca_ppe_port_fdb_del(struct dsa_switch *ds, int port,
 				    struct dsa_db db)
 {
 	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	u32 vsi;
 
-	return ppe_fdb_op(priv, addr, port, vid, PPE_FDB_OP_DEL);
+	guard(mutex)(&priv->flow_lock);
+	guard(mutex)(&priv->vlan_lock);
+
+	vsi = ppe_fdb_vsi(priv, vid, db);
+	if (vsi == PPE_VSI_INVALID)
+		return -EOPNOTSUPP;
+
+	return ppe_fdb_op(priv, addr, port, vsi, PPE_FDB_OP_DEL);
 }
 
 static int qca_ppe_port_fdb_dump(struct dsa_switch *ds, int port,
@@ -719,18 +772,19 @@ static int qca_ppe_port_fdb_dump(struct dsa_switch *ds, int port,
 	unsigned char addr[ETH_ALEN];
 	bool is_static;
 	int fdb_port;
-	u16 vid;
-	u32 i;
+	u32 i, vsi;
+
+	guard(mutex)(&priv->vlan_lock);
 
 	for (i = 0; i < PPE_FDB_TBL_NUM; i++) {
-		if (ppe_fdb_read_entry(priv, i, addr, &vid, &fdb_port,
+		if (ppe_fdb_read_entry(priv, i, addr, &vsi, &fdb_port,
 				       &is_static))
 			continue;
 
 		if (fdb_port != port)
 			continue;
 
-		if (cb(addr, vid, is_static, data))
+		if (cb(addr, ppe_fdb_vid(priv, vsi), is_static, data))
 			break;
 	}
 
@@ -742,17 +796,24 @@ static int qca_ppe_port_mdb_add(struct dsa_switch *ds, int port,
 				    struct dsa_db db)
 {
 	struct qca_ppe_priv *priv = ds_to_priv(ds);
-	u32 portmap;
+	u32 portmap, vsi;
 	int ret;
 
-	ret = ppe_fdb_lookup(priv, mdb->addr, mdb->vid, &portmap);
+	guard(mutex)(&priv->flow_lock);
+	guard(mutex)(&priv->vlan_lock);
+
+	vsi = ppe_fdb_vsi(priv, mdb->vid, db);
+	if (vsi == PPE_VSI_INVALID)
+		return -EOPNOTSUPP;
+
+	ret = ppe_fdb_lookup(priv, mdb->addr, vsi, &portmap);
 	if (ret)
 		portmap = BIT(QCA_PPE_CPU_PORT);
 
 	portmap |= BIT(port);
 
 	return ppe_fdb_mcast_op(priv, mdb->addr, portmap,
-				mdb->vid, PPE_FDB_OP_ADD);
+				vsi, PPE_FDB_OP_ADD);
 }
 
 static int qca_ppe_port_mdb_del(struct dsa_switch *ds, int port,
@@ -760,10 +821,17 @@ static int qca_ppe_port_mdb_del(struct dsa_switch *ds, int port,
 				    struct dsa_db db)
 {
 	struct qca_ppe_priv *priv = ds_to_priv(ds);
-	u32 portmap;
+	u32 portmap, vsi;
 	int ret;
 
-	ret = ppe_fdb_lookup(priv, mdb->addr, mdb->vid, &portmap);
+	guard(mutex)(&priv->flow_lock);
+	guard(mutex)(&priv->vlan_lock);
+
+	vsi = ppe_fdb_vsi(priv, mdb->vid, db);
+	if (vsi == PPE_VSI_INVALID)
+		return -EOPNOTSUPP;
+
+	ret = ppe_fdb_lookup(priv, mdb->addr, vsi, &portmap);
 
 	/* The bridge drops a port's multicast entries on every leave, STP
 	 * transition and membership expiry, without tracking which of them
@@ -783,10 +851,10 @@ static int qca_ppe_port_mdb_del(struct dsa_switch *ds, int port,
 
 	if (!portmap || portmap == BIT(QCA_PPE_CPU_PORT))
 		return ppe_fdb_mcast_op(priv, mdb->addr, 0,
-					mdb->vid, PPE_FDB_OP_DEL);
+					vsi, PPE_FDB_OP_DEL);
 
 	return ppe_fdb_mcast_op(priv, mdb->addr, portmap,
-				mdb->vid, PPE_FDB_OP_ADD);
+				vsi, PPE_FDB_OP_ADD);
 }
 
 static int qca_ppe_fill_available_pcs(struct phylink_config *config,

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -2807,6 +2807,7 @@ static int qca_ppe_probe(struct platform_device *pdev)
 
 	ppe_mac_hw_init(priv);
 	ppe_ctrlpkt_init(priv);
+	ppe_flow_init(priv);
 	ppe_acl_init(priv);
 
 	if (data->type == PPE_TYPE_IPQ6018) {
@@ -2821,6 +2822,7 @@ static int qca_ppe_probe(struct platform_device *pdev)
 
 	ppe_scheduler_ready(priv);
 	ppe_debugfs_init(priv);
+	ppe_flow_debugfs_init(priv);
 
 	platform_set_drvdata(pdev, priv);
 
@@ -2859,6 +2861,9 @@ static const struct ppe_data ipq6018_ppe_data = {
 	.qm_total_buf		= 1506,
 	.qm_ceiling		= 216,
 	.qm_green_max		= 144,
+	.num_flow_entries	= 2048,
+	.num_host_entries	= 768,
+	.num_nexthop_entries	= 768,
 	.psch_tdm		= &cppe_psch_tdm_data,
 	.bm_tdm			= &cppe_bm_tdm_data,
 };
@@ -2876,6 +2881,9 @@ static const struct ppe_data ipq8074_ppe_data = {
 	.qm_total_buf		= 2000,
 	.qm_ceiling		= 400,
 	.qm_green_max		= 250,
+	.num_flow_entries	= 4096,
+	.num_host_entries	= 6144,
+	.num_nexthop_entries	= 2560,
 	.psch_tdm		= &hppe_psch_tdm_data,
 	.bm_tdm			= &hppe_bm_tdm_data,
 };

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -1870,7 +1870,151 @@ static void qca_ppe_get_stats64(struct dsa_switch *ds, int port,
 	spin_unlock_bh(&priv->mib_lock);
 }
 
+/* CarrierSenseErrors, FramesLostDueToIntMACRcvError, InRangeLengthErrors and
+ * OutOfRangeLengthField have no counter in either MAC; left untouched they are
+ * reported as unset rather than as a measured zero.
+ */
+static void qca_ppe_get_eth_mac_stats(struct dsa_switch *ds, int port,
+				      struct ethtool_eth_mac_stats *s)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	struct qca_ppe_mib_stats *stats;
+
+	if (port < 1 || port >= ds->num_ports)
+		return;
+
+	stats = ppe_port_mib(priv, port);
+
+	spin_lock_bh(&priv->mib_lock);
+	ppe_mib_fold(priv, port);
+
+	s->FramesTransmittedOK = MIB(TXUNI) + MIB(TXMULTI) + MIB(TXBROAD);
+	s->SingleCollisionFrames = MIB(TXSINGLECOL);
+	s->MultipleCollisionFrames = MIB(TXMULTICOL);
+	s->FramesReceivedOK = MIB(RXUNI) + MIB(RXMULTI) + MIB(RXBROAD);
+	s->FrameCheckSequenceErrors = MIB(RXFCSERR);
+	s->AlignmentErrors = MIB(RXALIGNERR);
+	s->OctetsTransmittedOK = MIB(TXBYTE_L);
+	s->FramesWithDeferredXmissions = MIB(TXDEFER);
+	s->LateCollisions = MIB(TXLATECOL);
+	s->FramesAbortedDueToXSColls = MIB(TXABORTCOL);
+	s->FramesLostDueToIntMACXmitError = MIB(TXUNDERRUN);
+	s->OctetsReceivedOK = MIB(RXGOODBYTE_L);
+	s->MulticastFramesXmittedOK = MIB(TXMULTI);
+	s->BroadcastFramesXmittedOK = MIB(TXBROAD);
+	s->FramesWithExcessiveDeferral = MIB(TXEXCESSIVEDEFER);
+	s->MulticastFramesReceivedOK = MIB(RXMULTI);
+	s->BroadcastFramesReceivedOK = MIB(RXBROAD);
+	s->FrameTooLongErrors = MIB(RXTOOLONG);
+
+	spin_unlock_bh(&priv->mib_lock);
+}
+
+/* Pause is the only MAC control opcode either MAC counts. */
+static void qca_ppe_get_eth_ctrl_stats(struct dsa_switch *ds, int port,
+				       struct ethtool_eth_ctrl_stats *s)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	struct qca_ppe_mib_stats *stats;
+
+	if (port < 1 || port >= ds->num_ports)
+		return;
+
+	stats = ppe_port_mib(priv, port);
+
+	spin_lock_bh(&priv->mib_lock);
+	ppe_mib_fold(priv, port);
+
+	s->MACControlFramesTransmitted = MIB(TXPAUSE);
+	s->MACControlFramesReceived = MIB(RXPAUSE);
+
+	spin_unlock_bh(&priv->mib_lock);
+}
+
+/* The GMAC splits its top bin at 1518 and the XGMAC does not, so the two
+ * halves are summed below into the one 1024-to-max bin both can answer.
+ */
+static const struct ethtool_rmon_hist_range qca_ppe_rmon_ranges[] = {
+	{    0,   64 },
+	{   65,  127 },
+	{  128,  255 },
+	{  256,  511 },
+	{  512, 1023 },
+	{ 1024, PPE_MAX_FRAME_SIZE },
+	{}
+};
+
+static void
+qca_ppe_get_rmon_stats(struct dsa_switch *ds, int port,
+		       struct ethtool_rmon_stats *s,
+		       const struct ethtool_rmon_hist_range **ranges)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	struct qca_ppe_mib_stats *stats;
+
+	*ranges = qca_ppe_rmon_ranges;
+
+	if (port < 1 || port >= ds->num_ports)
+		return;
+
+	stats = ppe_port_mib(priv, port);
+
+	spin_lock_bh(&priv->mib_lock);
+	ppe_mib_fold(priv, port);
+
+	s->undersize_pkts = MIB(RXRUNT);
+	s->oversize_pkts = MIB(RXTOOLONG);
+	s->fragments = MIB(RXFRAG);
+	s->jabbers = MIB(RXJUMBOFCSERR);
+
+	s->hist[0] = MIB(RXPKT64);
+	s->hist[1] = MIB(RXPKT65TO127);
+	s->hist[2] = MIB(RXPKT128TO255);
+	s->hist[3] = MIB(RXPKT256TO511);
+	s->hist[4] = MIB(RXPKT512TO1023);
+	s->hist[5] = MIB(RXPKT1024TO1518) + MIB(RXPKT1519TOX);
+
+	s->hist_tx[0] = MIB(TXPKT64);
+	s->hist_tx[1] = MIB(TXPKT65TO127);
+	s->hist_tx[2] = MIB(TXPKT128TO255);
+	s->hist_tx[3] = MIB(TXPKT256TO511);
+	s->hist_tx[4] = MIB(TXPKT512TO1023);
+	s->hist_tx[5] = MIB(TXPKT1024TO1518) + MIB(TXPKT1519TOX);
+
+	spin_unlock_bh(&priv->mib_lock);
+}
+
+static void qca_ppe_get_pause_stats(struct dsa_switch *ds, int port,
+				    struct ethtool_pause_stats *s)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	struct qca_ppe_mib_stats *stats;
+
+	if (port < 1 || port >= ds->num_ports)
+		return;
+
+	stats = ppe_port_mib(priv, port);
+
+	spin_lock_bh(&priv->mib_lock);
+	ppe_mib_fold(priv, port);
+
+	s->tx_pause_frames = MIB(TXPAUSE);
+	s->rx_pause_frames = MIB(RXPAUSE);
+
+	spin_unlock_bh(&priv->mib_lock);
+}
+
 #undef MIB
+
+/* The switch timestamps nothing and has no PHC. Answering at all is still the
+ * difference between ethtool reporting the software timestamping the core
+ * provides and failing the query outright.
+ */
+static int qca_ppe_get_ts_info(struct dsa_switch *ds, int port,
+			       struct kernel_ethtool_ts_info *ts)
+{
+	return 0;
+}
 
 static void qca_ppe_teardown(struct dsa_switch *ds)
 {
@@ -2394,6 +2538,11 @@ static const struct dsa_switch_ops qca_ppe_ops = {
 	.get_sset_count		= qca_ppe_get_sset_count,
 	.get_ethtool_stats	= qca_ppe_get_ethtool_stats,
 	.get_stats64		= qca_ppe_get_stats64,
+	.get_eth_mac_stats	= qca_ppe_get_eth_mac_stats,
+	.get_eth_ctrl_stats	= qca_ppe_get_eth_ctrl_stats,
+	.get_rmon_stats		= qca_ppe_get_rmon_stats,
+	.get_pause_stats	= qca_ppe_get_pause_stats,
+	.get_ts_info		= qca_ppe_get_ts_info,
 	.get_regs_len		= qca_ppe_get_regs_len,
 	.get_regs		= qca_ppe_get_regs,
 	.devlink_info_get	= qca_ppe_devlink_info_get,

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -180,6 +180,7 @@ int ppe_vsi_alloc(struct qca_ppe_priv *priv)
 		return -ENOSPC;
 
 	set_bit(vsi, priv->vsi_bitmap);
+	priv->vsi_member[vsi] = 0;
 
 	regmap_write(priv->regmap, PPE_VSI_TBL(vsi), 0);
 	regmap_write(priv->regmap, PPE_VSI_TBL(vsi) + 4,
@@ -192,21 +193,75 @@ void ppe_vsi_free(struct qca_ppe_priv *priv, u32 vsi)
 {
 	regmap_write(priv->regmap, PPE_VSI_TBL(vsi), 0);
 	regmap_write(priv->regmap, PPE_VSI_TBL(vsi) + 4, 0);
+	priv->vsi_member[vsi] = 0;
 	clear_bit(vsi, priv->vsi_bitmap);
 }
 
+/* Each flood class is the member mask minus the ports whose bridge flags turned
+ * that class off, so narrowing one costs nothing on the ports that still want
+ * it. The member mask is remembered because a flag change has to reprogram a
+ * VSI whose membership did not move.
+ */
 void ppe_vsi_member_set(struct qca_ppe_priv *priv, u32 vsi,
 			       u32 portmask)
 {
-	u32 val;
+	u32 uuc = 0, umc = 0, bc = 0, val;
+	int port;
+
+	priv->vsi_member[vsi] = portmask;
+
+	for (port = 0; port < priv->ds.num_ports; port++) {
+		if (!(portmask & BIT(port)))
+			continue;
+
+		if (priv->port_brflags[port] & BR_FLOOD)
+			uuc |= BIT(port);
+		if (priv->port_brflags[port] & BR_MCAST_FLOOD)
+			umc |= BIT(port);
+		if (priv->port_brflags[port] & BR_BCAST_FLOOD)
+			bc |= BIT(port);
+	}
 
 	val = FIELD_PREP(PPE_VSI_TBL_MEMBER, portmask) |
-	      FIELD_PREP(PPE_VSI_TBL_UUC, portmask) |
-	      FIELD_PREP(PPE_VSI_TBL_UMC, portmask) |
-	      FIELD_PREP(PPE_VSI_TBL_BC, portmask);
+	      FIELD_PREP(PPE_VSI_TBL_UUC, uuc) |
+	      FIELD_PREP(PPE_VSI_TBL_UMC, umc) |
+	      FIELD_PREP(PPE_VSI_TBL_BC, bc);
 	regmap_write(priv->regmap, PPE_VSI_TBL(vsi), val);
 	regmap_write(priv->regmap, PPE_VSI_TBL(vsi) + 4,
 		PPE_VSI_TBL_NEW_ADDR_LRN_EN | PPE_VSI_TBL_STA_MOVE_LRN_EN);
+}
+
+/* VSI 0 is skipped: it carries the ports no bridge has claimed, whose flood set
+ * is the host alone whatever their flags say.
+ */
+static void ppe_vsi_flood_refresh(struct qca_ppe_priv *priv)
+{
+	int vsi;
+
+	for_each_set_bit(vsi, priv->vsi_bitmap, PPE_VSI_MAX)
+		if (vsi)
+			ppe_vsi_member_set(priv, vsi, priv->vsi_member[vsi]);
+}
+
+/* The bitmap names the ports a frame from this one may leave by, so an isolated
+ * port is expressed by taking the other isolated ports out of its own.
+ */
+static void ppe_port_isolation_update(struct qca_ppe_priv *priv)
+{
+	u32 all = BIT(priv->ds.num_ports) - 1;
+	u32 mask;
+	int port;
+
+	for (port = 0; port < priv->ds.num_ports; port++) {
+		mask = all;
+		if (priv->port_isolated & BIT(port))
+			mask = (all & ~priv->port_isolated) |
+			       BIT(QCA_PPE_CPU_PORT);
+
+		regmap_update_bits(priv->regmap, PPE_PORT_BRIDGE_CTRL(port),
+				   PPE_BRIDGE_PORT_ISOL,
+				   FIELD_PREP(PPE_BRIDGE_PORT_ISOL, mask));
+	}
 }
 
 /* The entry latches on the write to its last word: rewriting word 1 alone is
@@ -482,11 +537,20 @@ static int qca_ppe_setup(struct dsa_switch *ds)
 			regmap_write(priv->regmap, PPE_GMAC_MIB_CTRL(i - 1),
 				     PPE_MIB_EN);
 
-		val = PPE_BRIDGE_NEW_LRN_EN |
-		      PPE_BRIDGE_STA_MOVE_EN |
+		/* The state DSA gives a port no bridge has claimed: it floods,
+		 * and it does not learn, so two of them cannot reach each
+		 * other behind the CPU's back.
+		 */
+		priv->port_brflags[i] = BR_FLOOD | BR_MCAST_FLOOD |
+					BR_BCAST_FLOOD;
+
+		val = PPE_BRIDGE_STA_MOVE_EN |
 		      FIELD_PREP(PPE_BRIDGE_PORT_ISOL, port_mask);
-		if (dsa_is_cpu_port(ds, i))
-			val |= PPE_PORT_BRIDGE_CTRL_TXMAC_EN;
+		if (dsa_is_cpu_port(ds, i)) {
+			val |= PPE_PORT_BRIDGE_CTRL_TXMAC_EN |
+			       PPE_BRIDGE_NEW_LRN_EN;
+			priv->port_brflags[i] |= BR_LEARNING;
+		}
 		regmap_update_bits(priv->regmap, PPE_PORT_BRIDGE_CTRL(i),
 				   PPE_BRIDGE_NEW_LRN_EN |
 				   PPE_BRIDGE_STA_MOVE_EN |
@@ -1697,6 +1761,77 @@ static void qca_ppe_port_stp_state_set(struct dsa_switch *ds, int port,
 			   PPE_STP_STATE_MASK, stp_state);
 }
 
+#define QCA_PPE_BRIDGE_FLAGS	(BR_LEARNING | BR_FLOOD | BR_MCAST_FLOOD | \
+				 BR_BCAST_FLOOD | BR_ISOLATED)
+
+static int qca_ppe_port_pre_bridge_flags(struct dsa_switch *ds, int port,
+					 struct switchdev_brport_flags flags,
+					 struct netlink_ext_ack *extack)
+{
+	if (flags.mask & ~QCA_PPE_BRIDGE_FLAGS)
+		return -EINVAL;
+
+	return 0;
+}
+
+static int qca_ppe_port_bridge_flags(struct dsa_switch *ds, int port,
+				     struct switchdev_brport_flags flags,
+				     struct netlink_ext_ack *extack)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+
+	guard(mutex)(&priv->vlan_lock);
+
+	priv->port_brflags[port] &= ~flags.mask;
+	priv->port_brflags[port] |= flags.val & flags.mask;
+
+	if (flags.mask & BR_LEARNING)
+		regmap_update_bits(priv->regmap, PPE_PORT_BRIDGE_CTRL(port),
+				   PPE_BRIDGE_NEW_LRN_EN,
+				   flags.val & BR_LEARNING ?
+					PPE_BRIDGE_NEW_LRN_EN : 0);
+
+	if (flags.mask & (BR_FLOOD | BR_MCAST_FLOOD | BR_BCAST_FLOOD))
+		ppe_vsi_flood_refresh(priv);
+
+	if (flags.mask & BR_ISOLATED) {
+		if (flags.val & BR_ISOLATED)
+			priv->port_isolated |= BIT(port);
+		else
+			priv->port_isolated &= ~BIT(port);
+
+		ppe_port_isolation_update(priv);
+	}
+
+	return 0;
+}
+
+/* No hardware op deletes by port - the vendor walks the table too - so every
+ * learned entry naming the port is read back and deleted one at a time. The
+ * static ones are the bridge's own and outlive the transition that asked.
+ */
+static void qca_ppe_port_fast_age(struct dsa_switch *ds, int port)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	unsigned char addr[ETH_ALEN];
+	bool is_static;
+	int fdb_port;
+	u32 i, vsi;
+
+	guard(mutex)(&priv->vlan_lock);
+
+	for (i = 0; i < PPE_FDB_TBL_NUM; i++) {
+		if (ppe_fdb_read_entry(priv, i, addr, &vsi, &fdb_port,
+				       &is_static))
+			continue;
+
+		if (fdb_port != port || is_static)
+			continue;
+
+		ppe_fdb_op(priv, addr, fdb_port, vsi, PPE_FDB_OP_DEL);
+	}
+}
+
 /* One analyzer serves the whole switch, for both directions, so every mirror on
  * the box has to name the same destination; a second one naming another port is
  * refused rather than silently redirecting the first. The analyzer is a switch
@@ -1772,6 +1907,9 @@ static const struct dsa_switch_ops qca_ppe_ops = {
 	.port_stp_state_set	= qca_ppe_port_stp_state_set,
 	.port_bridge_join	= qca_ppe_port_bridge_join,
 	.port_bridge_leave	= qca_ppe_port_bridge_leave,
+	.port_pre_bridge_flags	= qca_ppe_port_pre_bridge_flags,
+	.port_bridge_flags	= qca_ppe_port_bridge_flags,
+	.port_fast_age		= qca_ppe_port_fast_age,
 	.port_fdb_add		= qca_ppe_port_fdb_add,
 	.port_fdb_del		= qca_ppe_port_fdb_del,
 	.port_fdb_dump		= qca_ppe_port_fdb_dump,

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -1835,31 +1835,53 @@ static void qca_ppe_port_fast_age(struct dsa_switch *ds, int port)
 /* One analyzer serves the whole switch, for both directions, so every mirror on
  * the box has to name the same destination; a second one naming another port is
  * refused rather than silently redirecting the first. The analyzer is a switch
- * port, so mirroring costs a LAN port for as long as it is on.
+ * port, so mirroring costs a LAN port for as long as it is on. A classifier
+ * rule that mirrors takes the same analyzer, which is why this is shared.
  */
+int ppe_mirror_analyzer_get(struct qca_ppe_priv *priv, int to_port)
+{
+	if (priv->mirror_ref && priv->mirror_port != to_port)
+		return -EBUSY;
+
+	regmap_write(priv->regmap, PPE_MIRROR_ANALYZER,
+		     FIELD_PREP(PPE_MIRROR_IN_ANALYZER, to_port) |
+		     FIELD_PREP(PPE_MIRROR_EG_ANALYZER, to_port));
+
+	priv->mirror_port = to_port;
+	priv->mirror_ref++;
+
+	return 0;
+}
+
+void ppe_mirror_analyzer_put(struct qca_ppe_priv *priv)
+{
+	if (--priv->mirror_ref)
+		return;
+
+	regmap_write(priv->regmap, PPE_MIRROR_ANALYZER, 0);
+	priv->mirror_port = -1;
+}
+
 int qca_ppe_port_mirror_add(struct dsa_switch *ds, int port,
 			    struct dsa_mall_mirror_tc_entry *mirror,
 			    bool ingress, struct netlink_ext_ack *extack)
 {
 	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	int ret;
 
-	if (priv->mirror_ref && priv->mirror_port != mirror->to_local_port) {
+	ret = ppe_mirror_analyzer_get(priv, mirror->to_local_port);
+	if (ret) {
 		NL_SET_ERR_MSG_MOD(extack,
 				   "another port is already mirrored elsewhere");
-		return -EBUSY;
+		return ret;
 	}
 
-	regmap_write(priv->regmap, PPE_MIRROR_ANALYZER,
-		     FIELD_PREP(PPE_MIRROR_IN_ANALYZER, mirror->to_local_port) |
-		     FIELD_PREP(PPE_MIRROR_EG_ANALYZER, mirror->to_local_port));
 	regmap_update_bits(priv->regmap, PPE_PORT_MIRROR(port),
 			   ingress ? PPE_PORT_MIRROR_IN_EN :
 				     PPE_PORT_MIRROR_EG_EN,
 			   ingress ? PPE_PORT_MIRROR_IN_EN :
 				     PPE_PORT_MIRROR_EG_EN);
 
-	priv->mirror_port = mirror->to_local_port;
-	priv->mirror_ref++;
 	priv->mirror_dir_ref[port][ingress]++;
 
 	return 0;
@@ -1878,15 +1900,15 @@ void qca_ppe_port_mirror_del(struct dsa_switch *ds, int port,
 				   mirror->ingress ? PPE_PORT_MIRROR_IN_EN :
 						     PPE_PORT_MIRROR_EG_EN, 0);
 
-	if (--priv->mirror_ref)
-		return;
-
-	regmap_write(priv->regmap, PPE_MIRROR_ANALYZER, 0);
-	priv->mirror_port = -1;
+	ppe_mirror_analyzer_put(priv);
 }
 
 static const struct dsa_switch_ops qca_ppe_ops = {
 	.port_setup_tc		= qca_ppe_setup_tc,
+	.cls_flower_add		= qca_ppe_cls_flower_add,
+	.cls_flower_del		= qca_ppe_cls_flower_del,
+	.get_rxnfc		= qca_ppe_get_rxnfc,
+	.set_rxnfc		= qca_ppe_set_rxnfc,
 	.port_mirror_add	= qca_ppe_port_mirror_add,
 	.port_mirror_del	= qca_ppe_port_mirror_del,
 	.port_policer_add	= qca_ppe_port_policer_add,
@@ -2139,16 +2161,17 @@ static int qca_ppe_probe(struct platform_device *pdev)
 
 	ppe_mac_hw_init(priv);
 	ppe_ctrlpkt_init(priv);
+	ppe_acl_init(priv);
 
 	if (data->type == PPE_TYPE_IPQ6018) {
 		ret = ppe_ipq6018_mux_setup(priv);
 		if (ret)
-			goto err_clk;
+			goto err_acl;
 	}
 
 	ret = dsa_register_switch(ds);
 	if (ret)
-		goto err_clk;
+		goto err_acl;
 
 	ppe_debugfs_init(priv);
 
@@ -2156,6 +2179,8 @@ static int qca_ppe_probe(struct platform_device *pdev)
 
 	return 0;
 
+err_acl:
+	ppe_acl_exit(priv);
 err_clk:
 	clk_bulk_disable_unprepare(priv->num_clks, priv->clks);
 	return ret;
@@ -2167,6 +2192,7 @@ static void qca_ppe_remove(struct platform_device *pdev)
 
 	ppe_debugfs_exit(priv);
 	dsa_unregister_switch(&priv->ds);
+	ppe_acl_exit(priv);
 	clk_bulk_disable_unprepare(priv->num_clks, priv->clks);
 }
 

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -197,6 +197,29 @@ void ppe_vsi_free(struct qca_ppe_priv *priv, u32 vsi)
 	clear_bit(vsi, priv->vsi_bitmap);
 }
 
+/* The one member of a trunk that carries its flooded copies, so that a frame
+ * flooded into a VSI crosses the aggregate once. A port outside every trunk
+ * carries its own.
+ */
+static int ppe_trunk_flood_port(struct qca_ppe_priv *priv, int port)
+{
+	u8 members;
+	int g;
+
+	for (g = 0; g < PPE_TRUNK_GROUPS; g++) {
+		if (!(priv->trunk_members[g] & BIT(port)))
+			continue;
+
+		members = priv->trunk_tx[g];
+		if (!members)
+			members = priv->trunk_members[g];
+
+		return __ffs(members);
+	}
+
+	return port;
+}
+
 /* Each flood class is the member mask minus the ports whose bridge flags turned
  * that class off, so narrowing one costs nothing on the ports that still want
  * it. The member mask is remembered because a flag change has to reprogram a
@@ -212,6 +235,13 @@ void ppe_vsi_member_set(struct qca_ppe_priv *priv, u32 vsi,
 
 	for (port = 0; port < priv->ds.num_ports; port++) {
 		if (!(portmask & BIT(port)))
+			continue;
+
+		/* A trunk's other members leave the flood classes, never the
+		 * member mask: the aggregate is one bridge port and must see
+		 * one copy.
+		 */
+		if (ppe_trunk_flood_port(priv, port) != port)
 			continue;
 
 		if (priv->port_brflags[port] & BR_FLOOD)
@@ -1951,26 +1981,241 @@ static int qca_ppe_port_bridge_flags(struct dsa_switch *ds, int port,
 	return 0;
 }
 
+/* The parser hashes on whole fields, so a policy has an expression only where
+ * it names a set of them: the encapsulated ones have no inner header to reach
+ * here and NETDEV_LAG_HASH_VLAN_SRCMAC no field at all.
+ */
+static u32 ppe_trunk_hash_field(enum netdev_lag_hash hash)
+{
+	switch (hash) {
+	case NETDEV_LAG_HASH_L2:
+		return PPE_TRUNK_HASH_MAC_DA | PPE_TRUNK_HASH_MAC_SA;
+	case NETDEV_LAG_HASH_L23:
+		return PPE_TRUNK_HASH_MAC_DA | PPE_TRUNK_HASH_MAC_SA |
+		       PPE_TRUNK_HASH_SIP | PPE_TRUNK_HASH_DIP;
+	case NETDEV_LAG_HASH_L34:
+		return PPE_TRUNK_HASH_SIP | PPE_TRUNK_HASH_DIP |
+		       PPE_TRUNK_HASH_L4_SPORT | PPE_TRUNK_HASH_L4_DPORT;
+	default:
+		return 0;
+	}
+}
+
+/* The member table is eight hash buckets rather than a member list: the
+ * hardware picks a bucket and reads a port id out of it, so the transmitting
+ * members are tiled across all eight. Falling back to every member when none
+ * transmits covers the join, which runs before the bond reports a lower state,
+ * and the aggregate whose links are all down - a dead port drops the frame,
+ * where an empty table would have sent it to bucket zero's port.
+ */
+static void ppe_trunk_program(struct qca_ppe_priv *priv, unsigned int id)
+{
+	u8 slot[PPE_TRUNK_MEMBER_SLOTS];
+	unsigned int g = id - 1;
+	int i, port, n = 0;
+	u32 val = 0;
+	u8 members;
+
+	members = priv->trunk_tx[g];
+	if (!members)
+		members = priv->trunk_members[g];
+
+	for (port = 0; port < priv->ds.num_ports; port++)
+		if (members & BIT(port))
+			slot[n++] = port;
+
+	for (i = 0; n && i < PPE_TRUNK_MEMBER_SLOTS; i++)
+		val |= (u32)slot[i % n] << (i * PPE_TRUNK_MEMBER_SLOT_SHIFT);
+
+	regmap_write(priv->regmap, PPE_TRUNK_MEMBER(g), val);
+	regmap_write(priv->regmap, PPE_TRUNK_FILTER(g),
+		     FIELD_PREP(PPE_TRUNK_FILTER_MEMBERS,
+				priv->trunk_members[g]));
+}
+
+static int qca_ppe_port_lag_join(struct dsa_switch *ds, int port,
+				 struct dsa_lag lag,
+				 struct netdev_lag_upper_info *info,
+				 struct netlink_ext_ack *extack)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	u32 hash;
+
+	/* DSA allocates one id per aggregate out of num_lag_ids, so its
+	 * allocator is the trunk group allocator and a zero id is a third bond
+	 * asking for a group the hardware does not have.
+	 */
+	if (!lag.id) {
+		NL_SET_ERR_MSG_MOD(extack, "the hardware has two trunk groups");
+		return -EOPNOTSUPP;
+	}
+
+	/* A frame arriving on a member is switched in hardware and never
+	 * reaches the bond, which is what every mode but hashing relies on to
+	 * drop what arrives on a link it is not using.
+	 */
+	if (info->tx_type != NETDEV_LAG_TX_TYPE_HASH) {
+		NL_SET_ERR_MSG_MOD(extack, "only a hashing bond is offloaded");
+		return -EOPNOTSUPP;
+	}
+
+	hash = ppe_trunk_hash_field(info->hash_type);
+	if (!hash) {
+		NL_SET_ERR_MSG_MOD(extack,
+				   "the trunk hash has no such field set");
+		return -EOPNOTSUPP;
+	}
+
+	guard(mutex)(&priv->vlan_lock);
+
+	/* One hash-field register serves both groups, so the second aggregate
+	 * may only ask for what the first is already hashing on.
+	 */
+	if (priv->trunk_hash && priv->trunk_hash != hash) {
+		NL_SET_ERR_MSG_MOD(extack,
+				   "the other trunk hashes on other fields");
+		return -EOPNOTSUPP;
+	}
+
+	priv->trunk_hash = hash;
+	regmap_write(priv->regmap, PPE_TRUNK_HASH_FIELD, hash);
+
+	priv->trunk_members[lag.id - 1] |= BIT(port);
+	ppe_trunk_program(priv, lag.id);
+
+	/* Last, so that the port is never a member of a group whose tables it
+	 * is not in yet; leaving unmarks it first for the same reason.
+	 */
+	regmap_update_bits(priv->regmap, PPE_PORT_TRUNK_ID(port),
+			   PPE_PORT_TRUNK_EN | PPE_PORT_TRUNK_GROUP,
+			   PPE_PORT_TRUNK_EN |
+			   FIELD_PREP(PPE_PORT_TRUNK_GROUP, lag.id - 1));
+
+	ppe_vsi_flood_refresh(priv);
+
+	return 0;
+}
+
+static int qca_ppe_port_lag_leave(struct dsa_switch *ds, int port,
+				  struct dsa_lag lag)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	int g;
+
+	guard(mutex)(&priv->vlan_lock);
+
+	regmap_update_bits(priv->regmap, PPE_PORT_TRUNK_ID(port),
+			   PPE_PORT_TRUNK_EN, 0);
+
+	priv->trunk_members[lag.id - 1] &= ~BIT(port);
+	priv->trunk_tx[lag.id - 1] &= ~BIT(port);
+	ppe_trunk_program(priv, lag.id);
+	ppe_vsi_flood_refresh(priv);
+
+	/* The hash-field register is released with the last group so that the
+	 * next aggregate is free to ask for another policy.
+	 */
+	for (g = 0; g < PPE_TRUNK_GROUPS; g++)
+		if (priv->trunk_members[g])
+			return 0;
+
+	priv->trunk_hash = 0;
+	regmap_write(priv->regmap, PPE_TRUNK_HASH_FIELD, 0);
+
+	return 0;
+}
+
+/* Rebuilding the buckets from the transmitting members is the failover, and it
+ * is the only thing that sees an aggregator deselecting a member whose link is
+ * still up. The flood member is chosen from the same set, so it moves too.
+ */
+static int qca_ppe_port_lag_change(struct dsa_switch *ds, int port)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	struct dsa_port *dp = dsa_to_port(ds, port);
+	unsigned int id = dp->lag->id;
+
+	guard(mutex)(&priv->vlan_lock);
+
+	if (dp->lag_tx_enabled)
+		priv->trunk_tx[id - 1] |= BIT(port);
+	else
+		priv->trunk_tx[id - 1] &= ~BIT(port);
+
+	ppe_trunk_program(priv, id);
+	ppe_vsi_flood_refresh(priv);
+
+	return 0;
+}
+
+/* A trunk is named in the destination field of an ordinary entry, so the only
+ * difference from a per-port address is the value written there.
+ */
+static int qca_ppe_lag_fdb_add(struct dsa_switch *ds, struct dsa_lag lag,
+			       const unsigned char *addr, u16 vid,
+			       struct dsa_db db)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	u32 vsi;
+
+	guard(mutex)(&priv->flow_lock);
+	guard(mutex)(&priv->vlan_lock);
+
+	vsi = ppe_fdb_vsi(priv, vid, db);
+	if (vsi == PPE_VSI_INVALID)
+		return -EOPNOTSUPP;
+
+	return ppe_fdb_op(priv, addr, PPE_FDB_DST_TRUNK(lag.id - 1), vsi,
+			  PPE_FDB_OP_ADD);
+}
+
+static int qca_ppe_lag_fdb_del(struct dsa_switch *ds, struct dsa_lag lag,
+			       const unsigned char *addr, u16 vid,
+			       struct dsa_db db)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	u32 vsi;
+
+	guard(mutex)(&priv->flow_lock);
+	guard(mutex)(&priv->vlan_lock);
+
+	vsi = ppe_fdb_vsi(priv, vid, db);
+	if (vsi == PPE_VSI_INVALID)
+		return -EOPNOTSUPP;
+
+	return ppe_fdb_op(priv, addr, PPE_FDB_DST_TRUNK(lag.id - 1), vsi,
+			  PPE_FDB_OP_DEL);
+}
+
 /* No hardware op deletes by port - the vendor walks the table too - so every
  * learned entry naming the port is read back and deleted one at a time. The
  * static ones are the bridge's own and outlive the transition that asked.
  */
 static void qca_ppe_port_fast_age(struct dsa_switch *ds, int port)
 {
+	struct dsa_port *dp = dsa_to_port(ds, port);
 	struct qca_ppe_priv *priv = ds_to_priv(ds);
 	unsigned char addr[ETH_ALEN];
+	int dst, fdb_port;
 	bool is_static;
-	int fdb_port;
 	u32 i, vsi;
 
 	guard(mutex)(&priv->vlan_lock);
+
+	/* Addresses behind a trunk are learned against the trunk, not the
+	 * member they arrived on, so ageing one member ages the aggregate -
+	 * which is what the bridge asked for, the aggregate being its port.
+	 * DSA leaves the bridge before it drops dp->lag, so an unenslaving
+	 * port still flushes them.
+	 */
+	dst = dp->lag ? PPE_FDB_DST_TRUNK(dp->lag->id - 1) : port;
 
 	for (i = 0; i < PPE_FDB_TBL_NUM; i++) {
 		if (ppe_fdb_read_entry(priv, i, addr, &vsi, &fdb_port,
 				       &is_static))
 			continue;
 
-		if (fdb_port != port || is_static)
+		if (fdb_port != dst || is_static)
 			continue;
 
 		ppe_fdb_op(priv, addr, fdb_port, vsi, PPE_FDB_OP_DEL);
@@ -2080,6 +2325,11 @@ static const struct dsa_switch_ops qca_ppe_ops = {
 	.port_fdb_add		= qca_ppe_port_fdb_add,
 	.port_fdb_del		= qca_ppe_port_fdb_del,
 	.port_fdb_dump		= qca_ppe_port_fdb_dump,
+	.port_lag_join		= qca_ppe_port_lag_join,
+	.port_lag_leave		= qca_ppe_port_lag_leave,
+	.port_lag_change	= qca_ppe_port_lag_change,
+	.lag_fdb_add		= qca_ppe_lag_fdb_add,
+	.lag_fdb_del		= qca_ppe_lag_fdb_del,
 	.port_mdb_add		= qca_ppe_port_mdb_add,
 	.port_mdb_del		= qca_ppe_port_mdb_del,
 	.phylink_get_caps	= qca_ppe_phylink_get_caps,
@@ -2277,6 +2527,10 @@ static int qca_ppe_probe(struct platform_device *pdev)
 	ds->dscp_prio_mapping_is_global = true;
 	/* mqprio carves these into traffic classes, one per hardware queue. */
 	ds->num_tx_queues = PPE_QOS_MAX_PRI + 1;
+	/* The id DSA hands an aggregate is the trunk group it is given, so this
+	 * is what stops a third bond from sharing one.
+	 */
+	ds->num_lag_ids = PPE_TRUNK_GROUPS;
 	priv->mirror_port = -1;
 	ds->phylink_mac_ops = &qca_ppe_phylink_mac_ops;
 

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -171,6 +171,33 @@ static void ppe_port_cnt_enable(struct qca_ppe_priv *priv, int port)
 			   PPE_PORT_EG_VLAN_TX_CNT_EN, PPE_PORT_EG_VLAN_TX_CNT_EN);
 }
 
+/* The sizes are word 0 of a two-word entry that latches on word 1, so editing
+ * them alone leaves the write staged. Word 1 holds the counter enables and the
+ * source profile and goes back unchanged.
+ */
+static void ppe_port_mtu_set(struct qca_ppe_priv *priv, int port,
+			     u32 frame_size)
+{
+	u32 reg = PPE_MRU_MTU_CTRL(port, priv->data->mru_mtu_ctrl_stride);
+	u32 w1;
+
+	regmap_read(priv->regmap, reg + 4, &w1);
+	regmap_write(priv->regmap, reg,
+		     FIELD_PREP(PPE_MRU_MTU_CTRL_MRU, frame_size) |
+		     FIELD_PREP(PPE_MRU_MTU_CTRL_MRU_CMD,
+				PPE_MTU_CMD_RDT_TO_CPU) |
+		     FIELD_PREP(PPE_MRU_MTU_CTRL_MTU, frame_size) |
+		     FIELD_PREP(PPE_MRU_MTU_CTRL_MTU_CMD,
+				PPE_MTU_CMD_RDT_TO_CPU));
+	regmap_write(priv->regmap, reg + 4, w1);
+
+	regmap_update_bits(priv->regmap, PPE_MC_MTU_CTRL(port),
+			   PPE_MC_MTU_CTRL_MTU | PPE_MC_MTU_CTRL_MTU_CMD,
+			   FIELD_PREP(PPE_MC_MTU_CTRL_MTU, frame_size) |
+			   FIELD_PREP(PPE_MC_MTU_CTRL_MTU_CMD,
+				      PPE_MTU_CMD_RDT_TO_CPU));
+}
+
 int ppe_vsi_alloc(struct qca_ppe_priv *priv)
 {
 	int vsi;
@@ -613,16 +640,7 @@ static int qca_ppe_setup(struct dsa_switch *ds)
 	for (i = 0; i < num_ports; i++) {
 		regmap_write(priv->regmap, PPE_CST_STATE(i), PPE_STP_FORWARDING);
 
-		regmap_write(priv->regmap,
-			     PPE_MRU_MTU_CTRL(i,
-					      priv->data->mru_mtu_ctrl_stride),
-			     FIELD_PREP(PPE_MRU_MTU_CTRL_MRU, frame_size) |
-			     FIELD_PREP(PPE_MRU_MTU_CTRL_MTU, frame_size));
-
-		regmap_update_bits(priv->regmap, PPE_MC_MTU_CTRL(i),
-				   PPE_MC_MTU_CTRL_MTU,
-				   FIELD_PREP(PPE_MC_MTU_CTRL_MTU,
-					      frame_size));
+		ppe_port_mtu_set(priv, i, frame_size);
 
 		if (i >= 1)
 			regmap_write(priv->regmap, PPE_GMAC_MIB_CTRL(i - 1),
@@ -698,21 +716,10 @@ static int qca_ppe_port_change_mtu(struct dsa_switch *ds, int port,
 				   int new_mtu)
 {
 	struct qca_ppe_priv *priv = ds_to_priv(ds);
-	u32 frame_size = new_mtu + ETH_HLEN + 2 * VLAN_HLEN;
-	int ret;
 
-	ret = regmap_update_bits(priv->regmap,
-				 PPE_MRU_MTU_CTRL(port,
-						  priv->data->mru_mtu_ctrl_stride),
-				 PPE_MRU_MTU_CTRL_MRU | PPE_MRU_MTU_CTRL_MTU,
-				 FIELD_PREP(PPE_MRU_MTU_CTRL_MRU, frame_size) |
-				 FIELD_PREP(PPE_MRU_MTU_CTRL_MTU, frame_size));
-	if (ret)
-		return ret;
+	ppe_port_mtu_set(priv, port, new_mtu + ETH_HLEN + 2 * VLAN_HLEN);
 
-	return regmap_update_bits(priv->regmap, PPE_MC_MTU_CTRL(port),
-				  PPE_MC_MTU_CTRL_MTU,
-				  FIELD_PREP(PPE_MC_MTU_CTRL_MTU, frame_size));
+	return 0;
 }
 
 static int qca_ppe_port_max_mtu(struct dsa_switch *ds, int port)

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -344,20 +344,53 @@ static void ppe_port_vsi_set(struct qca_ppe_priv *priv, int port, u32 vsi)
 			     val[i]);
 }
 
+#define PPE_FDB_OP_RETRIES	100
+
+/* The result register reports a command id and how many results are queued
+ * behind it. An operation has finished only once the queue holds one and it
+ * carries this command's id: without the count, a register that has posted
+ * nothing reads back as a completed command 0, and an operation issued
+ * without an id of its own is told it succeeded before the engine has run.
+ */
 static int ppe_fdb_op_wait(struct qca_ppe_priv *priv, u32 rslt_reg,
-			   u32 cmd_id)
+			   u32 cmd_id, u32 *data)
 {
 	u32 val;
 	int i;
 
-	for (i = 0; i < 100; i++) {
+	for (i = 0; i < PPE_FDB_OP_RETRIES; i++) {
+		/* The entry lands in the result data registers and the
+		 * operation is reported in a queue that a read advances, so
+		 * the data is taken first, in the same pass as the report
+		 * that qualifies it.
+		 */
+		if (data) {
+			regmap_read(priv->regmap, PPE_FDB_RD_RSLT_DATA0,
+				    &data[0]);
+			regmap_read(priv->regmap, PPE_FDB_RD_RSLT_DATA1,
+				    &data[1]);
+			regmap_read(priv->regmap, PPE_FDB_RD_RSLT_DATA2,
+				    &data[2]);
+		}
+
 		regmap_read(priv->regmap, rslt_reg, &val);
-		if (FIELD_GET(PPE_FDB_RSLT_CMD_ID, val) == cmd_id)
+		if (FIELD_GET(PPE_FDB_RSLT_VALID_CNT, val) &&
+		    FIELD_GET(PPE_FDB_RSLT_CMD_ID, val) == cmd_id)
 			return 0;
 		udelay(1);
 	}
 
 	return -ETIMEDOUT;
+}
+
+/* Ids are handed out in turn, so a result the previous operation left behind
+ * is never mistaken for this one's.
+ */
+static u32 ppe_fdb_next_cmd_id(struct qca_ppe_priv *priv)
+{
+	priv->fdb_cmd_id = (priv->fdb_cmd_id + 1) & PPE_FDB_OP_CMD_ID;
+
+	return priv->fdb_cmd_id;
 }
 
 static void ppe_fdb_encode(const unsigned char *addr, int port, u32 vsi,
@@ -378,7 +411,7 @@ static void ppe_fdb_encode(const unsigned char *addr, int port, u32 vsi,
 static int ppe_fdb_op(struct qca_ppe_priv *priv, const unsigned char *addr,
 		      int port, u32 vsi, u32 op_type)
 {
-	u32 data0, data1, data2;
+	u32 data0, data1, data2, cmd_id;
 	int ret;
 
 	ppe_fdb_encode(addr, port, vsi, op_type == PPE_FDB_OP_ADD,
@@ -389,11 +422,14 @@ static int ppe_fdb_op(struct qca_ppe_priv *priv, const unsigned char *addr,
 	regmap_write(priv->regmap, PPE_FDB_OP_DATA0, data0);
 	regmap_write(priv->regmap, PPE_FDB_OP_DATA1, data1);
 	regmap_write(priv->regmap, PPE_FDB_OP_DATA2, data2);
+
+	cmd_id = ppe_fdb_next_cmd_id(priv);
 	regmap_write(priv->regmap, PPE_FDB_OP,
+		     FIELD_PREP(PPE_FDB_OP_CMD_ID, cmd_id) |
 		     FIELD_PREP(PPE_FDB_OP_TYPE, op_type) |
 		     FIELD_PREP(PPE_FDB_OP_HASH_BLOCK, 3));
 
-	ret = ppe_fdb_op_wait(priv, PPE_FDB_OP_RSLT, 0);
+	ret = ppe_fdb_op_wait(priv, PPE_FDB_OP_RSLT, cmd_id, NULL);
 
 	spin_unlock_bh(&priv->fdb_lock);
 
@@ -404,12 +440,12 @@ static int ppe_fdb_read_entry(struct qca_ppe_priv *priv, u32 index,
 			      unsigned char *addr, u32 *vsi, int *port,
 			      bool *is_static)
 {
-	u32 data0, data1, data2, cmd_id, val;
+	u32 data[3], cmd_id, val;
 	int ret;
 
-	cmd_id = index % 15;
-
 	spin_lock_bh(&priv->fdb_lock);
+
+	cmd_id = ppe_fdb_next_cmd_id(priv);
 
 	regmap_write(priv->regmap, PPE_FDB_RD_OP_DATA0, 0);
 	regmap_write(priv->regmap, PPE_FDB_RD_OP_DATA1, 0);
@@ -422,51 +458,47 @@ static int ppe_fdb_read_entry(struct qca_ppe_priv *priv, u32 index,
 	      FIELD_PREP(PPE_FDB_OP_ENTRY_IDX, index);
 	regmap_write(priv->regmap, PPE_FDB_RD_OP, val);
 
-	ret = ppe_fdb_op_wait(priv, PPE_FDB_RD_OP_RSLT, cmd_id);
-	if (ret)
-		goto unlock;
+	ret = ppe_fdb_op_wait(priv, PPE_FDB_RD_OP_RSLT, cmd_id, data);
 
-	regmap_read(priv->regmap, PPE_FDB_RD_RSLT_DATA0, &data0);
-	regmap_read(priv->regmap, PPE_FDB_RD_RSLT_DATA1, &data1);
-	regmap_read(priv->regmap, PPE_FDB_RD_RSLT_DATA2, &data2);
-
-unlock:
 	spin_unlock_bh(&priv->fdb_lock);
 
 	if (ret)
 		return ret;
 
-	if (!(data1 & PPE_FDB_DATA1_VALID))
+	if (!(data[1] & PPE_FDB_DATA1_VALID))
 		return -ENOENT;
 
-	if (FIELD_GET(PPE_FDB_DATA2_DST_TYPE, data2) != PPE_FDB_DST_PORT)
+	if (FIELD_GET(PPE_FDB_DATA2_DST_TYPE, data[2]) != PPE_FDB_DST_PORT)
 		return -ENOENT;
 
-	addr[2] = (data0 >> 24) & 0xff;
-	addr[3] = (data0 >> 16) & 0xff;
-	addr[4] = (data0 >> 8) & 0xff;
-	addr[5] = data0 & 0xff;
-	addr[0] = (data1 >> 8) & 0xff;
-	addr[1] = data1 & 0xff;
+	addr[2] = (data[0] >> 24) & 0xff;
+	addr[3] = (data[0] >> 16) & 0xff;
+	addr[4] = (data[0] >> 8) & 0xff;
+	addr[5] = data[0] & 0xff;
+	addr[0] = (data[1] >> 8) & 0xff;
+	addr[1] = data[1] & 0xff;
 
-	*vsi = FIELD_GET(PPE_FDB_DATA1_VSI, data1);
-	*port = FIELD_GET(PPE_FDB_DATA1_DST_LO, data1) |
-		(FIELD_GET(PPE_FDB_DATA2_DST_HI, data2) << 9);
-	*is_static = FIELD_GET(PPE_FDB_DATA2_HIT_AGE, data2) == PPE_FDB_AGE_STATIC;
+	*vsi = FIELD_GET(PPE_FDB_DATA1_VSI, data[1]);
+	*port = FIELD_GET(PPE_FDB_DATA1_DST_LO, data[1]) |
+		(FIELD_GET(PPE_FDB_DATA2_DST_HI, data[2]) << 9);
+	*is_static = FIELD_GET(PPE_FDB_DATA2_HIT_AGE, data[2]) == PPE_FDB_AGE_STATIC;
 
 	return 0;
 }
 
 static int ppe_fdb_flush(struct qca_ppe_priv *priv)
 {
+	u32 cmd_id;
 	int ret;
 
 	spin_lock_bh(&priv->fdb_lock);
 
+	cmd_id = ppe_fdb_next_cmd_id(priv);
 	regmap_write(priv->regmap, PPE_FDB_OP,
+		FIELD_PREP(PPE_FDB_OP_CMD_ID, cmd_id) |
 		FIELD_PREP(PPE_FDB_OP_TYPE, PPE_FDB_OP_FLUSH));
 
-	ret = ppe_fdb_op_wait(priv, PPE_FDB_OP_RSLT, 0);
+	ret = ppe_fdb_op_wait(priv, PPE_FDB_OP_RSLT, cmd_id, NULL);
 
 	spin_unlock_bh(&priv->fdb_lock);
 
@@ -491,7 +523,7 @@ static void ppe_fdb_encode_mcast(const unsigned char *addr, u32 portmap,
 static int ppe_fdb_lookup(struct qca_ppe_priv *priv,
 			  const unsigned char *addr, u32 vsi, u32 *portmap)
 {
-	u32 data1, data2;
+	u32 data[3], cmd_id;
 	int ret;
 
 	spin_lock_bh(&priv->fdb_lock);
@@ -503,29 +535,28 @@ static int ppe_fdb_lookup(struct qca_ppe_priv *priv,
 		     FIELD_PREP(PPE_FDB_DATA1_VSI, vsi));
 	regmap_write(priv->regmap, PPE_FDB_RD_OP_DATA2, 0);
 
+	cmd_id = ppe_fdb_next_cmd_id(priv);
 	regmap_write(priv->regmap, PPE_FDB_RD_OP,
+		     FIELD_PREP(PPE_FDB_OP_CMD_ID, cmd_id) |
 		     FIELD_PREP(PPE_FDB_OP_TYPE, PPE_FDB_OP_GET) |
 		     FIELD_PREP(PPE_FDB_OP_HASH_BLOCK, 3));
 
-	ret = ppe_fdb_op_wait(priv, PPE_FDB_RD_OP_RSLT, 0);
+	ret = ppe_fdb_op_wait(priv, PPE_FDB_RD_OP_RSLT, cmd_id, data);
 	if (ret)
 		goto out;
-
-	regmap_read(priv->regmap, PPE_FDB_RD_RSLT_DATA1, &data1);
-	regmap_read(priv->regmap, PPE_FDB_RD_RSLT_DATA2, &data2);
 
 	/* The destination field of a unicast entry is a port number rather than
 	 * a member map, so an entry of the wrong type read back as one would
 	 * name a set of ports the group was never given.
 	 */
-	if (!(data1 & PPE_FDB_DATA1_VALID) ||
-	    FIELD_GET(PPE_FDB_DATA2_DST_TYPE, data2) != PPE_FDB_DST_PORTMAP) {
+	if (!(data[1] & PPE_FDB_DATA1_VALID) ||
+	    FIELD_GET(PPE_FDB_DATA2_DST_TYPE, data[2]) != PPE_FDB_DST_PORTMAP) {
 		ret = -ENOENT;
 		goto out;
 	}
 
-	*portmap = FIELD_GET(PPE_FDB_DATA1_DST_LO, data1) |
-		   (FIELD_GET(PPE_FDB_DATA2_DST_HI, data2) << 9);
+	*portmap = FIELD_GET(PPE_FDB_DATA1_DST_LO, data[1]) |
+		   (FIELD_GET(PPE_FDB_DATA2_DST_HI, data[2]) << 9);
 
 out:
 	spin_unlock_bh(&priv->fdb_lock);
@@ -536,7 +567,7 @@ static int ppe_fdb_mcast_op(struct qca_ppe_priv *priv,
 			    const unsigned char *addr, u32 portmap,
 			    u32 vsi, u32 op_type)
 {
-	u32 data0, data1, data2;
+	u32 data0, data1, data2, cmd_id;
 	int ret;
 
 	ppe_fdb_encode_mcast(addr, portmap, vsi, &data0, &data1, &data2);
@@ -546,11 +577,14 @@ static int ppe_fdb_mcast_op(struct qca_ppe_priv *priv,
 	regmap_write(priv->regmap, PPE_FDB_OP_DATA0, data0);
 	regmap_write(priv->regmap, PPE_FDB_OP_DATA1, data1);
 	regmap_write(priv->regmap, PPE_FDB_OP_DATA2, data2);
+
+	cmd_id = ppe_fdb_next_cmd_id(priv);
 	regmap_write(priv->regmap, PPE_FDB_OP,
+		     FIELD_PREP(PPE_FDB_OP_CMD_ID, cmd_id) |
 		     FIELD_PREP(PPE_FDB_OP_TYPE, op_type) |
 		     FIELD_PREP(PPE_FDB_OP_HASH_BLOCK, 3));
 
-	ret = ppe_fdb_op_wait(priv, PPE_FDB_OP_RSLT, 0);
+	ret = ppe_fdb_op_wait(priv, PPE_FDB_OP_RSLT, cmd_id, NULL);
 
 	spin_unlock_bh(&priv->fdb_lock);
 

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -726,6 +726,8 @@ static int qca_ppe_port_enable(struct dsa_switch *ds, int port,
 {
 	struct qca_ppe_priv *priv = ds_to_priv(ds);
 
+	ppe_port_queues_enable(priv, port, true);
+
 	/* A user port's gate is opened by qca_ppe_mac_link_up() once its MAC
 	 * is up. DSA calls this before phylink_start(), so opening it here
 	 * would aim the fabric at a MAC that is still down and about to be
@@ -742,6 +744,7 @@ static void qca_ppe_port_disable(struct dsa_switch *ds, int port)
 	struct qca_ppe_priv *priv = ds_to_priv(ds);
 
 	ppe_port_bridge_txmac_set(priv, port, false);
+	ppe_port_queues_enable(priv, port, false);
 }
 
 static struct qca_ppe_bridge_vsi *

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -1148,11 +1148,12 @@ static void ppe_pcs_set_mux_hppe(struct qca_ppe_priv *priv, int port,
 
 	switch (port) {
 	case 4:
+		/* The select names where port 4's GMII comes from, not the
+		 * protocol carried on it, so one value covers every interface
+		 * uniphy0 drives.
+		 */
 		mask = HPPE_PORT4_PCS_SEL;
-		if (interface == PHY_INTERFACE_MODE_QSGMII ||
-		    interface == PHY_INTERFACE_MODE_PSGMII)
-			val = FIELD_PREP(HPPE_PORT4_PCS_SEL,
-					 HPPE_PORT4_PCS0);
+		val = FIELD_PREP(HPPE_PORT4_PCS_SEL, HPPE_PORT4_PCS0);
 		break;
 	case 5:
 		mask = HPPE_PORT5_PCS_SEL | HPPE_PORT5_GMAC_SEL;

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -209,17 +209,27 @@ void ppe_vsi_member_set(struct qca_ppe_priv *priv, u32 vsi,
 		PPE_VSI_TBL_NEW_ADDR_LRN_EN | PPE_VSI_TBL_STA_MOVE_LRN_EN);
 }
 
+/* The entry latches on the write to its last word: rewriting word 1 alone is
+ * staged and never takes effect, so the whole entry is read and written back.
+ */
 static void ppe_port_vsi_set(struct qca_ppe_priv *priv, int port, u32 vsi)
 {
-	u32 val;
+	u32 val[3];
+	int i;
 
-	regmap_read(priv->regmap, PPE_L3_VP_PORT_TBL(port) + 4, &val);
-	val &= ~(PPE_L3_VP_VSI_VALID | PPE_L3_VP_VSI);
+	for (i = 0; i < ARRAY_SIZE(val); i++)
+		regmap_read(priv->regmap, PPE_L3_VP_PORT_TBL(port) + i * 4,
+			    &val[i]);
+
+	val[1] &= ~(PPE_L3_VP_VSI_VALID | PPE_L3_VP_VSI);
 	if (vsi != PPE_VSI_INVALID) {
-		val |= PPE_L3_VP_VSI_VALID;
-		val |= FIELD_PREP(PPE_L3_VP_VSI, vsi);
+		val[1] |= PPE_L3_VP_VSI_VALID;
+		val[1] |= FIELD_PREP(PPE_L3_VP_VSI, vsi);
 	}
-	regmap_write(priv->regmap, PPE_L3_VP_PORT_TBL(port) + 4, val);
+
+	for (i = 0; i < ARRAY_SIZE(val); i++)
+		regmap_write(priv->regmap, PPE_L3_VP_PORT_TBL(port) + i * 4,
+			     val[i]);
 }
 
 static int ppe_fdb_op_wait(struct qca_ppe_priv *priv, u32 rslt_reg,
@@ -1709,27 +1719,6 @@ static const struct dsa_switch_ops qca_ppe_ops = {
 	.get_stats64		= qca_ppe_get_stats64,
 };
 
-static void ppe_vsi_init(struct qca_ppe_priv *priv)
-{
-	int i;
-
-	/* All three words must be written back for the HW to latch the entry */
-	for (i = 1; i < priv->data->num_ports; i++) {
-		u32 val[3];
-
-		regmap_read(priv->regmap, PPE_L3_VP_PORT_TBL(i), &val[0]);
-		regmap_read(priv->regmap, PPE_L3_VP_PORT_TBL(i) + 4, &val[1]);
-		regmap_read(priv->regmap, PPE_L3_VP_PORT_TBL(i) + 8, &val[2]);
-
-		val[1] &= ~(PPE_L3_VP_VSI_VALID | PPE_L3_VP_VSI);
-		val[1] |= PPE_L3_VP_VSI_VALID;
-
-		regmap_write(priv->regmap, PPE_L3_VP_PORT_TBL(i), val[0]);
-		regmap_write(priv->regmap, PPE_L3_VP_PORT_TBL(i) + 4, val[1]);
-		regmap_write(priv->regmap, PPE_L3_VP_PORT_TBL(i) + 8, val[2]);
-	}
-}
-
 static void ppe_mac_hw_init(struct qca_ppe_priv *priv)
 {
 	const struct ppe_data *d = priv->data;
@@ -1931,8 +1920,6 @@ static int qca_ppe_probe(struct platform_device *pdev)
 			goto err_clk;
 		}
 	}
-
-	ppe_vsi_init(priv);
 
 	ppe_scheduler_init(priv);
 

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -1619,8 +1619,63 @@ static void qca_ppe_port_stp_state_set(struct dsa_switch *ds, int port,
 			   PPE_STP_STATE_MASK, stp_state);
 }
 
+/* One analyzer serves the whole switch, for both directions, so every mirror on
+ * the box has to name the same destination; a second one naming another port is
+ * refused rather than silently redirecting the first. The analyzer is a switch
+ * port, so mirroring costs a LAN port for as long as it is on.
+ */
+int qca_ppe_port_mirror_add(struct dsa_switch *ds, int port,
+			    struct dsa_mall_mirror_tc_entry *mirror,
+			    bool ingress, struct netlink_ext_ack *extack)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+
+	if (priv->mirror_ref && priv->mirror_port != mirror->to_local_port) {
+		NL_SET_ERR_MSG_MOD(extack,
+				   "another port is already mirrored elsewhere");
+		return -EBUSY;
+	}
+
+	regmap_write(priv->regmap, PPE_MIRROR_ANALYZER,
+		     FIELD_PREP(PPE_MIRROR_IN_ANALYZER, mirror->to_local_port) |
+		     FIELD_PREP(PPE_MIRROR_EG_ANALYZER, mirror->to_local_port));
+	regmap_update_bits(priv->regmap, PPE_PORT_MIRROR(port),
+			   ingress ? PPE_PORT_MIRROR_IN_EN :
+				     PPE_PORT_MIRROR_EG_EN,
+			   ingress ? PPE_PORT_MIRROR_IN_EN :
+				     PPE_PORT_MIRROR_EG_EN);
+
+	priv->mirror_port = mirror->to_local_port;
+	priv->mirror_ref++;
+	priv->mirror_dir_ref[port][ingress]++;
+
+	return 0;
+}
+
+void qca_ppe_port_mirror_del(struct dsa_switch *ds, int port,
+			     struct dsa_mall_mirror_tc_entry *mirror)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+
+	/* Two filters can name the same port and direction, and they share one
+	 * enable bit: it goes off with the last of them, not the first.
+	 */
+	if (!--priv->mirror_dir_ref[port][mirror->ingress])
+		regmap_update_bits(priv->regmap, PPE_PORT_MIRROR(port),
+				   mirror->ingress ? PPE_PORT_MIRROR_IN_EN :
+						     PPE_PORT_MIRROR_EG_EN, 0);
+
+	if (--priv->mirror_ref)
+		return;
+
+	regmap_write(priv->regmap, PPE_MIRROR_ANALYZER, 0);
+	priv->mirror_port = -1;
+}
+
 static const struct dsa_switch_ops qca_ppe_ops = {
 	.port_setup_tc		= qca_ppe_setup_tc,
+	.port_mirror_add	= qca_ppe_port_mirror_add,
+	.port_mirror_del	= qca_ppe_port_mirror_del,
 	.port_policer_add	= qca_ppe_port_policer_add,
 	.port_policer_del	= qca_ppe_port_policer_del,
 	.port_get_dscp_prio	= qca_ppe_port_get_dscp_prio,
@@ -1846,6 +1901,7 @@ static int qca_ppe_probe(struct platform_device *pdev)
 	 * so every port shares one and DSA replicates an entry to all of them.
 	 */
 	ds->dscp_prio_mapping_is_global = true;
+	priv->mirror_port = -1;
 	ds->phylink_mac_ops = &qca_ppe_phylink_mac_ops;
 
 	for (i = 1; i < data->num_ports; i++) {

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -971,6 +971,7 @@ static int qca_ppe_port_fdb_dump(struct dsa_switch *ds, int port,
 	bool is_static;
 	int fdb_port;
 	u32 i, vsi;
+	int ret;
 
 	guard(mutex)(&priv->vlan_lock);
 
@@ -982,8 +983,9 @@ static int qca_ppe_port_fdb_dump(struct dsa_switch *ds, int port,
 		if (fdb_port != port)
 			continue;
 
-		if (cb(addr, ppe_fdb_vid(priv, vsi), is_static, data))
-			break;
+		ret = cb(addr, ppe_fdb_vid(priv, vsi), is_static, data);
+		if (ret)
+			return ret;
 	}
 
 	return 0;

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -2622,6 +2622,7 @@ static int qca_ppe_probe(struct platform_device *pdev)
 	if (ret)
 		goto err_acl;
 
+	ppe_scheduler_ready(priv);
 	ppe_debugfs_init(priv);
 
 	platform_set_drvdata(pdev, priv);
@@ -2630,6 +2631,7 @@ static int qca_ppe_probe(struct platform_device *pdev)
 
 err_acl:
 	ppe_acl_exit(priv);
+	ppe_scheduler_exit(priv);
 err_clk:
 	clk_bulk_disable_unprepare(priv->num_clks, priv->clks);
 	return ret;
@@ -2640,8 +2642,10 @@ static void qca_ppe_remove(struct platform_device *pdev)
 	struct qca_ppe_priv *priv = platform_get_drvdata(pdev);
 
 	ppe_debugfs_exit(priv);
+	ppe_scheduler_unready();
 	dsa_unregister_switch(&priv->ds);
 	ppe_acl_exit(priv);
+	ppe_scheduler_exit(priv);
 	clk_bulk_disable_unprepare(priv->num_clks, priv->clks);
 }
 

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -1623,6 +1623,11 @@ static const struct dsa_switch_ops qca_ppe_ops = {
 	.port_setup_tc		= qca_ppe_setup_tc,
 	.port_policer_add	= qca_ppe_port_policer_add,
 	.port_policer_del	= qca_ppe_port_policer_del,
+	.port_get_dscp_prio	= qca_ppe_port_get_dscp_prio,
+	.port_add_dscp_prio	= qca_ppe_port_add_dscp_prio,
+	.port_del_dscp_prio	= qca_ppe_port_del_dscp_prio,
+	.port_get_apptrust	= qca_ppe_port_get_apptrust,
+	.port_set_apptrust	= qca_ppe_port_set_apptrust,
 	.get_tag_protocol	= qca_ppe_get_tag_protocol,
 	.setup			= qca_ppe_setup,
 	.teardown		= qca_ppe_teardown,
@@ -1837,6 +1842,10 @@ static int qca_ppe_probe(struct platform_device *pdev)
 	ds->num_ports = data->num_ports;
 	ds->ops = &qca_ppe_ops;
 	ds->priv = priv;
+	/* The two DSCP tables are chosen between per port, not filled per port,
+	 * so every port shares one and DSA replicates an entry to all of them.
+	 */
+	ds->dscp_prio_mapping_is_global = true;
 	ds->phylink_mac_ops = &qca_ppe_phylink_mac_ops;
 
 	for (i = 1; i < data->num_ports; i++) {

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -2026,7 +2026,9 @@ static const struct regmap_config ppe_regmap_cfg = {
 
 static int qca_ppe_probe(struct platform_device *pdev)
 {
+	struct regmap_config regmap_cfg;
 	const struct ppe_data *data;
+	struct resource *res;
 	struct device_node *ports;
 	struct qca_ppe_priv *priv;
 	struct reset_control *rst;
@@ -2057,11 +2059,17 @@ static int qca_ppe_probe(struct platform_device *pdev)
 	if (ret)
 		return ret;
 
-	base = devm_platform_ioremap_resource(pdev, 0);
+	base = devm_platform_get_and_ioremap_resource(pdev, 0, &res);
 	if (IS_ERR(base))
 		return dev_err_probe(&pdev->dev, PTR_ERR(base), "failed to ioremap resource");
 
-	priv->regmap = devm_regmap_init_mmio(&pdev->dev, base, &ppe_regmap_cfg);
+	/* Bound the regmap by what is actually mapped: a register the window
+	 * does not cover is an -EIO rather than a fault on unmapped memory.
+	 */
+	regmap_cfg = ppe_regmap_cfg;
+	regmap_cfg.max_register = resource_size(res) - sizeof(u32);
+
+	priv->regmap = devm_regmap_init_mmio(&pdev->dev, base, &regmap_cfg);
 	if (IS_ERR(priv->regmap))
 		return dev_err_probe(&pdev->dev, PTR_ERR(priv->regmap), "failed to init regmap");
 
@@ -2132,7 +2140,6 @@ static int qca_ppe_probe(struct platform_device *pdev)
 	ppe_mac_hw_init(priv);
 	ppe_ctrlpkt_init(priv);
 
-
 	if (data->type == PPE_TYPE_IPQ6018) {
 		ret = ppe_ipq6018_mux_setup(priv);
 		if (ret)
@@ -2142,6 +2149,8 @@ static int qca_ppe_probe(struct platform_device *pdev)
 	ret = dsa_register_switch(ds);
 	if (ret)
 		goto err_clk;
+
+	ppe_debugfs_init(priv);
 
 	platform_set_drvdata(pdev, priv);
 
@@ -2156,6 +2165,7 @@ static void qca_ppe_remove(struct platform_device *pdev)
 {
 	struct qca_ppe_priv *priv = platform_get_drvdata(pdev);
 
+	ppe_debugfs_exit(priv);
 	dsa_unregister_switch(&priv->ds);
 	clk_bulk_disable_unprepare(priv->num_clks, priv->clks);
 }

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -2479,6 +2479,7 @@ static int ppe_ipq6018_mux_setup(struct qca_ppe_priv *priv)
 			continue;
 
 		port3_ch = pcs_args.args[0];
+		of_node_put(pcs_args.np);
 	}
 
 	of_node_put(ports_np);
@@ -2536,8 +2537,10 @@ static int qca_ppe_probe(struct platform_device *pdev)
 		return ret;
 
 	base = devm_platform_get_and_ioremap_resource(pdev, 0, &res);
-	if (IS_ERR(base))
-		return dev_err_probe(&pdev->dev, PTR_ERR(base), "failed to ioremap resource");
+	if (IS_ERR(base)) {
+		ret = dev_err_probe(&pdev->dev, PTR_ERR(base), "failed to ioremap resource");
+		goto err_clk;
+	}
 
 	/* Bound the regmap by what is actually mapped: a register the window
 	 * does not cover is an -EIO rather than a fault on unmapped memory.
@@ -2546,8 +2549,10 @@ static int qca_ppe_probe(struct platform_device *pdev)
 	regmap_cfg.max_register = resource_size(res) - sizeof(u32);
 
 	priv->regmap = devm_regmap_init_mmio(&pdev->dev, base, &regmap_cfg);
-	if (IS_ERR(priv->regmap))
-		return dev_err_probe(&pdev->dev, PTR_ERR(priv->regmap), "failed to init regmap");
+	if (IS_ERR(priv->regmap)) {
+		ret = dev_err_probe(&pdev->dev, PTR_ERR(priv->regmap), "failed to init regmap");
+		goto err_clk;
+	}
 
 	rst = devm_reset_control_get(&pdev->dev, "ppe_rst");
 	if (IS_ERR(rst)) {

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -202,6 +202,8 @@ int ppe_vsi_alloc(struct qca_ppe_priv *priv)
 {
 	int vsi;
 
+	lockdep_assert_held(&priv->vlan_lock);
+
 	vsi = find_first_zero_bit(priv->vsi_bitmap, PPE_VSI_MAX);
 	if (vsi >= PPE_VSI_MAX)
 		return -ENOSPC;
@@ -218,6 +220,8 @@ int ppe_vsi_alloc(struct qca_ppe_priv *priv)
 
 void ppe_vsi_free(struct qca_ppe_priv *priv, u32 vsi)
 {
+	lockdep_assert_held(&priv->vlan_lock);
+
 	regmap_write(priv->regmap, PPE_VSI_TBL(vsi), 0);
 	regmap_write(priv->regmap, PPE_VSI_TBL(vsi) + 4, 0);
 	priv->vsi_member[vsi] = 0;
@@ -868,6 +872,7 @@ static void bridge_vsi_put(struct qca_ppe_priv *priv,
 	if (bvsi->refcount > 0)
 		return;
 
+	ppe_flow_purge_vsi(priv, bvsi->vsi);
 	ppe_vsi_free(priv, bvsi->vsi);
 	bvsi->br_dev = NULL;
 	bvsi->vsi = 0;
@@ -897,6 +902,9 @@ static int qca_ppe_port_bridge_join(struct dsa_switch *ds, int port,
 	struct qca_ppe_priv *priv = ds_to_priv(ds);
 	struct qca_ppe_bridge_vsi *bvsi;
 
+	guard(mutex)(&priv->flow_lock);
+	guard(mutex)(&priv->vlan_lock);
+
 	bvsi = bridge_vsi_find(priv, bridge.dev);
 	if (!bvsi) {
 		bvsi = bridge_vsi_alloc(priv, bridge.dev);
@@ -919,6 +927,9 @@ static void qca_ppe_port_bridge_leave(struct dsa_switch *ds, int port,
 {
 	struct qca_ppe_priv *priv = ds_to_priv(ds);
 	struct qca_ppe_bridge_vsi *bvsi;
+
+	guard(mutex)(&priv->flow_lock);
+	guard(mutex)(&priv->vlan_lock);
 
 	bvsi = bridge_vsi_find(priv, bridge.dev);
 	if (!bvsi)
@@ -2810,15 +2821,19 @@ static int qca_ppe_probe(struct platform_device *pdev)
 	ppe_flow_init(priv);
 	ppe_acl_init(priv);
 
+	ret = ppe_flow_offload_init(priv);
+	if (ret)
+		goto err_acl;
+
 	if (data->type == PPE_TYPE_IPQ6018) {
 		ret = ppe_ipq6018_mux_setup(priv);
 		if (ret)
-			goto err_acl;
+			goto err_flow;
 	}
 
 	ret = dsa_register_switch(ds);
 	if (ret)
-		goto err_acl;
+		goto err_flow;
 
 	ppe_scheduler_ready(priv);
 	ppe_debugfs_init(priv);
@@ -2828,6 +2843,8 @@ static int qca_ppe_probe(struct platform_device *pdev)
 
 	return 0;
 
+err_flow:
+	ppe_flow_offload_exit(priv);
 err_acl:
 	ppe_acl_exit(priv);
 	ppe_scheduler_exit(priv);
@@ -2843,6 +2860,10 @@ static void qca_ppe_remove(struct platform_device *pdev)
 	ppe_debugfs_exit(priv);
 	ppe_scheduler_unready();
 	dsa_unregister_switch(&priv->ds);
+	/* After the switch is gone: unregistration flushes the flowtables, and
+	 * their FLOW_CLS_DESTROY commands have to find the table still alive.
+	 */
+	ppe_flow_offload_exit(priv);
 	ppe_acl_exit(priv);
 	ppe_scheduler_exit(priv);
 	clk_bulk_disable_unprepare(priv->num_clks, priv->clks);

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -502,6 +502,67 @@ qca_ppe_get_tag_protocol(struct dsa_switch *ds, int port,
 	return DSA_TAG_PROTO_OOB;
 }
 
+/* The classifier's table. The hardware counts none of its entries, so
+ * occupancy is the driver's own bookkeeping, which is what makes "the table
+ * was full" a number rather than an inference from the rule that was refused.
+ */
+enum ppe_devlink_resource_id {
+	PPE_RESOURCE_ACL = 1,
+};
+
+static u64 ppe_devlink_acl_occ(void *p)
+{
+	struct qca_ppe_priv *priv = p;
+	u64 free = 0;
+	u32 i;
+
+	guard(mutex)(&priv->acl_lock);
+
+	for (i = 0; i < PPE_ACL_LISTS; i++)
+		free += hweight8(priv->acl_free[i]);
+
+	return PPE_ACL_LISTS * PPE_ACL_LIST_ENTRIES - free;
+}
+
+static int ppe_devlink_resource(struct dsa_switch *ds, const char *name,
+				u64 size, u64 id,
+				devlink_resource_occ_get_t *occ)
+{
+	struct devlink_resource_size_params params;
+	int ret;
+
+	/* Silicon geometry: the only size the resource can ever have. */
+	devlink_resource_size_params_init(&params, size, size, 1,
+					  DEVLINK_RESOURCE_UNIT_ENTRY);
+
+	ret = dsa_devlink_resource_register(ds, name, size, id,
+					    DEVLINK_RESOURCE_ID_PARENT_TOP,
+					    &params);
+	if (ret)
+		return ret;
+
+	dsa_devlink_resource_occ_get_register(ds, id, occ, ds_to_priv(ds));
+
+	return 0;
+}
+
+static int ppe_devlink_setup(struct dsa_switch *ds)
+{
+	int ret;
+
+	ret = ppe_devlink_resource(ds, "acl",
+				   PPE_ACL_LISTS * PPE_ACL_LIST_ENTRIES,
+				   PPE_RESOURCE_ACL, ppe_devlink_acl_occ);
+	if (!ret)
+		ret = qca_ppe_devlink_sb_setup(ds);
+	if (ret)
+		dsa_devlink_resources_unregister(ds);
+
+	return ret;
+}
+
+}
+
 static int qca_ppe_setup(struct dsa_switch *ds)
 {
 	struct qca_ppe_priv *priv = ds_to_priv(ds);
@@ -589,7 +650,7 @@ static int qca_ppe_setup(struct dsa_switch *ds)
 
 	schedule_delayed_work(&priv->mib_work, PPE_MIB_FOLD_INTERVAL);
 
-	return 0;
+	return ppe_devlink_setup(ds);
 }
 
 static int qca_ppe_set_ageing_time(struct dsa_switch *ds, unsigned int msecs)
@@ -1732,6 +1793,90 @@ static void qca_ppe_teardown(struct dsa_switch *ds)
 	struct qca_ppe_priv *priv = ds_to_priv(ds);
 
 	cancel_delayed_work_sync(&priv->mib_work);
+	devlink_sb_unregister(ds->devlink, PPE_DEVLINK_SB);
+	dsa_devlink_resources_unregister(ds);
+}
+
+/* Everything the PPE holds about one port that a value can be read out of:
+ * where the L2 stage has it, what its VLAN stages do to a frame, the routing
+ * entry that carries its VSI, the policer that meters what arrives and the
+ * shaper that meters what leaves. The MAC window is deliberately absent - the
+ * counters in it are what ethtool -S already reports, and the rest of it
+ * depends on which of the two MACs the port is driving.
+ *
+ * A dump is address and value in pairs. It costs a word per register and buys
+ * a dump that can be read without this table in hand, and an insertion here
+ * that breaks nothing downstream.
+ */
+enum ppe_port_reg {
+	PPE_REG_CST_STATE,
+	PPE_REG_BRIDGE_CTRL,
+	PPE_REG_MIRROR,
+	PPE_REG_QOS_CTRL,
+	PPE_REG_MC_MTU_CTRL,
+	PPE_REG_MRU_MTU_CTRL_W0,
+	PPE_REG_MRU_MTU_CTRL_W1,
+	PPE_REG_DEF_VID,
+	PPE_REG_VLAN_CFG,
+	PPE_REG_EG_VLAN,
+	PPE_REG_VP_PORT_W0,
+	PPE_REG_VP_PORT_W1,
+	PPE_REG_VP_PORT_W2,
+	PPE_REG_METER_W0,
+	PPE_REG_METER_W1,
+	PPE_REG_METER_W2,
+	PPE_REG_METER_W3,
+	PPE_REG_SHP_CFG_W0,
+	PPE_REG_SHP_CFG_W1,
+	PPE_REG_COUNT,
+};
+
+/* Bumped if a register leaves this list or the pairing changes. */
+#define PPE_REGS_VERSION	1
+
+static int qca_ppe_get_regs_len(struct dsa_switch *ds, int port)
+{
+	return PPE_REG_COUNT * 2 * sizeof(u32);
+}
+
+static void qca_ppe_get_regs(struct dsa_switch *ds, int port,
+			     struct ethtool_regs *regs, void *_p)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	u32 off[PPE_REG_COUNT];
+	u32 mru, vp;
+	u32 *p = _p;
+	int i;
+
+	mru = PPE_MRU_MTU_CTRL(port, priv->data->mru_mtu_ctrl_stride);
+	vp = PPE_L3_VP_PORT_TBL(port);
+
+	off[PPE_REG_CST_STATE]		= PPE_CST_STATE(port);
+	off[PPE_REG_BRIDGE_CTRL]	= PPE_PORT_BRIDGE_CTRL(port);
+	off[PPE_REG_MIRROR]		= PPE_PORT_MIRROR(port);
+	off[PPE_REG_QOS_CTRL]		= PPE_PORT_QOS_CTRL(port);
+	off[PPE_REG_MC_MTU_CTRL]	= PPE_MC_MTU_CTRL(port);
+	off[PPE_REG_MRU_MTU_CTRL_W0]	= mru;
+	off[PPE_REG_MRU_MTU_CTRL_W1]	= mru + 0x4;
+	off[PPE_REG_DEF_VID]		= PPE_PORT_DEF_VID(port);
+	off[PPE_REG_VLAN_CFG]		= PPE_PORT_VLAN_CFG(port);
+	off[PPE_REG_EG_VLAN]		= PPE_PORT_EG_VLAN(port);
+	off[PPE_REG_VP_PORT_W0]		= vp;
+	off[PPE_REG_VP_PORT_W1]		= vp + 0x4;
+	off[PPE_REG_VP_PORT_W2]		= vp + 0x8;
+	off[PPE_REG_METER_W0]		= PPE_PORT_METER_W0(port);
+	off[PPE_REG_METER_W1]		= PPE_PORT_METER_W1(port);
+	off[PPE_REG_METER_W2]		= PPE_PORT_METER_W2(port);
+	off[PPE_REG_METER_W3]		= PPE_PORT_METER_W3(port);
+	off[PPE_REG_SHP_CFG_W0]		= PPE_TM_PSCH_SHP_CFG_W0(port);
+	off[PPE_REG_SHP_CFG_W1]		= PPE_TM_PSCH_SHP_CFG_W1(port);
+
+	regs->version = PPE_REGS_VERSION;
+
+	for (i = 0; i < PPE_REG_COUNT; i++) {
+		p[i * 2] = off[i];
+		regmap_read(priv->regmap, off[i], &p[i * 2 + 1]);
+	}
 }
 
 static void qca_ppe_port_stp_state_set(struct dsa_switch *ds, int port,
@@ -1945,6 +2090,10 @@ static const struct dsa_switch_ops qca_ppe_ops = {
 	.get_sset_count		= qca_ppe_get_sset_count,
 	.get_ethtool_stats	= qca_ppe_get_ethtool_stats,
 	.get_stats64		= qca_ppe_get_stats64,
+	.get_regs_len		= qca_ppe_get_regs_len,
+	.get_regs		= qca_ppe_get_regs,
+	.devlink_sb_pool_get	= qca_ppe_devlink_sb_pool_get,
+	.devlink_sb_pool_set	= qca_ppe_devlink_sb_pool_set,
 };
 
 static void ppe_mac_hw_init(struct qca_ppe_priv *priv)

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -514,7 +514,12 @@ static int ppe_fdb_lookup(struct qca_ppe_priv *priv,
 	regmap_read(priv->regmap, PPE_FDB_RD_RSLT_DATA1, &data1);
 	regmap_read(priv->regmap, PPE_FDB_RD_RSLT_DATA2, &data2);
 
-	if (!(data1 & PPE_FDB_DATA1_VALID)) {
+	/* The destination field of a unicast entry is a port number rather than
+	 * a member map, so an entry of the wrong type read back as one would
+	 * name a set of ports the group was never given.
+	 */
+	if (!(data1 & PPE_FDB_DATA1_VALID) ||
+	    FIELD_GET(PPE_FDB_DATA2_DST_TYPE, data2) != PPE_FDB_DST_PORTMAP) {
 		ret = -ENOENT;
 		goto out;
 	}

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -1450,7 +1450,11 @@ static void qca_ppe_mac_link_up(struct phylink_config *config,
 	struct dsa_port *dp = dsa_phylink_to_port(config);
 	struct qca_ppe_priv *priv = ds_to_priv(dp->ds);
 	int port = dp->index;
-	unsigned long rate;
+	/* Neither speed table below is exhaustive, and a speed outside the one
+	 * its interface lands in leaves the gigabit rate rather than whatever
+	 * the stack held.
+	 */
+	unsigned long rate = 125000000;
 
 	/* Invalid mode for port < 5 */
 	if ((interface == PHY_INTERFACE_MODE_2500BASEX ||
@@ -1540,7 +1544,6 @@ static void qca_ppe_mac_link_up(struct phylink_config *config,
 		}
 		break;
 	default:
-		rate = 125000000;
 		break;
 	}
 

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -1465,6 +1465,22 @@ static u64 ppe_mib_total(const struct qca_ppe_mib_stats *stats,
 	return 0;
 }
 
+/* One counter's banked total, for a reader outside this file. The fold is what
+ * makes the value survive a register wrap and a port changing MAC, so a caller
+ * that read the register directly would report a rate spike for either.
+ */
+u64 ppe_mib_read(struct qca_ppe_priv *priv, int port, unsigned int off)
+{
+	u64 total;
+
+	spin_lock_bh(&priv->mib_lock);
+	ppe_mib_fold(priv, port);
+	total = ppe_mib_total(ppe_port_mib(priv, port), off);
+	spin_unlock_bh(&priv->mib_lock);
+
+	return total;
+}
+
 static void ppe_mib_work(struct work_struct *work)
 {
 	struct qca_ppe_priv *priv = container_of(to_delayed_work(work),
@@ -1604,6 +1620,9 @@ static void qca_ppe_port_stp_state_set(struct dsa_switch *ds, int port,
 }
 
 static const struct dsa_switch_ops qca_ppe_ops = {
+	.port_setup_tc		= qca_ppe_setup_tc,
+	.port_policer_add	= qca_ppe_port_policer_add,
+	.port_policer_del	= qca_ppe_port_policer_del,
 	.get_tag_protocol	= qca_ppe_get_tag_protocol,
 	.setup			= qca_ppe_setup,
 	.teardown		= qca_ppe_teardown,

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_main.c
@@ -149,7 +149,7 @@ static void ppe_xgmac_link_up(struct qca_ppe_priv *priv, int port,
 
 	regmap_write_bits(priv->regmap, PPE_XGMAC_TX_FLOW_CTRL(xgmac),
 			  PPE_XGMAC_TX_FLOW_ENABLE,
-			  tx_pause ? PPE_XGMAC_RX_FLOW_ENABLE : 0);
+			  tx_pause ? PPE_XGMAC_TX_FLOW_ENABLE : 0);
 
 	regmap_write_bits(priv->regmap, PPE_XGMAC_RX_FLOW_CTRL(xgmac),
 			  PPE_XGMAC_RX_FLOW_ENABLE,

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
@@ -902,6 +902,77 @@ static void ppe_l0_scheduler_init(struct qca_ppe_priv *priv)
 	}
 }
 
+static void ppe_queues_gate(struct qca_ppe_priv *priv, u16 base, u8 count,
+			    bool en)
+{
+	int i;
+
+	for (i = 0; i < count; i++) {
+		regmap_write(priv->regmap, PPE_QM_ENQ_OPR(base + i),
+			     en ? 0 : PPE_ENQ_DISABLE);
+		regmap_write(priv->regmap, PPE_TM_DEQ_DIS(base + i),
+			     en ? 0 : PPE_DEQ_DIS);
+	}
+}
+
+/* The flush is refused unless the queue's enqueue is already stopped; the
+ * vendor stops its dequeue with it.
+ */
+static void ppe_queue_flush(struct qca_ppe_priv *priv, int port, u16 queue)
+{
+	u32 val;
+	int ret;
+
+	regmap_update_bits(priv->regmap, PPE_QM_FLUSH_CFG,
+			   PPE_FLUSH_QID | PPE_FLUSH_DST_PORT |
+			   PPE_FLUSH_ALL_QUEUES | PPE_FLUSH_BUSY,
+			   FIELD_PREP(PPE_FLUSH_QID, queue) |
+			   FIELD_PREP(PPE_FLUSH_DST_PORT, port) |
+			   PPE_FLUSH_BUSY);
+
+	ret = regmap_read_poll_timeout(priv->regmap, PPE_QM_FLUSH_CFG, val,
+				       !(val & PPE_FLUSH_BUSY), 10, 10000);
+	if (ret || !(val & PPE_FLUSH_STATUS))
+		dev_warn(priv->ds.dev, "port %d: queue %u did not flush\n",
+			 port, queue);
+}
+
+/* What a port that goes down leaves behind: the frames already queued for it
+ * stay charged to its admission group, and with the fabric gated nothing
+ * dequeues them. Stop each of the port's queues at both ends and flush it, and
+ * the buffers come back at once; port_enable is what reopens the gates.
+ */
+void ppe_port_queues_enable(struct qca_ppe_priv *priv, int port, bool en)
+{
+	const struct port_l0_params *p = NULL;
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(port_l0); i++)
+		if (port_l0[i].port == port)
+			p = &port_l0[i];
+	if (!p)
+		return;
+
+	ppe_queues_gate(priv, p->ucast_base, p->ucast_count, en);
+	ppe_queues_gate(priv, p->mcast_base, p->mcast_count, en);
+
+	if (en)
+		return;
+
+	/* The vendor drops the QM clock gate around its own flush to
+	 * accelerate it, and restores it after.
+	 */
+	regmap_clear_bits(priv->regmap, PPE_CLK_GATING_CTRL,
+			  PPE_QM_CLK_GATE_EN);
+
+	for (i = 0; i < p->ucast_count; i++)
+		ppe_queue_flush(priv, port, p->ucast_base + i);
+	for (i = 0; i < p->mcast_count; i++)
+		ppe_queue_flush(priv, port, p->mcast_base + i);
+
+	regmap_set_bits(priv->regmap, PPE_CLK_GATING_CTRL, PPE_QM_CLK_GATE_EN);
+}
+
 static void ppe_edma_ring_map_init(struct qca_ppe_priv *priv)
 {
 	int i;

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
@@ -607,6 +607,115 @@ static void ppe_qm_init(struct qca_ppe_priv *priv)
 			   PPE_EG_QUEUE_CNT_EN, PPE_EG_QUEUE_CNT_EN);
 }
 
+/* The two buffer accountings a frame passes. On ingress the buffer manager
+ * admits it against one of four shared groups, on egress the queue manager
+ * holds it against one of four admission control groups, and both count in
+ * PPE_BM_BUF_SIZE buffers. Those eight groups are the devlink pools, ingress
+ * first: their limits are what the two inits above write once at probe, and
+ * until now neither could be read back, let alone moved, without a rebuild.
+ *
+ * Nothing else in devlink's shared buffer model fits this hardware. A per-port
+ * threshold would have to name the BM port a switch port sits behind, and the
+ * vendor says two contradictory things about that - its own init treats BM
+ * ports 8 to 13 as the physical ones, while its per-port counter API indexes
+ * the very same tables with the switch port number. Occupancy is reported by
+ * devlink as a current and a maximum together and this hardware keeps no
+ * watermark, so the live counts the debugfs `bm` and `queues` files already
+ * read are the current half and there is no honest second half.
+ */
+int qca_ppe_devlink_sb_setup(struct dsa_switch *ds)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+
+	/* The queue manager's group limit is what the vendor calls the total
+	 * buffer number, and no source states the buffer memory any other way.
+	 */
+	return devlink_sb_register(ds->devlink, PPE_DEVLINK_SB,
+				   priv->data->qm_total_buf * PPE_BM_BUF_SIZE,
+				   PPE_BM_SHARED_GROUPS,
+				   FIELD_MAX(PPE_AC_GRP_ID) + 1, 0, 0);
+}
+
+int qca_ppe_devlink_sb_pool_get(struct dsa_switch *ds, unsigned int sb_index,
+				u16 pool_index,
+				struct devlink_sb_pool_info *pool_info)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	u32 val;
+
+	if (pool_index < PPE_BM_SHARED_GROUPS) {
+		regmap_read(priv->regmap, PPE_BM_SHARED_GRP(pool_index), &val);
+		val = FIELD_GET(PPE_BM_SHARED_LIMIT, val);
+		pool_info->pool_type = DEVLINK_SB_POOL_TYPE_INGRESS;
+	} else {
+		regmap_read(priv->regmap,
+			    PPE_QM_AC_GRP_W1(pool_index -
+					     PPE_BM_SHARED_GROUPS), &val);
+		val = FIELD_GET(PPE_AC_GRP_LIMIT, val);
+		pool_info->pool_type = DEVLINK_SB_POOL_TYPE_EGRESS;
+	}
+
+	pool_info->size = val * PPE_BM_BUF_SIZE;
+	pool_info->cell_size = PPE_BM_BUF_SIZE;
+	/* What both blocks give a member of a group at probe. The queue
+	 * manager swaps a shaped port's queues to a ceiling of their own,
+	 * which is a per queue property this per pool field cannot carry.
+	 */
+	pool_info->threshold_type = DEVLINK_SB_THRESHOLD_TYPE_DYNAMIC;
+
+	return 0;
+}
+
+int qca_ppe_devlink_sb_pool_set(struct dsa_switch *ds, unsigned int sb_index,
+				u16 pool_index, u32 size,
+				enum devlink_sb_threshold_type threshold_type,
+				struct netlink_ext_ack *extack)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	u32 bufs = DIV_ROUND_UP(size, PPE_BM_BUF_SIZE);
+	u32 w[PPE_AC_GRP_WORDS];
+
+	if (threshold_type != DEVLINK_SB_THRESHOLD_TYPE_DYNAMIC) {
+		NL_SET_ERR_MSG_MOD(extack, "a group is shared dynamically or not at all");
+		return -EOPNOTSUPP;
+	}
+
+	if (pool_index < PPE_BM_SHARED_GROUPS) {
+		if (bufs > FIELD_MAX(PPE_BM_SHARED_LIMIT)) {
+			NL_SET_ERR_MSG_MOD(extack, "larger than the buffer manager's group limit field");
+			return -EINVAL;
+		}
+
+		regmap_write(priv->regmap, PPE_BM_SHARED_GRP(pool_index),
+			     FIELD_PREP(PPE_BM_SHARED_LIMIT, bufs));
+
+		return 0;
+	}
+
+	pool_index -= PPE_BM_SHARED_GROUPS;
+
+	if (bufs > FIELD_MAX(PPE_AC_GRP_LIMIT)) {
+		NL_SET_ERR_MSG_MOD(extack, "larger than the queue manager's group limit field");
+		return -EINVAL;
+	}
+
+	/* The group entry takes effect on the write to its last word, so the
+	 * whole entry goes back with only its limit changed.
+	 */
+	if (regmap_bulk_read(priv->regmap, PPE_QM_AC_GRP_W0(pool_index), w,
+			     ARRAY_SIZE(w)))
+		return -EIO;
+
+	w[1] &= ~PPE_AC_GRP_LIMIT;
+	w[1] |= FIELD_PREP(PPE_AC_GRP_LIMIT, bufs);
+
+	regmap_write(priv->regmap, PPE_QM_AC_GRP_W0(pool_index), w[0]);
+	regmap_write(priv->regmap, PPE_QM_AC_GRP_W1(pool_index), w[1]);
+	regmap_write(priv->regmap, PPE_QM_AC_GRP_W2(pool_index), w[2]);
+
+	return 0;
+}
+
 struct l1_cfg {
 	u8 index;
 	u8 port;

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
@@ -736,23 +736,25 @@ static void ppe_edma_ring_map_init(struct qca_ppe_priv *priv)
 	regmap_write(priv->regmap, PPE_TM_RING_Q_MAP(2) + 4 * 4, 0xffff);
 }
 
+/* Which classifier's internal priority wins when several offer one: the flow
+ * table first, then the CPU preheader, ACL, DSCP and last a VLAN's PCP.
+ */
 static void ppe_qos_init(struct qca_ppe_priv *priv)
 {
+	u32 prec;
 	int i;
-	u32 qos_bits;
 
-	qos_bits = FIELD_PREP(PPE_QOS_PREHEADER_PREC, 3) |
-		   FIELD_PREP(PPE_QOS_DSCP_PREC, 1) |
-		   FIELD_PREP(PPE_QOS_FLOW_PREC, 4) |
-		   FIELD_PREP(PPE_QOS_ACL_PREC, 2);
+	prec = FIELD_PREP(PPE_QOS_FLOW_PREC, 4) |
+	       FIELD_PREP(PPE_QOS_PREHEADER_PREC, 3) |
+	       FIELD_PREP(PPE_QOS_ACL_PREC, 2) |
+	       FIELD_PREP(PPE_QOS_DSCP_PREC, 1) |
+	       FIELD_PREP(PPE_QOS_PCP_PREC, 0);
 
 	for (i = 0; i < PPE_NUM_PORTS; i++)
-		regmap_update_bits(priv->regmap, PPE_PRX_MRU_MTU_W1(i),
-				   PPE_QOS_PCP_GRP | PPE_QOS_DSCP_GRP |
-				   PPE_QOS_PREHEADER_PREC | PPE_QOS_PCP_PREC |
-				   PPE_QOS_DSCP_PREC | PPE_QOS_FLOW_PREC |
-				   PPE_QOS_ACL_PREC,
-				   qos_bits);
+		regmap_update_bits(priv->regmap, PPE_PORT_QOS_CTRL(i),
+				   PPE_QOS_DSCP_PREC | PPE_QOS_PCP_PREC |
+				   PPE_QOS_PREHEADER_PREC | PPE_QOS_FLOW_PREC |
+				   PPE_QOS_ACL_PREC, prec);
 }
 
 const struct psch_tdm_data cppe_psch_tdm_data = {

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
@@ -1999,6 +1999,8 @@ int qca_ppe_setup_tc(struct dsa_switch *ds, int port, enum tc_setup_type type,
 	struct qca_ppe_priv *priv = ds_to_priv(ds);
 
 	switch (type) {
+	case TC_SETUP_FT:
+		return ppe_setup_ft_block(priv, type_data);
 	case TC_SETUP_QDISC_TBF:
 		return qca_ppe_setup_tc_tbf(priv, port, type_data);
 	case TC_SETUP_QDISC_ETS:

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
@@ -491,37 +491,30 @@ static void ppe_qm_init(struct qca_ppe_priv *priv)
 
 	for (i = 0; i < PPE_NUM_PORTS; i++) {
 		for (pri = 0; pri < 16; pri++) {
-			/* Two bands per port plus, on a user port, the queues
-			 * of the second scheduler node. On a user port the
-			 * hash offset is added to the class for every packet,
-			 * so a class must be as wide as the spread or the
-			 * smear crosses into the next; the CPU port is given
-			 * no spread, so its two are adjacent. Either way
-			 * l0_port0[] and ppe_l0_scheduler_init() have already
-			 * put the second band a strict priority above the
-			 * first, which is what the small-frame classifier in
-			 * the ACL needs to be worth anything: without it every
-			 * priority shares one queue, and a frame on its way to
-			 * a Wi-Fi client waits behind whatever bulk that queue
-			 * is holding.
+			/* Three bands per port. On a user port the hash offset
+			 * is added to the class for every packet, so a class
+			 * must be as wide as the spread or the smear crosses
+			 * into the next, and the third band is the second
+			 * scheduler node's queues; the CPU port is given no
+			 * spread, so its three are its first three queues.
+			 * Either way l0_port0[] and ppe_l0_scheduler_init()
+			 * have already put each band a strict priority above
+			 * the one below, which is what the small-frame
+			 * classifier in the ACL needs to be worth anything:
+			 * without it every priority shares one queue, and a
+			 * frame on its way to a Wi-Fi client waits behind
+			 * whatever bulk that queue is holding.
 			 *
-			 * Priorities eight and up select the second node's
-			 * queues. No classifier resolves there on its own -
-			 * the DSCP and PCP tables map below eight unless told
-			 * otherwise - so the node carries exactly the traffic
-			 * a rule names into it, and a shaper on the node then
-			 * governs that traffic and nothing else. The CPU port
-			 * has no second node built and folds these priorities
-			 * to best effort.
+			 * Priorities eight and up select the third band. No
+			 * classifier resolves there on its own - the DSCP and
+			 * PCP tables map below eight unless told otherwise -
+			 * so the band carries exactly the traffic a rule names
+			 * into it, and a shaper on it then governs that
+			 * traffic and nothing else: the node's on a user port,
+			 * the queue's own on the CPU port (cpu_port_rate).
 			 */
-			u8 cls;
-
-			if (pri < PPE_FLOW_SPREAD_QUEUES)
-				cls = 0;
-			else if (pri < 2 * PPE_FLOW_SPREAD_QUEUES)
-				cls = i ? PPE_FLOW_SPREAD_QUEUES : 1;
-			else
-				cls = i ? 2 * PPE_FLOW_SPREAD_QUEUES : 0;
+			u8 cls = min(pri / PPE_FLOW_SPREAD_QUEUES, 2) *
+				 (i ? PPE_FLOW_SPREAD_QUEUES : 1);
 
 			if (i) {
 				regmap_write(priv->regmap,
@@ -1261,8 +1254,13 @@ static u32 ppe_port_frame_len(struct qca_ppe_priv *priv, int port)
  */
 #define PPE_AC_MIN_FRAMES	8
 
+/* The CPU port's third band: the queue priorities eight and up select there
+ * (ppe_qm_init()), and the one cpu_port_rate shapes.
+ */
+#define PPE_CPU_PORT_DL_QUEUE	2
+
 static u32 ppe_ac_uni_static(struct qca_ppe_priv *priv, int port, u64 rate_bps,
-			     u32 limit)
+			     u32 limit, u32 ceiling)
 {
 	u32 bufs, min_bufs;
 
@@ -1276,7 +1274,7 @@ static u32 ppe_ac_uni_static(struct qca_ppe_priv *priv, int port, u64 rate_bps,
 				 BITS_PER_BYTE * PPE_BM_BUF_SIZE *
 				 (u64)USEC_PER_SEC);
 
-	bufs = clamp_t(u32, bufs, min_bufs, priv->data->qm_ceiling);
+	bufs = clamp_t(u32, bufs, min_bufs, ceiling);
 
 	return PPE_AC_EN | PPE_AC_FORCE_AC_EN |
 	       FIELD_PREP(PPE_AC_SHARED_WEIGHT, 4) |
@@ -1299,15 +1297,38 @@ static void ppe_port_queue_limit_set(struct qca_ppe_priv *priv, int port)
 	u32 w0;
 	int i;
 
+	/* A user port's download band is four hash queues, each at the
+	 * ceiling; the CPU port's is one queue, so it takes the four's worth.
+	 */
+	w0 = sh->rate_bps ? ppe_ac_uni_static(priv, port, sh->rate_bps,
+					      sh->limit,
+					      port == QCA_PPE_CPU_PORT ?
+					      PPE_FLOW_SPREAD_QUEUES *
+					      priv->data->qm_ceiling :
+					      priv->data->qm_ceiling) :
+			    ppe_ac_uni_default(priv);
+
+	/* The CPU port owns every queue below the first user port's base, and it
+	 * is not in the table below because the driver does not build its
+	 * scheduler. Its admission entries are still ours to size: the queue
+	 * cpu_port_rate shapes is a bottleneck the way a shaped port is, and
+	 * without this it keeps the dynamic limit every queue is probed with -
+	 * which the comment above this function explains does not bind.
+	 */
+	if (port == QCA_PPE_CPU_PORT) {
+		u32 def = ppe_ac_uni_default(priv);
+
+		for (i = 0; i < port_l0[0].ucast_base; i++)
+			ppe_ac_uni_write(priv, i,
+					 i == PPE_CPU_PORT_DL_QUEUE ? w0 : def);
+		return;
+	}
+
 	for (i = 0; i < ARRAY_SIZE(port_l0); i++)
 		if (port_l0[i].port == port)
 			p = &port_l0[i];
 	if (!p)
 		return;
-
-	w0 = sh->rate_bps ? ppe_ac_uni_static(priv, port, sh->rate_bps,
-					      sh->limit) :
-			    ppe_ac_uni_default(priv);
 
 	for (i = 0; i < p->ucast_count; i++) {
 		u64 rate = i < ARRAY_SIZE(sh->queue_rate) ? sh->queue_rate[i] : 0;
@@ -1323,7 +1344,8 @@ static void ppe_port_queue_limit_set(struct qca_ppe_priv *priv, int port)
 		if (rate)
 			w = ppe_ac_uni_static(priv, port, rate,
 					      div_u64(rate * 10,
-						      BITS_PER_BYTE * 1000));
+						      BITS_PER_BYTE * 1000),
+					      priv->data->qm_ceiling);
 		else if (sh->rate_bps && i < 3 * PPE_FLOW_SPREAD_QUEUES)
 			/* A band bucket holds a share of the flows and drains
 			 * at no less than its share of the port, so it takes
@@ -1332,7 +1354,8 @@ static void ppe_port_queue_limit_set(struct qca_ppe_priv *priv, int port)
 			 */
 			w = ppe_ac_uni_static(priv, port, sh->rate_bps,
 					      sh->limit /
-					      PPE_FLOW_SPREAD_QUEUES);
+					      PPE_FLOW_SPREAD_QUEUES,
+					      priv->data->qm_ceiling);
 
 		ppe_ac_uni_write(priv, p->ucast_base + i, w);
 	}
@@ -1546,8 +1569,8 @@ static void ppe_port_shaper_stats(struct qca_ppe_priv *priv, int port,
  * line rate with its committed credit pegged negative. A single rate is both
  * buckets - the rate in the committed one and the excess one armed empty.
  */
-static int ppe_node_shaper_set(struct qca_ppe_priv *priv, int port, u32 cfg,
-			       u32 credit, u32 slot, u64 rate_bps)
+static int ppe_node_shaper_set(struct qca_ppe_priv *priv, u32 cfg, u32 credit,
+			       u32 slot, u64 rate_bps, u32 burst)
 {
 	u32 cir = 0, cbs = 0;
 	unsigned long clk;
@@ -1558,12 +1581,7 @@ static int ppe_node_shaper_set(struct qca_ppe_priv *priv, int port, u32 cfg,
 		if (!clk)
 			return -ENODEV;
 
-		/* A bucket that cannot hold one full frame stalls the node, so
-		 * the burst is a frame of whatever size the port carries rather
-		 * than something to configure.
-		 */
-		sel = ppe_token_bucket(clk, slot, rate_bps,
-				       ppe_port_frame_len(priv, port),
+		sel = ppe_token_bucket(clk, slot, rate_bps, burst,
 				       FIELD_MAX(PPE_SHP_CIR),
 				       FIELD_MAX(PPE_SHP_CBS), &cir, &cbs);
 		if (sel < 0)
@@ -1605,15 +1623,14 @@ static void ppe_port_shapers_clear(struct qca_ppe_priv *priv,
 	int i, node;
 
 	for (i = 0; i < p->ucast_count; i++)
-		ppe_node_shaper_set(priv, p->port,
-				    PPE_TM_L0_SHP_CFG(p->ucast_base + i),
+		ppe_node_shaper_set(priv, PPE_TM_L0_SHP_CFG(p->ucast_base + i),
 				    PPE_TM_L0_SHP_CREDIT(p->ucast_base + i),
-				    PPE_L0_SHAPER_SLOT, 0);
+				    PPE_L0_SHAPER_SLOT, 0, 0);
 
 	for (i = 0; (node = ppe_l1_node(p->port, i)) >= 0; i++)
-		ppe_node_shaper_set(priv, p->port, PPE_TM_L1_SHP_CFG(node),
+		ppe_node_shaper_set(priv, PPE_TM_L1_SHP_CFG(node),
 				    PPE_TM_L1_SHP_CREDIT(node),
-				    PPE_L1_SHAPER_SLOT, 0);
+				    PPE_L1_SHAPER_SLOT, 0, 0);
 
 	memset(sh->queue_rate, 0, sizeof(sh->queue_rate));
 	ppe_port_queue_limit_set(priv, p->port);
@@ -1747,8 +1764,13 @@ int qca_ppe_setup_tc_mqprio(struct qca_ppe_priv *priv, int port,
 		if (!prog[tc].rate_bps)
 			continue;
 
-		ppe_node_shaper_set(priv, port, prog[tc].cfg, prog[tc].credit,
-				    prog[tc].slot, prog[tc].rate_bps);
+		/* A bucket that cannot hold one full frame stalls the node, and
+		 * a port drains its queues as fast as they fill, so a frame is
+		 * all the burst a class needs.
+		 */
+		ppe_node_shaper_set(priv, prog[tc].cfg, prog[tc].credit,
+				    prog[tc].slot, prog[tc].rate_bps,
+				    ppe_port_frame_len(priv, port));
 
 		for (i = q->offset[tc]; i < q->offset[tc] + q->count[tc]; i++)
 			priv->shaper[port].queue_rate[i] = prog[tc].rate_bps;
@@ -2041,6 +2063,99 @@ static void ppe_rss_hash_init(struct qca_ppe_priv *priv)
 		regmap_write(priv->regmap, PPE_RSS_HASH_FIN_IPV4(i), fin[i]);
 }
 
+/* The port every packet on its way to the host leaves by, and the only one with
+ * no netdev of its own: DSA gives a qdisc to the user ports and nothing to this
+ * one, so neither a tbf nor an mqprio can name it. A frame bound for a Wi-Fi
+ * client leaves here, which makes this the only queue in the switch that can
+ * hold that traffic - a meter on the arriving port is the alternative, and a
+ * meter drops where this delays.
+ *
+ * What is shaped is the port's third band, the queue priorities eight and up
+ * select (ppe_qm_init()): the traffic a rule marks into it, which is a routed
+ * download when the rule is on the uplink, and nothing else. A bridged
+ * transfer to a Wi-Fi client crosses this port unmarked and is not held.
+ */
+static struct qca_ppe_priv *ppe_sched_priv;
+static uint ppe_cpu_port_rate;
+
+static int ppe_cpu_port_dl_set(struct qca_ppe_priv *priv, u64 rate_bps)
+{
+	struct ppe_port_shaper *sh = &priv->shaper[QCA_PPE_CPU_PORT];
+	u32 depth = div_u64(rate_bps * 10, BITS_PER_BYTE * 1000);
+	int ret;
+
+	/* A user port's queue depth comes from its tbf limit. Nothing can put a
+	 * tbf on this port, so the depth is the driver's to choose, and it is
+	 * chosen the same way: ten milliseconds of the rate, which
+	 * ppe_port_queue_limit_set() then clamps to the four queues' worth of
+	 * admission a user port's download band gets. One millisecond - what a
+	 * shaped port falls back to with no limit - is too shallow to hold a
+	 * flow at the rate it was shaped to.
+	 *
+	 * The burst is the same ten milliseconds, and unlike a user port's
+	 * class it cannot be a frame: this port drains only as fast as the
+	 * host takes frames off the ring, and a bucket of one frame forgets
+	 * every token that accrues between two of the host's visits.
+	 */
+	ret = ppe_node_shaper_set(priv, PPE_TM_L0_SHP_CFG(PPE_CPU_PORT_DL_QUEUE),
+				  PPE_TM_L0_SHP_CREDIT(PPE_CPU_PORT_DL_QUEUE),
+				  PPE_L0_SHAPER_SLOT, rate_bps, depth);
+	if (ret)
+		return ret;
+
+	sh->rate_bps = rate_bps;
+	sh->limit = depth;
+	ppe_port_queue_limit_set(priv, QCA_PPE_CPU_PORT);
+
+	return 0;
+}
+
+static int ppe_cpu_port_rate_apply(struct qca_ppe_priv *priv)
+{
+	return ppe_cpu_port_dl_set(priv, (u64)ppe_cpu_port_rate * 1000);
+}
+
+static int ppe_cpu_port_rate_set(const char *val,
+				 const struct kernel_param *kp)
+{
+	int ret = param_set_uint(val, kp);
+
+	if (ret || !ppe_sched_priv)
+		return ret;
+
+	return ppe_cpu_port_rate_apply(ppe_sched_priv);
+}
+
+static const struct kernel_param_ops ppe_cpu_port_rate_ops = {
+	.set = ppe_cpu_port_rate_set,
+	.get = param_get_uint,
+};
+
+module_param_cb(cpu_port_rate, &ppe_cpu_port_rate_ops, &ppe_cpu_port_rate,
+		0644);
+MODULE_PARM_DESC(cpu_port_rate,
+		 "Shape the download band of the port the host is behind, in kbit/s (0 disables)");
+
+/* The parameter writer reaches this driver through the global above and ends in
+ * dsa_to_port(), so the global has to be gone before the switch is
+ * unregistered, not merely before the teardown below. The parameter lock is
+ * held across a whole set, so clearing it under that lock lets a writer already
+ * inside finish first - the same ordering ppe_acl_exit() needs for its own
+ * global.
+ */
+void ppe_scheduler_unready(void)
+{
+	kernel_param_lock(THIS_MODULE);
+	ppe_sched_priv = NULL;
+	kernel_param_unlock(THIS_MODULE);
+}
+
+/* The shaper goes with the driver, so the switch is left the way it was found. */
+void ppe_scheduler_exit(struct qca_ppe_priv *priv)
+{
+	ppe_cpu_port_dl_set(priv, 0);
+}
+
 void ppe_scheduler_init(struct qca_ppe_priv *priv)
 {
 	ppe_tdm_init(priv);
@@ -2052,4 +2167,18 @@ void ppe_scheduler_init(struct qca_ppe_priv *priv)
 	ppe_edma_ring_map_init(priv);
 	ppe_qos_init(priv);
 	ppe_rate_limit_init(priv);
+}
+
+/* The parameter setter reaches the hardware through the global above, and its
+ * path ends in dsa_to_port(), so the global cannot be published before the
+ * switch is registered. A rate handed in at load time is applied here instead,
+ * the way ppe_acl_init() applies its own.
+ */
+void ppe_scheduler_ready(struct qca_ppe_priv *priv)
+{
+	kernel_param_lock(THIS_MODULE);
+	ppe_sched_priv = priv;
+	if (ppe_cpu_port_rate)
+		ppe_cpu_port_rate_apply(priv);
+	kernel_param_unlock(THIS_MODULE);
 }

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
@@ -1003,15 +1003,6 @@ static int ppe_token_bucket(unsigned long clk, u32 slot, u64 rate_bps,
 	return -ERANGE;
 }
 
-/* A shaped port is the bottleneck by construction, so the standing queue lives
- * on its queues. Left as every queue is configured at probe - a dynamic limit
- * clamped at the SoC's ceiling, whose overrun asserts flow control rather than
- * dropping - the queue settles wherever the dynamic limit lands and the ceiling
- * has no effect at all: measured on IPQ8074 it holds around 250 buffers at any
- * ceiling from 400 down to 48. Enforcing the limit by dropping is what makes it
- * bind, and a limit worth binding at is one millisecond of the rate the shaper
- * was just given.
- */
 /* What one full frame costs on the wire for this port, which is what a token
  * bucket has to be able to hold and what a queue's floor is counted in.
  */
@@ -1031,6 +1022,37 @@ static u32 ppe_port_frame_len(struct qca_ppe_priv *priv, int port)
  */
 #define PPE_AC_MIN_FRAMES	8
 
+static u32 ppe_ac_uni_static(struct qca_ppe_priv *priv, int port, u64 rate_bps,
+			     u32 limit)
+{
+	u32 bufs, min_bufs;
+
+	min_bufs = DIV_ROUND_UP(ppe_port_frame_len(priv, port) *
+				PPE_AC_MIN_FRAMES, PPE_BM_BUF_SIZE);
+
+	if (limit)
+		bufs = limit / PPE_BM_BUF_SIZE;
+	else
+		bufs = div64_u64(rate_bps * PPE_AC_TARGET_US,
+				 BITS_PER_BYTE * PPE_BM_BUF_SIZE *
+				 (u64)USEC_PER_SEC);
+
+	bufs = clamp_t(u32, bufs, min_bufs, priv->data->qm_ceiling);
+
+	return PPE_AC_EN | PPE_AC_FORCE_AC_EN |
+	       FIELD_PREP(PPE_AC_SHARED_WEIGHT, 4) |
+	       FIELD_PREP(PPE_AC_SHARED_CEILING, bufs);
+}
+
+/* A shaped port is the bottleneck by construction, so the standing queue lives
+ * on its queues. Left as every queue is configured at probe - a dynamic limit
+ * clamped at the SoC's ceiling, whose overrun asserts flow control rather than
+ * dropping - the queue settles wherever the dynamic limit lands and the ceiling
+ * has no effect at all: measured on IPQ8074 it holds around 250 buffers at any
+ * ceiling from 400 down to 48. Enforcing the limit by dropping is what makes it
+ * bind, and a limit worth binding at is one millisecond of the rate the shaper
+ * was just given.
+ */
 static void ppe_port_queue_limit_set(struct qca_ppe_priv *priv, int port)
 {
 	struct ppe_port_shaper *sh = &priv->shaper[port];
@@ -1044,29 +1066,27 @@ static void ppe_port_queue_limit_set(struct qca_ppe_priv *priv, int port)
 	if (!p)
 		return;
 
-	if (sh->rate_bps) {
-		u32 bufs, min_bufs;
+	w0 = sh->rate_bps ? ppe_ac_uni_static(priv, port, sh->rate_bps,
+					      sh->limit) :
+			    ppe_ac_uni_default(priv);
 
-		min_bufs = DIV_ROUND_UP(ppe_port_frame_len(priv, port) *
-					PPE_AC_MIN_FRAMES, PPE_BM_BUF_SIZE);
+	for (i = 0; i < p->ucast_count; i++) {
+		u64 rate = i < ARRAY_SIZE(sh->queue_rate) ? sh->queue_rate[i] : 0;
 
-		if (sh->limit)
-			bufs = sh->limit / PPE_BM_BUF_SIZE;
-		else
-			bufs = div64_u64(sh->rate_bps * PPE_AC_TARGET_US,
-					 BITS_PER_BYTE * PPE_BM_BUF_SIZE *
-					 (u64)USEC_PER_SEC);
-
-		bufs = clamp_t(u32, bufs, min_bufs, priv->data->qm_ceiling);
-		w0 = PPE_AC_EN | PPE_AC_FORCE_AC_EN |
-		     FIELD_PREP(PPE_AC_SHARED_WEIGHT, 4) |
-		     FIELD_PREP(PPE_AC_SHARED_CEILING, bufs);
-	} else {
-		w0 = ppe_ac_uni_default(priv);
+		/* A queue given a ceiling of its own is a bottleneck the same
+		 * way a shaped port is, and a tighter one, so the standing
+		 * queue forms there and is sized from that rate instead: ten
+		 * milliseconds of it, as the port the host is behind is
+		 * given, because a millisecond is too shallow to hold one
+		 * flow at the rate.
+		 */
+		ppe_ac_uni_write(priv, p->ucast_base + i,
+				 rate ? ppe_ac_uni_static(priv, port, rate,
+							  div_u64(rate * 10,
+								  BITS_PER_BYTE *
+								  1000)) :
+					w0);
 	}
-
-	for (i = 0; i < p->ucast_count; i++)
-		ppe_ac_uni_write(priv, p->ucast_base + i, w0);
 }
 
 /* A rate of zero takes the shaper down. Its credit goes with it: a bucket left
@@ -1251,6 +1271,259 @@ static void ppe_port_shaper_stats(struct qca_ppe_priv *priv, int port,
 	sh->base_drops = drops;
 }
 
+/* The port scheduler serves the port's queues strictly, so a class that never
+ * runs dry starves every class below it, and the only thing on this silicon
+ * that can bound one is a shaper on the scheduler node the class hangs off.
+ * mqprio is where a class names a rate, and it names the queues the class
+ * spans as well, which is the choice the hardware offers: a class of one queue
+ * is that queue's own L0 node, and a class spanning every queue an L1 node
+ * serves is that node. Both at once is a tree, which is what htb offload is
+ * for, and nothing here has asked for one.
+ */
+#define PPE_L0_SHAPER_SLOT	300
+#define PPE_L1_SHAPER_SLOT	64
+
+/* A node offers its parent two inputs, committed and excess, and arming the
+ * committed bucket alone is not a rate: the excess input carries whatever the
+ * committed bucket refuses, unmetered, at the same priority, so the node passes
+ * line rate with its committed credit pegged negative. A single rate is both
+ * buckets - the rate in the committed one and the excess one armed empty.
+ */
+static int ppe_node_shaper_set(struct qca_ppe_priv *priv, int port, u32 cfg,
+			       u32 credit, u32 slot, u64 rate_bps)
+{
+	u32 cir = 0, cbs = 0;
+	unsigned long clk;
+	int sel = 0;
+
+	if (rate_bps) {
+		clk = ppe_clk_rate(priv);
+		if (!clk)
+			return -ENODEV;
+
+		/* A bucket that cannot hold one full frame stalls the node, so
+		 * the burst is a frame of whatever size the port carries rather
+		 * than something to configure.
+		 */
+		sel = ppe_token_bucket(clk, slot, rate_bps,
+				       ppe_port_frame_len(priv, port),
+				       FIELD_MAX(PPE_SHP_CIR),
+				       FIELD_MAX(PPE_SHP_CBS), &cir, &cbs);
+		if (sel < 0)
+			return sel;
+	}
+
+	regmap_write(priv->regmap, cfg,
+		     FIELD_PREP(PPE_SHP_CIR, cir) |
+		     FIELD_PREP(PPE_SHP_CBS, cbs));
+	regmap_write(priv->regmap, cfg + 0x4, 0);
+	regmap_write(priv->regmap, cfg + 0x8,
+		     FIELD_PREP(PPE_SHP_TOKEN_UNIT, sel) |
+		     (rate_bps ? PPE_SHP_C_EN | PPE_SHP_E_EN : 0));
+
+	/* Credit outlives the rate that filled it, and a bucket left negative
+	 * holds the node off until the new rate has refilled it.
+	 */
+	regmap_write(priv->regmap, credit, 0);
+	regmap_write(priv->regmap, credit + 0x4, 0);
+
+	return 0;
+}
+
+static int ppe_l1_node(int port, u8 group)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(l1_cfg); i++)
+		if (l1_cfg[i].port == port && l1_cfg[i].pri == group)
+			return l1_cfg[i].index;
+
+	return -ENOENT;
+}
+
+static void ppe_port_shapers_clear(struct qca_ppe_priv *priv,
+				   const struct port_l0_params *p)
+{
+	struct ppe_port_shaper *sh = &priv->shaper[p->port];
+	int i, node;
+
+	for (i = 0; i < p->ucast_count; i++)
+		ppe_node_shaper_set(priv, p->port,
+				    PPE_TM_L0_SHP_CFG(p->ucast_base + i),
+				    PPE_TM_L0_SHP_CREDIT(p->ucast_base + i),
+				    PPE_L0_SHAPER_SLOT, 0);
+
+	for (i = 0; (node = ppe_l1_node(p->port, i)) >= 0; i++)
+		ppe_node_shaper_set(priv, p->port, PPE_TM_L1_SHP_CFG(node),
+				    PPE_TM_L1_SHP_CREDIT(node),
+				    PPE_L1_SHAPER_SLOT, 0);
+
+	memset(sh->queue_rate, 0, sizeof(sh->queue_rate));
+	ppe_port_queue_limit_set(priv, p->port);
+}
+
+/* Where a class's rate goes: one queue's own node, or the node a whole group of
+ * them hangs off. Nothing is programmed from here - the caller wants every
+ * class checked before any of them is committed.
+ */
+static int ppe_class_node(int port, u16 base, u16 offset, u16 count,
+			  struct ppe_class_shaper *out)
+{
+	u8 group, span;
+	int node;
+
+	if (count == 1) {
+		out->cfg = PPE_TM_L0_SHP_CFG(base + offset);
+		out->credit = PPE_TM_L0_SHP_CREDIT(base + offset);
+		out->slot = PPE_L0_SHAPER_SLOT;
+		return 0;
+	}
+
+	/* The queues an L1 node serves are decided at probe: PPE_MAX_SP_PRI of
+	 * them, less what the priority ceiling takes off the last node. A class
+	 * that spans part of a node has no shaper of its own to be given.
+	 */
+	group = offset / PPE_MAX_SP_PRI;
+	span = min_t(u8, PPE_MAX_SP_PRI,
+		     PPE_QOS_MAX_PRI + 1 - group * PPE_MAX_SP_PRI);
+	node = ppe_l1_node(port, group);
+
+	if (node < 0 || offset % PPE_MAX_SP_PRI || count != span)
+		return -EINVAL;
+
+	out->cfg = PPE_TM_L1_SHP_CFG(node);
+	out->credit = PPE_TM_L1_SHP_CREDIT(node);
+	out->slot = PPE_L1_SHAPER_SLOT;
+
+	return 0;
+}
+
+int qca_ppe_setup_tc_mqprio(struct qca_ppe_priv *priv, int port,
+			    struct tc_mqprio_qopt_offload *qopt)
+{
+	struct ppe_class_shaper prog[PPE_QOS_MAX_PRI + 1] = { };
+	const struct tc_mqprio_qopt *q = &qopt->qopt;
+	struct net_device *dev = dsa_to_port(&priv->ds, port)->user;
+	const struct port_l0_params *p = NULL;
+	unsigned long clk;
+	int i, tc;
+
+	for (i = 0; i < ARRAY_SIZE(port_l0); i++)
+		if (port_l0[i].port == port)
+			p = &port_l0[i];
+	if (!p)
+		return -EOPNOTSUPP;
+
+	/* Nothing below touches the hardware: a request that turns out to be
+	 * unbuildable half way through would otherwise leave the port with its
+	 * shapers already cleared under a qdisc the qdisc layer keeps.
+	 */
+	if (q->num_tc > PPE_QOS_MAX_PRI + 1) {
+		dev_err(priv->ds.dev,
+			"port %d: %u classes, the port has %d priorities to give\n",
+			port, q->num_tc, PPE_QOS_MAX_PRI + 1);
+		return -EINVAL;
+	}
+
+	clk = ppe_clk_rate(priv);
+	if (q->num_tc && !clk)
+		return -ENODEV;
+
+	/* Which queue a packet leaves on is the internal priority a classifier
+	 * gave it, never the class the transmit queue it came from belongs to,
+	 * so a map that disagrees with the classes' queue ranges describes
+	 * something this hardware will not do.
+	 */
+	for (i = 0; q->num_tc && i <= PPE_QOS_MAX_PRI; i++) {
+		tc = q->prio_tc_map[i];
+
+		if (tc >= q->num_tc || i < q->offset[tc] ||
+		    i >= q->offset[tc] + q->count[tc]) {
+			dev_err(priv->ds.dev,
+				"port %d: priority %d is mapped to class %d, which does not own queue %d\n",
+				port, i, tc, i);
+			return -EINVAL;
+		}
+	}
+
+	for (tc = 0; tc < q->num_tc; tc++) {
+		u16 offset = q->offset[tc], count = q->count[tc];
+		u32 cir, cbs;
+
+		if (qopt->min_rate[tc]) {
+			dev_err(priv->ds.dev,
+				"port %d: class %d asks for a floor; the scheduler is strict, it can only be given a ceiling\n",
+				port, tc);
+			return -EOPNOTSUPP;
+		}
+
+		if (ppe_class_node(port, p->ucast_base, offset, count,
+				   &prog[tc])) {
+			dev_err(priv->ds.dev,
+				"port %d: class %d spans queues %u..%u, which is not a scheduler node; a class is one queue or all of a node's\n",
+				port, tc, offset, offset + count - 1);
+			return -EINVAL;
+		}
+
+		prog[tc].rate_bps = qopt->max_rate[tc] * BITS_PER_BYTE;
+		if (!prog[tc].rate_bps)
+			continue;
+
+		if (ppe_token_bucket(clk, prog[tc].slot, prog[tc].rate_bps,
+				     ppe_port_frame_len(priv, port),
+				     FIELD_MAX(PPE_SHP_CIR),
+				     FIELD_MAX(PPE_SHP_CBS), &cir, &cbs) < 0) {
+			dev_err(priv->ds.dev,
+				"port %d: class %d rate is outside the shaper's range\n",
+				port, tc);
+			return -ERANGE;
+		}
+	}
+
+	ppe_port_shapers_clear(priv, p);
+	netdev_reset_tc(dev);
+
+	if (!q->num_tc)
+		return 0;
+
+	for (tc = 0; tc < q->num_tc; tc++) {
+		if (!prog[tc].rate_bps)
+			continue;
+
+		ppe_node_shaper_set(priv, port, prog[tc].cfg, prog[tc].credit,
+				    prog[tc].slot, prog[tc].rate_bps);
+
+		for (i = q->offset[tc]; i < q->offset[tc] + q->count[tc]; i++)
+			priv->shaper[port].queue_rate[i] = prog[tc].rate_bps;
+	}
+
+	ppe_port_queue_limit_set(priv, port);
+
+	/* Asking for the offload hands the driver the transmit queue mapping
+	 * as well, which the qdisc otherwise sets itself.
+	 */
+	netdev_set_num_tc(dev, q->num_tc);
+	for (tc = 0; tc < q->num_tc; tc++)
+		netdev_set_tc_queue(dev, tc, q->count[tc], q->offset[tc]);
+
+	return 0;
+}
+
+/* mqprio leaves it to the driver to check that the classes name a sane set of
+ * queues unless the driver says otherwise; there is nothing here the core does
+ * not check better, so ask it to.
+ */
+int qca_ppe_tc_query_caps(struct tc_query_caps_base *base)
+{
+	struct tc_mqprio_caps *caps = base->caps;
+
+	if (base->type != TC_SETUP_QDISC_MQPRIO)
+		return -EOPNOTSUPP;
+
+	caps->validate_queue_counts = true;
+
+	return 0;
+}
 
 /* The port's scheduler is a strict-priority ladder over its unicast queues,
  * built at probe and not reconfigurable: one queue per priority, and each queue
@@ -1392,6 +1665,10 @@ int qca_ppe_setup_tc(struct dsa_switch *ds, int port, enum tc_setup_type type,
 		return qca_ppe_setup_tc_tbf(priv, port, type_data);
 	case TC_SETUP_QDISC_ETS:
 		return qca_ppe_setup_tc_ets(priv, port, type_data);
+	case TC_SETUP_QDISC_MQPRIO:
+		return qca_ppe_setup_tc_mqprio(priv, port, type_data);
+	case TC_QUERY_CAPS:
+		return qca_ppe_tc_query_caps(type_data);
 	default:
 		return -EOPNOTSUPP;
 	}
@@ -1406,6 +1683,10 @@ static void ppe_rate_limit_init(struct qca_ppe_priv *priv)
 {
 	regmap_write(priv->regmap, PPE_TM_SHP_SLOT_PORT,
 		     FIELD_PREP(PPE_PORT_SHP_SLOT_TIME, PPE_SHAPER_SLOT));
+	regmap_write(priv->regmap, PPE_TM_SHP_SLOT_L0,
+		     FIELD_PREP(PPE_SHP_SLOT_TIME, PPE_L0_SHAPER_SLOT));
+	regmap_write(priv->regmap, PPE_TM_SHP_SLOT_L1,
+		     FIELD_PREP(PPE_SHP_SLOT_TIME, PPE_L1_SHAPER_SLOT));
 	regmap_write(priv->regmap, PPE_TM_IPG_PRE_LEN,
 		     FIELD_PREP(PPE_IPG_PRE_LEN, PPE_IPG_PREAMBLE_LEN));
 	regmap_write(priv->regmap, PPE_POLICER_TIME_SLOT,

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
@@ -454,10 +454,6 @@ static const u8 port_queue_base[PPE_NUM_PORTS] = {
 	0, 144, 160, 176, 192, 208, 224, 240,
 };
 
-static const u8 port_l0_cdrr_num[PPE_NUM_PORTS] = {
-	48, 16, 16, 16, 16, 16, 16, 16,
-};
-
 /* A unicast queue's admission control is four words that take effect on the
  * last one, so the whole entry goes back every time.
  */
@@ -494,30 +490,67 @@ static void ppe_qm_init(struct qca_ppe_priv *priv)
 				port_queue_base[i], i);
 
 	for (i = 0; i < PPE_NUM_PORTS; i++) {
-		u8 max_pri = port_l0_cdrr_num[i];
-		u8 profile;
-
-		if (max_pri > 16)
-			max_pri = 1;
-
 		for (pri = 0; pri < 16; pri++) {
-			u8 cls = (pri >= max_pri) ? max_pri - 1 : pri;
+			/* Two bands per port plus, on a user port, the queues
+			 * of the second scheduler node. On a user port the
+			 * hash offset is added to the class for every packet,
+			 * so a class must be as wide as the spread or the
+			 * smear crosses into the next; the CPU port is given
+			 * no spread, so its two are adjacent. Either way
+			 * l0_port0[] and ppe_l0_scheduler_init() have already
+			 * put the second band a strict priority above the
+			 * first, which is what the small-frame classifier in
+			 * the ACL needs to be worth anything: without it every
+			 * priority shares one queue, and a frame on its way to
+			 * a Wi-Fi client waits behind whatever bulk that queue
+			 * is holding.
+			 *
+			 * Priorities eight and up select the second node's
+			 * queues. No classifier resolves there on its own -
+			 * the DSCP and PCP tables map below eight unless told
+			 * otherwise - so the node carries exactly the traffic
+			 * a rule names into it, and a shaper on the node then
+			 * governs that traffic and nothing else. The CPU port
+			 * has no second node built and folds these priorities
+			 * to best effort.
+			 */
+			u8 cls;
 
-			if (i == 0) {
-				profile = 0;
-				regmap_write(priv->regmap,
-					     PPE_QM_UCAST_PRI_MAP(profile * 16 + pri),
-					     FIELD_PREP(PPE_QM_PRI_CLASS, cls));
-				profile = 15;
-				regmap_write(priv->regmap,
-					     PPE_QM_UCAST_PRI_MAP(profile * 16 + pri),
-					     FIELD_PREP(PPE_QM_PRI_CLASS, cls));
-			} else {
+			if (pri < PPE_FLOW_SPREAD_QUEUES)
+				cls = 0;
+			else if (pri < 2 * PPE_FLOW_SPREAD_QUEUES)
+				cls = i ? PPE_FLOW_SPREAD_QUEUES : 1;
+			else
+				cls = i ? 2 * PPE_FLOW_SPREAD_QUEUES : 0;
+
+			if (i) {
 				regmap_write(priv->regmap,
 					     PPE_QM_UCAST_PRI_MAP(i * 16 + pri),
 					     FIELD_PREP(PPE_QM_PRI_CLASS, cls));
+				continue;
 			}
+
+			/* Profiles 0 and 15 both resolve to the CPU port. */
+			regmap_write(priv->regmap,
+				     PPE_QM_UCAST_PRI_MAP(pri),
+				     FIELD_PREP(PPE_QM_PRI_CLASS, cls));
+			regmap_write(priv->regmap,
+				     PPE_QM_UCAST_PRI_MAP(15 * 16 + pri),
+				     FIELD_PREP(PPE_QM_PRI_CLASS, cls));
 		}
+	}
+
+	/* The 5-tuple hash picks the queue inside a band on every user port;
+	 * profile id equals port id. Profiles 14/15 (CPU code, point offload)
+	 * stay collapsed to offset 0 below.
+	 */
+	for (i = 1; i < PPE_NUM_PORTS; i++) {
+		int h;
+
+		for (h = 0; h < 256; h++)
+			regmap_write(priv->regmap,
+				     PPE_QM_UCAST_HASH_MAP(i * 256 + h),
+				     h % PPE_FLOW_SPREAD_QUEUES);
 	}
 
 	for (i = 0; i < 256; i++) {
@@ -716,13 +749,30 @@ static void ppe_l0_scheduler_init(struct qca_ppe_priv *priv)
 		for (k = 0; k < 2; k++) {
 			for (j = 0; j < counts[k]; j++) {
 				int slot = k ? p->ucast_count - counts[k] + j : j;
-				struct l0_cfg c = {
+				int pri = slot % PPE_MAX_SP_PRI;
+				struct l0_cfg c;
+
+				/* The three bands: queues of one band share one
+				 * (SP, priority) and therefore one DRR list -
+				 * the same layout the CPU port's RSS spread
+				 * uses - draining round-robin at equal weight,
+				 * so a hash bucket is served at no less than
+				 * its share of the port. Band two sits a
+				 * priority above band one; band three is the
+				 * second node's, under the mcast slots that
+				 * share that node.
+				 */
+				if (!k && slot < 3 * PPE_FLOW_SPREAD_QUEUES)
+					pri = slot / PPE_FLOW_SPREAD_QUEUES == 1 ?
+					      PPE_FLOW_SPREAD_QUEUES : 0;
+
+				c = (struct l0_cfg) {
 					.queue = bases[k] + j,
 					.port = p->port,
 					.sp = p->sp_base + slot / PPE_MAX_SP_PRI,
-					.cpri = slot % PPE_MAX_SP_PRI,
+					.cpri = pri,
 					.cdrr = p->cdrr_base + slot,
-					.epri = slot % PPE_MAX_SP_PRI,
+					.epri = pri,
 					.edrr = p->cdrr_base + slot,
 				};
 
@@ -1072,6 +1122,7 @@ static void ppe_port_queue_limit_set(struct qca_ppe_priv *priv, int port)
 
 	for (i = 0; i < p->ucast_count; i++) {
 		u64 rate = i < ARRAY_SIZE(sh->queue_rate) ? sh->queue_rate[i] : 0;
+		u32 w = w0;
 
 		/* A queue given a ceiling of its own is a bottleneck the same
 		 * way a shaped port is, and a tighter one, so the standing
@@ -1080,12 +1131,21 @@ static void ppe_port_queue_limit_set(struct qca_ppe_priv *priv, int port)
 		 * given, because a millisecond is too shallow to hold one
 		 * flow at the rate.
 		 */
-		ppe_ac_uni_write(priv, p->ucast_base + i,
-				 rate ? ppe_ac_uni_static(priv, port, rate,
-							  div_u64(rate * 10,
-								  BITS_PER_BYTE *
-								  1000)) :
-					w0);
+		if (rate)
+			w = ppe_ac_uni_static(priv, port, rate,
+					      div_u64(rate * 10,
+						      BITS_PER_BYTE * 1000));
+		else if (sh->rate_bps && i < 3 * PPE_FLOW_SPREAD_QUEUES)
+			/* A band bucket holds a share of the flows and drains
+			 * at no less than its share of the port, so it takes
+			 * a share of the depth: what one bucket's flows wait
+			 * behind stays bounded whatever the other buckets do.
+			 */
+			w = ppe_ac_uni_static(priv, port, sh->rate_bps,
+					      sh->limit /
+					      PPE_FLOW_SPREAD_QUEUES);
+
+		ppe_ac_uni_write(priv, p->ucast_base + i, w);
 	}
 }
 
@@ -1693,11 +1753,41 @@ static void ppe_rate_limit_init(struct qca_ppe_priv *priv)
 		     FIELD_PREP(PPE_POLICER_SLOT_TIME, PPE_POLICER_SLOT));
 }
 
+/* The 5-tuple RSS hash every unicast packet carries into queue selection.
+ * Out of reset the mask, seed and mix stages are zero and the hash is
+ * degenerate - every flow one bucket - so the spread depends on this. The
+ * seed is fixed rather than random so a flow's bucket survives a reboot.
+ */
+static void ppe_rss_hash_init(struct qca_ppe_priv *priv)
+{
+	static const u32 mix[5] = { 0x13, 0xb, 0x13, 0xb, 0x13 };
+	static const u32 fin[5] = { 0x205, 0x264, 0x227, 0x245, 0x201 };
+	int i;
+
+	regmap_write(priv->regmap, PPE_RSS_HASH_MASK, 0xfff);
+	regmap_write(priv->regmap, PPE_RSS_HASH_SEED, 0x5eedc0de);
+	/* v6 mix: sip[0..3], dip[0..3], proto, dport, sport - one weight per
+	 * field, alternating in that order.
+	 */
+	for (i = 0; i < 11; i++)
+		regmap_write(priv->regmap, PPE_RSS_HASH_MIX(i), mix[i % 2]);
+	for (i = 0; i < 5; i++)
+		regmap_write(priv->regmap, PPE_RSS_HASH_FIN(i), fin[i]);
+
+	regmap_write(priv->regmap, PPE_RSS_HASH_MASK_IPV4, 0xfff);
+	regmap_write(priv->regmap, PPE_RSS_HASH_SEED_IPV4, 0x5eedc0de);
+	for (i = 0; i < 5; i++)
+		regmap_write(priv->regmap, PPE_RSS_HASH_MIX_IPV4(i), mix[i]);
+	for (i = 0; i < 5; i++)
+		regmap_write(priv->regmap, PPE_RSS_HASH_FIN_IPV4(i), fin[i]);
+}
+
 void ppe_scheduler_init(struct qca_ppe_priv *priv)
 {
 	ppe_tdm_init(priv);
 	ppe_bm_init(priv);
 	ppe_qm_init(priv);
+	ppe_rss_hash_init(priv);
 	ppe_l1_scheduler_init(priv);
 	ppe_l0_scheduler_init(priv);
 	ppe_edma_ring_map_init(priv);

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
@@ -1009,7 +1009,6 @@ const struct bm_tdm_data hppe_bm_tdm_data = {
  * the one that gets programmed, exactly as the vendor driver picks it.
  */
 #define PPE_SHAPER_SLOT		8
-#define PPE_POLICER_SLOT	600
 #define PPE_TOKEN_UNIT_MAX	16384
 #define PPE_BUCKET_UNIT		65536
 /* 12 byte inter-packet gap plus the 8 byte preamble and start delimiter: what
@@ -1032,9 +1031,8 @@ unsigned long ppe_clk_rate(struct qca_ppe_priv *priv)
 	return 0;
 }
 
-static int ppe_token_bucket(unsigned long clk, u32 slot, u64 rate_bps,
-			    u32 burst, u32 cir_max, u32 cbs_max,
-			    u32 *cir, u32 *cbs)
+int ppe_token_bucket(unsigned long clk, u32 slot, u64 rate_bps, u32 burst,
+		     u32 cir_max, u32 cbs_max, u32 *cir, u32 *cbs)
 {
 	int sel;
 

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
@@ -1432,6 +1432,14 @@ static int ppe_port_policer_set(struct qca_ppe_priv *priv, int port,
 	regmap_write(priv->regmap, PPE_PORT_METER_W2(port), 0);
 	regmap_write(priv->regmap, PPE_PORT_METER_W3(port), 0);
 
+	/* Credit outlives the rate that filled it: what a re-armed meter would
+	 * spend on its first frames was bought at a rate the port has lost.
+	 */
+	if (!rate_bps) {
+		regmap_write(priv->regmap, PPE_PORT_METER_CRDT(port), 0);
+		regmap_write(priv->regmap, PPE_PORT_METER_CRDT(port) + 0x4, 0);
+	}
+
 	return 0;
 }
 

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
@@ -585,15 +585,17 @@ static void ppe_qm_init(struct qca_ppe_priv *priv)
 	for (i = 0; i < PPE_L0_UCAST_QUEUES; i++)
 		ppe_ac_uni_write(priv, i, ppe_ac_uni_default(priv));
 
+	/* A multicast queue's limit is a static threshold, not the unicast
+	 * queues' dynamic share, so its ceiling field carries the green
+	 * threshold and the colour gaps under it are unused.
+	 */
 	for (i = 0; i < PPE_L0_QUEUES - PPE_L0_UCAST_QUEUES; i++) {
 		regmap_write(priv->regmap, PPE_QM_AC_MUL_W0(i),
 			     PPE_AC_MUL_EN |
-			     FIELD_PREP(PPE_AC_MUL_CEILING, d->qm_ceiling) |
-			     FIELD_PREP(PPE_AC_MUL_GRN_MAX_LO, d->qm_green_max & 0x1f));
-		regmap_write(priv->regmap, PPE_QM_AC_MUL_W1(i),
-			     FIELD_PREP(PPE_AC_MUL_GRN_MAX_HI, d->qm_green_max >> 5));
+			     FIELD_PREP(PPE_AC_MUL_CEILING, d->qm_green_max));
+		regmap_write(priv->regmap, PPE_QM_AC_MUL_W1(i), 0);
 		regmap_write(priv->regmap, PPE_QM_AC_MUL_W2(i),
-			     FIELD_PREP(PPE_AC_MUL_GRN_RESUME_HI, 36));
+			     FIELD_PREP(PPE_AC_MUL_GRN_RESUME_OFF, 36));
 	}
 
 	regmap_write(priv->regmap, PPE_QM_AC_GRP_W0(0), 0);
@@ -779,6 +781,15 @@ static void ppe_l0_scheduler_init(struct qca_ppe_priv *priv)
 				ppe_l0_entry_write(priv, &c);
 			}
 		}
+
+		/* Which multicast queue the port floods a frame onto is the
+		 * frame's internal priority, clamped to the queues the port
+		 * has: left at reset every priority resolves to the first.
+		 */
+		for (j = 0; j < 16; j++)
+			regmap_write(priv->regmap,
+				     PPE_QM_MCAST_PRI_MAP(p->port, j),
+				     min_t(u8, j, p->mcast_count - 1));
 	}
 }
 
@@ -1737,10 +1748,13 @@ int qca_ppe_setup_tc(struct dsa_switch *ds, int port, enum tc_setup_type type,
 /* Both token buckets refresh on a period the hardware keeps in its own
  * register, and the policer's comes up at zero, which is no period at all. The
  * preamble and gap the shaper never sees are added back from a third register,
- * shared by every shaper in the block.
+ * shared by every shaper in the block; the policer has a compensation of its
+ * own, per port, which the vendor sets to the frame checksum alone.
  */
 static void ppe_rate_limit_init(struct qca_ppe_priv *priv)
 {
+	int i;
+
 	regmap_write(priv->regmap, PPE_TM_SHP_SLOT_PORT,
 		     FIELD_PREP(PPE_PORT_SHP_SLOT_TIME, PPE_SHAPER_SLOT));
 	regmap_write(priv->regmap, PPE_TM_SHP_SLOT_L0,
@@ -1751,6 +1765,15 @@ static void ppe_rate_limit_init(struct qca_ppe_priv *priv)
 		     FIELD_PREP(PPE_IPG_PRE_LEN, PPE_IPG_PREAMBLE_LEN));
 	regmap_write(priv->regmap, PPE_POLICER_TIME_SLOT,
 		     FIELD_PREP(PPE_POLICER_SLOT_TIME, PPE_POLICER_SLOT));
+
+	/* A frame already marked for drop is never forwarded, so metering it
+	 * would spend the port's tokens on bandwidth nothing receives.
+	 */
+	regmap_write(priv->regmap, PPE_POLICER_DROP_BYPASS, PPE_DROP_BYPASS_EN);
+
+	for (i = 0; i < priv->data->num_ports; i++)
+		regmap_write(priv->regmap, PPE_POLICER_CMPST_LEN(i),
+			     FIELD_PREP(PPE_CMPST_LENGTH, ETH_FCS_LEN));
 }
 
 /* The 5-tuple RSS hash every unicast packet carries into queue selection.

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
@@ -1,5 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
+#include <linux/clk.h>
+#include <linux/math64.h>
+#include <linux/string.h>
+#include <net/flow_offload.h>
+#include <net/pkt_cls.h>
+
 #include "qca_ppe.h"
 
 struct psch_tdm_entry {
@@ -451,6 +457,25 @@ static const u8 port_l0_cdrr_num[PPE_NUM_PORTS] = {
 	48, 16, 16, 16, 16, 16, 16, 16,
 };
 
+/* A unicast queue's admission control is four words that take effect on the
+ * last one, so the whole entry goes back every time.
+ */
+static void ppe_ac_uni_write(struct qca_ppe_priv *priv, u32 queue, u32 w0)
+{
+	regmap_write(priv->regmap, PPE_QM_AC_UNI_W0(queue), w0);
+	regmap_write(priv->regmap, PPE_QM_AC_UNI_W1(queue), 0);
+	regmap_write(priv->regmap, PPE_QM_AC_UNI_W2(queue), 0);
+	regmap_write(priv->regmap, PPE_QM_AC_UNI_W3(queue),
+		     FIELD_PREP(PPE_AC_GRN_RESUME_OFF, 36));
+}
+
+static u32 ppe_ac_uni_default(struct qca_ppe_priv *priv)
+{
+	return PPE_AC_EN | PPE_AC_SHARED_DYNAMIC |
+	       FIELD_PREP(PPE_AC_SHARED_WEIGHT, 4) |
+	       FIELD_PREP(PPE_AC_SHARED_CEILING, priv->data->qm_ceiling);
+}
+
 static void ppe_qm_init(struct qca_ppe_priv *priv)
 {
 	const struct ppe_data *d = priv->data;
@@ -523,17 +548,8 @@ static void ppe_qm_init(struct qca_ppe_priv *priv)
 	for (i = PPE_NUM_PORTS; i < PPE_MAX_VPORT; i++)
 		ppe_qm_map_set(priv, QM_VP_PORT_OFFSET + (1 << 8) + i, 4, 0);
 
-	for (i = 0; i < PPE_L0_UCAST_QUEUES; i++) {
-		regmap_write(priv->regmap, PPE_QM_AC_UNI_W0(i),
-			     PPE_AC_EN |
-			     PPE_AC_SHARED_DYNAMIC |
-			     FIELD_PREP(PPE_AC_SHARED_WEIGHT, 4) |
-			     FIELD_PREP(PPE_AC_SHARED_CEILING, d->qm_ceiling));
-		regmap_write(priv->regmap, PPE_QM_AC_UNI_W1(i), 0);
-		regmap_write(priv->regmap, PPE_QM_AC_UNI_W2(i), 0);
-		regmap_write(priv->regmap, PPE_QM_AC_UNI_W3(i),
-			     FIELD_PREP(PPE_AC_GRN_RESUME_OFF, 36));
-	}
+	for (i = 0; i < PPE_L0_UCAST_QUEUES; i++)
+		ppe_ac_uni_write(priv, i, ppe_ac_uni_default(priv));
 
 	for (i = 0; i < PPE_L0_QUEUES - PPE_L0_UCAST_QUEUES; i++) {
 		regmap_write(priv->regmap, PPE_QM_AC_MUL_W0(i),
@@ -777,6 +793,398 @@ const struct bm_tdm_data hppe_bm_tdm_data = {
 	.num = ARRAY_SIZE(hppe_bm_tdm),
 };
 
+/* Rate limiting. The port shaper meters what leaves a port and the port policer
+ * meters what arrives on it; both are in the hardware datapath, which is the
+ * whole point once a flow is offloaded and no qdisc on this box ever sees it
+ * again.
+ *
+ * Both encode a rate the same way: a refresh count added to a token bucket once
+ * every slot_time * 8 PPE clocks, in units of 1/token_unit byte, with the burst
+ * as a bucket depth in units of 65536/token_unit bytes. The token unit is not a
+ * choice to expose - the finest one whose two fields still hold the request is
+ * the one that gets programmed, exactly as the vendor driver picks it.
+ */
+#define PPE_SHAPER_SLOT		8
+#define PPE_POLICER_SLOT	600
+#define PPE_TOKEN_UNIT_MAX	16384
+#define PPE_BUCKET_UNIT		65536
+/* 12 byte inter-packet gap plus the 8 byte preamble and start delimiter: what
+ * the wire costs per frame that the shaper is not otherwise shown.
+ */
+#define PPE_IPG_PREAMBLE_LEN	20
+
+/* Every period the PPE derives from its own clock - the shaper and policer
+ * refresh below - is wrong by whatever the board clocks the block at, so read
+ * the rate rather than assuming one.
+ */
+unsigned long ppe_clk_rate(struct qca_ppe_priv *priv)
+{
+	int i;
+
+	for (i = 0; i < priv->num_clks; i++)
+		if (!strcmp(priv->clks[i].id, "nss_ppe_clk"))
+			return clk_get_rate(priv->clks[i].clk);
+
+	return 0;
+}
+
+static int ppe_token_bucket(unsigned long clk, u32 slot, u64 rate_bps,
+			    u32 burst, u32 cir_max, u32 cbs_max,
+			    u32 *cir, u32 *cbs)
+{
+	int sel;
+
+	/* The refresh count is a u64 product, and a rate large enough to wrap
+	 * it comes back out as a small one the loop would accept. Such a rate
+	 * is out of range at every unit, so refuse it here rather than let it
+	 * arrive as a plausible answer.
+	 */
+	if (rate_bps > div64_ul(U64_MAX, PPE_TOKEN_UNIT_MAX * (u64)slot))
+		return -ERANGE;
+
+	for (sel = 0; sel < 8; sel++) {
+		u32 unit = PPE_TOKEN_UNIT_MAX >> (2 * sel);
+		u64 c = div64_ul(rate_bps * unit * slot, clk);
+		u64 b = mul_u32_u32(burst, unit) / PPE_BUCKET_UNIT;
+
+		if (c > cir_max || b > cbs_max)
+			continue;
+		if (!c || !b)
+			return -ERANGE;
+
+		*cir = c;
+		*cbs = b;
+		return sel;
+	}
+
+	return -ERANGE;
+}
+
+/* A shaped port is the bottleneck by construction, so the standing queue lives
+ * on its queues. Left as every queue is configured at probe - a dynamic limit
+ * clamped at the SoC's ceiling, whose overrun asserts flow control rather than
+ * dropping - the queue settles wherever the dynamic limit lands and the ceiling
+ * has no effect at all: measured on IPQ8074 it holds around 250 buffers at any
+ * ceiling from 400 down to 48. Enforcing the limit by dropping is what makes it
+ * bind, and a limit worth binding at is one millisecond of the rate the shaper
+ * was just given.
+ */
+/* What one full frame costs on the wire for this port, which is what a token
+ * bucket has to be able to hold and what a queue's floor is counted in.
+ */
+static u32 ppe_port_frame_len(struct qca_ppe_priv *priv, int port)
+{
+	struct net_device *dev = dsa_to_port(&priv->ds, port)->user;
+
+	return (dev ? dev->mtu : ETH_DATA_LEN) + ETH_HLEN + ETH_FCS_LEN;
+}
+
+#define PPE_AC_TARGET_US	1000
+/* A queue that is the bottleneck cannot be shorter than a handful of full
+ * frames and still keep a single flow at the rate it was shaped to: measured
+ * on IPQ8074 under a 20 Mbit/s ceiling, two frames' worth of buffers costs a
+ * third of the rate and eight frames' worth costs nothing. A frame is whatever
+ * the port carries, so a jumbo port gets a jumbo floor.
+ */
+#define PPE_AC_MIN_FRAMES	8
+
+static void ppe_port_queue_limit_set(struct qca_ppe_priv *priv, int port)
+{
+	struct ppe_port_shaper *sh = &priv->shaper[port];
+	const struct port_l0_params *p = NULL;
+	u32 w0;
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(port_l0); i++)
+		if (port_l0[i].port == port)
+			p = &port_l0[i];
+	if (!p)
+		return;
+
+	if (sh->rate_bps) {
+		u32 bufs, min_bufs;
+
+		min_bufs = DIV_ROUND_UP(ppe_port_frame_len(priv, port) *
+					PPE_AC_MIN_FRAMES, PPE_BM_BUF_SIZE);
+
+		if (sh->limit)
+			bufs = sh->limit / PPE_BM_BUF_SIZE;
+		else
+			bufs = div64_u64(sh->rate_bps * PPE_AC_TARGET_US,
+					 BITS_PER_BYTE * PPE_BM_BUF_SIZE *
+					 (u64)USEC_PER_SEC);
+
+		bufs = clamp_t(u32, bufs, min_bufs, priv->data->qm_ceiling);
+		w0 = PPE_AC_EN | PPE_AC_FORCE_AC_EN |
+		     FIELD_PREP(PPE_AC_SHARED_WEIGHT, 4) |
+		     FIELD_PREP(PPE_AC_SHARED_CEILING, bufs);
+	} else {
+		w0 = ppe_ac_uni_default(priv);
+	}
+
+	for (i = 0; i < p->ucast_count; i++)
+		ppe_ac_uni_write(priv, p->ucast_base + i, w0);
+}
+
+/* A rate of zero takes the shaper down. Its credit goes with it: a bucket left
+ * negative from the old rate would hold the port off for as long as it takes
+ * the new one to refill it.
+ */
+static int ppe_port_shaper_set(struct qca_ppe_priv *priv, int port,
+			       u64 rate_bps, u32 burst)
+{
+	u32 cir = 0, cbs = 0;
+	unsigned long clk;
+	int sel = 0;
+
+	if (rate_bps) {
+		clk = ppe_clk_rate(priv);
+		if (!clk)
+			return -ENODEV;
+
+		sel = ppe_token_bucket(clk, PPE_SHAPER_SLOT, rate_bps, burst,
+				       FIELD_MAX(PPE_PSCH_SHP_CIR),
+				       FIELD_MAX(PPE_PSCH_SHP_CBS),
+				       &cir, &cbs);
+		if (sel < 0) {
+			dev_err(priv->ds.dev,
+				"port %d: %llu bit/s burst %u bytes is outside the shaper's range\n",
+				port, rate_bps, burst);
+			return sel;
+		}
+	}
+
+	regmap_write(priv->regmap, PPE_TM_PSCH_SHP_CFG_W0(port),
+		     FIELD_PREP(PPE_PSCH_SHP_CIR, cir) |
+		     FIELD_PREP(PPE_PSCH_SHP_CBS, cbs));
+	regmap_write(priv->regmap, PPE_TM_PSCH_SHP_CFG_W1(port),
+		     FIELD_PREP(PPE_PSCH_SHP_TOKEN_UNIT, sel) |
+		     (rate_bps ? PPE_PSCH_SHP_EN : 0));
+
+	if (!rate_bps) {
+		regmap_write(priv->regmap, PPE_TM_PSCH_SHP_CREDIT(port), 0);
+		regmap_write(priv->regmap, PPE_TM_PSCH_SHP_SIGN(port), 0);
+	}
+
+	priv->shaper[port].rate_bps = rate_bps;
+	if (!rate_bps)
+		priv->shaper[port].limit = 0;
+	ppe_port_queue_limit_set(priv, port);
+
+	return 0;
+}
+
+/* Metering mode 1 is RFC 2697: one rate, one bucket, and everything the
+ * committed burst cannot hold is red. Leaving the excess burst at zero is what
+ * makes red mean "over the rate" rather than "over the excess rate", and red is
+ * dropped by the reset value of the violate command.
+ */
+static int ppe_port_policer_set(struct qca_ppe_priv *priv, int port,
+				u64 rate_bps, u32 burst)
+{
+	u32 cir = 0, cbs = 0;
+	unsigned long clk;
+	int sel = 0;
+
+	if (rate_bps) {
+		clk = ppe_clk_rate(priv);
+		if (!clk)
+			return -ENODEV;
+
+		sel = ppe_token_bucket(clk, PPE_POLICER_SLOT, rate_bps, burst,
+				       FIELD_MAX(PPE_METER_CIR_HI) << 3 |
+				       FIELD_MAX(PPE_METER_CIR_LO),
+				       FIELD_MAX(PPE_METER_CBS),
+				       &cir, &cbs);
+		if (sel < 0) {
+			dev_err(priv->ds.dev,
+				"port %d: %llu bit/s burst %u bytes is outside the policer's range\n",
+				port, rate_bps, burst);
+			return sel;
+		}
+	}
+
+	/* The entry spans four words and takes effect on the last one, so it is
+	 * written in address order like every other multi-word PPE table.
+	 */
+	regmap_write(priv->regmap, PPE_PORT_METER_W0(port),
+		     (rate_bps ? PPE_METER_EN : 0) |
+		     PPE_METER_MODE |
+		     FIELD_PREP(PPE_METER_FRAME_TYPE,
+				FIELD_MAX(PPE_METER_FRAME_TYPE)) |
+		     FIELD_PREP(PPE_METER_TOKEN_UNIT, sel) |
+		     FIELD_PREP(PPE_METER_CBS, cbs) |
+		     FIELD_PREP(PPE_METER_CIR_LO, cir));
+	regmap_write(priv->regmap, PPE_PORT_METER_W1(port),
+		     FIELD_PREP(PPE_METER_CIR_HI, cir >> 3));
+	regmap_write(priv->regmap, PPE_PORT_METER_W2(port), 0);
+	regmap_write(priv->regmap, PPE_PORT_METER_W3(port), 0);
+
+	return 0;
+}
+
+int qca_ppe_port_policer_add(struct dsa_switch *ds, int port,
+			     const struct flow_action_police *policer,
+			     struct netlink_ext_ack *extack)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+
+	/* One rate, one burst, drop on red is all this meter has. Everything
+	 * else the police action can carry is refused rather than dropped on
+	 * the floor: a filter that asked for a packet rate and got a byte
+	 * meter, or asked for pass on exceed and got drop, would report
+	 * offloaded and police something other than what it says.
+	 */
+	if (!policer->rate_bytes_ps ||
+	    policer->peakrate_bytes_ps || policer->rate_pkt_ps ||
+	    policer->burst_pkt || policer->avrate ||
+	    policer->exceed.act_id != FLOW_ACTION_DROP ||
+	    (policer->notexceed.act_id != FLOW_ACTION_PIPE &&
+	     policer->notexceed.act_id != FLOW_ACTION_ACCEPT)) {
+		NL_SET_ERR_MSG_MOD(extack, "the meter is one byte rate, one burst and drop on red");
+		return -EOPNOTSUPP;
+	}
+
+	/* The meter counts the frame the port puts on the wire, so a link
+	 * layer the filter wants accounted on top of it goes in the port's
+	 * compensation length, which already carries the checksum.
+	 */
+	if (ETH_FCS_LEN + policer->overhead > FIELD_MAX(PPE_CMPST_LENGTH)) {
+		NL_SET_ERR_MSG_MOD(extack, "larger than the port's compensation length field");
+		return -EOPNOTSUPP;
+	}
+
+	regmap_write(priv->regmap, PPE_POLICER_CMPST_LEN(port),
+		     FIELD_PREP(PPE_CMPST_LENGTH,
+				ETH_FCS_LEN + policer->overhead));
+
+	return ppe_port_policer_set(priv, port,
+				    policer->rate_bytes_ps * BITS_PER_BYTE,
+				    policer->burst);
+}
+
+void qca_ppe_port_policer_del(struct dsa_switch *ds, int port)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+
+	regmap_write(priv->regmap, PPE_POLICER_CMPST_LEN(port),
+		     FIELD_PREP(PPE_CMPST_LENGTH, ETH_FCS_LEN));
+	ppe_port_policer_set(priv, port, 0, 0);
+}
+
+/* The counters a shaped port can answer with are the MAC's own transmit MIB and
+ * the port's egress drop counter, which is where the queue limit above lands.
+ * They are free-running, so what tc is handed is the delta since it last asked.
+ */
+static void ppe_port_tx_counters(struct qca_ppe_priv *priv, int port,
+				 u64 *bytes, u32 *pkts, u32 *drops)
+{
+	regmap_read(priv->regmap, PPE_PORT_TX_DROP_CNT(port), drops);
+
+	*bytes = ppe_mib_read(priv, port, PPE_MIB_TXBYTE_L);
+	*pkts = ppe_mib_read(priv, port, PPE_MIB_TXUNI) +
+		ppe_mib_read(priv, port, PPE_MIB_TXBROAD) +
+		ppe_mib_read(priv, port, PPE_MIB_TXMULTI);
+}
+
+static void ppe_port_shaper_stats(struct qca_ppe_priv *priv, int port,
+				  struct tc_qopt_offload_stats *stats)
+{
+	struct ppe_port_shaper *sh = &priv->shaper[port];
+	u64 bytes;
+	u32 pkts, drops;
+
+	ppe_port_tx_counters(priv, port, &bytes, &pkts, &drops);
+
+	/* The packet and drop counters are 32 bits wide and wrap, so their
+	 * deltas are taken in their own width.
+	 */
+	_bstats_update(stats->bstats, bytes - sh->base_bytes,
+		       pkts - sh->base_pkts);
+	stats->qstats->drops += (u32)(drops - sh->base_drops);
+
+	sh->base_bytes = bytes;
+	sh->base_pkts = pkts;
+	sh->base_drops = drops;
+}
+
+/* The hardware has one shaper per port and nowhere to hang a class off it, so
+ * only a root tbf is a rate this switch can keep. The qdisc's overhead, mpu and
+ * linklayer are not carried into the hardware, which meters the frame it puts
+ * on the wire including preamble, inter-packet gap and CRC.
+ */
+int qca_ppe_setup_tc_tbf(struct qca_ppe_priv *priv, int port,
+			 struct tc_tbf_qopt_offload *qopt)
+{
+	int ret;
+
+	if (qopt->parent != TC_H_ROOT)
+		return -EOPNOTSUPP;
+
+	switch (qopt->command) {
+	case TC_TBF_REPLACE:
+		ret = ppe_port_shaper_set(priv, port,
+					  qopt->replace_params.rate.rate_bytes_ps *
+					  BITS_PER_BYTE,
+					  qopt->replace_params.max_size);
+		if (ret)
+			return ret;
+
+		priv->shaper[port].tbf_handle = qopt->handle;
+		ppe_port_tx_counters(priv, port,
+				     &priv->shaper[port].base_bytes,
+				     &priv->shaper[port].base_pkts,
+				     &priv->shaper[port].base_drops);
+		return 0;
+	case TC_TBF_DESTROY:
+		/* A replacement's destroy arrives after the new qdisc has
+		 * already programmed the shaper, so only the qdisc that owns
+		 * the rate may take it down.
+		 */
+		if (qopt->handle != priv->shaper[port].tbf_handle)
+			return 0;
+
+		priv->shaper[port].tbf_handle = 0;
+		return ppe_port_shaper_set(priv, port, 0, 0);
+	case TC_TBF_STATS:
+		if (!priv->shaper[port].tbf_handle ||
+		    qopt->handle != priv->shaper[port].tbf_handle)
+			return -EOPNOTSUPP;
+		ppe_port_shaper_stats(priv, port, &qopt->stats);
+		return 0;
+	default:
+		return -EOPNOTSUPP;
+	}
+}
+
+int qca_ppe_setup_tc(struct dsa_switch *ds, int port, enum tc_setup_type type,
+		     void *type_data)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+
+	switch (type) {
+	case TC_SETUP_QDISC_TBF:
+		return qca_ppe_setup_tc_tbf(priv, port, type_data);
+	default:
+		return -EOPNOTSUPP;
+	}
+}
+
+/* Both token buckets refresh on a period the hardware keeps in its own
+ * register, and the policer's comes up at zero, which is no period at all. The
+ * preamble and gap the shaper never sees are added back from a third register,
+ * shared by every shaper in the block.
+ */
+static void ppe_rate_limit_init(struct qca_ppe_priv *priv)
+{
+	regmap_write(priv->regmap, PPE_TM_SHP_SLOT_PORT,
+		     FIELD_PREP(PPE_PORT_SHP_SLOT_TIME, PPE_SHAPER_SLOT));
+	regmap_write(priv->regmap, PPE_TM_IPG_PRE_LEN,
+		     FIELD_PREP(PPE_IPG_PRE_LEN, PPE_IPG_PREAMBLE_LEN));
+	regmap_write(priv->regmap, PPE_POLICER_TIME_SLOT,
+		     FIELD_PREP(PPE_POLICER_SLOT_TIME, PPE_POLICER_SLOT));
+}
+
 void ppe_scheduler_init(struct qca_ppe_priv *priv)
 {
 	ppe_tdm_init(priv);
@@ -786,4 +1194,5 @@ void ppe_scheduler_init(struct qca_ppe_priv *priv)
 	ppe_l0_scheduler_init(priv);
 	ppe_edma_ring_map_init(priv);
 	ppe_qos_init(priv);
+	ppe_rate_limit_init(priv);
 }

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
@@ -3,6 +3,7 @@
 #include <linux/clk.h>
 #include <linux/math64.h>
 #include <linux/string.h>
+#include <net/dcbnl.h>
 #include <net/flow_offload.h>
 #include <net/pkt_cls.h>
 
@@ -755,6 +756,139 @@ static void ppe_edma_ring_map_init(struct qca_ppe_priv *priv)
 /* Which classifier's internal priority wins when several offer one: the flow
  * table first, then the CPU preheader, ACL, DSCP and last a VLAN's PCP.
  */
+/* Which classifier decides a packet's priority is a precedence order per port,
+ * and DCB's apptrust is that order in the other direction: the selectors a user
+ * lists, most trusted first. Only the two this hardware can be told about are
+ * offered - PCP and DSCP - and the classifiers a user cannot name keep the
+ * ranking the driver gave them at probe.
+ */
+static const u8 ppe_apptrust_sel[] = { DCB_APP_SEL_PCP, IEEE_8021QAZ_APP_SEL_DSCP };
+
+#define PPE_QOS_GROUP		0
+
+static int ppe_apptrust_prec(struct qca_ppe_priv *priv, int port, u8 sel)
+{
+	u32 val, mask;
+
+	regmap_read(priv->regmap, PPE_PORT_QOS_CTRL(port), &val);
+	mask = sel == IEEE_8021QAZ_APP_SEL_DSCP ? PPE_QOS_DSCP_PREC :
+						  PPE_QOS_PCP_PREC;
+
+	return field_get(mask, val);
+}
+
+int qca_ppe_port_get_apptrust(struct dsa_switch *ds, int port, u8 *sel,
+			      int *nsel)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	int dscp, pcp;
+
+	dscp = ppe_apptrust_prec(priv, port, IEEE_8021QAZ_APP_SEL_DSCP);
+	pcp = ppe_apptrust_prec(priv, port, DCB_APP_SEL_PCP);
+
+	*nsel = 2;
+	sel[0] = dscp > pcp ? IEEE_8021QAZ_APP_SEL_DSCP : DCB_APP_SEL_PCP;
+	sel[1] = dscp > pcp ? DCB_APP_SEL_PCP : IEEE_8021QAZ_APP_SEL_DSCP;
+
+	return 0;
+}
+
+int qca_ppe_port_set_apptrust(struct dsa_switch *ds, int port, const u8 *sel,
+			      int nsel)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	u32 dscp = 0, pcp = 0;
+	int i, j;
+
+	/* A precedence of zero is a rank and not an off switch: measured, a port
+	 * whose DSCP precedence is zero classifies by DSCP exactly as it does at
+	 * one. This generation can order the two and cannot take either out of
+	 * the running, so a list that leaves one out is refused rather than
+	 * answered with a port that still trusts it.
+	 */
+	if (nsel != ARRAY_SIZE(ppe_apptrust_sel)) {
+		dev_err(priv->ds.dev,
+			"port %d: both selectors have to be listed; this hardware ranks them and cannot untrust one\n",
+			port);
+		return -EOPNOTSUPP;
+	}
+
+	/* Most trusted first. The two keep the band the other classifiers leave
+	 * them - ACL, preheader and flow sit above both - so ordering them is a
+	 * choice between one and zero rather than a rank that could collide.
+	 */
+	for (i = 0; i < nsel; i++) {
+		for (j = 0; j < ARRAY_SIZE(ppe_apptrust_sel); j++)
+			if (sel[i] == ppe_apptrust_sel[j])
+				break;
+		if (j == ARRAY_SIZE(ppe_apptrust_sel))
+			return -EOPNOTSUPP;
+
+		if (sel[i] == IEEE_8021QAZ_APP_SEL_DSCP)
+			dscp = i ? 0 : 1;
+		else
+			pcp = i ? 0 : 1;
+	}
+
+	regmap_update_bits(priv->regmap, PPE_PORT_QOS_CTRL(port),
+			   PPE_QOS_DSCP_PREC | PPE_QOS_PCP_PREC,
+			   FIELD_PREP(PPE_QOS_DSCP_PREC, dscp) |
+			   FIELD_PREP(PPE_QOS_PCP_PREC, pcp));
+
+	return 0;
+}
+
+/* One DSCP table serves every port - the hardware has two of them and selects
+ * between them per port, which is not the per-port mapping DCB describes, so
+ * the driver keeps every port on the same one and tells DSA the mapping is
+ * global.
+ */
+int qca_ppe_port_get_dscp_prio(struct dsa_switch *ds, int port, u8 dscp)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	u32 val;
+
+	regmap_read(priv->regmap, PPE_DSCP_QOS_GROUP(PPE_QOS_GROUP, dscp),
+		    &val);
+
+	return FIELD_GET(PPE_QOS_INFO_PRI, val);
+}
+
+int qca_ppe_port_add_dscp_prio(struct dsa_switch *ds, int port, u8 dscp,
+			       u8 prio)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+
+	if (prio > PPE_QOS_MAX_PRI)
+		return -ERANGE;
+
+	regmap_update_bits(priv->regmap,
+			   PPE_DSCP_QOS_GROUP(PPE_QOS_GROUP, dscp),
+			   PPE_QOS_INFO_PRI,
+			   FIELD_PREP(PPE_QOS_INFO_PRI, prio));
+
+	return 0;
+}
+
+/* `dcb app replace` adds the new entry before deleting the old one, so a delete
+ * naming a priority the table no longer holds is that ordering and not a
+ * request to undo anything.
+ */
+int qca_ppe_port_del_dscp_prio(struct dsa_switch *ds, int port, u8 dscp,
+			       u8 prio)
+{
+	struct qca_ppe_priv *priv = ds_to_priv(ds);
+
+	if (qca_ppe_port_get_dscp_prio(ds, port, dscp) != prio)
+		return 0;
+
+	regmap_update_bits(priv->regmap,
+			   PPE_DSCP_QOS_GROUP(PPE_QOS_GROUP, dscp),
+			   PPE_QOS_INFO_PRI, 0);
+
+	return 0;
+}
+
 static void ppe_qos_init(struct qca_ppe_priv *priv)
 {
 	u32 prec;
@@ -771,6 +905,15 @@ static void ppe_qos_init(struct qca_ppe_priv *priv)
 				   PPE_QOS_DSCP_PREC | PPE_QOS_PCP_PREC |
 				   PPE_QOS_PREHEADER_PREC | PPE_QOS_FLOW_PREC |
 				   PPE_QOS_ACL_PREC, prec);
+
+	/* Trusting PCP is only meaningful if the map behind it says something:
+	 * it resets to zero, which would resolve every tagged frame to priority
+	 * 0 and, because the classifier outranks DSCP once trusted, stop DSCP
+	 * deciding as well. The table is indexed by PCP over both DEI halves.
+	 */
+	for (i = 0; i < PPE_PCP_QOS_ENTRIES; i++)
+		regmap_write(priv->regmap, PPE_PCP_QOS_GROUP(0, i),
+			     FIELD_PREP(PPE_QOS_INFO_PRI, i & 7));
 }
 
 const struct psch_tdm_data cppe_psch_tdm_data = {
@@ -1108,6 +1251,88 @@ static void ppe_port_shaper_stats(struct qca_ppe_priv *priv, int port,
 	sh->base_drops = drops;
 }
 
+
+/* The port's scheduler is a strict-priority ladder over its unicast queues,
+ * built at probe and not reconfigurable: one queue per priority, and each queue
+ * already owns the DRR node it hangs off, so a weight has nothing to share
+ * bandwidth with. ETS is how that shape is expressed to tc, and a band this
+ * hardware cannot give is refused rather than quietly flattened into one it can.
+ */
+int qca_ppe_setup_tc_ets(struct qca_ppe_priv *priv, int port,
+			 struct tc_ets_qopt_offload *qopt)
+{
+	struct ppe_port_shaper *sh = &priv->shaper[port];
+	unsigned int i;
+
+	if (qopt->parent != TC_H_ROOT)
+		return -EOPNOTSUPP;
+
+	switch (qopt->command) {
+	case TC_ETS_REPLACE:
+		if (qopt->replace_params.bands > PPE_QOS_MAX_PRI + 1) {
+			dev_err(priv->ds.dev,
+				"port %d: %u bands, the port has %d priorities to give\n",
+				port, qopt->replace_params.bands,
+				PPE_QOS_MAX_PRI + 1);
+			return -EINVAL;
+		}
+
+		for (i = 0; i < qopt->replace_params.bands; i++) {
+			if (!qopt->replace_params.quanta[i])
+				continue;
+
+			dev_err(priv->ds.dev,
+				"port %d: band %u wants a weight, but its queue has a scheduler node to itself and nothing to share it with\n",
+				port, i);
+			return -EOPNOTSUPP;
+		}
+
+		/* The ladder is the priority itself: priority p leaves on the
+		 * port's queue p, and the classifier's own map clamps anything
+		 * above the last band onto it. A priomap that says otherwise
+		 * describes a scheduler this port does not have - except the
+		 * one the qdisc fills in when the user gave none, which puts
+		 * every priority on the last band and is an absence of an
+		 * opinion rather than a different one.
+		 */
+		for (i = 0; i < TC_PRIO_MAX + 1; i++)
+			if (qopt->replace_params.priomap[i] !=
+			    qopt->replace_params.bands - 1)
+				break;
+
+		if (i < TC_PRIO_MAX + 1) {
+			for (i = 0; i < TC_PRIO_MAX + 1; i++) {
+				u8 band = min_t(u8, i,
+						qopt->replace_params.bands - 1);
+
+				if (qopt->replace_params.priomap[i] == band)
+					continue;
+
+				dev_err(priv->ds.dev,
+					"port %d: priority %u is mapped to band %u; this scheduler is fixed and gives it band %u\n",
+					port, i,
+					qopt->replace_params.priomap[i], band);
+				return -EOPNOTSUPP;
+			}
+		}
+
+		sh->handle = qopt->handle;
+		ppe_port_tx_counters(priv, port, &sh->base_bytes,
+				     &sh->base_pkts, &sh->base_drops);
+		return 0;
+	case TC_ETS_DESTROY:
+		sh->handle = 0;
+		return 0;
+	case TC_ETS_STATS:
+		if (!sh->handle || qopt->handle != sh->handle)
+			return -EOPNOTSUPP;
+		ppe_port_shaper_stats(priv, port, &qopt->stats);
+		return 0;
+	default:
+		return -EOPNOTSUPP;
+	}
+}
+
 /* The hardware has one shaper per port and nowhere to hang a class off it, so
  * only a root tbf is a rate this switch can keep. The qdisc's overhead, mpu and
  * linklayer are not carried into the hardware, which meters the frame it puts
@@ -1165,6 +1390,8 @@ int qca_ppe_setup_tc(struct dsa_switch *ds, int port, enum tc_setup_type type,
 	switch (type) {
 	case TC_SETUP_QDISC_TBF:
 		return qca_ppe_setup_tc_tbf(priv, port, type_data);
+	case TC_SETUP_QDISC_ETS:
+		return qca_ppe_setup_tc_ets(priv, port, type_data);
 	default:
 		return -EOPNOTSUPP;
 	}

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
@@ -1947,13 +1947,23 @@ int qca_ppe_setup_tc_tbf(struct qca_ppe_priv *priv, int port,
 		return -EOPNOTSUPP;
 
 	switch (qopt->command) {
-	case TC_TBF_REPLACE:
+	case TC_TBF_REPLACE: {
+		/* The qdisc's own limit is the depth it wants behind the
+		 * shaper, and the queue limit is taken from it, so it is in
+		 * place before the rate is programmed and put back if the
+		 * rate is refused.
+		 */
+		u32 limit = priv->shaper[port].limit;
+
+		priv->shaper[port].limit = qopt->replace_params.limit;
 		ret = ppe_port_shaper_set(priv, port,
 					  qopt->replace_params.rate.rate_bytes_ps *
 					  BITS_PER_BYTE,
 					  qopt->replace_params.max_size);
-		if (ret)
+		if (ret) {
+			priv->shaper[port].limit = limit;
 			return ret;
+		}
 
 		priv->shaper[port].tbf_handle = qopt->handle;
 		ppe_port_tx_counters(priv, port,
@@ -1961,6 +1971,7 @@ int qca_ppe_setup_tc_tbf(struct qca_ppe_priv *priv, int port,
 				     &priv->shaper[port].base_pkts,
 				     &priv->shaper[port].base_drops);
 		return 0;
+	}
 	case TC_TBF_DESTROY:
 		/* A replacement's destroy arrives after the new qdisc has
 		 * already programmed the shaper, so only the qdisc that owns

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
@@ -516,6 +516,15 @@ static void ppe_qm_init(struct qca_ppe_priv *priv)
 			u8 cls = min(pri / PPE_FLOW_SPREAD_QUEUES, 2) *
 				 (i ? PPE_FLOW_SPREAD_QUEUES : 1);
 
+			/* From PPE_QOS_SPARSE_PRI up: the fourth list, past
+			 * the three bands on a user port. The CPU port has
+			 * none - no flow entry egresses there - so a rule
+			 * that marks that high keeps the third band and its
+			 * shaper.
+			 */
+			if (i && pri >= PPE_QOS_SPARSE_PRI)
+				cls = 3 * PPE_FLOW_SPREAD_QUEUES;
+
 			if (i) {
 				regmap_write(priv->regmap,
 					     PPE_QM_UCAST_PRI_MAP(i * 16 + pri),
@@ -884,6 +893,27 @@ static void ppe_l0_scheduler_init(struct qca_ppe_priv *priv)
 			}
 		}
 
+		/* A fourth list, for the flows the driver finds sparse: the
+		 * port's remaining unicast queues, on the download band's node
+		 * one priority above it, so the band's shaper covers them and
+		 * the scheduler serves them first. The band's queues wrote
+		 * their ids in turn to one register that holds the last, so
+		 * the earlier ones are unreferenced, and the list takes one.
+		 */
+		for (j = 3 * PPE_FLOW_SPREAD_QUEUES; j < p->ucast_count; j++) {
+			struct l0_cfg c = {
+				.queue = p->ucast_base + j,
+				.port = p->port,
+				.sp = p->sp_base + 1,
+				.cpri = 1,
+				.cdrr = p->cdrr_base + 2 * PPE_FLOW_SPREAD_QUEUES,
+				.epri = 1,
+				.edrr = p->cdrr_base + 2 * PPE_FLOW_SPREAD_QUEUES,
+			};
+
+			ppe_l0_entry_write(priv, &c);
+		}
+
 		/* Which multicast queue the port floods a frame onto is the
 		 * frame's internal priority, clamped to the queues the port
 		 * has: left at reset every priority resolves to the first.
@@ -1148,6 +1178,18 @@ static void ppe_qos_init(struct qca_ppe_priv *priv)
 	for (i = 0; i < PPE_PCP_QOS_ENTRIES; i++)
 		regmap_write(priv->regmap, PPE_PCP_QOS_GROUP(0, i),
 			     FIELD_PREP(PPE_QOS_INFO_PRI, i & 7));
+
+	/* A flow entry names a profile, not a priority, so give the profiles
+	 * the identity mapping and let the entry carry the number itself.
+	 * Profile 0 is left at priority 0: it is what an entry given no
+	 * priority holds, and leaving it there is what lets DSCP still decide
+	 * those. The sparse list sits above the bands and takes its own.
+	 */
+	for (i = 1; i <= PPE_QOS_MAX_PRI; i++)
+		regmap_write(priv->regmap, PPE_FLOW_QOS_GROUP(0, i),
+			     FIELD_PREP(PPE_QOS_INFO_PRI, i));
+	regmap_write(priv->regmap, PPE_FLOW_QOS_GROUP(0, PPE_QOS_SPARSE_PRI),
+		     FIELD_PREP(PPE_QOS_INFO_PRI, PPE_QOS_SPARSE_PRI));
 }
 
 const struct psch_tdm_data cppe_psch_tdm_data = {
@@ -1346,7 +1388,7 @@ static void ppe_port_queue_limit_set(struct qca_ppe_priv *priv, int port)
 					      div_u64(rate * 10,
 						      BITS_PER_BYTE * 1000),
 					      priv->data->qm_ceiling);
-		else if (sh->rate_bps && i < 3 * PPE_FLOW_SPREAD_QUEUES)
+		else if (sh->rate_bps)
 			/* A band bucket holds a share of the flows and drains
 			 * at no less than its share of the port, so it takes
 			 * a share of the depth: what one bucket's flows wait

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_scheduler.c
@@ -1596,12 +1596,63 @@ int qca_ppe_tc_query_caps(struct tc_query_caps_base *base)
 	return 0;
 }
 
-/* The port's scheduler is a strict-priority ladder over its unicast queues,
- * built at probe and not reconfigurable: one queue per priority, and each queue
- * already owns the DRR node it hangs off, so a weight has nothing to share
- * bandwidth with. ETS is how that shape is expressed to tc, and a band this
- * hardware cannot give is refused rather than quietly flattened into one it can.
+/* The port's unicast scheduler is three strict bands built at probe and not
+ * reconfigurable: priorities eight and up at the top, the classified
+ * priorities under them, best-effort below both, and the queues inside a band
+ * a hash spread served round robin rather than a ladder of their own. ETS and
+ * prio are how that shape is expressed to tc, which numbers bands from the
+ * top, so the top band is band 0. A shape this hardware cannot give is refused
+ * rather than quietly flattened into one it can; nothing is programmed either
+ * way, an accepted qdisc only gains the port's counters.
  */
+#define PPE_QOS_BANDS		3
+
+static int ppe_qos_bands_set(struct qca_ppe_priv *priv, int port, u32 handle,
+			     unsigned int bands, const u8 *priomap)
+{
+	struct ppe_port_shaper *sh = &priv->shaper[port];
+	unsigned int i;
+
+	if (bands != PPE_QOS_BANDS) {
+		dev_err(priv->ds.dev,
+			"port %d: %u bands, this scheduler is fixed at %d\n",
+			port, bands, PPE_QOS_BANDS);
+		return -EINVAL;
+	}
+
+	/* The priomap the qdisc fills in when the user gave none puts every
+	 * priority on the last band, which is an absence of an opinion rather
+	 * than a different one.
+	 */
+	for (i = 0; i < TC_PRIO_MAX + 1; i++)
+		if (priomap[i] != bands - 1)
+			break;
+
+	if (i < TC_PRIO_MAX + 1) {
+		for (i = 0; i < TC_PRIO_MAX + 1; i++) {
+			/* The band split ppe_qm_init gives a user port. */
+			u8 band = PPE_QOS_BANDS - 1 -
+				  min_t(unsigned int,
+					i / PPE_FLOW_SPREAD_QUEUES,
+					PPE_QOS_BANDS - 1);
+
+			if (priomap[i] == band)
+				continue;
+
+			dev_err(priv->ds.dev,
+				"port %d: priority %u is mapped to band %u; this scheduler is fixed and gives it band %u\n",
+				port, i, priomap[i], band);
+			return -EOPNOTSUPP;
+		}
+	}
+
+	sh->bands_handle = handle;
+	ppe_port_tx_counters(priv, port, &sh->base_bytes, &sh->base_pkts,
+			     &sh->base_drops);
+
+	return 0;
+}
+
 int qca_ppe_setup_tc_ets(struct qca_ppe_priv *priv, int port,
 			 struct tc_ets_qopt_offload *qopt)
 {
@@ -1613,62 +1664,59 @@ int qca_ppe_setup_tc_ets(struct qca_ppe_priv *priv, int port,
 
 	switch (qopt->command) {
 	case TC_ETS_REPLACE:
-		if (qopt->replace_params.bands > PPE_QOS_MAX_PRI + 1) {
-			dev_err(priv->ds.dev,
-				"port %d: %u bands, the port has %d priorities to give\n",
-				port, qopt->replace_params.bands,
-				PPE_QOS_MAX_PRI + 1);
-			return -EINVAL;
-		}
-
-		for (i = 0; i < qopt->replace_params.bands; i++) {
-			if (!qopt->replace_params.quanta[i])
+		/* sch_ets gives every band a quantum whether the user asked
+		 * for one or not, so a non-zero quantum is not a request. Bands
+		 * that differ are: refuse those, because the bands are strict
+		 * and the only round robin under them is between a band's hash
+		 * buckets, which no priority selects.
+		 */
+		for (i = 1; i < qopt->replace_params.bands; i++) {
+			if (qopt->replace_params.quanta[i] ==
+			    qopt->replace_params.quanta[0])
 				continue;
 
 			dev_err(priv->ds.dev,
-				"port %d: band %u wants a weight, but its queue has a scheduler node to itself and nothing to share it with\n",
+				"port %d: band %u asks for a weight of its own; these bands are strict\n",
 				port, i);
 			return -EOPNOTSUPP;
 		}
 
-		/* The ladder is the priority itself: priority p leaves on the
-		 * port's queue p, and the classifier's own map clamps anything
-		 * above the last band onto it. A priomap that says otherwise
-		 * describes a scheduler this port does not have - except the
-		 * one the qdisc fills in when the user gave none, which puts
-		 * every priority on the last band and is an absence of an
-		 * opinion rather than a different one.
-		 */
-		for (i = 0; i < TC_PRIO_MAX + 1; i++)
-			if (qopt->replace_params.priomap[i] !=
-			    qopt->replace_params.bands - 1)
-				break;
-
-		if (i < TC_PRIO_MAX + 1) {
-			for (i = 0; i < TC_PRIO_MAX + 1; i++) {
-				u8 band = min_t(u8, i,
-						qopt->replace_params.bands - 1);
-
-				if (qopt->replace_params.priomap[i] == band)
-					continue;
-
-				dev_err(priv->ds.dev,
-					"port %d: priority %u is mapped to band %u; this scheduler is fixed and gives it band %u\n",
-					port, i,
-					qopt->replace_params.priomap[i], band);
-				return -EOPNOTSUPP;
-			}
-		}
-
-		sh->handle = qopt->handle;
-		ppe_port_tx_counters(priv, port, &sh->base_bytes,
-				     &sh->base_pkts, &sh->base_drops);
-		return 0;
+		return ppe_qos_bands_set(priv, port, qopt->handle,
+					 qopt->replace_params.bands,
+					 qopt->replace_params.priomap);
 	case TC_ETS_DESTROY:
-		sh->handle = 0;
+		if (qopt->handle == sh->bands_handle)
+			sh->bands_handle = 0;
 		return 0;
 	case TC_ETS_STATS:
-		if (!sh->handle || qopt->handle != sh->handle)
+		if (!sh->bands_handle || qopt->handle != sh->bands_handle)
+			return -EOPNOTSUPP;
+		ppe_port_shaper_stats(priv, port, &qopt->stats);
+		return 0;
+	default:
+		return -EOPNOTSUPP;
+	}
+}
+
+int qca_ppe_setup_tc_prio(struct qca_ppe_priv *priv, int port,
+			  struct tc_prio_qopt_offload *qopt)
+{
+	struct ppe_port_shaper *sh = &priv->shaper[port];
+
+	if (qopt->parent != TC_H_ROOT)
+		return -EOPNOTSUPP;
+
+	switch (qopt->command) {
+	case TC_PRIO_REPLACE:
+		return ppe_qos_bands_set(priv, port, qopt->handle,
+					 qopt->replace_params.bands,
+					 qopt->replace_params.priomap);
+	case TC_PRIO_DESTROY:
+		if (qopt->handle == sh->bands_handle)
+			sh->bands_handle = 0;
+		return 0;
+	case TC_PRIO_STATS:
+		if (!sh->bands_handle || qopt->handle != sh->bands_handle)
 			return -EOPNOTSUPP;
 		ppe_port_shaper_stats(priv, port, &qopt->stats);
 		return 0;
@@ -1736,6 +1784,8 @@ int qca_ppe_setup_tc(struct dsa_switch *ds, int port, enum tc_setup_type type,
 		return qca_ppe_setup_tc_tbf(priv, port, type_data);
 	case TC_SETUP_QDISC_ETS:
 		return qca_ppe_setup_tc_ets(priv, port, type_data);
+	case TC_SETUP_QDISC_PRIO:
+		return qca_ppe_setup_tc_prio(priv, port, type_data);
 	case TC_SETUP_QDISC_MQPRIO:
 		return qca_ppe_setup_tc_mqprio(priv, port, type_data);
 	case TC_QUERY_CAPS:

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_vlan.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_vlan.c
@@ -22,7 +22,12 @@ static void ppe_xlt_rule_set(struct qca_ppe_priv *priv, int idx,
 {
 	u32 w0, w1;
 
-	w0 = PPE_XLT_VALID | FIELD_PREP(PPE_XLT_PORT_BMP, port_bmp);
+	/* The frame-format fields are match bitmaps, so a zero matches no frame
+	 * at all and the rule never fires. These keys are single-tagged, which
+	 * leaves the S-tag side to accept the untagged format.
+	 */
+	w0 = PPE_XLT_VALID | FIELD_PREP(PPE_XLT_PORT_BMP, port_bmp) |
+	     FIELD_PREP(PPE_XLT_SKEY_FMT, PPE_XLT_SKEY_UNTAGGED);
 	w1 = 0;
 
 	if (untagged) {
@@ -39,18 +44,16 @@ static void ppe_xlt_rule_set(struct qca_ppe_priv *priv, int idx,
 	regmap_write(priv->regmap, PPE_XLT_RULE_TBL(idx) + 8, 0);
 }
 
-static void ppe_xlt_action_set(struct qca_ppe_priv *priv, int idx,
-			       u32 vsi, bool strip_ctag)
+/* Classify into the VLAN's VSI and leave the tag alone: the VSI carries the
+ * domain from here on, while the tag still has to reach the CPU for the software
+ * bridge and survive to a port that egresses this VLAN tagged. Which ports strip
+ * it is EG_VSI_TAG's decision, not this rule's.
+ */
+static void ppe_xlt_action_set(struct qca_ppe_priv *priv, int idx, u32 vsi)
 {
-	u32 w0 = 0, w1;
-
-	if (strip_ctag)
-		w0 = FIELD_PREP(PPE_XLT_CVID_CMD, PPE_XLT_CVID_DEL);
-
-	w1 = PPE_XLT_VSI_CMD | FIELD_PREP(PPE_XLT_VSI, vsi);
-
-	regmap_write(priv->regmap, PPE_XLT_ACTION_TBL(idx), w0);
-	regmap_write(priv->regmap, PPE_XLT_ACTION_W1(idx), w1);
+	regmap_write(priv->regmap, PPE_XLT_ACTION_TBL(idx), 0);
+	regmap_write(priv->regmap, PPE_XLT_ACTION_W1(idx),
+		     PPE_XLT_VSI_CMD | FIELD_PREP(PPE_XLT_VSI, vsi));
 }
 
 static void ppe_xlt_clear(struct qca_ppe_priv *priv, int idx)
@@ -140,6 +143,9 @@ static void ppe_vlan_free(struct qca_ppe_priv *priv,
 	entry->br_dev = NULL;
 }
 
+static void ppe_vlan_port_remove(struct qca_ppe_priv *priv,
+				 struct qca_ppe_vlan_entry *entry, int port);
+
 static void ppe_vlan_members_update(struct qca_ppe_priv *priv,
 				    struct qca_ppe_vlan_entry *entry)
 {
@@ -196,6 +202,7 @@ int qca_ppe_port_vlan_filtering(struct dsa_switch *ds, int port,
 				struct netlink_ext_ack *extack)
 {
 	struct qca_ppe_priv *priv = ds_to_priv(ds);
+	int i;
 
 	regmap_update_bits(priv->regmap, PPE_PORT_EG_VLAN(port),
 			   PPE_PORT_EG_VSI_TAG_EN,
@@ -206,7 +213,43 @@ int qca_ppe_port_vlan_filtering(struct dsa_switch *ds, int port,
 			   vlan_filtering ?
 			   FIELD_PREP(PPE_VLAN_XLT_MISS_FWD, PPE_XLT_MISS_FWD_DROP) : 0);
 
+	/* DSA stops offering VLAN configuration once filtering is off, but it
+	 * never withdraws what it already programmed, so the rules naming this
+	 * port have to come down here or they keep classifying its traffic
+	 * into a VLAN the bridge no longer enforces.
+	 */
+	if (!vlan_filtering)
+		for (i = 0; i < PPE_VSI_MAX; i++)
+			if (priv->vlans[i].br_dev &&
+			    priv->vlans[i].ports & BIT(port))
+				ppe_vlan_port_remove(priv, &priv->vlans[i],
+						     port);
+
 	return 0;
+}
+
+static void ppe_vlan_port_remove(struct qca_ppe_priv *priv,
+				 struct qca_ppe_vlan_entry *entry, int port)
+{
+	entry->ports &= ~BIT(port);
+	ppe_eg_vsi_tag_port_set(priv, entry->vsi, port, PPE_EG_UNMODIFIED);
+
+	if (priv->port_pvid[port] == entry->vid) {
+		ppe_port_def_cvid_set(priv, port, 0, false);
+		priv->port_pvid[port] = 0;
+		entry->pvid_ports &= ~BIT(port);
+	}
+
+	if (!entry->ports) {
+		ppe_vlan_free(priv, entry);
+		return;
+	}
+
+	ppe_xlt_rule_set(priv, entry->xlt_idx,
+			 entry->ports | BIT(QCA_PPE_CPU_PORT), entry->vid,
+			 false);
+	ppe_vlan_pvid_update(priv, entry);
+	ppe_vlan_members_update(priv, entry);
 }
 
 int qca_ppe_port_vlan_add(struct dsa_switch *ds, int port,
@@ -249,20 +292,34 @@ int qca_ppe_port_vlan_add(struct dsa_switch *ds, int port,
 
 	ppe_xlt_rule_set(priv, entry->xlt_idx,
 			 entry->ports | BIT(QCA_PPE_CPU_PORT), vid, false);
-	ppe_xlt_action_set(priv, entry->xlt_idx, entry->vsi, true);
+	ppe_xlt_action_set(priv, entry->xlt_idx, entry->vsi);
 
 	ppe_eg_vsi_tag_port_set(priv, entry->vsi, port,
 				untagged ? PPE_EG_UNTAGGED : PPE_EG_TAGGED);
 
 	if (pvid) {
+		/* The bridge notifies only the vid coming in, so the entry that
+		 * held this port's untagged rule gives it up here or keeps a
+		 * member it no longer has.
+		 */
+		if (priv->port_pvid[port] != vid) {
+			struct qca_ppe_vlan_entry *old;
+
+			old = ppe_vlan_find(priv, br_dev,
+					    priv->port_pvid[port]);
+			if (old) {
+				old->pvid_ports &= ~BIT(port);
+				ppe_vlan_pvid_update(priv, old);
+			}
+		}
+
 		ppe_port_def_cvid_set(priv, port, vid, true);
 		priv->port_pvid[port] = vid;
 		entry->pvid_ports |= BIT(port);
 
 		ppe_xlt_rule_set(priv, entry->xlt_pvid_idx,
 				 entry->pvid_ports, 0, true);
-		ppe_xlt_action_set(priv, entry->xlt_pvid_idx, entry->vsi,
-				   false);
+		ppe_xlt_action_set(priv, entry->xlt_pvid_idx, entry->vsi);
 	} else if (priv->port_pvid[port] == vid) {
 		ppe_port_def_cvid_set(priv, port, 0, false);
 		priv->port_pvid[port] = 0;
@@ -296,26 +353,7 @@ int qca_ppe_port_vlan_del(struct dsa_switch *ds, int port,
 	if (!entry)
 		return 0;
 
-	entry->ports &= ~BIT(port);
-	ppe_eg_vsi_tag_port_set(priv, entry->vsi, port, PPE_EG_UNMODIFIED);
-
-	if (priv->port_pvid[port] == vid) {
-		ppe_port_def_cvid_set(priv, port, 0, false);
-		priv->port_pvid[port] = 0;
-		entry->pvid_ports &= ~BIT(port);
-	}
-
-	if (!entry->ports) {
-		ppe_vlan_free(priv, entry);
-		return 0;
-	}
-
-	ppe_xlt_rule_set(priv, entry->xlt_idx,
-			 entry->ports | BIT(QCA_PPE_CPU_PORT), vid, false);
-
-	ppe_vlan_pvid_update(priv, entry);
-
-	ppe_vlan_members_update(priv, entry);
+	ppe_vlan_port_remove(priv, entry, port);
 
 	return 0;
 }

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_vlan.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_vlan.c
@@ -289,9 +289,13 @@ int qca_ppe_port_vlan_add(struct dsa_switch *ds, int port,
 
 	entry->ports |= BIT(port);
 
+	/* The action names the VSI the rule classifies into, so it is programmed
+	 * first: a rule made live over the action of whichever VLAN held the
+	 * index before would bridge the frame in that VLAN's domain.
+	 */
+	ppe_xlt_action_set(priv, entry->xlt_idx, entry->vsi);
 	ppe_xlt_rule_set(priv, entry->xlt_idx,
 			 entry->ports | BIT(QCA_PPE_CPU_PORT), vid, false);
-	ppe_xlt_action_set(priv, entry->xlt_idx, entry->vsi);
 
 	ppe_eg_vsi_tag_port_set(priv, entry->vsi, port,
 				untagged ? PPE_EG_UNTAGGED : PPE_EG_TAGGED);
@@ -316,9 +320,9 @@ int qca_ppe_port_vlan_add(struct dsa_switch *ds, int port,
 		priv->port_pvid[port] = vid;
 		entry->pvid_ports |= BIT(port);
 
+		ppe_xlt_action_set(priv, entry->xlt_pvid_idx, entry->vsi);
 		ppe_xlt_rule_set(priv, entry->xlt_pvid_idx,
 				 entry->pvid_ports, 0, true);
-		ppe_xlt_action_set(priv, entry->xlt_pvid_idx, entry->vsi);
 	} else if (priv->port_pvid[port] == vid) {
 		ppe_port_def_cvid_set(priv, port, 0, false);
 		priv->port_pvid[port] = 0;

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_vlan.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_vlan.c
@@ -88,9 +88,8 @@ static void ppe_port_def_cvid_set(struct qca_ppe_priv *priv,
 			   PPE_PORT_DEF_CVID_EN : 0);
 }
 
-static struct qca_ppe_vlan_entry *
-ppe_vlan_find(struct qca_ppe_priv *priv, struct net_device *br_dev,
-	      u16 vid)
+struct qca_ppe_vlan_entry *
+ppe_vlan_find(struct qca_ppe_priv *priv, struct net_device *br_dev, u16 vid)
 {
 	int i;
 

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_vlan.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_ppe_vlan.c
@@ -5,9 +5,11 @@
 
 #include "qca_ppe.h"
 
-static int ppe_xlt_idx_alloc(struct qca_ppe_priv *priv)
+int ppe_xlt_idx_alloc(struct qca_ppe_priv *priv)
 {
 	int idx;
+
+	lockdep_assert_held(&priv->vlan_lock);
 
 	idx = find_first_zero_bit(priv->xlt_bitmap, PPE_XLT_TBL_NUM);
 	if (idx >= PPE_XLT_TBL_NUM)
@@ -65,8 +67,10 @@ static void ppe_xlt_clear(struct qca_ppe_priv *priv, int idx)
 	regmap_write(priv->regmap, PPE_XLT_ACTION_W1(idx), 0);
 }
 
-static void ppe_xlt_idx_free(struct qca_ppe_priv *priv, int *idx)
+void ppe_xlt_idx_free(struct qca_ppe_priv *priv, int *idx)
 {
+	lockdep_assert_held(&priv->vlan_lock);
+
 	ppe_xlt_clear(priv, *idx);
 	clear_bit(*idx, priv->xlt_bitmap);
 	*idx = -1;
@@ -138,6 +142,7 @@ static void ppe_vlan_free(struct qca_ppe_priv *priv,
 		ppe_xlt_idx_free(priv, &entry->xlt_idx);
 	if (entry->xlt_pvid_idx >= 0)
 		ppe_xlt_idx_free(priv, &entry->xlt_pvid_idx);
+	ppe_flow_purge_vsi(priv, entry->vsi);
 	ppe_vsi_free(priv, entry->vsi);
 	entry->br_dev = NULL;
 }
@@ -203,6 +208,9 @@ int qca_ppe_port_vlan_filtering(struct dsa_switch *ds, int port,
 	struct qca_ppe_priv *priv = ds_to_priv(ds);
 	int i;
 
+	guard(mutex)(&priv->flow_lock);
+	guard(mutex)(&priv->vlan_lock);
+
 	regmap_update_bits(priv->regmap, PPE_PORT_EG_VLAN(port),
 			   PPE_PORT_EG_VSI_TAG_EN,
 			   vlan_filtering ? PPE_PORT_EG_VSI_TAG_EN : 0);
@@ -265,6 +273,9 @@ int qca_ppe_port_vlan_add(struct dsa_switch *ds, int port,
 
 	if (!br_dev)
 		return 0;
+
+	guard(mutex)(&priv->flow_lock);
+	guard(mutex)(&priv->vlan_lock);
 
 	entry = ppe_vlan_find(priv, br_dev, vid);
 	if (!entry) {
@@ -351,6 +362,9 @@ int qca_ppe_port_vlan_del(struct dsa_switch *ds, int port,
 
 	if (!br_dev)
 		return 0;
+
+	guard(mutex)(&priv->flow_lock);
+	guard(mutex)(&priv->vlan_lock);
 
 	entry = ppe_vlan_find(priv, br_dev, vid);
 	if (!entry)

--- a/target/linux/qualcommax/files/include/dt-bindings/net/qualcomm,ipq-ppe.yaml
+++ b/target/linux/qualcommax/files/include/dt-bindings/net/qualcomm,ipq-ppe.yaml
@@ -208,7 +208,7 @@ examples:
 
     ppe@3a000000 {
         compatible = "qualcomm,ipq8074-ppe";
-        reg = <0x3a000000 0x900000>;
+        reg = <0x3a000000 0xa00000>;
 
         clocks = <&gcc GCC_CMN_12GPLL_AHB_CLK>,
                  <&gcc GCC_CMN_12GPLL_SYS_CLK>,

--- a/target/linux/qualcommax/patches-6.18/0952-net-ethernet-qca-add-ppe.patch
+++ b/target/linux/qualcommax/patches-6.18/0952-net-ethernet-qca-add-ppe.patch
@@ -21,7 +21,7 @@
  obj-$(CONFIG_QCA7000_UART) += qcauart.o
  qcauart-objs := qca_uart.o
 +obj-$(CONFIG_QCOM_80211AX_PPE) += qca_ppe.o
-+qca_ppe-objs := qca_ppe_main.o qca_ppe_vlan.o qca_ppe_scheduler.o qca_ppe_debugfs.o qca_ppe_acl.o
++qca_ppe-objs := qca_ppe_main.o qca_ppe_vlan.o qca_ppe_scheduler.o qca_ppe_debugfs.o qca_ppe_acl.o qca_ppe_flow.o
  
  obj-y += emac/
  

--- a/target/linux/qualcommax/patches-6.18/0952-net-ethernet-qca-add-ppe.patch
+++ b/target/linux/qualcommax/patches-6.18/0952-net-ethernet-qca-add-ppe.patch
@@ -21,7 +21,7 @@
  obj-$(CONFIG_QCA7000_UART) += qcauart.o
  qcauart-objs := qca_uart.o
 +obj-$(CONFIG_QCOM_80211AX_PPE) += qca_ppe.o
-+qca_ppe-objs := qca_ppe_main.o qca_ppe_vlan.o qca_ppe_scheduler.o qca_ppe_debugfs.o qca_ppe_acl.o qca_ppe_flow.o
++qca_ppe-objs := qca_ppe_main.o qca_ppe_vlan.o qca_ppe_scheduler.o qca_ppe_debugfs.o qca_ppe_acl.o qca_ppe_flow.o qca_ppe_flow_offload.o
  
  obj-y += emac/
  

--- a/target/linux/qualcommax/patches-6.18/0952-net-ethernet-qca-add-ppe.patch
+++ b/target/linux/qualcommax/patches-6.18/0952-net-ethernet-qca-add-ppe.patch
@@ -21,7 +21,7 @@
  obj-$(CONFIG_QCA7000_UART) += qcauart.o
  qcauart-objs := qca_uart.o
 +obj-$(CONFIG_QCOM_80211AX_PPE) += qca_ppe.o
-+qca_ppe-objs := qca_ppe_main.o qca_ppe_vlan.o qca_ppe_scheduler.o qca_ppe_debugfs.o
++qca_ppe-objs := qca_ppe_main.o qca_ppe_vlan.o qca_ppe_scheduler.o qca_ppe_debugfs.o qca_ppe_acl.o
  
  obj-y += emac/
  

--- a/target/linux/qualcommax/patches-6.18/0952-net-ethernet-qca-add-ppe.patch
+++ b/target/linux/qualcommax/patches-6.18/0952-net-ethernet-qca-add-ppe.patch
@@ -21,7 +21,7 @@
  obj-$(CONFIG_QCA7000_UART) += qcauart.o
  qcauart-objs := qca_uart.o
 +obj-$(CONFIG_QCOM_80211AX_PPE) += qca_ppe.o
-+qca_ppe-objs := qca_ppe_main.o qca_ppe_vlan.o qca_ppe_scheduler.o
++qca_ppe-objs := qca_ppe_main.o qca_ppe_vlan.o qca_ppe_scheduler.o qca_ppe_debugfs.o
  
  obj-y += emac/
  

--- a/target/linux/qualcommax/patches-6.18/0953-net-ethernet-qca-add-EDMA.patch
+++ b/target/linux/qualcommax/patches-6.18/0953-net-ethernet-qca-add-EDMA.patch
@@ -17,7 +17,7 @@
 @@ -10,6 +10,7 @@ obj-$(CONFIG_QCA7000_UART) += qcauart.o
  qcauart-objs := qca_uart.o
  obj-$(CONFIG_QCOM_80211AX_PPE) += qca_ppe.o
- qca_ppe-objs := qca_ppe_main.o qca_ppe_vlan.o qca_ppe_scheduler.o qca_ppe_debugfs.o qca_ppe_acl.o
+ qca_ppe-objs := qca_ppe_main.o qca_ppe_vlan.o qca_ppe_scheduler.o qca_ppe_debugfs.o qca_ppe_acl.o qca_ppe_flow.o
 +obj-$(CONFIG_QCOM_EDMA) += qca_edma.o
  
  obj-y += emac/

--- a/target/linux/qualcommax/patches-6.18/0953-net-ethernet-qca-add-EDMA.patch
+++ b/target/linux/qualcommax/patches-6.18/0953-net-ethernet-qca-add-EDMA.patch
@@ -17,7 +17,7 @@
 @@ -10,6 +10,7 @@ obj-$(CONFIG_QCA7000_UART) += qcauart.o
  qcauart-objs := qca_uart.o
  obj-$(CONFIG_QCOM_80211AX_PPE) += qca_ppe.o
- qca_ppe-objs := qca_ppe_main.o qca_ppe_vlan.o qca_ppe_scheduler.o qca_ppe_debugfs.o qca_ppe_acl.o qca_ppe_flow.o
+ qca_ppe-objs := qca_ppe_main.o qca_ppe_vlan.o qca_ppe_scheduler.o qca_ppe_debugfs.o qca_ppe_acl.o qca_ppe_flow.o qca_ppe_flow_offload.o
 +obj-$(CONFIG_QCOM_EDMA) += qca_edma.o
  
  obj-y += emac/

--- a/target/linux/qualcommax/patches-6.18/0953-net-ethernet-qca-add-EDMA.patch
+++ b/target/linux/qualcommax/patches-6.18/0953-net-ethernet-qca-add-EDMA.patch
@@ -17,7 +17,7 @@
 @@ -10,6 +10,7 @@ obj-$(CONFIG_QCA7000_UART) += qcauart.o
  qcauart-objs := qca_uart.o
  obj-$(CONFIG_QCOM_80211AX_PPE) += qca_ppe.o
- qca_ppe-objs := qca_ppe_main.o qca_ppe_vlan.o qca_ppe_scheduler.o qca_ppe_debugfs.o
+ qca_ppe-objs := qca_ppe_main.o qca_ppe_vlan.o qca_ppe_scheduler.o qca_ppe_debugfs.o qca_ppe_acl.o
 +obj-$(CONFIG_QCOM_EDMA) += qca_edma.o
  
  obj-y += emac/

--- a/target/linux/qualcommax/patches-6.18/0953-net-ethernet-qca-add-EDMA.patch
+++ b/target/linux/qualcommax/patches-6.18/0953-net-ethernet-qca-add-EDMA.patch
@@ -17,7 +17,7 @@
 @@ -10,6 +10,7 @@ obj-$(CONFIG_QCA7000_UART) += qcauart.o
  qcauart-objs := qca_uart.o
  obj-$(CONFIG_QCOM_80211AX_PPE) += qca_ppe.o
- qca_ppe-objs := qca_ppe_main.o qca_ppe_vlan.o qca_ppe_scheduler.o
+ qca_ppe-objs := qca_ppe_main.o qca_ppe_vlan.o qca_ppe_scheduler.o qca_ppe_debugfs.o
 +obj-$(CONFIG_QCOM_EDMA) += qca_edma.o
  
  obj-y += emac/

--- a/target/linux/realtek/patches-6.18/700-dsa-mdio-increase-max-ports-for-rtl839x-rtl931x.patch
+++ b/target/linux/realtek/patches-6.18/700-dsa-mdio-increase-max-ports-for-rtl839x-rtl931x.patch
@@ -32,7 +32,7 @@ Signed-off-by: Markus Stockhausen <markus.stockhausen@gmx.de>
  struct dsa_chip_data {
 --- a/include/net/dsa.h
 +++ b/include/net/dsa.h
-@@ -480,7 +480,7 @@ struct dsa_switch {
+@@ -486,7 +486,7 @@ struct dsa_switch {
  	/*
  	 * User mii_bus and devices for the individual ports.
  	 */
@@ -41,7 +41,7 @@ Signed-off-by: Markus Stockhausen <markus.stockhausen@gmx.de>
  	struct mii_bus		*user_mii_bus;
  
  	/* Ageing Time limits in msecs */
-@@ -616,24 +616,24 @@ static inline bool dsa_is_user_port(stru
+@@ -622,24 +622,24 @@ static inline bool dsa_is_user_port(stru
  	dsa_switch_for_each_port_continue_reverse((_dp), (_ds)) \
  		if (dsa_port_is_cpu((_dp)))
  


### PR DESCRIPTION
`nf_flow_rule_match()` fills the vlan and cvlan keys and sets their dissector
offsets, but does not set their bits in `used_keys`. That bit is how a driver
learns that a rule has the key: `flow_rule_match_key()` reads `used_keys`, and
a key the rule does not declare cannot be read. So no driver sees the vlan
match, although the rule carries the vlan pop action built from the same
encapsulation.

Two commits: the fix, and the PPE driver taking the tag it now sees.

### The kernel patch

`target/linux/generic/pending-6.18/777-netfilter-flowtable-advertise-the-vlan-match-in-used_keys.patch`

```
Fixes: 3e1b0c168f6c ("netfilter: flowtable: add vlan match offload support")
```

`mtk_ppe_offload.c` reads the ingress vlan through `flow_rule_match_key()` and
so never gets it, and a driver that checks `used_keys` against the keys it
supports installs an entry that ignores the tag.

It is already posted as `[PATCH nf] netfilter: flowtable: advertise the vlan
match in used_keys`:
https://lore.kernel.org/all/20260906141947.480524-1-julius@bairaktaris.de/
and is carried here in `pending-6.18` until it lands.

### What the driver does with it

An ingress tag is matched by the VSI it is classified into - the uplink's tag
on a PPPoE port, a bridge VLAN the port is a member of - never by the tag
itself, which the hardware key cannot hold. Before this, a tagged ingress was
accepted on the PVID's VSI, which is the wrong routing domain for a host on a
tagged member. Now the tag picks the VSI the entry keys on, and a tag this
driver has no classification for stays in software.

### Measured

IPQ8074 (Xiaomi AX3600), kernel 6.18.44. A host on a tagged member of a
VLAN-filtering bridge (lan2 tagged in VLAN 20, the host sending tagged
frames), three downloads of 346 to 412 MB: a hardware entry per direction
while they run, the VLAN interface's transmit counter moving by 452.3, 382.9
and 380.5 MB and its receive counter by 3.00, 2.48 and 2.92 MB, with the
ingress-VLAN decline counter at zero. The PPPoE uplink, whose ingress rule now
carries vid 7, offloads as before in three runs.

Without the fix a driver probe shows every such rule with the vlan pop action
and no vlan bit in `used_keys`.

### Depends on

The PPE flow offload pull request, and through it the PPE switch pull request.


### For self-builders

A single branch with all of this on it, plus the `ppe-qos` package, is
`ppe-offload` on the fork:
https://github.com/JuliusBairaktaris/openwrt-nss-edma/tree/ppe-offload
It is not proposed for merge - it exists so that anyone building their own
image gets the whole feature set from one checkout instead of stacking these
pull requests by hand.
