### PR TITLE
mediatek: filogic: add support for EdgePi E87N

### DIFF
--- a/package/kernel/linux/modules/video.mk
+++ b/package/kernel/linux/modules/video.mk
@@ -290,6 +290,21 @@ endef
 
 $(eval $(call KernelPackage,fb-tft-ili9486))
 
+define KernelPackage/fb-tft-nv3007
+  SUBMENU:=$(VIDEO_MENU)
+  TITLE:=FB driver for the NewVision NV3007 LCD Controller
+  DEPENDS:=@TARGET_mediatek_filogic +kmod-fb-tft
+  KCONFIG:=CONFIG_FB_TFT_NV3007
+  FILES:=$(LINUX_DIR)/drivers/staging/fbtft/fb_nv3007.ko
+  AUTOLOAD:=$(call AutoLoad,09,fb_nv3007)
+endef
+
+define KernelPackage/fb-tft-nv3007/description
+  FB driver for the NewVision NV3007 LCD Controller (EdgePi E87N)
+endef
+
+$(eval $(call KernelPackage,fb-tft-nv3007))
+
 
 define KernelPackage/cec-core
   SUBMENU:=$(VIDEO_MENU)

--- a/target/linux/mediatek/dts/mt7987a-edgepi-e87n.dts
+++ b/target/linux/mediatek/dts/mt7987a-edgepi-e87n.dts
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include "mt7987a.dtsi"
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "EdgePi E87N";
+	compatible = "edgepi,e87n", "mediatek,mt7987a", "mediatek,mt7987";
+
+	aliases {
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_amber;
+		led-upgrade = &led_status_amber;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		bootargs = "earlycon=uart8250,mmio32,0x11000000 \
+			    root=PARTLABEL=rootfs rootwait pci=pcie_bus_perf";
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <10>;
+		};
+	};
+
+	/*
+	 * LED Indicator Layout
+	 * -------------------
+	 * Two general-purpose, software-controllable status LEDs.
+	 * The board has no WiFi radio, so these are not WLAN indicators.
+	 */
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_amber: led-1 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&pio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: led-2 {
+			function = LED_FUNCTION_INDICATOR;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	reg_usb_5v: regulator-usb-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "usb-5v";
+		regulator-max-microvolt = <5000000>;
+		regulator-min-microvolt = <5000000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+	backlight: backlight {
+		compatible = "pwm-backlight";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pwm_backlight_pins>;
+		pwms = <&pwm 2 50000>;
+		brightness-levels = <0 10 20 30 40 50 60 70 80 90 100 110 120
+			130 140 150 160 170 180 190 200 210 220 230 240 250 255>;
+		default-brightness-level = <16>;
+		status = "okay";
+	};
+};
+
+&eth {
+	status = "okay";
+};
+
+&fan {
+	pwms = <&pwm 1 50000 0>;
+	status = "okay";
+};
+
+&gmac0 {
+	phy-mode = "2500base-x";
+	phy-handle = <&phy0>;
+	status = "okay";
+};
+
+&gmac1 {
+	phy-mode = "internal";
+	phy-handle = <&phy1>;
+	status = "okay";
+};
+
+&mdio {
+	/* RTL8221B-VB-CG 2.5Gbps PHY (away from power) eth0 */
+	phy0: phy@3 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <3>;
+		reset-gpios = <&pio 42 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <100000>;
+		reset-deassert-us = <100000>;
+		interrupt-parent = <&pio>;
+		interrupts = <41 IRQ_TYPE_LEVEL_LOW>;
+		realtek,aldps-enable;
+	};
+
+	/* built-in 2.5G Ethernet PHY (near power) eth1 */
+	phy1: phy@15 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <15>;
+		pinctrl-names = "i2p5gbe-led";
+		pinctrl-0 = <&i2p5gbe_led0_pins>;
+
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led@0 {
+				reg = <0>;
+				function = LED_FUNCTION_WAN;
+				color = <LED_COLOR_ID_RED>;
+			};
+		};
+	};
+};
+
+&mmc0 {
+	pinctrl-names = "default", "state_uhs";
+	pinctrl-0 = <&mmc_pins_default>;
+	pinctrl-1 = <&mmc_pins_uhs>;
+	bus-width = <8>;
+	max-frequency = <48000000>;
+	cap-mmc-highspeed;
+	vmmc-supply = <&reg_3p3v>;
+	non-removable;
+	status = "okay";
+};
+
+&pcie0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_pins>;
+	reset-gpios = <&pio 33 GPIO_ACTIVE_HIGH>;
+	num-lanes = <1>;
+	status = "okay";
+};
+
+&pcie1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie1_pins>;
+	reset-gpios = <&pio 36 GPIO_ACTIVE_HIGH>;
+	num-lanes = <1>;
+	status = "okay";
+};
+
+&pio {
+	pwm_fan_pins: pwm-fan-pins {
+		mux {
+			function = "pwm";
+			groups = "pwm1_0";
+		};
+	};
+
+	pwm_backlight_pins: pwm-backlight-pins {
+		mux {
+			function = "pwm";
+			groups = "pwm2_0";
+		};
+	};
+};
+
+&pwm {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm_fan_pins>;
+};
+
+&ssusb {
+	status = "okay";
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&reg_usb_5v>;
+};
+
+&tphyu3port0 {
+	status = "okay";
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_pins>;
+	status = "okay";
+};
+
+/* Values transcribed from the vendor E87N FIT device tree. */
+&spi2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi2_flash_pins>;
+	status = "okay";
+
+	display@0 {
+		compatible = "newvision,nv3007";
+		reg = <0>;
+		regwidth = <8>;
+		buswidth = <8>;
+		height = <428>;
+		width = <142>;
+		fps = <100>;
+		rotate = <270>;
+		reset-gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		dc-gpios = <&pio 11 GPIO_ACTIVE_HIGH>;
+		spi-max-frequency = <10000000>;
+		status = "okay";
+	};
+};

