### PR TITLE
[25.12] mediatek: add support for JioRouter AX6000 JIDU6J01/6201/6401/6601/6701

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -141,7 +141,8 @@ gatonetworks,gdsp)
 glinet,gl-mt3000)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x20000"
 	;;
-jiorouter,ax6000-jidu6101)
+jiorouter,ax6000-jidu6101|\
+jiorouter,ax6000-jidu6j01)
 	. /lib/upgrade/nand.sh
 	envubi=$(nand_find_ubi ubi)
 	envdev=/dev/$(nand_find_volume "$envubi" u-boot-env)

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -145,7 +145,7 @@ jiorouter,ax6000-jidu6101)
 	. /lib/upgrade/nand.sh
 	envubi=$(nand_find_ubi ubi)
 	envdev=/dev/$(nand_find_volume "$envubi" u-boot-env)
-	ubootenv_add_uci_config "$envdev" "0x0" "0x80000" "0x80000" "1"
+	ubootenv_add_uci_config "$envdev" "0x0" "0x80000" "0x1f000" "5"
 	;;
 openembed,som7981)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x80000"

--- a/target/linux/mediatek/dts/mt7986a-jiorouter-ax6000-jidu6j01.dts
+++ b/target/linux/mediatek/dts/mt7986a-jiorouter-ax6000-jidu6j01.dts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include "mt7986a-jiorouter-common.dtsi"
+
+/ {
+	compatible = "jiorouter,ax6000-jidu6j01", "mediatek,mt7986a";
+	model = "JioRouter AX6000 JIDU6J01";
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "wan";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan1";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan2";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan3";
+		};
+
+		port@4 {
+			reg = <4>;
+			label = "lan4";
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};

--- a/target/linux/mediatek/dts/mt7986a-jiorouter-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-jiorouter-common.dtsi
@@ -123,12 +123,12 @@
 		conf-pu {
 			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
 			drive-strength = <MTK_DRIVE_8mA>;
-			bias-disable;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
 		};
 		conf-pd {
 			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
 			drive-strength = <MTK_DRIVE_8mA>;
-			bias-disable;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
 		};
 	};
 

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -285,6 +285,30 @@ mediatek_setup_macs()
 		wan_mac=$label_mac
 		lan_mac=$(macaddr_add "$label_mac" 1)
 		;;
+	jiorouter,ax6000-jidu6j01)
+		local mfg_dev
+		local model
+		mfg_dev=$(find_mtd_chardev "MFG")
+		[ -z "$mfg_dev" ] && return
+		model=$(dd if="$mfg_dev" bs=1024 count=1 2>/dev/null | strings | grep -o -m1 'JIDU[0-9A-Z][0-9A-Z]*')
+		case "$model" in
+		JIDU6401)
+			label_mac=$(get_mac_binary "$mfg_dev" 0x20)
+			;;
+		JIDU6601)
+			label_mac=$(mtd_get_mac_text "MFG" 0x1d0)
+			;;
+		JIDU6701)
+			label_mac=$(mtd_get_mac_ascii "MFG" mac)
+			;;
+		*)
+			label_mac=$(get_mac_binary "$mfg_dev" 0)
+			;;
+		esac
+		[ -n "$label_mac" ] || return
+		wan_mac=$label_mac
+		lan_mac=$(macaddr_add "$label_mac" 1)
+		;;
 	mercusys,mr80x-v3|\
 	mercusys,mr85x)
 		mac_dirty=$(cat "/tmp/tp_data/default-mac" | sed -n 's/^'"MAC"'://p')

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -176,6 +176,28 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
 		;;
