### PR TITLE
ppe-qos: configure the PPE queue classifiers from uci

### DIFF
--- a/package/kernel/linux/modules/netsupport.mk
+++ b/package/kernel/linux/modules/netsupport.mk
@@ -743,6 +743,22 @@ endef
 $(eval $(call KernelPackage,sched-core))
 
 
+define KernelPackage/sched-act-pedit
+  SUBMENU:=$(NETWORK_SUPPORT_MENU)
+  TITLE:=Traffic Packet Editing
+  DEPENDS:=+kmod-sched-core
+  KCONFIG:=CONFIG_NET_ACT_PEDIT
+  FILES:=$(LINUX_DIR)/net/sched/act_pedit.ko
+  AUTOLOAD:=$(call AutoProbe,act_pedit)
+endef
+
+define KernelPackage/sched-act-pedit/description
+ Allows to configure rules to rewrite header fields, such as the DSCP.
+endef
+
+$(eval $(call KernelPackage,sched-act-pedit))
+
+
 define KernelPackage/sched-act-police
   SUBMENU:=$(NETWORK_SUPPORT_MENU)
   TITLE:=Traffic Policing
@@ -858,6 +874,22 @@ define KernelPackage/sched-drr/description
 endef
 
 $(eval $(call KernelPackage,sched-drr))
+
+
+define KernelPackage/sched-ets
+  SUBMENU:=$(NETWORK_SUPPORT_MENU)
+  TITLE:=Enhanced Transmission Selection scheduler
+  DEPENDS:=+kmod-sched-core
+  KCONFIG:=CONFIG_NET_SCH_ETS
+  FILES:=$(LINUX_DIR)/net/sched/sch_ets.ko
+  AUTOLOAD:=$(call AutoProbe,sch_ets)
+endef
+
+define KernelPackage/sched-ets/description
+ Strict priority and weighted round-robin bands, offloadable to a switch.
+endef
+
+$(eval $(call KernelPackage,sched-ets))
 
 
 define KernelPackage/sched-flower
@@ -1007,13 +1039,14 @@ endef
 $(eval $(call KernelPackage,bpf-test))
 
 
-SCHED_MODULES_EXTRA = sch_codel sch_gred sch_multiq sch_sfq sch_teql sch_fq sch_ets act_pedit act_simple act_skbmod act_csum em_cmp em_nbyte em_meta em_text
+SCHED_MODULES_EXTRA = sch_codel sch_gred sch_multiq sch_sfq sch_teql sch_fq act_simple act_skbmod act_csum em_cmp em_nbyte em_meta em_text
 SCHED_FILES_EXTRA = $(foreach mod,$(SCHED_MODULES_EXTRA),$(LINUX_DIR)/net/sched/$(mod).ko)
 
 define KernelPackage/sched
   SUBMENU:=$(NETWORK_SUPPORT_MENU)
   TITLE:=Extra traffic schedulers
-  DEPENDS:=+kmod-sched-core +LINUX_6_12:kmod-lib-crc32c +kmod-lib-textsearch
+  DEPENDS:=+kmod-sched-core +kmod-sched-ets +kmod-sched-act-pedit \
+	+LINUX_6_12:kmod-lib-crc32c +kmod-lib-textsearch
   KCONFIG:= \
 	CONFIG_NET_SCH_CODEL \
 	CONFIG_NET_SCH_GRED \
@@ -1021,8 +1054,6 @@ define KernelPackage/sched
 	CONFIG_NET_SCH_SFQ \
 	CONFIG_NET_SCH_TEQL \
 	CONFIG_NET_SCH_FQ \
-	CONFIG_NET_SCH_ETS \
-	CONFIG_NET_ACT_PEDIT \
 	CONFIG_NET_ACT_SIMP \
 	CONFIG_NET_ACT_SKBMOD \
 	CONFIG_NET_ACT_CSUM \

--- a/package/network/config/ppe-qos/Makefile
+++ b/package/network/config/ppe-qos/Makefile
@@ -1,0 +1,44 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ppe-qos
+PKG_VERSION:=1.0
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=
+PKG_MAINTAINER:=Julius Bairaktaris <julius@bairaktaris.de>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/ppe-qos
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Qualcomm PPE hardware QoS classifiers
+  DEPENDS:=@TARGET_qualcommax +dcb +tc +kmod-sched-flower +kmod-sched-act-pedit \
+	+kmod-sched-prio +kmod-sched-ets +kmod-sched-mqprio +kmod-sched-act-police
+  PKGARCH:=all
+endef
+
+define Package/ppe-qos/description
+Configures the classifiers that pick a hardware egress queue on the
+Qualcomm PPE: per-port DSCP-to-priority maps (via dcb app) and the
+switch's small-packet priority, so latency-sensitive traffic is served
+past the bulk queue of a shaped port. Pairs with sqm-scripts' hw_ppe.qos,
+which owns the rates and the bulk queue depth.
+endef
+
+define Build/Compile
+endef
+
+define Package/ppe-qos/conffiles
+/etc/config/ppe-qos
+endef
+
+define Package/ppe-qos/install
+	$(INSTALL_DIR) $(1)/etc/config $(1)/etc/init.d
+	$(INSTALL_CONF) ./files/ppe-qos.config $(1)/etc/config/ppe-qos
+	$(INSTALL_BIN) ./files/ppe-qos.init $(1)/etc/init.d/ppe-qos
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/net
+	$(INSTALL_DATA) ./files/ppe-qos.hotplug $(1)/etc/hotplug.d/net/20-ppe-qos
+endef
+
+$(eval $(call BuildPackage,ppe-qos))

