### PR TITLE
realtek: dsa: rtl83xx: tc flower lifecycle and locking fixes

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/common.c
@@ -933,6 +933,7 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 err_register_l3:
 	dsa_switch_shutdown(priv->ds);
 err_register_switch:
+	rtldsa_tc_cleanup(priv);
 	destroy_workqueue(priv->wq);
 
 	return err;
@@ -981,6 +982,8 @@ static void rtl83xx_sw_remove(struct platform_device *pdev)
 	cancel_delayed_work_sync(&priv->counters_work);
 
 	dsa_switch_shutdown(priv->ds);
+
+	rtldsa_tc_cleanup(priv);
 
 	destroy_workqueue(priv->wq);
 

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/dsa.c
@@ -204,6 +204,7 @@ static int rtldsa_83xx_setup(struct dsa_switch *ds)
 static int rtldsa_93xx_setup(struct dsa_switch *ds)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
+	int err;
 
 	pr_info("%s called\n", __func__);
 
@@ -241,6 +242,11 @@ static int rtldsa_93xx_setup(struct dsa_switch *ds)
 	ds->assisted_learning_on_cpu_port = true;
 
 	priv->r->pie_init(priv);
+
+	err = rtldsa_tc_init(priv);
+	if (err)
+		return err;
+
 	priv->r->led_init(priv);
 
 	return 0;

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl-otto.h
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl-otto.h
@@ -1543,6 +1543,7 @@ struct rtl838x_switch_priv {
 	unsigned long mc_group_bm[MAX_MC_GROUPS >> 5];
 	struct rhashtable tc_ht;
 	bool tc_initialized;
+	struct mutex tc_flow_lock;	/* Serializes tc flower add/del/stats */
 	unsigned long pie_use_bm[MAX_PIE_ENTRIES >> 5];
 	unsigned long octet_cntr_use_bm[MAX_COUNTERS >> 5];
 	unsigned long packet_cntr_use_bm[MAX_COUNTERS >> 4];

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl-otto.h
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl-otto.h
@@ -1542,6 +1542,7 @@ struct rtl838x_switch_priv {
 	bool eee_enabled;
 	unsigned long mc_group_bm[MAX_MC_GROUPS >> 5];
 	struct rhashtable tc_ht;
+	bool tc_initialized;
 	unsigned long pie_use_bm[MAX_PIE_ENTRIES >> 5];
 	unsigned long octet_cntr_use_bm[MAX_COUNTERS >> 5];
 	unsigned long packet_cntr_use_bm[MAX_COUNTERS >> 4];
@@ -1649,6 +1650,8 @@ int rtldsa_port_get_stp_state(struct rtl838x_switch_priv *priv, int port);
 int rtl83xx_port_is_under(const struct net_device *dev, struct rtl838x_switch_priv *priv);
 void rtldsa_port_stp_state_set(struct dsa_switch *ds, int port, u8 state);
 int rtl83xx_setup_tc(struct net_device *dev, enum tc_setup_type type, void *type_data);
+int rtldsa_tc_init(struct rtl838x_switch_priv *priv);
+void rtldsa_tc_cleanup(struct rtl838x_switch_priv *priv);
 
 /* Port register accessor functions for the RTL839x and RTL931X SoCs */
 void rtl839x_mask_port_reg_be(u64 clear, u64 set, int reg);

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
@@ -340,12 +340,31 @@ int rtldsa_tc_init(struct rtl838x_switch_priv *priv)
 	return 0;
 }
 
+/* Zero the hardware LOG counter and hand its allocator slot back. Done
+ * together so a slot is never returned to rtldsa_packet_cntr_alloc() while
+ * the hardware entry still holds the previous flow's count.
+ */
+static void rtldsa_packet_cntr_release(struct rtl838x_switch_priv *priv, int counter)
+{
+	if (counter < 0)
+		return;
+
+	if (priv->r->packet_cntr_clear) {
+		mutex_lock(&priv->reg_mutex);
+		priv->r->packet_cntr_clear(priv, counter);
+		mutex_unlock(&priv->reg_mutex);
+	}
+
+	rtldsa_packet_cntr_free(priv, counter);
+}
+
 static void rtldsa_tc_flow_free(void *ptr, void *arg)
 {
 	struct rtl83xx_flow *flow = ptr;
 	struct rtl838x_switch_priv *priv = arg;
 
 	priv->r->pie_rule_rm(priv, &flow->rule);
+	rtldsa_packet_cntr_release(priv, flow->rule.packet_cntr);
 
 	/* Readers may still hold an RCU-protected reference after the
 	 * object has been removed from the hash table.
@@ -424,7 +443,7 @@ static int rtldsa_configure_flower(struct rtl838x_switch_priv *priv,
 
 out_remove:
 	rhashtable_remove_fast(&priv->tc_ht, &flow->node, tc_ht_params);
-	rtldsa_packet_cntr_free(priv, flow->rule.packet_cntr);
+	rtldsa_packet_cntr_release(priv, flow->rule.packet_cntr);
 	/* published in tc_ht above; a concurrent reader may still hold a ref */
 	kfree_rcu(flow, rcu_head);
 	goto out_err;
@@ -462,6 +481,7 @@ static int rtldsa_delete_flower(struct rtl838x_switch_priv *priv,
 		goto out_unlock;
 
 	priv->r->pie_rule_rm(priv, &flow->rule);
+	rtldsa_packet_cntr_release(priv, flow->rule.packet_cntr);
 
 	kfree_rcu(flow, rcu_head);
 

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
@@ -377,11 +377,18 @@ void rtldsa_tc_cleanup(struct rtl838x_switch_priv *priv)
 	if (!priv->tc_initialized)
 		return;
 
+	/* Hold tc_flow_lock like the add/del/stats callbacks do: any
+	 * callback that slipped in before teardown must finish before the
+	 * table and rules are torn down, otherwise it can walk a half-freed
+	 * flow or run pie_rule_rm() against a rule this path already removed.
+	 */
+	mutex_lock(&priv->tc_flow_lock);
 	rhashtable_free_and_destroy(&priv->tc_ht, rtldsa_tc_flow_free, priv);
-	rcu_barrier();
-
-	mutex_destroy(&priv->tc_flow_lock);
 	priv->tc_initialized = false;
+	mutex_unlock(&priv->tc_flow_lock);
+
+	rcu_barrier();
+	mutex_destroy(&priv->tc_flow_lock);
 }
 
 static int rtldsa_configure_flower(struct rtl838x_switch_priv *priv,
@@ -393,6 +400,15 @@ static int rtldsa_configure_flower(struct rtl838x_switch_priv *priv,
 	pr_debug("In %s\n", __func__);
 
 	mutex_lock(&priv->tc_flow_lock);
+
+	/* rtldsa_tc_cleanup() clears this under the lock before it destroys
+	 * tc_ht; a callback that was parked on the lock must bail rather than
+	 * walk the freed table.
+	 */
+	if (!priv->tc_initialized) {
+		err = -ENODEV;
+		goto out_unlock;
+	}
 
 	rcu_read_lock();
 	pr_debug("Cookie %08lx\n", f->cookie);
@@ -467,6 +483,12 @@ static int rtldsa_delete_flower(struct rtl838x_switch_priv *priv,
 
 	mutex_lock(&priv->tc_flow_lock);
 
+	/* see rtldsa_configure_flower(): bail if teardown already ran */
+	if (!priv->tc_initialized) {
+		err = -ENODEV;
+		goto out_unlock;
+	}
+
 	rcu_read_lock();
 	flow = rhashtable_lookup_fast(&priv->tc_ht, &cls_flower->cookie, tc_ht_params);
 	if (!flow) {
@@ -502,6 +524,12 @@ static int rtldsa_stats_flower(struct rtl838x_switch_priv *priv,
 	pr_debug("%s:\n", __func__);
 
 	mutex_lock(&priv->tc_flow_lock);
+
+	/* see rtldsa_configure_flower(): bail if teardown already ran */
+	if (!priv->tc_initialized) {
+		err = -ENODEV;
+		goto out_unlock;
+	}
 
 	rcu_read_lock();
 	flow = rhashtable_lookup_fast(&priv->tc_ht, &cls_flower->cookie, tc_ht_params);

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
@@ -323,6 +323,44 @@ static const struct rhashtable_params tc_ht_params = {
 	.automatic_shrinking = true,
 };
 
+int rtldsa_tc_init(struct rtl838x_switch_priv *priv)
+{
+	int err;
+
+	if (priv->tc_initialized)
+		return 0;
+
+	err = rhashtable_init(&priv->tc_ht, &tc_ht_params);
+	if (!err)
+		priv->tc_initialized = true;
+
+	return err;
+}
+
+static void rtldsa_tc_flow_free(void *ptr, void *arg)
+{
+	struct rtl83xx_flow *flow = ptr;
+	struct rtl838x_switch_priv *priv = arg;
+
+	priv->r->pie_rule_rm(priv, &flow->rule);
+
+	/* Readers may still hold an RCU-protected reference after the
+	 * object has been removed from the hash table.
+	 */
+	kfree_rcu(flow, rcu_head);
+}
+
+void rtldsa_tc_cleanup(struct rtl838x_switch_priv *priv)
+{
+	if (!priv->tc_initialized)
+		return;
+
+	rhashtable_free_and_destroy(&priv->tc_ht, rtldsa_tc_flow_free, priv);
+	rcu_barrier();
+
+	priv->tc_initialized = false;
+}
+
 static int rtl83xx_configure_flower(struct rtl838x_switch_priv *priv,
 				    struct flow_cls_offload *f)
 {
@@ -476,8 +514,6 @@ int rtl83xx_setup_tc(struct net_device *dev, enum tc_setup_type type, void *type
 {
 	struct rtl838x_switch_priv *priv;
 	struct flow_block_offload *f = type_data;
-	static bool first_time = true;
-	int err;
 
 	pr_debug("%s: %d\n", __func__, type);
 
@@ -489,13 +525,9 @@ int rtl83xx_setup_tc(struct net_device *dev, enum tc_setup_type type, void *type
 
 	switch (type) {
 	case TC_SETUP_BLOCK:
-		if (first_time) {
-			first_time = false;
-			err = rhashtable_init(&priv->tc_ht, &tc_ht_params);
-			if (err)
-				pr_err("%s: Could not initialize hash table\n", __func__);
-		}
-
+		/* tc_ht is set up for the switch's lifetime in
+		 * rtldsa_93xx_setup(); nothing to do here.
+		 */
 		f->unlocked_driver_cb = true;
 		return flow_block_cb_setup_simple(type_data,
 						  &rtl83xx_block_cb_list,

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
@@ -476,30 +476,42 @@ static int rtldsa_stats_flower(struct rtl838x_switch_priv *priv,
 {
 	struct rtl83xx_flow *flow;
 	unsigned long lastused = 0;
-	int total_packets, new_packets;
+	u32 total_packets, new_packets = 0;
+	int err = 0;
 
 	pr_debug("%s:\n", __func__);
 
 	mutex_lock(&priv->tc_flow_lock);
+
+	rcu_read_lock();
 	flow = rhashtable_lookup_fast(&priv->tc_ht, &cls_flower->cookie, tc_ht_params);
+	rcu_read_unlock();
 	if (!flow) {
-		mutex_unlock(&priv->tc_flow_lock);
-		return -1;
+		err = -ENOENT;
+		goto out_unlock;
 	}
 
+	/* tc_flow_lock keeps the flow alive for the duration of the sleeping
+	 * counter read, so it is safe to dereference it after the RCU lock.
+	 */
 	if (flow->rule.packet_cntr >= 0) {
+		mutex_lock(&priv->reg_mutex);
 		total_packets = priv->r->packet_cntr_read(priv, flow->rule.packet_cntr);
-		pr_debug("Total packets: %d\n", total_packets);
+		mutex_unlock(&priv->reg_mutex);
+		dev_dbg(priv->dev, "total packets: %u\n", total_packets);
+
 		new_packets = total_packets - flow->rule.last_packet_cnt;
 		flow->rule.last_packet_cnt = total_packets;
 	}
 
-	/* TODO: We need a second PIE rule to count the bytes */
-	flow_stats_update(&cls_flower->stats, 100 * new_packets, new_packets, 0, lastused,
+	/* We have no byte counter, report packets only */
+	flow_stats_update(&cls_flower->stats, 0, new_packets, 0, lastused,
 			  FLOW_ACTION_HW_STATS_IMMEDIATE);
 
+out_unlock:
 	mutex_unlock(&priv->tc_flow_lock);
-	return 0;
+
+	return err;
 }
 
 static int rtl83xx_setup_tc_cls_flower(struct rtl838x_switch_priv *priv,

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/tc.c
@@ -331,10 +331,13 @@ int rtldsa_tc_init(struct rtl838x_switch_priv *priv)
 		return 0;
 
 	err = rhashtable_init(&priv->tc_ht, &tc_ht_params);
-	if (!err)
-		priv->tc_initialized = true;
+	if (err)
+		return err;
 
-	return err;
+	mutex_init(&priv->tc_flow_lock);
+	priv->tc_initialized = true;
+
+	return 0;
 }
 
 static void rtldsa_tc_flow_free(void *ptr, void *arg)
@@ -358,16 +361,19 @@ void rtldsa_tc_cleanup(struct rtl838x_switch_priv *priv)
 	rhashtable_free_and_destroy(&priv->tc_ht, rtldsa_tc_flow_free, priv);
 	rcu_barrier();
 
+	mutex_destroy(&priv->tc_flow_lock);
 	priv->tc_initialized = false;
 }
 
-static int rtl83xx_configure_flower(struct rtl838x_switch_priv *priv,
-				    struct flow_cls_offload *f)
+static int rtldsa_configure_flower(struct rtl838x_switch_priv *priv,
+				   struct flow_cls_offload *f)
 {
 	struct rtl83xx_flow *flow;
 	int err = 0;
 
 	pr_debug("In %s\n", __func__);
+
+	mutex_lock(&priv->tc_flow_lock);
 
 	rcu_read_lock();
 	pr_debug("Cookie %08lx\n", f->cookie);
@@ -375,13 +381,16 @@ static int rtl83xx_configure_flower(struct rtl838x_switch_priv *priv,
 	rcu_read_unlock();
 	if (flow) {
 		pr_info("%s: Got flow\n", __func__);
-		return -EEXIST;
+		err = -EEXIST;
+		goto out_unlock;
 	}
 	pr_debug("%s: New flow\n", __func__);
 
 	flow = kzalloc(sizeof(*flow), GFP_KERNEL);
-	if (!flow)
-		return -ENOMEM;
+	if (!flow) {
+		err = -ENOMEM;
+		goto out_unlock;
+	}
 
 	flow->cookie = f->cookie;
 	flow->priv = priv;
@@ -410,6 +419,7 @@ static int rtl83xx_configure_flower(struct rtl838x_switch_priv *priv,
 	if (err)
 		goto out_remove;
 
+	mutex_unlock(&priv->tc_flow_lock);
 	return 0;
 
 out_remove:
@@ -422,47 +432,60 @@ out_free:
 	kfree(flow);
 out_err:
 	pr_err("%s: error %d\n", __func__, err);
+out_unlock:
+	mutex_unlock(&priv->tc_flow_lock);
 
 	return err;
 }
 
-static int rtl83xx_delete_flower(struct rtl838x_switch_priv *priv,
-				 struct flow_cls_offload *cls_flower)
+static int rtldsa_delete_flower(struct rtl838x_switch_priv *priv,
+				struct flow_cls_offload *cls_flower)
 {
 	struct rtl83xx_flow *flow;
 	int err;
 
 	pr_debug("In %s\n", __func__);
+
+	mutex_lock(&priv->tc_flow_lock);
+
 	rcu_read_lock();
 	flow = rhashtable_lookup_fast(&priv->tc_ht, &cls_flower->cookie, tc_ht_params);
 	if (!flow) {
 		rcu_read_unlock();
-		return -ENOENT;
+		err = -ENOENT;
+		goto out_unlock;
 	}
 
 	err = rhashtable_remove_fast(&priv->tc_ht, &flow->node, tc_ht_params);
 	rcu_read_unlock();
 	if (err)
-		return err;
+		goto out_unlock;
 
 	priv->r->pie_rule_rm(priv, &flow->rule);
 
 	kfree_rcu(flow, rcu_head);
 
-	return 0;
+out_unlock:
+	mutex_unlock(&priv->tc_flow_lock);
+
+	return err;
 }
 
-static int rtl83xx_stats_flower(struct rtl838x_switch_priv *priv,
-				struct flow_cls_offload *cls_flower)
+static int rtldsa_stats_flower(struct rtl838x_switch_priv *priv,
+			       struct flow_cls_offload *cls_flower)
 {
 	struct rtl83xx_flow *flow;
 	unsigned long lastused = 0;
 	int total_packets, new_packets;
 
 	pr_debug("%s:\n", __func__);
+
+	mutex_lock(&priv->tc_flow_lock);
 	flow = rhashtable_lookup_fast(&priv->tc_ht, &cls_flower->cookie, tc_ht_params);
-	if (!flow)
+	if (!flow) {
+		mutex_unlock(&priv->tc_flow_lock);
 		return -1;
+	}
 
 	if (flow->rule.packet_cntr >= 0) {
 		total_packets = priv->r->packet_cntr_read(priv, flow->rule.packet_cntr);
@@ -475,6 +498,7 @@ static int rtl83xx_stats_flower(struct rtl838x_switch_priv *priv,
 	flow_stats_update(&cls_flower->stats, 100 * new_packets, new_packets, 0, lastused,
 			  FLOW_ACTION_HW_STATS_IMMEDIATE);
 
+	mutex_unlock(&priv->tc_flow_lock);
 	return 0;
 }
 
@@ -484,11 +508,11 @@ static int rtl83xx_setup_tc_cls_flower(struct rtl838x_switch_priv *priv,
 	pr_debug("%s: %d\n", __func__, cls_flower->command);
 	switch (cls_flower->command) {
 	case FLOW_CLS_REPLACE:
-		return rtl83xx_configure_flower(priv, cls_flower);
+		return rtldsa_configure_flower(priv, cls_flower);
 	case FLOW_CLS_DESTROY:
-		return rtl83xx_delete_flower(priv, cls_flower);
+		return rtldsa_delete_flower(priv, cls_flower);
 	case FLOW_CLS_STATS:
-		return rtl83xx_stats_flower(priv, cls_flower);
+		return rtldsa_stats_flower(priv, cls_flower);
 	default:
 		return -EOPNOTSUPP;
 	}


### PR DESCRIPTION
Five patches split out of #24994 at @plappermaul's request. They harden the
existing tc-flower code and apply against current main without the offload
feature; #24994 rebases on top once this lands and keeps only the offload
itself (its old patches 5-7 and 9).

- **give the tc flow hashtable a real lifecycle** - move `tc_ht` init/teardown
  out of a `first_time` static into `rtldsa_tc_init()` / `rtldsa_tc_cleanup()`
  tied to the switch probe/remove, and free it RCU-safely.
- **serialize the tc flower add/del/stats callbacks** - a `tc_flow_lock` mutex
  around the three cls_flower callbacks; they had no mutual exclusion.
- **read the tc flow counter outside the RCU lock** - `rtldsa_stats_flower()`
  called the sleeping `packet_cntr_read()` with no rcu_read_lock at all; do the
  lookup in a short RCU section, read the counter under `reg_mutex`, report the
  real packet count instead of a synthetic byte estimate.
- **clear a flow's LOG counter when it is destroyed** - a removed flow left its
  LOG-table counter with a stale value for the next flow that got the same id.
- **hold tc_flow_lock in rtldsa_tc_cleanup()** - teardown walked and destroyed
  `tc_ht` (and the mutex) without the lock the callbacks use; take it, and have
  the callbacks re-check `tc_initialized` after acquiring it.

rtl930x build clean; the whole stack (this + #24994) was verified on a Zyxel
XGS1210-12 (tc-flower assertion suite, 11/11).
