### PR TITLE
realtek: move Otto table access into its own SoC driver

### DIFF
--- a/target/linux/realtek/dts/rtl838x.dtsi
+++ b/target/linux/realtek/dts/rtl838x.dtsi
@@ -280,6 +280,10 @@
 			};
 		};
 
+		table {
+			compatible = "realtek,rtl8380-table", "realtek,otto-table";
+		};
+
 		soc_thermal: thermal {
 			compatible = "realtek,rtl8380-thermal";
 			#thermal-sensor-cells = <0>;

--- a/target/linux/realtek/dts/rtl839x.dtsi
+++ b/target/linux/realtek/dts/rtl839x.dtsi
@@ -325,6 +325,10 @@
 			};
 		};
 
+		table {
+			compatible = "realtek,rtl8392-table", "realtek,otto-table";
+		};
+
 		soc_thermal: thermal {
 			compatible = "realtek,rtl8390-thermal";
 			#thermal-sensor-cells = <0>;

--- a/target/linux/realtek/dts/rtl930x.dtsi
+++ b/target/linux/realtek/dts/rtl930x.dtsi
@@ -319,6 +319,10 @@
 			};
 		};
 
+		table {
+			compatible = "realtek,rtl9301-table", "realtek,otto-table";
+		};
+
 		soc_thermal: thermal {
 			compatible = "realtek,rtl9300-thermal";
 			#thermal-sensor-cells = <0>;

--- a/target/linux/realtek/dts/rtl931x.dtsi
+++ b/target/linux/realtek/dts/rtl931x.dtsi
@@ -344,6 +344,10 @@
 				#pcs-cells = <1>;
 			};
 		};