--- a/package/network/config/ppe-qos/files/ppe-qos.config
+++ b/package/network/config/ppe-qos/files/ppe-qos.config
@@ -1,0 +1,229 @@
+# PPE hardware QoS - which egress queue of the switch a flow rides.
+#
+# Three things happen here, in the order a packet meets them:
+#
+#   1. A marking rule ('config rule') puts a DSCP on a flow. The switch's ACL
+#      engine does it, so it applies to flows the PPE has offloaded too - which
+#      is the whole point, since an offloaded flow never returns to the CPU for
+#      an nftables rule to see.
+#   2. A map ('config dscp') turns a DSCP into an internal priority, applied
+#      with dcb app on every switch port. A marking rule also carries that
+#      priority itself, because the map reads the header as it arrived and the
+#      download half of a rule arrives unmarked.
+#   3. The priority picks the egress queue. A shaped port has two bands, and
+#      the upper one is served past the bulk queue, so marked traffic keeps
+#      idle latency while the bulk queue stays deep enough for full throughput.
+#      Priorities 4 and up ride the upper band.
+#
+# Shaper rates and the bulk queue depth are not here - they belong to SQM
+# (hw_ppe.qos), which owns the token buckets.
+#
+# A mark also reaches the air: mac80211 maps DSCP to a Wi-Fi access category
+# (ef/cs6/cs7 -> Voice, cs4/cs5/af4x/cs3/af3x -> Video, cs1 -> Background), so
+# marking helps Wi-Fi even where the switch queue does not.
+#
+# Rule options:
+#   name       - free-form label
+#   enabled    - '1' to activate, '0' to keep as an inert example
+#   proto      - 'udp', 'tcp' or 'tcpudp'
+#   src_ip     - source host(s)/CIDR(s), space separated, IPv4 and/or IPv6
+#                (optional; a list is split per family and each family gets
+#                its own filter)
+#   dest_ip    - destination host(s)/CIDR(s), same syntax (optional)
+#   src_port   - source port(s) or range(s): '443', '27015-27030' (optional)
+#   dest_port  - destination port(s) or range(s), same syntax (optional)
+#   class      - cs0-cs7, af11-af43, ef, va, le, or a plain DSCP number
+#
+# A rule is applied to the uplink port, matched as the returning half of the
+# connection (source and destination swapped from how it is written), so the
+# download direction is marked. Set mark_upload to also apply it as written on
+# every client-facing port - see the note on what that costs.
+#
+# There is no 'domain' option, unlike the nftables version of this: the switch
+# matches addresses and ports, and nothing else.
+#
+# The classifier is finite: 512 entries shared by every port, and a rule costs
+# one entry per port it is installed on - more where it matches an IPv6 address,
+# which does not fit in one. These rules fit with room for a few of your own; if
+# you add many, watch for the 'marking rules: N filters installed' log line.
+#
+# Global options:
+#   enabled           - master switch for the marking rules
+#   mark_upload       - '1' also marks the outbound half of every rule, which
+#                       needs a classifier entry on every port rather than one
+#                       on the uplink, and buys little: sparse upload traffic
+#                       already takes the priority band through
+#                       small_pkt_len, and the ISP bleaches the mark
+#   small_pkt_len     - frames up to this IP length take small_pkt_prio
+#                       whatever their marking; 0 disables. 1000 covers acks,
+#                       DNS, VoIP, game state and a speed test's latency
+#                       probes, and stays under a full-size segment on any
+#                       path with an MSS above 1000; 256 leaves the probes
+#                       in the bulk queue, and a bulk segment must never
+#                       qualify, since it would ride the priority band.
+#                       The Wi-Fi egress stamp keeps its own 256-byte
+#                       cutoff whatever this is set to; only 0 reaches it
+#   small_pkt_prio    - the priority they take
+#   wan_port          - override the uplink switch port; by default it is
+#                       taken from network.wan.device, with any VLAN id
+#                       stripped, since the switch knows only the port
+
+config global 'global'
+	option enabled '1'
+	option mark_upload '0'
+	option small_pkt_len '1000'
+	option small_pkt_prio '5'
+
+# --- DSCP to priority: what a mark is worth once the switch reads it -------
+# The upper band starts at 4. Real-time classes go there; anything unlisted
+# stays at 0 and rides the bulk queue.
+
+config dscp
+	option dscp '46'	# ef  - voice bearer
+	option prio '5'
+
+config dscp
+	option dscp '40'	# cs5 - signalling, DNS
+	option prio '5'
+
+config dscp
+	option dscp '32'	# cs4 - real-time interactive (games)
+	option prio '5'
+
+config dscp
+	option dscp '34'	# af41 - multimedia conferencing (calls)
+	option prio '4'
+
+config dscp
+	option dscp '48'	# cs6 - network control
+	option prio '5'
+
+# --- Active by default: sparse, latency-critical, low false-positive -------
+
+# DNS - tiny, sparse and latency-critical. Matches any resolver; the mirrored
+# reply direction is covered automatically. Add 853 to the port list for DNS
+# over TLS, at the cost of another entry per port per family - and note that
+# small-packet priority already covers a sparse resolver either way.
+config rule
+	option name 'DNS'
+	option enabled '1'
+	option proto 'tcpudp'
+	option dest_port '53'
+	option class 'cs5'
+
+# Real-Time Interactive (RFC 4594 CS4) - one class for all interactive gaming.
+# Xbox / CoD game-state on UDP 3074 (older titles up to 3079), CoD-PC via
+# Battle.net on 20500/20510/28960 plus the Blizzard range 6112-6119. NOT
+# matched on purpose: shared STUN 3478-3480, the Xbox IPsec/Teredo transports
+# 500/4500/3544, and PSN's dynamic 49152-65535 range.
+config rule
+	option name 'Game consoles / Call of Duty'
+	option enabled '1'
+	option proto 'udp'
+	option dest_port '3074-3079 6112-6119 20500 20510 28960'
+	option class 'cs4'
+
+# Valve's game-traffic and voice envelope. UDP only: bulk Steam downloads ride
+# HTTP/TCP and must never take the priority band.
+config rule
+	option name 'PC games - Steam/Source/CS2'
+	option enabled '1'
+	option proto 'udp'
+	option dest_port '27000-27250 4379 4380'
+	option class 'cs4'
+
+# Riot game-state (League 5000-5500 + 7000-8000, Valorant 7000-8000 +
+# 8180-8181). The client, chat and patcher are deliberately not matched.
+config rule
+	option name 'PC games - Riot (League/Valorant)'
+	option enabled '1'
+	option proto 'udp'
+	option dest_port '5000-5500 7000-8000 8180-8181'
+	option class 'cs4'
+
+# MS Teams media, scoped to Microsoft's Teams relay ranges so that 3478 is not
+# confused with console or game STUN.
+config rule
+	option name 'Video call - MS Teams'
+	option enabled '1'
+	option proto 'udp'
+	option dest_ip '52.112.0.0/14 52.122.0.0/15 2603:1063::/38'
+	option dest_port '3478-3481'
+	option class 'af41'
+
+# Discord voice/video, per Discord's published destination ranges. Not
+# guaranteed static - if voice stops matching, re-check them.
+config rule
+	option name 'Video call - Discord voice'
+	option enabled '1'
+	option proto 'udp'
+	option dest_port '50000-50032 19294-19344'
+	option class 'af41'
+
+# WhatsApp voice/video. 443 is deliberately NOT matched - it is all of HTTPS and
+# would sweep the web into this class. UDP only, because the calls are UDP and
+# the TCP form is a fallback that would double what this rule costs the
+# classifier. 3478/3480 are shared WebRTC/STUN, which is harmless here: af41 is
+# the managed-queue class the other call rules already use, not the
+# sparse-traffic band the games take.
+config rule
+	option name 'Video call - WhatsApp'
+	option enabled '1'
+	option proto 'udp'
+	option dest_port '3478 3480 3484'
+	option class 'af41'
+
+# --- Examples (enabled '0'): flip on and scope to your setup ---------------
+
+# Telephony signalling (RFC 4594 CS5). 5060/5061 cover SIP and SIP-over-TLS;
+# 5070/5080 catch the platform's inbound SIP toward a PBX.
+config rule
+	option name 'VoIP - SIP signalling'
+	option enabled '0'
+	option proto 'tcpudp'
+	option dest_port '5060 5061 5070 5080'
+	option class 'cs5'
+
+# Voice bearer (RFC 4594 EF). Scope this to your provider's documented RTP
+# range or to the phone's address: a bulk UDP flow inside a too-broad range
+# would sit in the priority band and starve everything else.
+config rule
+	option name 'VoIP - RTP media'
+	option enabled '0'
+	option proto 'udp'
+	option dest_port '30000-31000 40000-41000'
+	option class 'ef'
+
+# Multimedia conferencing (RFC 4594 AF41). Zoom meeting media is UDP
+# 8801-8810; its 3478/3479 TURN fallback is shared STUN and not matched.
+config rule
+	option name 'Video call - Zoom'
+	option enabled '0'
+	option proto 'udp'
+	option dest_port '8801-8810'
+	option class 'af41'
+
+# Scavenger (RFC 4594 CS1). Matches the classic BitTorrent range; to hold back
+# a NAS or backup host instead, drop dest_port and set src_ip to that host.
+# cs1 is unmapped above, so it rides the bulk queue and buys Wi-Fi Background.
+config rule
+	option name 'Bulk / backups / torrents'
+	option enabled '0'
+	option proto 'tcpudp'
+	option dest_port '6881-6889'
+	option class 'cs1'
+
+# A host of your own - a media server, a console, a workstation - marked by
+# address rather than by port. Set src_ip to it for what it sends and dest_ip
+# for what it receives; leave the ports out to cover everything it does.
+config rule
+	option name 'My server'
+	option enabled '0'
+	option proto 'tcpudp'
+	option dest_ip '192.0.2.10'
+	option class 'af31'
+
+# Big-name streaming (Netflix / YouTube / Spotify / Twitch) has no rule on
+# purpose. By port it is indistinguishable from the rest of the web - all of
+# it is HTTPS on 443 - and the switch cannot match a name. Best practice for
+# buffered video is to leave it at cs0 and let the shaper's queue do its job.

