### PR TITLE
realtek: rtl930x: add support for Sirivision SR-ST3808F

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -96,6 +96,7 @@ realtek_setup_macs()
 	plasmacloud,psx10|\
 	plasmacloud,psx28|\
 	sirivision,sr-st3408f|\
+	sirivision,sr-st3808f|\
 	ubnt,usw-pro-xg-8-poe|\
 	zyxel,gs1920-24-v1|\
 	zyxel,gs1920-24hp-v2)

--- a/target/linux/realtek/dts/rtl9303_sirivision_sr-st3808f.dts
+++ b/target/linux/realtek/dts/rtl9303_sirivision_sr-st3808f.dts
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "rtl930x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "sirivision,sr-st3808f", "realtek,rtl9303-soc";
+	model = "Sirivision SR-ST3808F";
+
+	aliases {
+		label-mac-device = &ethernet0;
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>, /* first 256 MiB */
+		      <0x20000000 0x10000000>; /* remaining 256 MiB */
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinmux_disable_sys_led>, <&pinmux_enable_led_sync>;
+
+		led_sys: led-0 {
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			linux,default-trigger = "heartbeat";
+		};
+	};
+
+	led_set {
+		compatible = "realtek,rtl9300-leds";
+		active-low;
+
+		led_set0 = <(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_5G | RTL93XX_LED_SET_2P5G |
+			     RTL93XX_LED_SET_1G | RTL93XX_LED_SET_100M | RTL93XX_LED_SET_10M |
+			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)>;
+	};
+
+	sfp0: sfp-p1 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		tx-disable-gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
+		los-gpios = <&gpio1 2 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2900>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp1: sfp-p2 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		tx-disable-gpios = <&gpio1 3 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio1 4 GPIO_ACTIVE_LOW>;
+		los-gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <1500>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp2: sfp-p3 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2>;
+		tx-disable-gpios = <&gpio1 6 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		los-gpios = <&gpio1 8 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <1500>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp3: sfp-p4 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c3>;
+		tx-disable-gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+		los-gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp4: sfp-p5 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c4>;
+		tx-disable-gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio1 13 GPIO_ACTIVE_LOW>;
+		los-gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp5: sfp-p6 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c5>;
+		tx-disable-gpios = <&gpio1 21 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio1 22 GPIO_ACTIVE_LOW>;
+		los-gpios = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <1500>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp6: sfp-p7 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c6>;
+		tx-disable-gpios = <&gpio1 24 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio1 25 GPIO_ACTIVE_LOW>;
+		los-gpios = <&gpio1 26 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <1500>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp7: sfp-p8 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c7>;
+		tx-disable-gpios = <&gpio1 27 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio1 28 GPIO_ACTIVE_LOW>;
+		los-gpios = <&gpio1 29 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2900>;
+		#thermal-sensor-cells = <0>;
+	};
+};
+
+&i2c_mst1 {
+	status = "okay";
+
+	i2c0: i2c@0 { reg = <0>; };
+	i2c1: i2c@1 { reg = <1>; };
+	i2c2: i2c@2 { reg = <2>; };
+	i2c3: i2c@3 { reg = <3>; };
+	i2c4: i2c@4 { reg = <4>; };
+	i2c5: i2c@5 { reg = <5>; };
+	i2c6: i2c@6 { reg = <6>; };
+	i2c7: i2c@7 { reg = <7>; };
+};
+
+&mdio_aux {
+	status = "okay";
+
+	gpio1: gpio@0 {
+		compatible = "realtek,rtl8231";
+		reg = <0>;
+
+		gpio-controller;
+		#gpio-cells = <2>;
+		gpio-ranges = <&gpio1 0 0 37>;
+
+		led-controller {
+			compatible = "realtek,rtl8231-leds";
+			status = "disabled";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0xe0000>;
+				read-only;
+			};
+
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0xe0000 0x10000>;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+
+					macaddr_ubootenv_ethaddr: ethaddr {
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@f0000 {
+				label = "u-boot-env2";
+				reg = <0xf0000 0x10000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "jffs";
+				reg = <0x100000 0x100000>;
+			};
+
+			partition@200000 {
+				label = "jffs2";
+				reg = <0x200000 0x100000>;
+			};
+
+			partition@300000 {
+				label = "firmware";
+				reg = <0x300000 0xd00000>;
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <0x93000000>;
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	nvmem-cells = <&macaddr_ubootenv_ethaddr 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ethernet-ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT_SFP(0, 1, 2, 0, 0)
+		SWITCH_PORT_SFP(8, 2, 3, 0, 1)
+		SWITCH_PORT_SFP(16, 3, 4, 0, 2)
+		SWITCH_PORT_SFP(20, 4, 5, 0, 3)
+		SWITCH_PORT_SFP(24, 5, 6, 0, 4)
+		SWITCH_PORT_SFP(25, 6, 7, 0, 5)
+		SWITCH_PORT_SFP(26, 7, 8, 0, 6)
+		SWITCH_PORT_SFP(27, 8, 9, 0, 7)
+
+		port@1c {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&thermal_zones {
+	sfp-thermal {
+		polling-delay-passive = <10000>;
+		polling-delay = <10000>;
+		thermal-sensors = <&sfp0>, <&sfp1>, <&sfp2>, <&sfp3>, <&sfp4>, <&sfp5>, <&sfp6>, <&sfp7>;
+		trips {
+			sfp-crit {
+				temperature = <110000>;
+				hysteresis = <1000>;
+				type = "critical";
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -23,6 +23,16 @@ define Device/sirivision_sr-st3408f
 endef
 TARGET_DEVICES += sirivision_sr-st3408f
 
+define Device/sirivision_sr-st3808f
+  SOC := rtl9303
+  UIMAGE_MAGIC := 0x93000000
+  DEVICE_VENDOR := Sirivision
+  DEVICE_MODEL := SR-ST3808F
+  IMAGE_SIZE := 13312k
+  $(Device/kernel-lzma)
+endef
+TARGET_DEVICES += sirivision_sr-st3808f
+
 define Device/hasivo_f1100w-4sx-4xgt-common
   SOC := rtl9303
   DEVICE_VENDOR := Hasivo


### PR DESCRIPTION
This commit adds support for the Sirivision SR-ST3808F, an 8-port 10G
switch with 8x SFP ports.

- SoC:      Realtek RTL9303
- RAM:      512 MiB DDR3 (Micron)
- Flash:    SPI-NOR 16 MiB (Winbond)
- Ethernet: 8x SFP+
- LEDs:     1x power, 1x system green, 1x SFP+ LED/port (link/act)
- Button:   Reset
- Console:  Cisco-style RJ45, 115200 8n1
- Power:    12V 3A/3.33A internal PSU, input AC 100-240V 50/60Hz

Hardware revisions
------------

There're **at least 2** revisions judging from 2 SR-ST3808Fs I bought

The cases are in same length (~195 mm) and height (~40 mm), except the
width of the new revision is bigger (~165 mm vs ~159 mm), also with
Sirivision logo.

The hardware is basically the same, using the same `ST3808F_V1.1` PCB
design, but with slightly different components.

| Component            | 2411 batch            | 2550 batch            |
|----------------------|-----------------------|-----------------------|
| LDO                  | AZ1117H-ADJTRE1 @ EH11A | AZ1117H-ADJTRG1 @ GH17K |
| R102 near LV08A*     | Yes                   | No                    |
| Power Supply         | TPT36S1203A @ 3A        | FC042X01-120333 @ 3.33A |

The newer one also provides web-only variant without RJ45 console port
with a slight discount.

Board Layout
-----------

The following is a simplified view of the board layout:

```
Board Rear     Board Front                                  Power
--------------+--------------------------------------------+----------
              |Console        TI-MAX3232C                  |
              |PWR&SYS-LEDs      R102        DC-4PIN-Header|
              |SFP1-4-LEDs TI-HC164 TI-LV08A               |12V Supply
              |SFP5-8-LEDs                                 |
              |SFP1                                        |
              |SFP2                                        |
              |SFP3           SMD2520      RAM:Micron-D9SHD|
              |SFP4          SoC:RTL9303                   |
LDO           |SFP5            74HC125D                    |
              |SFP6               SPI:WinBound-W25Q128JVSIQ|
              |SFP7            74HC125D                    |
      RTL8231 |SFP8                    SPI-6PIN-EmptyHeader|AC-Socket
              |ResetButton                                 |
--------------+--------------------------------------------+----------
```

**Important** R102 removal
------------

On old batches (at least 2411), one of LV08A's positive AND channel has
its output 3Y wired through R102 to RTL8231's reset pin; the channel's
input 3A has no input and 3B is connected through a resistor to VCC.
This means 3A & 3B = GND = 3Y, therefore pulling RTL8231 reset pin to
ground, locking it in forever reset state. This means one would see some
log like the following during boot:

```
rtl8231-expander realtek-aux-mdio:00: RTL8231 not present or ready 0x0 != 0x37
```

As 3 GPIOs per SFP cage are provided by RTL8231, all of SFP would be
stuck in probe state and any non-DAC module would not be usable.

On new batches (at least 2550), R102 is not soldered so there would not
be such problem. Note this **does not** mean a PCB revision: it's the
same `ST3808F_V1.1` PCB.

To confirm the existence of R102 and remove it, power off the switch and
ensure there's no AC cable connected to the switch, then open the case
and place the board in a similar way to the above Board Layout section.
Let's call the SFP side "west". The R102 is at northwest of the board,
between HC164 and LV08A, and is next to the northwest pin of LV08A. Use
a solder iron between 340C and 380C and forceps to carefully desolder
and remove R102.

Further information around this can be checked at:

https://forum.openwrt.org/t/support-for-rtl838x-and-rtl93xx-based-managed-switches/57875/4509?u=nomad7ji

Firmware / software revisions
------------

The firmware (from vendor mtd5) and loader (from vendor mtd0) can be
cross-flashed for the two revisions I have on hand. Which should prove
no breaking hardware changes have happened other than R102 issue above.

Here's a table to list the differences I've noticed

|                              | Old         | New          |
|------------------------------|-------------|--------------|
| Bought                       | 20240726    | 20260805     |
| Loader Version               | 3.6.8.55120 | 3.6.11.55242 |
| Loader Built                 | 20240514    | 20251128     |
| Loader auto `rtk network on` | Yes         | No           |
| Loader DAC support           | No          | Yes          |
| Loader RTL8261N support      | Yes         | No           |
| Firmware Version             | 3.5.0.22    | 3.5.0.10     |
| Firmware Built               | 20240723    | 20251128     |
| Firmware DAC fixups          | No          | Yes          |
| Firmware OSPF Support        | No          | Yes          |

So for `tftpboot` to work, you'd have to use a 10G RJ-45 module on the
old loader, but on the new loader you'd have to use a DAC cable instead.
It's better to prepare both.

Initial Flashing
------------

1. Attach to serial console using a Cisco cable, 115200 8n1.
2. Power on the switch and rapidly press Esc to interrupt U-Boot; note
   on older loader it would force a `rtk network on` before autoboot,
   which takes ~8 extra seconds before the 1-second autoboot window.
3. Initialize the network if you're **on new loader** that does not do
   it automatically, by running `rtk network on`; note doing this again
   after network is on does nothing on new loader, but would initialize
   the network again on old loader which may have side effects.
4. Serve the `initramfs-kernel.bin` image on TFTP, IP 192.168.1.111
5. If running older loader, connect a RTL8261N-based 10G RJ-45 PHY
   module and use its RJ-45 port to connect to your TFTP server.
   If running newer loader, use a DAC cable to connect to your TFTP
   server.
6. Do a `ping 192.168.1.111` on loader console to confirm the switch can
   contact with your server. There's a gotcha that the switch appears to
   have connected to the other end and your NIC on that end reports the
   interface connected, but no L2/L3 traffic could make through. If that
   happens, do not re-run `rtk network on` or `off` then `on` on the
   switch loader; instead just down-up-cycle your NIC, i.e. `ip link set
   sfp1 down && ip link set sfp1 up` and do a `ping` from the switch
   again and confirm the L2/L3 traffic is now OK.
7. Run `tftpboot 0x81000000 initramfs-kernel.bin; bootm` to boot OpenWrt
8. In OpenWrt shell, run `dmesg | grep rtl8231-expander` to check if
   there's an error message `RTL8231 not present or ready 0x0 != 0x37`.
   If that error occurs, you can also double check that by running
   `ethtool -m` on ports with module and `netlink error: Not supported`
   would appear. If that's the case then the switch is from old batch
   and you'd need to disconnect everything and remove resistor R102 from
   the PCB following the instructions in "R102 Removal" section before
   re-doing the initial flashing from step 1 again.
9. In OpenWrt you now have to use a DAC cable regardless of what you
   used during loader; as the RTL8261N phy driver is not pre-bundled. As
   OpenWrt currently doesn't have DAC fixups, a DAC cable working in
   loader might seem not functioning inside OpenWrt. If that happens,
   you may try to limit its speed e.g. `ethtool -s lan1 speed 1000m`
10. Use `mtd dump` or `dd` to backup the original firmware at `mtd5`
11. Send `sysupgrade.bin` to the in-memory OpenWrt instance and run
    sysupgrade to flash it into the switch and reboot

Return to Stock
------------

While the vendor WebUI provides methods to restore/backup firmware, the
backup from there only downloads the real firmware data, excluding some
CoW data inside the firmware partition (similar to OpenWrt's uimage
kernel+rootfs). Therefore you should have made a full backup of `mtd5`
on OpenWrt as mentioned in "Initial Flashing" so a `mtd write` restore
doesn't render the remaining non-firmware part there "corrupted".

Send your previous backup of `mtd5` to running OpenWrt and use `mtd
write` to restore it. It's recommended to do this on a initramfs to
avoid potential conflicts.

MAC Address
------------

All 8 SFP interfaces are under one DSA switch and share the same MAC
address as the switch itself, derived from the U-Boot env `ethaddr`.
This MAC address is also printed on the device label.

If u-boot env is corrupted or reverted then the env would be set to
`00:E0:4C:00:00:00`, multiple switches therefore might conflict in the
same LAN. If that happens, one needs to set it back manually either in
loader or in OpenWrt.