### PR TITLE
ramips: fix dwr-921-c3 compatibility

### DIFF
--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -329,7 +329,6 @@ define Device/dlink_dwr-921-c3
   DEVICE_MODEL := DWR-921
   DEVICE_VARIANT := C3
   DLINK_ROM_ID := DLK6E2414009
-  SUPPORTED_DEVICES := dlink,dwr-921-c1
 endef
 TARGET_DEVICES += dlink_dwr-921-c3
 


### PR DESCRIPTION
The `dlink_dwr-921-c3` incorrectly claimed compatibility with the `-c1` version, causing confusion during automated sysupgrades.  Remove the conflict so upgrades stay on the correct variant.

Fixes: https://github.com/openwrt/openwrt/issues/25077

---
Should probably get backported to 25.12...