--- a/package/network/config/ppe-qos/files/ppe-qos.hotplug
+++ b/package/network/config/ppe-qos/files/ppe-qos.hotplug
@@ -1,0 +1,8 @@
+#!/bin/sh
+# The small-packet egress stamp has to follow the interface, not the service:
+# ppe-qos starts before hostapd creates the AP netdev, so applying it only at
+# start leaves every boot without it.
+[ "$ACTION" = add ] || exit 0
+[ -e "/sys/class/net/$DEVICENAME/phy80211" ] || exit 0
+[ -x /etc/init.d/ppe-qos ] || exit 0
+/etc/init.d/ppe-qos wifi_dev "$DEVICENAME"

--- a/package/network/config/ppe-qos/files/ppe-qos.init
+++ b/package/network/config/ppe-qos/files/ppe-qos.init
@@ -1,0 +1,436 @@
+#!/bin/sh /etc/rc.common
+# Apply the PPE hardware QoS classifiers: the DSCP-to-priority maps and the
+# driver's small-packet priority on every switch port, and the marking rules
+# that put a DSCP on a flow in the first place. Idempotent; reload reapplies
+# the whole config.
+#
+# Marking is done by the switch's own ACL engine, reached through tc flower:
+# a flow the PPE has offloaded never returns to the CPU, so an nftables mangle
+# rule would only ever see the packets before the offload took over. A flower
+# filter with a pedit of the IP traffic class becomes an ACL entry, which is
+# applied to every packet including the offloaded ones.
+
+START=25
+
+PARAM_DIR=/sys/module/qca_ppe/parameters
+
+# Our own filter priorities, so that a reload removes what this script put on a
+# shared ingress block and leaves anything else alone. The switch ranks a rule
+# by the preference it was given and holds nine bits of it, so the range sits
+# inside that and high, where a rule this script installs by default yields to
+# anything the user placed deliberately. It stops one short of the last
+# preference the switch holds, so a rule placed there - a download mark from
+# whatever owns the shaper - outranks every rule here.
+PREF_BASE=256
+PREF_MAX=510
+
+# The classifier holds 512 entries for the whole switch. A rule's address and
+# port lists become a filter per combination, so the product of four lists can
+# ask for arbitrarily many; past the engine's capacity every one is refused and
+# still costs a fork and a netlink round trip.
+ACL_MAX=512
+
+# Class name -> DSCP value, RFC 4594 service classes.
+class_to_dscp() {
+	local d
+
+	case "$1" in
+	cs0) echo 0 ;;  cs1) echo 8 ;;  cs2) echo 16 ;; cs3) echo 24 ;;
+	cs4) echo 32 ;; cs5) echo 40 ;; cs6) echo 48 ;; cs7) echo 56 ;;
+	af11) echo 10 ;; af12) echo 12 ;; af13) echo 14 ;;
+	af21) echo 18 ;; af22) echo 20 ;; af23) echo 22 ;;
+	af31) echo 26 ;; af32) echo 28 ;; af33) echo 30 ;;
+	af41) echo 34 ;; af42) echo 36 ;; af43) echo 38 ;;
+	ef) echo 46 ;; va) echo 44 ;; le) echo 1 ;;
+	# The leading zero goes here rather than at the reader: the shell reads
+	# a padded value as octal in arithmetic, and the priority map is keyed
+	# on the unpadded number.
+	[0-9]|[0-9][0-9]) [ "$1" -le 63 ] && { d="${1#0}"; echo "${d:-0}"; } ;;
+	*) return 1 ;;
+	esac
+}
+
+# The priority the dscp map gives a mark; empty where it maps none, which
+# leaves the flow in the bulk queue the way an unlisted DSCP does.
+prio_of() {
+	local e
+	for e in $PRIO_MAP; do
+		[ "${e%%:*}" = "$1" ] && { echo "${e#*:}"; return 0; }
+	done
+}
+
+# Trust boundary: /etc/config/ppe-qos is writable by any LuCI role holding the
+# ppe-qos ACL, and its values are pasted into the tc command lines below, which
+# run as root. The LuCI form's datatype checks run in the browser only, so
+# re-validate here - none of these fields legitimately holds a shell
+# metacharacter.
+valid_addrs() {		# space/comma separated addresses or CIDRs; empty = any
+	local t
+	for t in $(echo "$1" | tr ',' ' '); do
+		case "$t" in *[!0-9A-Fa-f:./]*) return 1 ;; esac
+	done
+	return 0
+}
+valid_ports() {		# space/comma separated ports or ranges; empty = any
+	local t
+	for t in $(echo "$1" | tr ',' ' '); do
+		case "$t" in ''|*[!0-9-]*) return 1 ;; esac
+	done
+	return 0
+}
+
+# Every DSA user port of the switch, from what is present rather than from a
+# name or a count - the port set differs across boards.
+switch_ports() {
+	local d
+	for d in /sys/class/net/*/phys_switch_id ; do
+		[ -s "$d" ] || continue
+		d="${d%/phys_switch_id}"
+		echo "${d##*/}"
+	done
+}
+
+# The switch port the uplink rides, so that a rule can be applied to the
+# direction it actually matches on each side. network.wan.device names the
+# device the interface sits on ('wan.7' for a VLAN, 'wan' bare); the switch
+# knows only the port, so take the part before any VLAN id.
+wan_port() {
+	local dev
+	config_get dev global wan_port
+	[ -z "$dev" ] && dev=$(uci -q get network.wan.device)
+	dev="${dev%%.*}"
+	[ -n "$dev" ] && [ -s "/sys/class/net/$dev/phys_switch_id" ] && echo "$dev"
+}
+
+# One flower filter. $1=port $2=protocol $3=ip_proto $4=match $5=tos byte
+#                    $6=internal priority, empty where the map has none
+add_filter() {
+	local mangle prio=""
+
+	case "$2" in
+	ip) mangle="munge ip tos set $5" ;;
+	*)  mangle="munge ip6 traffic_class set $5" ;;
+	esac
+
+	# The mark alone does not pick the queue: the engine ranks the ACL above
+	# the DSCP map, and the map reads the header as it arrived - bleached, on
+	# the download half this rule exists for. The rule that matched carries
+	# the priority itself, as a tc handle - base 16, so a decimal 10 would
+	# reach the driver as 16 and lose the whole filter, mark included.
+	[ -n "$6" ] && prio="action skbedit priority $(printf '%x' "$6")"
+
+	# skip_sw: if the switch cannot take the rule, fail here rather than
+	# quietly classifying on the CPU, which an offloaded flow never reaches.
+	if tc filter add dev "$1" parent ffff: pref $PREF protocol "$2" flower \
+		skip_sw ip_proto "$3" $4 \
+		action pedit ex $mangle $prio >/dev/null 2>&1 ; then
+		INSTALLED=$((INSTALLED + 1))
+	else
+		SKIPPED=$((SKIPPED + 1))
+		logger -t ppe-qos "port $1: switch refused $2/$3 $4"
+	fi
+}
+
+# Address list restricted to one family; a list with no member of that family
+# excludes the rule from it.
+addrs_of() {
+	local a out=""
+	for a in $(echo "$1" | tr ',' ' '); do
+		case "$a" in
+		*:*) [ "$2" = ipv6 ] && out="$out $a" ;;
+		*)   [ "$2" = ip ] && out="$out $a" ;;
+		esac
+	done
+	echo $out
+}
+
+# Emit both directions of one rule for one family and one L4 protocol.
+#  as written, a LAN port sees the flow leaving: match the destination
+#  mirrored, the uplink port sees it coming back: match the source
+emit() {
+	local fam="$1" l4="$2" tos="$3" sip="$4" dip="$5" sport="$6" dport="$7"
+	local prio="$8"
+	local fsip fdip p sa da sp dp m
+
+	fsip=$(addrs_of "$sip" "$fam")
+	fdip=$(addrs_of "$dip" "$fam")
+	[ -n "$sip" ] && [ -z "$fsip" ] && return 0
+	[ -n "$dip" ] && [ -z "$fdip" ] && return 0
+
+	# One filter per combination: flower matches a single prefix and a single
+	# port or range per key, so a list becomes a filter each.
+	for sa in ${fsip:-any}; do
+	for da in ${fdip:-any}; do
+	for sp in ${sport:-any}; do
+	for dp in ${dport:-any}; do
+		[ $((INSTALLED + SKIPPED)) -lt $ACL_MAX ] || {
+			SKIPPED=$((SKIPPED + 1))
+			return 0
+		}
+
+		# As written, on the ports a client sits behind: the service is
+		# the destination.
+		m=""
+		[ "$sa" = any ] || m="$m src_ip $sa"
+		[ "$da" = any ] || m="$m dst_ip $da"
+		[ "$sp" = any ] || m="$m src_port $sp"
+		[ "$dp" = any ] || m="$m dst_port $dp"
+		for p in $MARK_PORTS; do
+			add_filter "$p" "$fam" "$l4" "$m" "$tos" "$prio"
+		done
+
+		# Mirrored, on the uplink port: the same connection coming back,
+		# so source and destination swap.
+		[ -n "$WAN_PORT" ] || continue
+		m=""
+		[ "$da" = any ] || m="$m src_ip $da"
+		[ "$sa" = any ] || m="$m dst_ip $sa"
+		[ "$dp" = any ] || m="$m src_port $dp"
+		[ "$sp" = any ] || m="$m dst_port $sp"
+		add_filter "$WAN_PORT" "$fam" "$l4" "$m" "$tos" "$prio"
+	done
+	done
+	done
+	done
+}
+
+apply_rule() {
+	local cfg="$1" enabled name proto class sip dip sport dport dscp tos fam l4
+	local prio
+
+	config_get_bool enabled "$cfg" enabled 0
+	[ "$enabled" = 1 ] || return 0
+
+	config_get name "$cfg" name "$cfg"
+	config_get proto "$cfg" proto tcpudp
+	config_get class "$cfg" class
+	config_get sip "$cfg" src_ip
+	config_get dip "$cfg" dest_ip
+	config_get sport "$cfg" src_port
+	config_get dport "$cfg" dest_port
+
+	dscp=$(class_to_dscp "$class") || {
+		logger -t ppe-qos "rule '$name': unknown class '$class', skipped"
+		return 0
+	}
+	valid_addrs "$sip" && valid_addrs "$dip" &&
+	valid_ports "${sport:-0}" && valid_ports "${dport:-0}" || {
+		logger -t ppe-qos "rule '$name': address or port list rejected, skipped"
+		return 0
+	}
+
+	# The engine rewrites the whole traffic-class byte or none of it, so the
+	# two ECN bits go to zero with the mark. Nothing here negotiates ECN.
+	tos=$((dscp * 4))
+
+	# What the dscp map would resolve this mark to, taken here because the
+	# map cannot do it itself for traffic that arrives unmarked.
+	prio=$(prio_of "$dscp")
+
+	for l4 in $(echo "$proto" | sed 's/tcpudp/tcp udp/'); do
+		case "$l4" in tcp|udp) ;; *) continue ;; esac
+		for fam in ip ipv6; do
+			PREF=$((PREF_BASE + PREF_N))
+			[ $PREF -gt $PREF_MAX ] && return 0
+			PREF_N=$((PREF_N + 1))
+			emit "$fam" "$l4" "$tos" "$sip" "$dip" "$sport" \
+			     "$dport" "$prio"
+		done
+	done
+}
+
+# Remove only what this script put on a shared ingress block: the prefs it
+# owns, read back from the block rather than swept blindly, since the range is
+# a thousand wide and every delete is a netlink round trip.
+flush_filters() {
+	local p n
+	for p in $(switch_ports); do
+		for n in $(tc filter show dev "$p" parent ffff: 2>/dev/null |
+			   sed -n 's/.* pref \([0-9]*\) .*/\1/p' | sort -u); do
+			[ "$n" -ge $PREF_BASE ] && [ "$n" -le $PREF_MAX ] &&
+				tc filter del dev "$p" parent ffff: pref "$n" \
+					>/dev/null 2>&1
+		done
+	done
+}
+
+wifi_devs() {
+	local d
+	for d in /sys/class/ieee80211/*/device/net/* ; do
+		[ -e "$d" ] || continue
+		echo "${d##*/}"
+	done
+}
+
+# u32 takes its offsets from the network header, which puts the length field
+# at 2 for IPv4 and at 4 for IPv6. The egress block is shared, so these carry
+# the same prefs the ingress half owns.
+wifi_small_pkt() {
+	local dev="$1" prio="$2"
+
+	tc qdisc add dev "$dev" clsact 2>/dev/null
+
+	# u32 has no handle here, so a replace appends a second node rather
+	# than standing in for the first; the pref is cleared to keep a reload
+	# from growing the block.
+	wifi_clear "$dev"
+
+	tc filter add dev "$dev" egress pref $PREF_BASE protocol ip u32 \
+		match u16 0x0000 0xff00 at 2 \
+		action skbedit priority $(printf '%x' $((256 + prio))) 2>/dev/null
+	tc filter add dev "$dev" egress pref $((PREF_BASE + 1)) \
+		protocol ipv6 u32 match u16 0x0000 0xff00 at 4 \
+		action skbedit priority $(printf '%x' $((256 + prio))) 2>/dev/null
+}
+
+wifi_clear() {
+	tc filter del dev "$1" egress pref $PREF_BASE >/dev/null 2>&1
+	tc filter del dev "$1" egress pref $((PREF_BASE + 1)) >/dev/null 2>&1
+}
+
+apply() {
+	local len prio pairs="" port dev
+
+	config_load ppe-qos
+	config_get_bool ENABLED global enabled 1
+	config_get len global small_pkt_len 1000
+	config_get prio global small_pkt_prio 5
+
+	# Everything below arms a classifier, so an off config takes the same
+	# path as stop rather than programming half of it.
+	[ "$ENABLED" = 1 ] || { teardown; return 0; }
+
+	if [ -w "$PARAM_DIR/small_pkt_len" ]; then
+		echo "$prio" > "$PARAM_DIR/small_pkt_prio"
+		echo "$len" > "$PARAM_DIR/small_pkt_len"
+	fi
+
+	# The same policy, on the one egress the switch classifier cannot reach.
+	# A frame to a Wi-Fi client leaves by the CPU port and is then queued by
+	# mac80211, which picks its access category from skb->priority - a value
+	# nothing on the way from the switch has set. So the small-packet rule
+	# stops at the CPU port and the frame contends as best effort.
+	#
+	# cfg80211_classify8021d() takes skb->priority in 256..263 as a direct
+	# 802.1d tag, and sch_handle_egress() runs before the queue is picked, so
+	# a clsact filter on the AP netdev is enough. Matching the high byte of
+	# the length field for zero is the cheapest "small" test u32 can do; the
+	# exact threshold matters far less than the frame not being best effort.
+	for dev in $(wifi_devs); do
+		if [ "$len" -gt 0 ]; then
+			wifi_small_pkt "$dev" "$prio"
+		else
+			wifi_clear "$dev"
+		fi
+	done
+
+	add_pair() {
+		local d p
+		config_get d "$1" dscp
+		config_get p "$1" prio
+		[ -n "$d" ] && [ -n "$p" ] || return 0
+		case "$d$p" in *[!0-9]*)
+			logger -t ppe-qos "dscp map '$d:$p' is not numeric, skipped"
+			return 0 ;;
+		esac
+		pairs="$pairs dscp-prio $d:$p"
+		PRIO_MAP="$PRIO_MAP $d:$p"
+	}
+	PRIO_MAP=""
+	config_foreach add_pair dscp
+
+	# Every DSA user port classifies on ingress; the set is derived from
+	# what is present, never hardcoded.
+	for port in $(switch_ports); do
+		dcb app flush dev "$port" dscp-prio 2>/dev/null
+		[ -n "$pairs" ] && dcb app add dev "$port" $pairs
+	done
+
+	flush_filters
+
+	WAN_PORT=$(wan_port)
+	[ -n "$WAN_PORT" ] ||
+		logger -t ppe-qos "the uplink is not a switch port; every rule's download half is skipped - set ppe-qos.global.wan_port"
+
+	# The uplink port carries the download half of every rule, which is what
+	# a mark is actually worth here: it picks the egress queue toward the
+	# client and it is what mac80211 reads for its Wi-Fi access category.
+	#
+	# The upload half needs a rule on each port a client sits behind, so it
+	# costs as many classifier entries as there are ports - and it buys
+	# little, because sparse upload traffic already takes the priority band
+	# through small_pkt_len without any marking, and the DSCP that leaves
+	# toward the ISP is routinely bleached on the way. Off by default; turn
+	# it on if something downstream of this router acts on the mark.
+	config_get_bool MARK_UPLOAD global mark_upload 0
+	MARK_PORTS=""
+	if [ "$MARK_UPLOAD" = 1 ]; then
+		for port in $(switch_ports); do
+			[ "$port" = "$WAN_PORT" ] || MARK_PORTS="$MARK_PORTS $port"
+		done
+	fi
+
+	# The marking filters share the ingress qdisc with sqm's meter, so the
+	# qdisc is only ever added, never replaced.
+	for port in $(switch_ports); do
+		tc qdisc add dev "$port" handle ffff: ingress 2>/dev/null
+	done
+
+	PREF_N=0
+	INSTALLED=0
+	SKIPPED=0
+	config_foreach apply_rule rule
+
+	# The classifier is a fixed 512 entries shared by every port, and a rule
+	# costs one entry per port it is installed on - more where it matches an
+	# IPv6 address, which does not fit in a single entry. Say what fitted, so
+	# that a rule quietly missing from half the ports is visible.
+	logger -t ppe-qos "marking rules: $INSTALLED filters installed, $SKIPPED refused"
+	[ "$SKIPPED" = 0 ] ||
+		logger -t ppe-qos "the switch classifier is full; disable rules or narrow their port lists"
+}
+
+EXTRA_COMMANDS="wifi_dev"
+EXTRA_HELP="\twifi_dev <netdev>  apply the small-packet egress stamp to one Wi-Fi netdev"
+
+start() {
+	apply
+}
+
+# A Wi-Fi netdev does not exist when this service starts - hostapd creates it a
+# moment later - so the egress stamp has to be applied when the interface
+# appears as well as at start. The hotplug hook calls this for one device.
+wifi_dev() {
+	local dev="$1" len prio
+
+	[ -n "$dev" ] || return 1
+	config_load ppe-qos
+	config_get_bool ENABLED global enabled 1
+	config_get len global small_pkt_len 1000
+	config_get prio global small_pkt_prio 5
+	[ "$ENABLED" = 1 ] && [ "$len" -gt 0 ] || return 0
+	wifi_small_pkt "$dev" "$prio"
+}
+
+reload() {
+	apply
+}
+
+# The egress block on an AP netdev is shared with whatever else is on the
+# interface, so only the prefs this script owns are removed.
+teardown() {
+	local dev
+
+	flush_filters
+	[ -w "$PARAM_DIR/small_pkt_len" ] && echo 0 > "$PARAM_DIR/small_pkt_len"
+	for dev in $(switch_ports); do
+		dcb app flush dev "$dev" dscp-prio 2>/dev/null
+	done
+	for dev in $(wifi_devs); do
+		wifi_clear "$dev"
+	done
+}
+
+stop() {
+	teardown
+}