+
+		table {
+			compatible = "realtek,rtl9311-table", "realtek,otto-table";
+		};
 	};
 
 	pinmux@1b00103c {

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/Kconfig
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/Kconfig
@@ -3,6 +3,7 @@ config NET_DSA_RTL83XX
 	tristate "Realtek RTL838x/RTL839x switch support"
 	depends on MACH_REALTEK_RTL
 	select NET_DSA_TAG_RTL_OTTO
+	select REALTEK_OTTO_TABLE
 	help
 	  This driver adds support for Realtek RTL83xx series switching.
 

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/Makefile
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/Makefile
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: GPL-2.0
 obj-$(CONFIG_NET_DSA_RTL83XX) += rtl_otto_dsa.o
-rtl_otto_dsa-objs := common.o table.o dsa.o rtl838x.o rtl839x.o rtl930x.o rtl931x.o debugfs.o qos.o tc.o l3.o
+rtl_otto_dsa-objs := common.o dsa.o rtl838x.o rtl839x.o rtl930x.o rtl931x.o debugfs.o qos.o tc.o l3.o

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/common.c
@@ -811,8 +811,9 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 	if (err)
 		return err;
 
-	/* Initialize access to RTL switch tables */
-	otto_table_init();
+	err = otto_table_loaded();
+	if (err)
+		return dev_err_probe(dev, err, "no switch table access\n");
 
 	r = device_get_match_data(&pdev->dev);
 	priv = devm_kzalloc(dev, struct_size(priv, msts, r->n_mst - 1), GFP_KERNEL);

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl-otto.h
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl-otto.h
@@ -6,7 +6,7 @@
 #include <asm/mach-rtl-otto/mach-rtl-otto.h>
 #include <net/dsa.h>
 
-#include "table.h"
+#include <linux/soc/realtek/otto_table.h>
 
 /* Register definition */
 #define RTL838X_MAC_PORT_CTRL(port)		(0xd560 + (((port) << 7)))

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl931x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl931x.c
@@ -1852,33 +1852,34 @@ static int rtldsa_931x_lag_table(void)
 static u64 rtldsa_931x_stat_port_table_read(int port, unsigned int mib_size,
 					    unsigned int mib_offset, bool is_pvt)
 {
-	int tbl;
+	enum otto_table_id id;
 	int field_offset;
-	u64 ret = 0;
+	u32 val[2];
 
 	if (is_pvt) {
-		tbl = otto_table_acquire(RTL9310_TBL_STAT_PORT_PRVTE_CNTR);
+		id = RTL9310_TBL_STAT_PORT_PRVTE_CNTR;
 		field_offset = 27;
 	} else {
-		tbl = otto_table_acquire(RTL9310_TBL_STAT_PORT_MIB_CNTR);
+		id = RTL9310_TBL_STAT_PORT_MIB_CNTR;
 		field_offset = 52;
 	}
 
-	/* The word offset is computed per field, so the row is picked apart in
-	 * the data registers rather than copied into a buffer.
+	/* Counter fields are numbered down from the last data word of the
+	 * entry, so the high half of a 64 bit counter sits at the lower word
+	 * index.
 	 */
-	__otto_table_fetch(tbl, port);
-
 	if (mib_size == 2) {
-		ret = __otto_table_word_read(tbl, field_offset - (mib_offset + 1));
-		ret <<= 32;
+		otto_table_read_bytes(id, port, val,
+				      field_offset - (mib_offset + 1),
+				      sizeof(val));
+
+		return (u64)val[0] << 32 | val[1];
 	}
 
-	ret |= __otto_table_word_read(tbl, field_offset - mib_offset);
+	otto_table_read_bytes(id, port, val, field_offset - mib_offset,
+			      sizeof(val[0]));
 
-	otto_table_release(tbl);
-
-	return ret;
+	return val[0];
 }
 
 static void rtldsa_931x_qos_set_group_selector(int port, int group)

--- a/target/linux/realtek/files-6.18/drivers/soc/realtek/Kconfig
+++ b/target/linux/realtek/files-6.18/drivers/soc/realtek/Kconfig
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+config REALTEK_OTTO_TABLE
+	bool
+	depends on MACH_REALTEK_RTL
+	select MFD_SYSCON
+	help
+	  Serialise access to the switch tables that the RTL83xx and RTL93xx
+	  SoCs reach through a command register and a window of data
+	  registers. Selected by the drivers that use them.

--- a/target/linux/realtek/files-6.18/drivers/soc/realtek/Makefile
+++ b/target/linux/realtek/files-6.18/drivers/soc/realtek/Makefile
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: GPL-2.0-only
+obj-$(CONFIG_REALTEK_OTTO_TABLE) += otto_table.o

--- a/target/linux/realtek/files-6.18/drivers/soc/realtek/otto_table.c
+++ b/target/linux/realtek/files-6.18/drivers/soc/realtek/otto_table.c
@@ -22,7 +22,6 @@ static struct regmap *otto_map;
 struct otto_table {
 	u16 addr;
 	u16 data;
-	u8  max_data;
 	u8 c_bit;
 	u8 t_bit;
 	u8 rmode;
@@ -72,7 +71,7 @@ enum otto_table_reg_max {
 
 #define OTTO_REG_DESC(name, addr_, data_, max_, cbit_, tbit_, rmode_)	\
 	[name] = {							\
-		.addr = addr_, .data = data_, .max_data = max_,		\
+		.addr = addr_, .data = data_,				\
 		.c_bit = cbit_, .t_bit = tbit_, .rmode = rmode_,	\
 	},
 
@@ -390,96 +389,36 @@ static int otto_table_exec(int handle, bool is_write, int idx)
 	return ret;
 }
 
-static u16 otto_table_word_addr(struct otto_table *r, int word)
-{
-	if (word < 0)
-		word = 0;
-	else if (word >= r->max_data)
-		word = r->max_data - 1;
-
-	return r->data + word * 4;
-}
-
-int __otto_table_fetch(int handle, int idx)
+int __otto_table_read_bytes(int handle, int idx, void *buf, int word_offset,
+			    size_t size)
 {
 	struct otto_table *r = otto_table_reg(handle);
-	int ret = 0;
-	int err;
-
-	if (!r)
-		return -EINVAL;
-
-	/* The data registers are what this call produces, and the word reader
-	 * takes them as they stand. Clear them first so that a refused or timed
-	 * out access does not hand out the previous transaction's row.
-	 */
-	for (unsigned int i = 0; i < otto_table_maps[handle].width; i++) {
-		err = regmap_write(otto_map, r->data + i * 4, 0);
-		if (err && !ret)
-			ret = err;
-	}
-
-	if (!otto_table_index_ok(handle, idx))
-		return -EINVAL;
-
-	err = otto_table_exec(handle, false, idx);
-
-	return err ? err : ret;
-}
-EXPORT_SYMBOL_GPL(__otto_table_fetch);
-
-u32 __otto_table_word_read(int handle, int word)
-{
-	struct otto_table *r = otto_table_reg(handle);
-	u32 val = 0;
-	int ret;
-
-	if (!r)
-		return 0;
-
-	ret = regmap_read(otto_map, otto_table_word_addr(r, word), &val);
-	if (ret)
-		pr_err_ratelimited("otto_table: read of table %d failed: %d\n",
-				   otto_table_handle_to_id(handle), ret);
-
-	return val;
-}
-EXPORT_SYMBOL_GPL(__otto_table_word_read);
-
-int __otto_table_read_bytes(int handle, int idx, void *buf, size_t size)
-{
-	struct otto_table *r = otto_table_reg(handle);
-	unsigned int words;
+	unsigned int words, width;
 	u32 *out = buf;
 	int ret;
 
 	/* The buffer is what this call produces. Clear it first so a refusal
 	 * hands back zeroes rather than the stack the caller arrived with: no
 	 * caller checks the return value, and every read-modify-write writes
-	 * this buffer back to the table. A timeout still copies the window, so
-	 * that such a write commits the row as the hardware left it.
+	 * this buffer back to the table.
 	 */
 	memset(buf, 0, size);
 
 	if (!r || !otto_table_index_ok(handle, idx))
 		return -EINVAL;
 
-	words = otto_table_maps[handle].width;
-	if (WARN_ONCE(size != words * sizeof(u32),
-		      "otto_table: %zu bytes for table %d, a %u word entry\n",
-		      size, otto_table_handle_to_id(handle), words))
+	words = size / sizeof(u32);
+	width = otto_table_maps[handle].width;
+	if (WARN_ONCE(size % sizeof(u32) || word_offset < 0 || word_offset + words > width,
+		      "otto_table: %zu bytes at word %d of table %d, a %u word entry\n",
+		      size, word_offset, otto_table_handle_to_id(handle), width))
 		return -EINVAL;
 
 	ret = otto_table_exec(handle, false, idx);
+	if (ret)
+		return ret;
 
-	for (unsigned int i = 0; i < words; i++) {
-		int err = regmap_read(otto_map, r->data + i * 4, &out[i]);
-
-		if (err && !ret)
-			ret = err;
-	}
-
-	return ret;
+	return regmap_bulk_read(otto_map, r->data + word_offset * 4, out, words);
 }
 EXPORT_SYMBOL_GPL(__otto_table_read_bytes);
 
@@ -509,7 +448,8 @@ int __otto_table_write_bytes(int handle, int idx, const void *buf, size_t size)
 }
 EXPORT_SYMBOL_GPL(__otto_table_write_bytes);
 
-int otto_table_read_bytes(enum otto_table_id id, int idx, void *buf, size_t size)
+int otto_table_read_bytes(enum otto_table_id id, int idx, void *buf,
+			  int word_offset, size_t size)
 {
 	int handle = otto_table_acquire(id);
 	int ret;
@@ -519,7 +459,7 @@ int otto_table_read_bytes(enum otto_table_id id, int idx, void *buf, size_t size
 		return handle;
 	}
 
-	ret = __otto_table_read_bytes(handle, idx, buf, size);
+	ret = __otto_table_read_bytes(handle, idx, buf, word_offset, size);
 	otto_table_release(handle);
 
 	return ret;

--- a/target/linux/realtek/files-6.18/drivers/soc/realtek/otto_table.c
+++ b/target/linux/realtek/files-6.18/drivers/soc/realtek/otto_table.c
@@ -368,6 +368,15 @@ static int otto_table_exec(int handle, bool is_write, int idx)
 	cmd |= map->type << r->t_bit; /* Table type */
 	cmd |= idx & (BIT(r->t_bit) - 1); /* Index */
 
+	/* Defensive pre check in case an earlier command never completed */
+	ret = regmap_read_poll_timeout(otto_map, r->addr, val,
+				       !(val & BIT(r->c_bit + 1)), 20, 10000);
+	if (ret) {
+		pr_err_ratelimited("otto_table: table %d busy, command not sent\n",
+				   otto_table_handle_to_id(handle));
+		return ret;
+	}
+
 	ret = regmap_write(otto_map, r->addr, cmd);
 	if (ret)
 		return ret;
@@ -375,7 +384,8 @@ static int otto_table_exec(int handle, bool is_write, int idx)
 	ret = regmap_read_poll_timeout(otto_map, r->addr, val,
 				       !(val & BIT(r->c_bit + 1)), 20, 10000);
 	if (ret)
-		pr_err("%s: timeout\n", __func__);
+		pr_err_ratelimited("otto_table: table %d did not complete\n",
+				   otto_table_handle_to_id(handle));
 
 	return ret;
 }

--- a/target/linux/realtek/files-6.18/drivers/soc/realtek/otto_table.c
+++ b/target/linux/realtek/files-6.18/drivers/soc/realtek/otto_table.c
@@ -438,11 +438,9 @@ int __otto_table_write_bytes(int handle, int idx, const void *buf, size_t size)
 		      size, otto_table_handle_to_id(handle), words))
 		return -EINVAL;
 
