### PR TITLE
[25.12] mediatek: correct MT7986 system timer rate

### DIFF
--- a/target/linux/mediatek/patches-6.12/197-arm64-dts-mediatek-mt7986-correct-timer-frequency.patch
+++ b/target/linux/mediatek/patches-6.12/197-arm64-dts-mediatek-mt7986-correct-timer-frequency.patch
@@ -1,0 +1,35 @@
+From d99238733debc1e1e8783f794e88adf5f17820f5 Mon Sep 17 00:00:00 2001
+From: Andrea Pesaresi <andreapesaresi82@gmail.com>
+Date: Sat, 29 Aug 2026 17:06:18 +0200
+Subject: [PATCH] arm64: dts: mediatek: mt7986: correct timer frequency
+
+The MT7986 architected timer runs at 12,986,200 Hz rather than 13 MHz.
+Firmware reports 13 MHz through CNTFRQ_EL0, causing the system clock to
+run slow by about 1062 ppm. This exceeds the kernel's 500 ppm NTP
+correction limit and leaves clock discipline saturated.
+
+The corrected rate comes from MediaTek's downstream OpenWrt feed, where
+it is applied to both MT7986A and MT7986B. Since upstream mt7986b.dtsi
+includes mt7986a.dtsi, add it once to the common timer node so the
+architected timer driver uses the actual counter rate.
+
+Fixes: 50137c150f5f ("arm64: dts: mediatek: add basic mt7986 support")
+Cc: stable@vger.kernel.org
+Link: https://github.com/mediatek/mtk-openwrt-feeds/commit/6a4c41c41410cd5042ad10c39da6593ba036283c
+Link: https://github.com/openwrt/openwrt/issues/24789
+Link: https://lore.kernel.org/r/20260829151955.3661893-1-andreapesaresi82@gmail.com
+Signed-off-by: Andrea Pesaresi <andreapesaresi82@gmail.com>
+---
+ arch/arm64/boot/dts/mediatek/mt7986a.dtsi | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/arch/arm64/boot/dts/mediatek/mt7986a.dtsi
++++ b/arch/arm64/boot/dts/mediatek/mt7986a.dtsi
+@@ -645,6 +645,7 @@
+ 	timer {
+ 		compatible = "arm,armv8-timer";
+ 		interrupt-parent = <&gic>;
++		clock-frequency = <12986200>;
+ 		interrupts = <GIC_PPI 13 IRQ_TYPE_LEVEL_LOW>,
+ 			     <GIC_PPI 14 IRQ_TYPE_LEVEL_LOW>,
+ 			     <GIC_PPI 11 IRQ_TYPE_LEVEL_LOW>,


### PR DESCRIPTION
Backport of f36067d/#24943 from main to openwrt-25.12.

Fixes: #24789