### PR DESCRIPTION
The switch decides latency: traffic in a higher-priority egress queue is served
past the bulk queue of a shaped port. This package owns which queue traffic
rides, from one uci config - per-port DSCP-to-priority maps applied with `dcb
app` on every DSA user port, the driver's small-packet priority through its
module parameters, and the marking rules that put a DSCP on a flow in the
first place. Rates and the bulk queue depth stay with SQM, which the config
documents.

Two commits: `kmod-sched-ets` and `kmod-sched-act-pedit` split out of
`kmod-sched` so the package can depend on them, and the package itself.

### Why the switch has to do the marking

A flow the PPE has offloaded never returns to the CPU, so an nftables mangle
rule sees only the packets before the offload takes over and the rest of the
flow goes out unmarked. The switch's ACL engine can rewrite the traffic class,
and the driver exposes it through `tc flower`, so a rule becomes a flower
filter with a pedit of that byte and the mark applies to every packet
including the offloaded ones.

The mark alone does not pick the queue. The engine ranks the ACL above the
DSCP map, and the map resolves the priority from the header as it arrives -
bleached, on the download half these rules exist for - so a rule that only
rewrites the byte changes what the client sees and nothing about where the
frame queues. Each rule therefore carries the priority its DSCP maps to as a
second action, which the flower parser takes as `FLOW_ACTION_PRIORITY`. The
map stays, for traffic that arrives already marked.