-	for (unsigned int i = 0; i < words; i++) {
-		ret = regmap_write(otto_map, r->data + i * 4, in[i]);
-		if (ret)
-			return ret;
-	}
+	ret = regmap_bulk_write(otto_map, r->data, in, words);
+	if (ret)
+		return ret;
 
 	return otto_table_exec(handle, true, idx);
 }

--- a/target/linux/realtek/files-6.18/drivers/soc/realtek/otto_table.c
+++ b/target/linux/realtek/files-6.18/drivers/soc/realtek/otto_table.c
@@ -2,12 +2,19 @@
 
 #include <linux/bug.h>
 #include <linux/errno.h>
-#include <linux/iopoll.h>
+#include <linux/mfd/syscon.h>
 #include <linux/mutex.h>
+#include <linux/of.h>
+#include <linux/platform_device.h>
+#include <linux/regmap.h>
 #include <linux/string.h>
-#include <asm/mach-rtl-otto/mach-rtl-otto.h>
 
-#include "table.h"
+#include <linux/soc/realtek/otto_table.h>
+
+/* The switch register block, taken from the parent syscon at probe. Every
+ * access below goes through it, so it is also what says the driver is up.
+ */
+static struct regmap *otto_map;
 
 /* One table access register: a command register selecting table and index,
  * and a window of data registers holding the entry.
@@ -220,11 +227,62 @@ static const struct otto_table_map otto_table_maps[OTTO_TBL_COUNT] = {
 	TBL_MAP(RTL9310_TBL_STAT_PORT_PRVTE_CNTR, OTTO_REG_9310_5, 1, 28, 57),
 };
 
-void otto_table_init(void)
+/* Whether the tables can be reached yet. A consumer that probes before this
+ * driver has bound gets -EPROBE_DEFER and comes back; one running on a
+ * devicetree without the node gets -ENODEV and should give up.
+ */
+int otto_table_loaded(void)
 {
+	struct device_node *np;
+	bool present;
+
+	/* Pairs with the release in probe: a map means the locks are usable */
+	if (smp_load_acquire(&otto_map))
+		return 0;
+
+	np = of_find_compatible_node(NULL, NULL, "realtek,otto-table");
+	present = of_device_is_available(np);
+	of_node_put(np);
+
+	return present ? -EPROBE_DEFER : -ENODEV;
+}
+EXPORT_SYMBOL_GPL(otto_table_loaded);
+
+static int otto_table_probe(struct platform_device *pdev)
+{
+	struct device *dev = &pdev->dev;
+	struct regmap *map;
+
+	map = syscon_node_to_regmap(dev->of_node->parent);
+	if (IS_ERR(map))
+		return dev_err_probe(dev, PTR_ERR(map), "no switch register map\n");
+
 	for (int i = 0; i < OTTO_REG_END; i++)
 		mutex_init(&otto_regs[i].lock);
+
+	/* Publish the map only once the locks above can be taken */
+	smp_store_release(&otto_map, map);
+
+	return 0;
 }