+	jiorouter,ax6000-jidu6j01)
+		mfg_dev=$(find_mtd_chardev "MFG")
+		[ -z "$mfg_dev" ] && exit 0
+		model=$(dd if="$mfg_dev" bs=1024 count=1 2>/dev/null | strings | grep -o -m1 'JIDU[0-9A-Z][0-9A-Z]*')
+		case "$model" in
+		JIDU6401)
+			label_mac=$(get_mac_binary "$mfg_dev" 0x20)
+			;;
+		JIDU6601)
+			label_mac=$(mtd_get_mac_text "MFG" 0x1d0)
+			;;
+		JIDU6701)
+			label_mac=$(mtd_get_mac_ascii "MFG" mac)
+			;;
+		*)
+			label_mac=$(get_mac_binary "$mfg_dev" 0)
+			;;
+		esac
+		[ -n "$label_mac" ] || exit 0
+		[ "$PHYNBR" = "0" ] && macaddr_add $label_mac 2 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $label_mac 3 > /sys${DEVPATH}/macaddress
+		;;
 	keenetic,kap-630|\
 	keenetic,kn-3711|\
 	keenetic,kn-3811|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -35,9 +35,20 @@ jiorouter_initial_setup()
 	fi
 
 	ubidetach -m "$mtdnum" 2>/dev/null
-	ubiformat /dev/mtd$mtdnum -y
-	ubiattach -m "$mtdnum"
-	ubimkvol /dev/ubi0 -n 0 -N u-boot-env -s 0x80000
+	ubiformat /dev/mtd$mtdnum -y || exit 1
+	ubiattach -m "$mtdnum" || exit 1
+
+	local ubidev="$(nand_find_ubi ubi)"
+	[ -n "$ubidev" ] || { echo "cannot attach ubi"; exit 1; }
+
+	if ! ubimkvol /dev/$ubidev -n 0 -N u-boot-env -s 0x80000; then
+		echo "failed to create u-boot-env volume - aborting"
+		exit 1
+	fi
+
+	local envdev="$(nand_find_volume "$ubidev" u-boot-env)"
+	[ -n "$envdev" ] || { echo "cannot find u-boot-env volume - aborting"; exit 1; }
+	echo "/dev/$envdev 0x0 0x80000 0x1f000 5" > /etc/fw_env.config
 
 	# Set boot arguments in freshly created U-Boot environment
 	fw_setenv bootcmd 'ubi read 46000000 kernel;fdt addr $(fdtcontroladdr);fdt rm /signature;bootm 0x46000000'

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -236,7 +236,8 @@ platform_do_upgrade() {
 	cudy,wr3000p-v1|\
 	huasifei,wh3000-pro-nand|\
 	huasifei,wh3000r-nand|\
-	jiorouter,ax6000-jidu6101)
+	jiorouter,ax6000-jidu6101|\
+	jiorouter,ax6000-jidu6j01)
 		CI_UBIPART="ubi"
 		nand_do_upgrade "$1"
 		;;
@@ -487,7 +488,8 @@ platform_pre_upgrade() {
 	buffalo,wsr-6000ax8)
 		buffalo_initial_setup
 		;;
-	jiorouter,ax6000-jidu6101)
+	jiorouter,ax6000-jidu6101|\
+	jiorouter,ax6000-jidu6j01)
 		jiorouter_initial_setup
 		;;
 	xiaomi,mi-router-ax3000t|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2090,7 +2090,7 @@ define Device/jiorouter_ax6000-jidu6101
   DEVICE_VARIANT := JIDU6101
   DEVICE_DTS := mt7986a-jiorouter-ax6000-jidu6101
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7916-firmware kmod-mt7986-firmware mt7986-wo-firmware
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
   UBINIZE_OPTS := -E 5
   UBOOTENV_IN_UBI := 1
   BLOCKSIZE := 128k

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2099,6 +2099,33 @@ define Device/jiorouter_ax6000-jidu6101
 endef
 TARGET_DEVICES += jiorouter_ax6000-jidu6101
 