### The kmod split

`kmod-sched` is a 190K bundle. `sch_ets` is 9K and `act_pedit` 7K, and this
package needs exactly those two out of it; both get their own package, the
bundle keeps pulling them in.

### Measured

IPQ8074 (Xiaomi AX3600), kernel 6.18.44. The shipped set renders to 53
filters, all reporting `in_hw` and each carrying both actions - a pedit of
`ipv4+0` and `skbedit priority :5` on the DNS rule - with the classifier
reporting no refusals, and sqm's meter surviving on the ingress block they
share.

The small-packet cutoff ships at 1000 bytes rather than 256. Waveform
bufferbloat, wired client, 300/150 Mbit/s PPPoE uplink shaped to 305/165,
three runs per cutoff interleaved in one window (download-active /
upload-active ms, download Mbit/s):

| cutoff | runs |
|---|---|
| 256 bytes | +8/+3 at 282, +8/+1 at 284, +6/+10 at 290 |
| 1000 bytes | +1/+0 at 294, +0/+0 at 283, +1/+0 at 285 |

A full-size segment stays out of the priority band on any path with an MSS
above 1000, which is every path measured here (MSS 1378 to 1452 in 60 captured
handshakes). At 1400 the bulk does reach the band and the probes read +10 to
+15 ms.

The Wi-Fi half, HE 160 MHz client, interleaved run for run against no filter,
seven pairs of a browser bufferbloat test: without it two runs of seven
exceeded 8 ms (+15 and +10) against a median of 4; with it none did, median 4
and worst 6. Three confirming runs on the persisted configuration read
+1/+0/+1 ms at 287-296 Mbit/s.

### Depends on

The PPE switch pull request at runtime - the classifiers this programs are the
ones that series adds - and its own LuCI page is openwrt/luci#8965, which
cannot build before this. `kernel: split sch_ets and act_pedit out of
kmod-sched` is also carried by the PPE switch pull request, which needs the
same two modules in the target's default package set; whichever lands first,
the other rebases to nothing.


### For self-builders

A single branch with all of this on it, plus the `ppe-qos` package, is
`ppe-offload` on the fork:
https://github.com/JuliusBairaktaris/openwrt-nss-edma/tree/ppe-offload
It is not proposed for merge - it exists so that anyone building their own
image gets the whole feature set from one checkout instead of stacking these
pull requests by hand.