+
+static const struct of_device_id otto_table_of_ids[] = {
+	{ .compatible = "realtek,otto-table" },
+	{ /* sentinel */ }
+};
+
+static struct platform_driver otto_table_driver = {
+	.probe = otto_table_probe,
+	.driver = {
+		.name = "otto-table",
+		.of_match_table = otto_table_of_ids,
+		/* The tables are held across calls, so the driver must not go
+		 * away under a consumer.
+		 */
+		.suppress_bind_attrs = true,
+	},
+};
+builtin_platform_driver(otto_table_driver);
 
 static int otto_table_id_to_handle(enum otto_table_id id)
 {
@@ -244,6 +302,9 @@ static enum otto_table_id otto_table_handle_to_id(int handle)
  */
 static struct otto_table *otto_table_reg(int handle)
 {
+	if (WARN_ONCE(!otto_map, "otto_table: access before the driver bound\n"))
+		return NULL;
+
 	if (handle < 0 || handle >= OTTO_TBL_COUNT)
 		return NULL;
 
@@ -277,6 +338,7 @@ int otto_table_acquire(enum otto_table_id id)
 
 	return handle;
 }
+EXPORT_SYMBOL_GPL(otto_table_acquire);
 
 void otto_table_release(int handle)
 {
@@ -287,6 +349,7 @@ void otto_table_release(int handle)
 
 	mutex_unlock(&r->lock);
 }
+EXPORT_SYMBOL_GPL(otto_table_release);
 
 static int otto_table_exec(int handle, bool is_write, int idx)
 {
@@ -305,10 +368,12 @@ static int otto_table_exec(int handle, bool is_write, int idx)
 	cmd |= map->type << r->t_bit; /* Table type */
 	cmd |= idx & (BIT(r->t_bit) - 1); /* Index */
 
-	sw_w32(cmd, r->addr);
+	ret = regmap_write(otto_map, r->addr, cmd);
+	if (ret)
+		return ret;
 
-	ret = readx_poll_timeout(sw_r32, r->addr, val,
-				 !(val & BIT(r->c_bit + 1)), 20, 10000);
+	ret = regmap_read_poll_timeout(otto_map, r->addr, val,
+				       !(val & BIT(r->c_bit + 1)), 20, 10000);
 	if (ret)
 		pr_err("%s: timeout\n", __func__);
 
@@ -328,6 +393,8 @@ static u16 otto_table_word_addr(struct otto_table *r, int word)
 int __otto_table_fetch(int handle, int idx)
 {
 	struct otto_table *r = otto_table_reg(handle);
+	int ret = 0;
+	int err;
 
 	if (!r)
 		return -EINVAL;
@@ -336,24 +403,38 @@ int __otto_table_fetch(int handle, int idx)
 	 * takes them as they stand. Clear them first so that a refused or timed
 	 * out access does not hand out the previous transaction's row.
 	 */
-	for (unsigned int i = 0; i < otto_table_maps[handle].width; i++)
-		sw_w32(0, r->data + i * 4);
+	for (unsigned int i = 0; i < otto_table_maps[handle].width; i++) {
+		err = regmap_write(otto_map, r->data + i * 4, 0);
+		if (err && !ret)
+			ret = err;
+	}
 
 	if (!otto_table_index_ok(handle, idx))
 		return -EINVAL;
 
-	return otto_table_exec(handle, false, idx);
+	err = otto_table_exec(handle, false, idx);
+
+	return err ? err : ret;
 }
+EXPORT_SYMBOL_GPL(__otto_table_fetch);
 
 u32 __otto_table_word_read(int handle, int word)
 {
 	struct otto_table *r = otto_table_reg(handle);
+	u32 val = 0;
+	int ret;
 
 	if (!r)
 		return 0;
 
-	return sw_r32(otto_table_word_addr(r, word));
+	ret = regmap_read(otto_map, otto_table_word_addr(r, word), &val);
+	if (ret)
+		pr_err_ratelimited("otto_table: read of table %d failed: %d\n",
+				   otto_table_handle_to_id(handle), ret);
+
+	return val;
 }
+EXPORT_SYMBOL_GPL(__otto_table_word_read);
 
 int __otto_table_read_bytes(int handle, int idx, void *buf, size_t size)
 {
@@ -381,17 +462,23 @@ int __otto_table_read_bytes(int handle, int idx, void *buf, size_t size)
 
 	ret = otto_table_exec(handle, false, idx);
 
-	for (unsigned int i = 0; i < words; i++)
-		out[i] = sw_r32(r->data + i * 4);
+	for (unsigned int i = 0; i < words; i++) {
+		int err = regmap_read(otto_map, r->data + i * 4, &out[i]);
+
+		if (err && !ret)
+			ret = err;
+	}
 
 	return ret;
 }
+EXPORT_SYMBOL_GPL(__otto_table_read_bytes);
 
 int __otto_table_write_bytes(int handle, int idx, const void *buf, size_t size)
 {
 	struct otto_table *r = otto_table_reg(handle);
 	unsigned int words;
 	const u32 *in = buf;
+	int ret;
 
 	if (!r || !otto_table_index_ok(handle, idx))
 		return -EINVAL;
@@ -402,11 +489,15 @@ int __otto_table_write_bytes(int handle, int idx, const void *buf, size_t size)
 		      size, otto_table_handle_to_id(handle), words))
 		return -EINVAL;
 
-	for (unsigned int i = 0; i < words; i++)
-		sw_w32(in[i], r->data + i * 4);
+	for (unsigned int i = 0; i < words; i++) {
+		ret = regmap_write(otto_map, r->data + i * 4, in[i]);
+		if (ret)
+			return ret;
+	}
 
 	return otto_table_exec(handle, true, idx);
 }
