### PR TITLE
ramips: mt76x8: fix cudy tr1200-v1 switch port leak on boot

### DIFF
--- a/package/base-files/files/etc/init.d/95-switch-port-fixup
+++ b/package/base-files/files/etc/init.d/95-switch-port-fixup
@@ -1,0 +1,30 @@
+#!/bin/sh /etc/rc.common
+# Re-enable switch ports that may have been left disabled by the
+# hardware-level portdisable devicetree property, after both preinit
+# and netifd have finished applying their own switch/VLAN configuration.
+# Runs deliberately late (START=99) to win any race with a second
+# switch reset issued later in the boot sequence (e.g. by netifd).
+
+START=99
+
+reenable_switch_ports() {
+	local cfg="$1"
+	local device ports
+
+	config_get device "$cfg" device
+	config_get ports "$cfg" ports
+
+	[ -n "$device" ] || return
+
+	for p in $ports; do
+		swconfig dev "$device" port "${p%%[a-z]*}" set disable 0
+	done
+	swconfig dev "$device" set apply
+}
+
+boot() {
+	[ -x /sbin/swconfig ] || return
+	. /lib/functions.sh
+	config_load network
+	config_foreach reenable_switch_ports switch_vlan
+}

--- a/package/base-files/files/lib/preinit/10_indicate_preinit
+++ b/package/base-files/files/lib/preinit/10_indicate_preinit
@@ -51,6 +51,9 @@ preinit_config_switch() {
 
 			if [ "$device" = "$lan_if" ]; then
 				swconfig dev $name vlan $role set ports "$ports"
+				for p in $ports; do
+					swconfig dev $name port ${p%%[a-z]*} set disable 0
+				done
 			fi
 		done
 

--- a/package/base-files/files/lib/preinit/10_indicate_preinit
+++ b/package/base-files/files/lib/preinit/10_indicate_preinit
@@ -51,9 +51,6 @@ preinit_config_switch() {
 
 			if [ "$device" = "$lan_if" ]; then
 				swconfig dev $name vlan $role set ports "$ports"
-				for p in $ports; do
-					swconfig dev $name port ${p%%[a-z]*} set disable 0
-				done
 			fi
 		done
 

--- a/target/linux/ramips/dts/mt7628an_cudy_tr1200-v1.dts
+++ b/target/linux/ramips/dts/mt7628an_cudy_tr1200-v1.dts
@@ -194,5 +194,5 @@
 
 &esw {
 	mediatek,portmap = <0x3d>;
-	mediatek,portdisable = <0x3c>;
+	mediatek,portdisable = <0x3f>;
 };


### PR DESCRIPTION
Problem

On the Cudy TR1200 v1, port 0 is used as LAN and port 1 as WAN,
isolated via VLANs configured through swconfig. However, during
boot there is a window of a few seconds where both ports are
electrically up and unfiltered, before OpenWrt's preinit script
applies the VLAN configuration.

Traced via kernel boot log timestamps:

    rt3050-esw driver brings ports 0 and 1 link-up at ~6s uptime
    (hardware probe), with no VLAN filtering active yet.
    preinit only resets the switch and applies VLAN isolation via
    swconfig at ~17-21s uptime.

For roughly 12-15 seconds, ports 0 and 1 share the same unfiltered
L2 domain. If a client is powered on in that window, it can reach
a DHCP server on the wrong port and get an IP from the wrong
network segment. On the affected device, this was reproduced with
two separate physical networks connected to LAN and WAN: some
Windows clients ended up with an IP from the wrong network and
would not recover automatically — they kept the wrong lease until
an explicit ipconfig /renew was run, since Windows does not
retry DHCP on its own once a lease is (wrongly) obtained.

Confirmed the leak directly in the router's own DHCP log:
a client briefly received an IP from the unintended network,
followed by a DHCPNAK ("wrong network") and a corrected DHCPACK
on the intended subnet moments later.
Root cause

target/linux/ramips/dts/mt7628an_cudy_tr1200-v1.dts sets:

mediatek,portdisable = <0x3c>;   // ports 2-5 disabled by default

This does not cover ports 0 and 1, the two ports actually used
(LAN/WAN) on this device, so they come up enabled at the hardware
level before any VLAN configuration is applied.
Fix

Extend portdisable to also cover ports 0 and 1, so all
user-facing ports stay disabled at power-on until preinit/netifd
apply VLAN isolation:

mediatek,portdisable = <0x3f>;   // ports 0-5 disabled by default

Port 6 (CPU port) is unaffected. This mirrors the approach already
used on other rt3050/rt3052-family devices to avoid the same class
of issue (e.g. mt7628an_duzun_dm06.dts, mt7628an_tplink_tl-mr6400-v4.dts).
Testing

Verified live on hardware via swconfig/devicetree inspection
(/sys/firmware/devicetree/base/esw@10110000/mediatek,portdisable)
that the current value matches the dts (0x3c), and confirmed the
boot timeline and DHCP leak via logread/dmesg.

See the update below for full build/boot testing results.
Update: revised approach after real-hardware testing

The original approach (re-enabling ports inside preinit's
preinit_config_switch) was tested on real hardware and found
insufficient: preinit only re-enables ports for the role matching
$lan_if (LAN only, never WAN), and boot logs show the switch is
touched a second time by netifd around 50-55s uptime — any
re-enable done during preinit gets raced/undone by this later
event, leaving even the LAN port disabled after boot.

Revised fix: instead of re-enabling ports from within preinit,
add a very-late (START=99) init script
(/etc/init.d/95-switch-port-fixup) that re-enables every port
referenced in the active switch_vlan UCI config, running after
both preinit and netifd have finished touching the switch. This
avoids the race entirely rather than trying to win it.

Tested by compiling a full firmware image from this branch and
flashing it on the actual Cudy TR1200 v1 device described in the
original report. Boot log confirms a single port-up event at
~77s uptime (no early hardware-probe link-up, no leak window),
and a real power-cycle test with a client PC on the LAN port
showed no wrong-network DHCP lease and no need for ipconfig /renew.

Trade-off worth noting: ports now stay down for the full boot
duration (~1 minute) instead of coming up early with the leak.
Network connectivity to LAN/WAN clients is available only once
boot fully completes.

Keeping this PR in draft for further real-world testing before
requesting review.