### PR TITLE
realtek: dsa: fix mirror teardown on RTL839x/931x

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/dsa.c
@@ -2285,7 +2285,8 @@ static void rtldsa_port_mirror_del(struct dsa_switch *ds, int port,
 		priv->r->mask_port_reg_be(1ULL << port, 0, config.dpm);
 	}
 
-	if (!(sw_r32(config.spm) || sw_r32(config.dpm))) {
+	if (!(priv->r->get_port_reg_be(config.spm) ||
+	      priv->r->get_port_reg_be(config.dpm))) {
 		priv->mirror_group_ports[group] = -1;
 		sw_w32(0, config.ctrl);
 	}


### PR DESCRIPTION
One-line fix for #25087: `rtldsa_port_mirror_del()` clears the port bit with the 64-bit family accessor but then tests the group for emptiness with a plain `sw_r32()`, which on RTL839x/RTL931x reads only the word holding ports 32 and above. The twin `rtldsa_port_mirror_add()` already reads the same matrix with `priv->r->get_port_reg_be()` (dsa.c:2240).

**Testing.** Compile-tested on realtek/rtl839x, realtek/rtl931x and realtek/rtl930x, against `main` at 769116266b.

**Not tested on hardware.** We have no RTL839x or RTL931x board — the only Realtek switch here is an RTL9303, which is exactly the family the defect cannot affect. #25087 carries a test procedure and a contrast run on the same board for anyone who has one, and a `Tested-by:` would be welcome before this is applied.

Behaviourally a no-op on RTL838x and RTL930x: `.get_port_reg_be` is `rtl838x_get_port_reg()` there (rtl838x.c:1756, rtl930x.c:2189), whose body is `return ((u64)sw_r32(reg));`, and their SPM/DPM are single 32-bit registers anyway (stride `group * 4`).

*Analysis assisted by Claude Opus 5 (Anthropic AI).*
