### PR TITLE
ipq-wifi/ath10k: fix 5GHz radio detection on TP-Link Archer C60 v3

### DIFF
--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -95,6 +95,7 @@ ALLWIFIBOARDS:= \
 	tplink_archer-c6-v2 \
 	tplink_archer-c60-v1 \
 	tplink_archer-c60-v2 \
+	tplink_archer-c60-v3 \
 	tplink_deco-x80-5g \
 	tplink_eap225-wall-v2 \
 	tplink_eap610-outdoor \
@@ -297,6 +298,7 @@ $(eval $(call generate-ipq-wifi-package,tplink_archer-c59-v1,TP-Link Archer C59 
 $(eval $(call generate-ipq-wifi-package,tplink_archer-c6-v2,TP-Link Archer C6 V2))
 $(eval $(call generate-ipq-wifi-package,tplink_archer-c60-v1,TP-Link Archer C60 V1))
 $(eval $(call generate-ipq-wifi-package,tplink_archer-c60-v2,TP-Link Archer C60 V2))
+$(eval $(call generate-ipq-wifi-package,tplink_archer-c60-v3,TP-Link Archer C60 V3))
 $(eval $(call generate-ipq-wifi-package,tplink_deco-x80-5g,TP-Link Deco X80-5G))
 $(eval $(call generate-ipq-wifi-package,tplink_eap225-wall-v2,TP-Link EAP225-Wall v2))
 $(eval $(call generate-ipq-wifi-package,tplink_eap610-outdoor,TPLink EAP610-Outdoor))

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c60-v3.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c60-v3.dts
@@ -27,6 +27,7 @@
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&precal_art_5000>, <&macaddr_info_8 (-1)>;
 		nvmem-cell-names = "pre-calibration", "mac-address";
+		qcom,ath10k-calibration-variant = "TP-Link-Archer-c60-v3";
 	};
 };
 

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -153,7 +153,7 @@ define Device/tplink_archer-c60-v3
   DEVICE_MODEL := Archer C60
   DEVICE_VARIANT := v3
   TPLINK_BOARD_ID := ARCHER-C60-V3
-  DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca9888-ct
+  DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca9888-ct ipq-wifi-tplink_archer-c60-v3
 endef
 TARGET_DEVICES += tplink_archer-c60-v3
 


### PR DESCRIPTION
Fixes https://github.com/openwrt/openwrt/issues/14541

This fixes the 5ghz radio detection on TP-Link Archer C60 v3. Boarddata was extracted from the vendor firmware
`ArcherC60v3_up-ver1-2-2-P1[20260206-rel59310].bin` and tested on OpenWrt 25.12.5.

Requires https://github.com/openwrt/firmware_qca-wireless/pull/152 to be merged first and ipq-wifi to be updated to head.

The local OpenWrt commit already has the DTS variant, ALLWIFIBOARDS entry, and DEVICE_PACKAGES; **it does not yet have a valid source bump - todo once firmware PR is merged.**