+EXPORT_SYMBOL_GPL(__otto_table_write_bytes);
 
 int otto_table_read_bytes(enum otto_table_id id, int idx, void *buf, size_t size)
 {
@@ -423,6 +514,7 @@ int otto_table_read_bytes(enum otto_table_id id, int idx, void *buf, size_t size
 
 	return ret;
 }
+EXPORT_SYMBOL_GPL(otto_table_read_bytes);
 
 int otto_table_write_bytes(enum otto_table_id id, int idx, const void *buf, size_t size)
 {
@@ -437,3 +529,4 @@ int otto_table_write_bytes(enum otto_table_id id, int idx, const void *buf, size
 
 	return ret;
 }
+EXPORT_SYMBOL_GPL(otto_table_write_bytes);

--- a/target/linux/realtek/files-6.18/include/linux/soc/realtek/otto_table.h
+++ b/target/linux/realtek/files-6.18/include/linux/soc/realtek/otto_table.h
@@ -148,8 +148,6 @@ enum otto_table_id {
 
 #define OTTO_TBL_COUNT		OTTO_TBL_HANDLE(OTTO_TBL_END)
 
-void otto_table_init(void);
-
 /* Size of the object p points at. A bare array is refused: the whole-entry
  * forms take the transfer size from the caller's buffer, which only holds
  * when p addresses the whole object rather than its first element.
@@ -170,6 +168,7 @@ void otto_table_init(void);
 /* Hold a table across more than one access. The __ variants expect the caller
  * to hold it.
  */
+int otto_table_loaded(void);
 int otto_table_acquire(enum otto_table_id id);
 void otto_table_release(int handle);
 

--- a/target/linux/realtek/files-6.18/include/linux/soc/realtek/otto_table.h
+++ b/target/linux/realtek/files-6.18/include/linux/soc/realtek/otto_table.h
@@ -156,12 +156,11 @@ enum otto_table_id {
 	(sizeof(*(p)) + BUILD_BUG_ON_ZERO(__is_array(p), "pass &array, not the array"))
 
 /* Read or write one whole entry. p addresses the caller's object: a u32 for a
- * one-word table, &array for a wider one. The size comes from the object and
- * has to match the entry, so a transfer can neither run past the object nor
- * move part of a row.
+ * one-word table, &array for a wider one. The size comes from the object, so a
+ * transfer cannot run past it.
  */
 #define otto_table_read(id, idx, p) \
-	otto_table_read_bytes((id), (idx), (p), otto_table_size(p))
+	otto_table_read_bytes((id), (idx), (p), 0, otto_table_size(p))
 #define otto_table_write(id, idx, p) \
 	otto_table_write_bytes((id), (idx), (p), otto_table_size(p))
 
@@ -173,24 +172,23 @@ int otto_table_acquire(enum otto_table_id id);
 void otto_table_release(int handle);
 
 #define __otto_table_read(handle, idx, p) \
-	__otto_table_read_bytes((handle), (idx), (p), otto_table_size(p))
+	__otto_table_read_bytes((handle), (idx), (p), 0, otto_table_size(p))
 #define __otto_table_write(handle, idx, p) \
 	__otto_table_write_bytes((handle), (idx), (p), otto_table_size(p))
 
-/* What the macros above expand to. size is the caller's object size and must
- * equal the entry width; a mismatch is refused and warned about rather than
- * silently truncated, because no caller checks the return value.
+/* What the macros above expand to. A read takes size bytes starting at word of
+ * the entry and has to end inside it; the whole-entry forms start at word zero.
+ * A write always moves the whole entry, because the command commits the whole
+ * data window, so its size has to equal the entry width. Either mismatch is
+ * refused and warned about rather than silently truncated, because no caller
+ * checks the return value.
  */
-int otto_table_read_bytes(enum otto_table_id id, int idx, void *buf, size_t size);
+int otto_table_read_bytes(enum otto_table_id id, int idx, void *buf,
+			  int word_offset, size_t size);
 int otto_table_write_bytes(enum otto_table_id id, int idx, const void *buf, size_t size);
 
-int __otto_table_read_bytes(int handle, int idx, void *buf, size_t size);
+int __otto_table_read_bytes(int handle, int idx, void *buf, int word_offset,
+			    size_t size);
 int __otto_table_write_bytes(int handle, int idx, const void *buf, size_t size);
-
-/* Load an entry into the data registers without copying it out, for the caller
- * that then picks single words at offsets it computes at run time.
- */
-int __otto_table_fetch(int handle, int idx);
-u32 __otto_table_word_read(int handle, int word);
 
 #endif /* _OTTO_TABLE_H */

--- a/target/linux/realtek/patches-6.18/331-add-realtek-otto-table-driver.patch
+++ b/target/linux/realtek/patches-6.18/331-add-realtek-otto-table-driver.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gennaro Cimmino <gcimmino@rayonra.net>
+Date: Tue, 9 Sep 2026 00:05:00 +0200
+Subject: [PATCH] realtek: add patch to enable the Otto table driver in kernel
+
+The switch table access code lives under drivers/soc/realtek and needs
+the two lines that let the kernel build it.
+
+Signed-off-by: Gennaro Cimmino <gcimmino@rayonra.net>
+--- a/drivers/soc/Kconfig
++++ b/drivers/soc/Kconfig
+@@ -20,6 +20,7 @@ source "drivers/soc/microchip/Kconfig"
+ source "drivers/soc/nuvoton/Kconfig"
+ source "drivers/soc/pxa/Kconfig"
+ source "drivers/soc/qcom/Kconfig"
++source "drivers/soc/realtek/Kconfig"
+ source "drivers/soc/renesas/Kconfig"
+ source "drivers/soc/rockchip/Kconfig"
+ source "drivers/soc/samsung/Kconfig"
+--- a/drivers/soc/Makefile
++++ b/drivers/soc/Makefile
+@@ -26,6 +26,7 @@ obj-y				+= nuvoton/
+ obj-y				+= pxa/
+ obj-y				+= amlogic/
+ obj-y				+= qcom/
++obj-$(CONFIG_REALTEK_OTTO_TABLE)	+= realtek/
+ obj-y				+= renesas/
+ obj-y				+= rockchip/
+ obj-$(CONFIG_SOC_SAMSUNG)	+= samsung/


### PR DESCRIPTION
Table access moves out of the DSA driver into a platform driver of its own, as asked in #25027. Four commits: the devicetree node, the move, then the two rounds of review @plappermaul asked for.

The shape follows what @plappermaul settled in that issue:

- the driver takes its **own** regmap from the parent syscon in probe
- that map is not exposed to any consumer
- a consumer asks whether the driver has initialised, through `otto_table_loaded()` — 0, `-EPROBE_DEFER`, or `-ENODEV` for a devicetree without the node
- the table functions are otherwise unchanged, and reach consumers through `EXPORT_SYMBOL_GPL`

`sw_r32()` was `__raw_readl(RTL838X_SW_BASE + reg)` and `RTL838X_SW_BASE` is the KSEG1 alias of the `switch0` reg the syscon covers, so the six accesses convert offset for offset — it is the same map `rtl838x_eth.c` already drives those registers through. `otto_table_reg()`, which every accessor already passes through, refuses and warns if it is reached before the map exists.

After @plappermaul's review, three things changed. `otto_map` is published with `smp_store_release()` and read back with `smp_load_acquire()`, so a consumer that sees the driver as up also sees the per-register mutexes probe initialised — they are zeroed in the image and only become real mutexes there. The table helpers propagate what the regmap layer returns, and `otto_table_exec()` polls the execute bit before writing a command. And the `fetch()` path is gone: `read_bytes()` now takes the word of the entry to start at, which is what the one consumer that picked single words out of the data registers needed, so `__otto_table_fetch()`, `__otto_table_word_read()` and `otto_table_word_addr()` could go with it.

Codegen cost of the barriers, since two families cannot be tested here: `otto_table.o` gains no `sync` at all on rtl838x and rtl930x, and exactly two on rtl931x, one in `otto_table_probe()` after the `mutex_init()` loop and one in `otto_table_loaded()`, neither inside a loop.

The sources live in the files overlay, so only the two lines that let the kernel descend into `drivers/soc/realtek` need a kernel patch, the same split `318-add-rtl83xx-clk-support.patch` uses.

**Testing.** Compile-tested on realtek/rtl930x, realtek/rtl931x, realtek/rtl838x and realtek/rtl839x, each commit of the series built on its own tree. RAM-booted twice on an **RTL9303, Hasivo S1100W-8XGT-SE**, against `main` at 769116266b:

| check | result |
|---|---|
| provider bound | `1b000000.ethernet-switch:table` under `/sys/bus/platform/drivers/otto-table/` |
| `devices_deferred` | empty |
| `dmesg \| grep -c WARNING` | 0 — the guard never fired |
| ports | all eight up, forwarding, real traffic |
| L2 table | 81 and 60 entries over the two boots, port MACs intact |
| VLAN table | VID 0 all 29 ports tagged; VID 1 member `0x1f110101`, untagged `0x0f110101` |

The table dumps come from the driver's debugfs, so every word of them was read out of the data registers through the new regmap path — a byteswapped window would have shown scrambled OUIs, a dead read would have shown empty tables.

**What this does not show.** RTL838x, RTL839x and RTL931x cannot be tested here, and for them this is not a no-op: the switch now depends on a provider that must bind. The node is a child of the same syscon with the same reg on all four families, which is the reason to expect it to work, not evidence that it does. The `-ENODEV` and `-EPROBE_DEFER` arms are unexercised too, since `drivers/soc` is linked before `drivers/net` and the gate answers 0 on the first try. Every table word now goes through regmap rather than `__raw_readl`, which adds a spinlock and an indirect call per 32-bit access; that was not measured, and it falls hardest on the RTL931x counter poll.

Deliverables 1 to 3 of #25027; 4 to 7 were 870c10eb8f, 11ee1eed06 and 9f62ca8ff1.

*Bench testing and analysis assisted by Claude Opus 5 (Anthropic AI).*