--- a/target/linux/mediatek/files-6.18/drivers/staging/fbtft/fb_nv3007.c
+++ b/target/linux/mediatek/files-6.18/drivers/staging/fbtft/fb_nv3007.c
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * NewVision NV3007 FBTFT driver for the EdgePi E87N SPI TFT panel.
+ * Register initialization sequence follows the same set of vendor
+ * registers documented in the MIT-licensed LVGL nv3007 driver
+ * (lvgl/lvgl, src/drivers/display/nv3007/lv_nv3007.c), with timing/
+ * gamma values tuned for this panel.
+ */
+#include <linux/delay.h>
+#include <linux/init.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <video/mipi_display.h>
+
+#include "fbtft.h"
+
+#define DRVNAME "fb_nv3007"
+#define WIDTH 428
+#define HEIGHT 142
+#define TXBUFLEN (16 * PAGE_SIZE)
+
+#define DEFAULT_GAMMA \
+	"00 02 04 07 05 02 21 23 3A 08 13 13 29 31 0F\n" \
+	"00 02 04 07 05 02 21 23 3A 08 13 13 29 31 0F"
+
+static int init_display(struct fbtft_par *par)
+{
+	par->fbtftops.reset(par);
+	write_reg(par, 0x11);
+	mdelay(5);
+	write_reg(par, 0x28);
+	write_reg(par, 0xff, 0xa5);
+	write_reg(par, 0x9a, 0x08);
+	write_reg(par, 0x9b, 0x08);
+	write_reg(par, 0x9c, 0xb0);
+	write_reg(par, 0x9d, 0x17);
+	write_reg(par, 0x9e, 0xc2);
+	write_reg(par, 0x8f, 0x22, 0x04);
+	write_reg(par, 0x84, 0x90);
+	write_reg(par, 0x83, 0x7b);
+	write_reg(par, 0x85, 0x4f);
+	write_reg(par, 0x50, 0x00);
+	write_reg(par, 0x52, 0xd6);
+	write_reg(par, 0x53, 0x04);
+	write_reg(par, 0x54, 0x04);
+	write_reg(par, 0x55, 0x1b);
+	write_reg(par, 0x56, 0x1b);
+	write_reg(par, 0xa0, 0x2a, 0x24, 0x00);
+	write_reg(par, 0xa1, 0x84);
+	write_reg(par, 0xa2, 0x85);
+	write_reg(par, 0xa8, 0x34);
+	write_reg(par, 0xa9, 0x80);
+	write_reg(par, 0xaa, 0x73);
+	write_reg(par, 0xab, 0x03, 0x61);
+	write_reg(par, 0xac, 0x03, 0x65);
+	write_reg(par, 0xad, 0x03, 0x60);
+	write_reg(par, 0xae, 0x03, 0x64);
+	write_reg(par, 0xb9, 0x82);
+	write_reg(par, 0xba, 0x83);
+	write_reg(par, 0xbb, 0x80);
+	write_reg(par, 0xbc, 0x81);
+	write_reg(par, 0xbd, 0x02);
+	write_reg(par, 0xbe, 0x01);
+	write_reg(par, 0xbf, 0x04);
+	write_reg(par, 0xc0, 0x03);
+	write_reg(par, 0xc4, 0x33);
+	write_reg(par, 0xc5, 0x80);
+	write_reg(par, 0xc6, 0x73);
+	write_reg(par, 0xc7, 0x00);
+	write_reg(par, 0xc8, 0x33, 0x33);
+	write_reg(par, 0xc9, 0x5b);
+	write_reg(par, 0xca, 0x5a);
+	write_reg(par, 0xcb, 0x5d);
+	write_reg(par, 0xcc, 0x5c);
+	write_reg(par, 0xcd, 0x33, 0x33);
+	write_reg(par, 0xce, 0x5f);
+	write_reg(par, 0xcf, 0x5e);
+	write_reg(par, 0xd0, 0x61);
+	write_reg(par, 0xd1, 0x60);
+	write_reg(par, 0xb0, 0x3a, 0x3a, 0x00, 0x00);
+	write_reg(par, 0xb6, 0x32);
+	write_reg(par, 0xb7, 0x80);
+	write_reg(par, 0xb8, 0x73);
+	write_reg(par, 0xe0, 0x00);
+	write_reg(par, 0xe1, 0x03, 0x0f);
+	write_reg(par, 0xe2, 0x04);
+	write_reg(par, 0xe3, 0x01);
+	write_reg(par, 0xe4, 0x0e);
+	write_reg(par, 0xe5, 0x01);
+	write_reg(par, 0xe6, 0x19);
+	write_reg(par, 0xe7, 0x10);
+	write_reg(par, 0xe8, 0x10);
+	write_reg(par, 0xe9, 0x21);
+	write_reg(par, 0xea, 0x12);
+	write_reg(par, 0xeb, 0xd0);
+	write_reg(par, 0xec, 0x04);
+	write_reg(par, 0xed, 0x07);
+	write_reg(par, 0xee, 0x07);
+	write_reg(par, 0xef, 0x09);
+	write_reg(par, 0xf0, 0xd0);
+	write_reg(par, 0xf1, 0x0e);
+	write_reg(par, 0xf9, 0x56);
+	write_reg(par, 0xf2, 0x26, 0x1b, 0x0b, 0x20);
+	write_reg(par, 0xec, 0x04);
+	write_reg(par, 0x35, 0x00);
+	write_reg(par, 0x44, 0x00, 0x10);
+	write_reg(par, 0x46, 0x10);
+	write_reg(par, 0xff, 0x00);
+	write_reg(par, 0x3a, 0x05);
+	write_reg(par, 0x11);
+	mdelay(200);
+	write_reg(par, 0x29);
+	mdelay(150);
+	write_reg(par, 0x2a, 0x00, 0x0c, 0x00, 0x99);
+	write_reg(par, 0x2b, 0x00, 0x00, 0x01, 0xab);
+	mdelay(20);
+
+	return 0;
+}
+
+static void set_addr_win(struct fbtft_par *par, int xs, int ys, int xe, int ye)
+{
+	switch (par->info->var.rotate) {
+	case 0:
+		xs += 14;
+		xe += 14;
+		break;
+	case 90:
+		ys += 14;
+		ye += 14;
+		break;
+	case 180:
+		xs += 12;
+		xe += 12;
+		break;
+	case 270:
+		ys += 12;
+		ye += 12;
+		break;
+	default:
+		break;
+	}
+
+	write_reg(par, 0x2a, (xs >> 8) & 0xff, xs & 0xff,
+		  (xe >> 8) & 0xff, xe & 0xff);
+	write_reg(par, 0x2b, (ys >> 8) & 0xff, ys & 0xff,
+		  (ye >> 8) & 0xff, ye & 0xff);
+	write_reg(par, 0x2c);
+}
+
+static int set_var(struct fbtft_par *par)
+{
+	u8 madctl = par->bgr ? 0x08 : 0x00;
+
+	switch (par->info->var.rotate) {
+	case 0:
+		madctl |= 0xc0;
+		break;
+	case 90:
+		madctl |= 0x60;
+		break;
+	case 180:
+		break;
+	case 270:
+		madctl |= 0xa0;
+		break;
+	default:
+		return 0;
+	}
+
+	write_reg(par, 0x36, madctl);
+	return 0;
+}
+
+static int set_gamma(struct fbtft_par *par, u32 *curves)
+{
+	int i;
+	int j;
+
+	write_reg(par, 0xff, 0xa5);
+	for (i = 0; i < par->gamma.num_curves; i++)
+		for (j = 0; j < par->gamma.num_values; j++)
+			write_reg(par, 0x60 + 0x10 * i + j,
+				  curves[i * par->gamma.num_values + j]);
+	write_reg(par, 0xff, 0x00);
+	return 0;
+}
+
+static int blank(struct fbtft_par *par, bool on)
+{
+	write_reg(par, on ? 0x28 : 0x29);
+	return 0;
+}
+
+static struct fbtft_display display = {
+	.regwidth = 8,
+	.width = WIDTH,
+	.height = HEIGHT,
+	.txbuflen = TXBUFLEN,
+	.gamma_num = 2,
+	.gamma_len = 15,
+	.gamma = DEFAULT_GAMMA,
+	.fbtftops = {
+		.init_display = init_display,
+		.set_addr_win = set_addr_win,
+		.blank = blank,
+		.set_var = set_var,
+		.set_gamma = set_gamma,
+	},
+};
+
+FBTFT_REGISTER_SPI_DRIVER(DRVNAME, "newvision", "nv3007", &display);
+
+MODULE_ALIAS("spi:nv3007");
+MODULE_ALIAS("platform:nv3007");
+MODULE_ALIAS("spi:fb_nv3007");
+MODULE_ALIAS("platform:fb_nv3007");
+MODULE_AUTHOR("Navas Abubacker <navas@outlook.com>");
+MODULE_DESCRIPTION("FB driver for the NewVision NV3007 LCD controller");
+MODULE_LICENSE("GPL");

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -154,6 +154,7 @@ mediatek_setup_interfaces()
 	airpi,ap3000m|\
 	bananapi,bpi-r3-mini|\
 	edgecore,eap111|\