+define Device/jiorouter_ax6000-jidu6j01
+  DEVICE_VENDOR := JioRouter
+  DEVICE_MODEL := AX6000
+  DEVICE_VARIANT := JIDU6J01
+  DEVICE_ALT0_VENDOR := JioRouter
+  DEVICE_ALT0_MODEL := AX6000
+  DEVICE_ALT0_VARIANT := JIDU6201
+  DEVICE_ALT1_VENDOR := JioRouter
+  DEVICE_ALT1_MODEL := AX6000
+  DEVICE_ALT1_VARIANT := JIDU6401
+  DEVICE_ALT2_VENDOR := JioRouter
+  DEVICE_ALT2_MODEL := AX6000
+  DEVICE_ALT2_VARIANT := JIDU6601
+  DEVICE_ALT3_VENDOR := JioRouter
+  DEVICE_ALT3_MODEL := AX6000
+  DEVICE_ALT3_VARIANT := JIDU6701
+  DEVICE_DTS := mt7986a-jiorouter-ax6000-jidu6j01
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
+  UBINIZE_OPTS := -E 5
+  UBOOTENV_IN_UBI := 1
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += jiorouter_ax6000-jidu6j01
+
 define Device/kebidumei_ax3000-u22
   DEVICE_VENDOR := Kebidumei
   DEVICE_MODEL := AX3000-U22


### PR DESCRIPTION
Backport support for JioRouter AX6000 JIDU6J01/6201/6401/6601/6701

| Component        | Details                                         |
|------------------|-------------------------------------------------|
| **SoC**          | MediaTek MT7986A (4× ARM Cortex-A53 @ 2.0 GHz) |
| **RAM**          | 512 MB                                          |
| **Flash**        | 256 MB NAND                                     |
| **Ethernet**     | 5× 10/100/1000 Mbps (1 WAN + 4 LAN)            |
| **WLAN 2.4 GHz** | MediaTek MT7976GN — 802.11b/g/n/ax, 4×4 MIMO   |
| **WLAN 5 GHz**   | MediaTek MT7976AN — 802.11n/ac/ax, 4×4 MIMO    |
| **LEDs**         | 1× RGB LED (GPIO-controlled)                    |
| **Button**       | 1× Reset                                        |
| **USB**          | Yes                                             |

**MAC Addresses:**

| Interface  | Source                                          |
|------------|-------------------------------------------------|
| WAN/Label  | MFG MTD partition (JIDU6201/6J01: binary at 0x00, JIDU6401: binary at 0x20, JIDU6601: ASCII at 0x1d0, JIDU6701: ASCII mac= key)              |
| LAN        | WAN + 1                                         |
| 2.4 GHz    | WAN + 2                                         |
| 5 GHz      | WAN + 3                                         |

---

**1. Extracting U-Boot Credentials**
The U-Boot username and password are stored in the `MFG` partition. To retrieve them:
- With root access on stock OS: Read directly from the MFG partition.
- Without root access: Dump the NAND flash first, then extract the credentials from the dump.

**2. Prepare TFTP server**
- Set a static IP on the ethernet interface of your computer (e.g. default: ip `192.168.1.2`, gateway `192.168.1.1`).
- Download the initramfs image and host it with the TFTP server.

**3. Interrupt boot**

Attach UART and power on the router. When the boot menu appears, select **Failsafe Mode**,
then  press `Ctrl-C` to interrupt and enter username and password you extracted from `MFG` partition.

**4. Load and run initramfs image**
```sh
setenv ipaddr 192.168.1.1
setenv serverip 192.168.1.2
tftpboot 0x46000000 openwrt-mediatek-filogic-jiorouter_ax6000-jidu6j01-initramfs-kernel.bin
fdt addr $(fdtcontroladdr)
fdt rm /signature
bootm
```

**5. Flash sysupgrade image**

Place the sysupgrade image in `/tmp`, then run:
```sh
sysupgrade /tmp/openwrt-mediatek-filogic-jiorouter_ax6000-jidu6j01-squashfs-sysupgrade.bin
```
Alternatively, use the sysupgrade option in LuCI.

Link: #23510 