+	edgepi,e87n|\
 	hiveton,h5000m|\
 	huasifei,wh3000|\
 	huasifei,wh3000-pro-emmc|\
@@ -299,6 +300,7 @@ mediatek_setup_macs()
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		label_mac=$wan_mac
 		;;
+	edgepi,e87n|\
 	hiveton,h5000m)
 		lan_mac=$(macaddr_generate_from_mmc_cid mmcblk0)
 		wan_mac=$(macaddr_add "$lan_mac" 1)

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -227,6 +227,7 @@ platform_do_upgrade() {
 	acer,vero-w6m|\
 	airpi,ap3000m|\
 	arcadyan,mozart|\
+	edgepi,e87n|\
 	glinet,gl-mt2500|\
 	glinet,gl-mt2500-airoha|\
 	glinet,gl-mt6000|\
@@ -470,6 +471,7 @@ platform_check_image() {
 		;;
 	creatlentem,clt-r30b1|\
 	creatlentem,clt-r30b1-112m|\
+	edgepi,e87n|\
 	hiveton,h5000m|\
 	nradio,c8-668gl)
 		# tar magic `ustar`
@@ -512,6 +514,7 @@ platform_copy_config() {
 	acer,vero-w6m|\
 	airpi,ap3000m|\
 	arcadyan,mozart|\
+	edgepi,e87n|\
 	glinet,gl-mt2500|\
 	glinet,gl-mt2500-airoha|\
 	glinet,gl-mt6000|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1810,6 +1810,19 @@ define Device/edgecore_eap111
 endef
 TARGET_DEVICES += edgecore_eap111
 
+define Device/edgepi_e87n
+  DEVICE_VENDOR := EdgePi
+  DEVICE_MODEL := E87N
+  DEVICE_DTS := mt7987a-edgepi-e87n
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-hwmon-pwmfan kmod-usb3 mt7987-2p5g-phy-firmware \
+	kmod-fb-tft kmod-fb-tft-nv3007 kmod-backlight-pwm kmod-nvme \
+	f2fsck mkf2fs
+  KERNEL_LOADADDR := 0x40000000
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += edgepi_e87n
+
 define Device/elecom_wrc-x3000gs3
   DEVICE_VENDOR := ELECOM
   DEVICE_MODEL := WRC-X3000GS3

--- a/target/linux/mediatek/patches-6.18/999-fbtft-add-nv3007-driver.patch
+++ b/target/linux/mediatek/patches-6.18/999-fbtft-add-nv3007-driver.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Navas Abubacker <navas@outlook.com>
+Date: Sat, 5 Sep 2026 11:52:06 +0530
+Subject: [PATCH] staging: fbtft: add NV3007 driver Kconfig/Makefile entries
+
+Add Kconfig and Makefile entries for the NewVision NV3007 SPI TFT
+display driver, wiring fb_nv3007.o into the generic fbtft staging
+framework.
+
+Signed-off-by: Navas Abubacker <navas@outlook.com>
+---
+ drivers/staging/fbtft/Kconfig  | 5 +++++
+ drivers/staging/fbtft/Makefile | 1 +
+ 2 files changed, 6 insertions(+)
+
+--- a/drivers/staging/fbtft/Kconfig
++++ b/drivers/staging/fbtft/Kconfig
+@@ -75,6 +75,11 @@ config FB_TFT_ILI9486
+ 	help
+ 	  Generic Framebuffer support for ILI9486
+ 
++config FB_TFT_NV3007
++	tristate "FB driver for the NewVision NV3007 LCD Controller"
++	help
++	  Generic framebuffer support for NewVision NV3007 SPI displays.
++
+ config FB_TFT_PCD8544
+ 	tristate "FB driver for the PCD8544 LCD Controller"
+ 	help
+--- a/drivers/staging/fbtft/Makefile
++++ b/drivers/staging/fbtft/Makefile
+@@ -17,6 +17,7 @@ obj-$(CONFIG_FB_TFT_ILI9340)     += fb_i
+ obj-$(CONFIG_FB_TFT_ILI9341)     += fb_ili9341.o
+ obj-$(CONFIG_FB_TFT_ILI9481)     += fb_ili9481.o
+ obj-$(CONFIG_FB_TFT_ILI9486)     += fb_ili9486.o
++obj-$(CONFIG_FB_TFT_NV3007)      += fb_nv3007.o
+ obj-$(CONFIG_FB_TFT_PCD8544)     += fb_pcd8544.o
+ obj-$(CONFIG_FB_TFT_RA8875)      += fb_ra8875.o
+ obj-$(CONFIG_FB_TFT_S6D02A1)     += fb_s6d02a1.o


### PR DESCRIPTION
Add device tree, kernel display driver, and board registration for
the EdgePi E87N (MediaTek MT7987A, 8GB eMMC, no WiFi).

Hardware:
- SoC: MediaTek MT7987A
- Storage: 8GB eMMC + dual M.2 NVMe slots
- Network: 2x 2.5GbE (RTL8221B-VB-CG PHY + SoC internal 2.5G PHY)
- Display: 142x428 NewVision NV3007 SPI TFT with PWM backlight
- Fan: PWM-controlled, no tachometer

Tested and confirmed working:
- Boot via initramfs and persistent squashfs sysupgrade
- Both NVMe drives detected and mountable
- Both ethernet ports (LAN via eth0, WAN via eth1)
- NV3007 display, rendering correctly via kmod-fb-tft-nv3007
- PWM backlight control
- PWM fan control via standard kmod-hwmon-pwmfan sysfs interface

Not yet tested/covered by this PR:
- WiFi: N/A, board has no WiFi radio
- No board-specific fan-control LuCI app or userspace daemon is
  included in this PR (may be submitted separately as an OpenWrt
  package)