### PR TITLE
qualcommax: qca_edma: add checksum, scatter-gather, TSO and RSS hash offloads

### DIFF
--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
@@ -139,6 +139,8 @@ static irqreturn_t edma_misc_irq_handle(int irq, void *ctx)
 	if (!val)
 		return IRQ_NONE;
 
+	dev_warn_ratelimited(&priv->pdev->dev, "misc error %#x\n", val);
+
 	return IRQ_HANDLED;
 }
 
@@ -406,6 +408,12 @@ static u32 edma_clean_tx(struct edma_priv *priv, struct edma_ring *txcmpl_ring,
 
 	while (cons != prod && cleaned < budget) {
 		txcmpl = EDMA_TXCMPL_DESC(txcmpl_ring, cons);
+
+		if (unlikely(txcmpl->status & EDMA_TXCMPL_ERROR)) {
+			dev_warn_ratelimited(&pdev->dev, "tx error %#x\n",
+					     txcmpl->status);
+			priv->netdev->stats.tx_errors++;
+		}
 
 		/* A frame is named by the first completion of its run and
 		 * released on the one that clears the more bit; the opaque of

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
@@ -506,6 +506,7 @@ static u32 edma_clean_rx(struct edma_priv *priv, int budget,
 			 struct edma_ring *rxdesc_ring)
 {
 	const struct edma_soc_data *soc = priv->soc;
+	struct net_device *netdev = priv->netdev;
 	struct platform_device *pdev = priv->pdev;
 	struct dsa_oob_tag_info *tag_info;
 	struct edma_rx_preheader *rxph;
@@ -541,8 +542,10 @@ static u32 edma_clean_rx(struct edma_priv *priv, int budget,
 		page_pool_dma_sync_for_cpu(priv->page_pool, page, 0,
 					   EDMA_RX_PREHDR_SIZE + pkt_len);
 		store_idx = le32_to_cpu(rxph->opaque);
-		if (unlikely(!edma_rx_page_take(priv, page, store_idx)))
+		if (unlikely(!edma_rx_page_take(priv, page, store_idx))) {
+			netdev->stats.rx_errors++;
 			goto next;
+		}
 
 		if (EDMA_RXPH_SRC_INFO_TYPE_GET(rxph) !=
 		    EDMA_PREHDR_DSTINFO_PORTID_IND) {
@@ -552,6 +555,7 @@ static u32 edma_clean_rx(struct edma_priv *priv, int budget,
 					     le16_to_cpu(rxph->src_info),
 					     le16_to_cpu(rxph->dst_info));
 			page_pool_put_full_page(priv->page_pool, page, true);
+			netdev->stats.rx_errors++;
 			goto next;
 		}
 
@@ -560,6 +564,7 @@ static u32 edma_clean_rx(struct edma_priv *priv, int budget,
 		skb = napi_build_skb(page_address(page), page_size(page));
 		if (unlikely(!skb)) {
 			page_pool_put_full_page(priv->page_pool, page, true);
+			netdev->stats.rx_dropped++;
 			goto next;
 		}
 
@@ -573,6 +578,7 @@ static u32 edma_clean_rx(struct edma_priv *priv, int budget,
 		tag_info = skb_ext_add(skb, SKB_EXT_DSA_OOB);
 		if (unlikely(!tag_info)) {
 			dev_kfree_skb_any(skb);
+			netdev->stats.rx_dropped++;
 			goto next;
 		}
 		tag_info->port = src_port;
@@ -652,6 +658,7 @@ static int edma_rx_napi(struct napi_struct *napi, int budget)
 		if (prod == cons) {
 			dev_warn_ratelimited(&priv->pdev->dev,
 					     "RXFILL ring starved\n");
+			priv->netdev->stats.rx_missed_errors++;
 			edma_rx_fill(priv, &priv->rxfill_ring);
 			return budget;
 		}

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
@@ -410,6 +410,32 @@ next:
 	return cleaned;
 }
 
+/* The engine verifies the transport checksum of a TCP or UDP frame and
+ * reports the result per descriptor. It reports a header checksum too, which
+ * only IPv4 carries, and it names the packet type it parsed so that a verdict
+ * on a frame it does not checksum is never taken for one it does.
+ */
+static void edma_rx_csum(struct net_device *netdev, struct sk_buff *skb,
+			 u32 status)
+{
+	u8 pid;
+
+	if (!(netdev->features & NETIF_F_RXCSUM))
+		return;
+
+	pid = (status >> EDMA_RXDESC_PID_SHIFT) & EDMA_RXDESC_PID_MASK;
+	if (!(BIT(pid) & EDMA_RXDESC_PID_TCP_UDP))
+		return;
+
+	if (!(status & EDMA_RXDESC_L4_CSUM_OK))
+		return;
+
+	if (!(pid & EDMA_RXDESC_PID_IPV6) && !(status & EDMA_RXDESC_L3_CSUM_OK))
+		return;
+
+	skb->ip_summed = CHECKSUM_UNNECESSARY;
+}
+
 static u32 edma_clean_rx(struct edma_priv *priv, int budget,
 			 struct edma_ring *rxdesc_ring)
 {
@@ -476,6 +502,7 @@ static u32 edma_clean_rx(struct edma_priv *priv, int budget,
 		skb_put(skb, pkt_len);
 
 		skb->protocol = eth_type_trans(skb, priv->netdev);
+		edma_rx_csum(priv->netdev, skb, desc_status);
 
 		tag_info = skb_ext_add(skb, SKB_EXT_DSA_OOB);
 		if (unlikely(!tag_info)) {
@@ -1363,7 +1390,10 @@ static int edma_probe(struct platform_device *pdev)
 	SET_NETDEV_DEV(netdev, dev);
 	netdev->dev.of_node = dev->of_node;
 	netdev->netdev_ops = &edma_netdev_ops;
-	netdev->features = NETIF_F_GRO;
+	netdev->hw_features = NETIF_F_RXCSUM;
+	netdev->features = NETIF_F_GRO | netdev->hw_features;
+	/* A DSA user port takes its features from the conduit's vlan_features. */
+	netdev->vlan_features = netdev->hw_features;
 	netdev->pcpu_stat_type = NETDEV_PCPU_STAT_TSTATS;
 	netdev->watchdog_timeo = 5 * HZ;
 	netdev->max_mtu = EDMA_MAX_MTU;

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
@@ -486,24 +486,53 @@ static u32 edma_clean_tx(struct edma_priv *priv, struct edma_ring *txcmpl_ring,
  * on a frame it does not checksum is never taken for one it does.
  */
 static void edma_rx_csum(struct net_device *netdev, struct sk_buff *skb,
-			 u32 status)
+			 const struct edma_rx_preheader *rxph, u32 status,
+			 unsigned int l2_len)
 {
+	u32 pre4, sum, l4_off;
+	__sum16 hw;
 	u8 pid;
 
 	if (!(netdev->features & NETIF_F_RXCSUM))
 		return;
 
 	pid = (status >> EDMA_RXDESC_PID_SHIFT) & EDMA_RXDESC_PID_MASK;
-	if (!(BIT(pid) & EDMA_RXDESC_PID_TCP_UDP))
+
+	/* A transport the engine parses is answered with a verdict, which
+	 * settles the frame without the stack reading it at all.
+	 */
+	if (BIT(pid) & EDMA_RXDESC_PID_TCP_UDP) {
+		if (!(status & EDMA_RXDESC_L4_CSUM_OK))
+			return;
+
+		if (!(pid & EDMA_RXDESC_PID_IPV6) &&
+		    !(status & EDMA_RXDESC_L3_CSUM_OK))
+			return;
+
+		skb->ip_summed = CHECKSUM_UNNECESSARY;
+		return;
+	}
+
+	/* Every other transport over IP is summed rather than judged, and the
+	 * engine reports the complement of that sum in packet order, writing a
+	 * sum of zero as its other representation. Carrying it up spares the
+	 * stack the walk over the payload; only the headers ahead of the
+	 * transport are left to add.
+	 */
+	if (pid == EDMA_RXDESC_PID_NON_IP)
 		return;
 
-	if (!(status & EDMA_RXDESC_L4_CSUM_OK))
+	pre4 = le32_to_cpu(rxph->rx_pre4);
+	l4_off = (pre4 >> EDMA_RXPH_L4_OFFSET_SHIFT) & EDMA_RXPH_L4_OFFSET_MASK;
+	if (l4_off <= l2_len || l4_off > skb_headlen(skb) + l2_len)
 		return;
 
-	if (!(pid & EDMA_RXDESC_PID_IPV6) && !(status & EDMA_RXDESC_L3_CSUM_OK))
-		return;
+	sum = (le32_to_cpu(rxph->rx_pre6) >> EDMA_RXPH_CSUM_SHIFT) &
+	      EDMA_RXPH_CSUM_MASK;
+	hw = (__force __sum16)cpu_to_be16(sum);
 
-	skb->ip_summed = CHECKSUM_UNNECESSARY;
+	skb->csum = csum_partial(skb->data, l4_off - l2_len, csum_unfold(~hw));
+	skb->ip_summed = CHECKSUM_COMPLETE;
 }
 
 /* The parser hashes the tuple it matched and says which tuple that was. The
@@ -542,6 +571,7 @@ static u32 edma_clean_rx(struct edma_priv *priv, int budget,
 	struct dsa_oob_tag_info *tag_info;
 	struct edma_rx_preheader *rxph;
 	struct edma_rxdesc *rxdesc;
+	unsigned char *frame;
 	struct sk_buff *skb;
 	u16 prod, cons;
 	struct page *page;
@@ -609,8 +639,10 @@ static u32 edma_clean_rx(struct edma_priv *priv, int budget,
 		skb_reserve(skb, NET_SKB_PAD + EDMA_RX_PREHDR_SIZE);
 		skb_put(skb, pkt_len);
 
+		frame = skb->data;
 		skb->protocol = eth_type_trans(skb, priv->netdev);
-		edma_rx_csum(netdev, skb, desc_status);
+		edma_rx_csum(netdev, skb, rxph, desc_status,
+			     skb->data - frame);
 		edma_rx_hash(netdev, skb, rxph);
 
 		tag_info = skb_ext_add(skb, SKB_EXT_DSA_OOB);

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
@@ -6,6 +6,7 @@
 
 #include <linux/clk.h>
 #include <linux/ethtool.h>
+#include <linux/hash.h>
 #include <linux/if_vlan.h>
 #include <linux/interrupt.h>
 #include <linux/module.h>
@@ -502,6 +503,33 @@ static void edma_rx_csum(struct net_device *netdev, struct sk_buff *skb,
 	skb->ip_summed = CHECKSUM_UNNECESSARY;
 }
 
+/* The parser hashes the tuple it matched and says which tuple that was. The
+ * same field takes other values that are not a tuple hash, so only the two
+ * tuple verdicts are taken.
+ *
+ * The value arrives in the low bits of the word while the stack scales a hash
+ * across the whole of it, so a hash left where the parser put it selects the
+ * same receive queue for every flow. Spreading it over the word is one to one,
+ * so the frames of a flow still land together.
+ */
+static void edma_rx_hash(struct net_device *netdev, struct sk_buff *skb,
+			 const struct edma_rx_preheader *rxph)
+{
+	u32 pre2 = le32_to_cpu(rxph->rx_pre2);
+	u8 flag;
+
+	if (!(netdev->features & NETIF_F_RXHASH))
+		return;
+
+	flag = (pre2 >> EDMA_RXPH_HASH_FLAG_SHIFT) & EDMA_RXPH_HASH_FLAG_MASK;
+	if (flag != EDMA_RXPH_HASH_5TUPLE && flag != EDMA_RXPH_HASH_3TUPLE)
+		return;
+
+	skb_set_hash(skb, hash_32(pre2 & EDMA_RXPH_HASH_MASK, 32),
+		     flag == EDMA_RXPH_HASH_5TUPLE ? PKT_HASH_TYPE_L4 :
+						     PKT_HASH_TYPE_L3);
+}
+
 static u32 edma_clean_rx(struct edma_priv *priv, int budget,
 			 struct edma_ring *rxdesc_ring)
 {
@@ -573,7 +601,8 @@ static u32 edma_clean_rx(struct edma_priv *priv, int budget,
 		skb_put(skb, pkt_len);
 
 		skb->protocol = eth_type_trans(skb, priv->netdev);
-		edma_rx_csum(priv->netdev, skb, desc_status);
+		edma_rx_csum(netdev, skb, desc_status);
+		edma_rx_hash(netdev, skb, rxph);
 
 		tag_info = skb_ext_add(skb, SKB_EXT_DSA_OOB);
 		if (unlikely(!tag_info)) {
@@ -1597,7 +1626,7 @@ static int edma_probe(struct platform_device *pdev)
 	netdev->netdev_ops = &edma_netdev_ops;
 	netdev->hw_features = NETIF_F_RXCSUM | NETIF_F_IP_CSUM |
 			      NETIF_F_IPV6_CSUM | NETIF_F_SG | NETIF_F_TSO |
-			      NETIF_F_TSO6;
+			      NETIF_F_TSO6 | NETIF_F_RXHASH;
 	netdev->features = NETIF_F_GRO | netdev->hw_features;
 	/* A DSA user port takes its features from the conduit's vlan_features. */
 	netdev->vlan_features = netdev->hw_features;

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
@@ -673,6 +673,20 @@ static void edma_tx_csum(struct sk_buff *skb, struct edma_tx_preheader *txph,
 		txph->tx_pre6 |= EDMA_TX_PRE6_IP_CSUM_EN;
 }
 
+/* Segmentation is one bit in every descriptor of the frame and the segment
+ * size in the preheader. The engine writes the headers of each segment it
+ * cuts, so the checksums it is already asked for cover what it produced.
+ */
+static u32 edma_tx_tso(struct sk_buff *skb, struct edma_tx_preheader *txph)
+{
+	if (!skb_is_gso(skb))
+		return 0;
+
+	txph->tx_pre6 |= skb_shinfo(skb)->gso_size & EDMA_TX_PRE6_MSS_MASK;
+
+	return EDMA_TXDESC_TSO_EN;
+}
+
 static netdev_tx_t edma_ring_xmit(struct edma_priv *priv, struct net_device *netdev,
 				  struct sk_buff *skb,
 				  struct edma_ring *txdesc_ring)
@@ -686,7 +700,7 @@ static netdev_tx_t edma_ring_xmit(struct edma_priv *priv, struct net_device *net
 	u16 ndesc = shinfo->nr_frags + 1;
 	struct edma_txdesc *txdesc;
 	u16 prod, cons, dst_info;
-	u32 val, idx, i, len, bytes;
+	u32 val, idx, i, len, bytes, tso;
 	dma_addr_t head_dma;
 	bool taken = false;
 	__be16 proto;
@@ -739,6 +753,7 @@ static netdev_tx_t edma_ring_xmit(struct edma_priv *priv, struct net_device *net
 
 	txph->dst_info = dst_info;
 	edma_tx_csum(skb, txph, proto);
+	tso = edma_tx_tso(skb, txph);
 
 	txdesc_ring->skb_store[idx] = skb;
 	txph->opaque = idx;
@@ -752,7 +767,7 @@ static netdev_tx_t edma_ring_xmit(struct edma_priv *priv, struct net_device *net
 
 	txdesc = EDMA_TXDESC_DESC(txdesc_ring, idx);
 	txdesc->buffer_addr = cpu_to_le32(head_dma);
-	txdesc->word1 = (1 << EDMA_TXDESC_PREHEADER_SHIFT) |
+	txdesc->word1 = tso | (1 << EDMA_TXDESC_PREHEADER_SHIFT) |
 			(ndesc > 1 ? EDMA_TXDESC_MORE : 0) |
 			((EDMA_TX_PREHDR_SIZE & EDMA_TXDESC_DATA_OFFSET_MASK)
 			 << EDMA_TXDESC_DATA_OFFSET_SHIFT) |
@@ -771,8 +786,8 @@ static netdev_tx_t edma_ring_xmit(struct edma_priv *priv, struct net_device *net
 		txdesc_ring->skb_store[fidx] = skb;
 		txdesc = EDMA_TXDESC_DESC(txdesc_ring, fidx);
 		txdesc->buffer_addr = cpu_to_le32(dma);
-		txdesc->word1 = (i + 1 < shinfo->nr_frags ?
-				 EDMA_TXDESC_MORE : 0) |
+		txdesc->word1 = tso | (i + 1 < shinfo->nr_frags ?
+				       EDMA_TXDESC_MORE : 0) |
 				(len & EDMA_TXDESC_DATA_LENGTH_MASK);
 	}
 
@@ -1493,7 +1508,8 @@ static int edma_probe(struct platform_device *pdev)
 	netdev->dev.of_node = dev->of_node;
 	netdev->netdev_ops = &edma_netdev_ops;
 	netdev->hw_features = NETIF_F_RXCSUM | NETIF_F_IP_CSUM |
-			      NETIF_F_IPV6_CSUM | NETIF_F_SG;
+			      NETIF_F_IPV6_CSUM | NETIF_F_SG | NETIF_F_TSO |
+			      NETIF_F_TSO6;
 	netdev->features = NETIF_F_GRO | netdev->hw_features;
 	/* A DSA user port takes its features from the conduit's vlan_features. */
 	netdev->vlan_features = netdev->hw_features;

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
@@ -207,14 +207,22 @@ static void edma_ring_free(struct edma_priv *priv, struct edma_ring *ring,
 	}
 }
 
+static u32 edma_tx_release(struct edma_priv *priv, u32 idx, struct sk_buff *skb,
+			   int napi_budget);
+
 static void edma_tx_ring_free(struct edma_priv *priv, struct edma_ring *ring,
 			      int desc_size)
 {
 	int i;
 
 	if (ring->skb_store) {
-		for (i = 0; i < ring->count; i++)
-			dev_kfree_skb_any(ring->skb_store[i]);
+		for (i = 0; i < ring->count; i++) {
+			struct edma_txdesc *txdesc = EDMA_TXDESC_DESC(ring, i);
+			struct sk_buff *skb = ring->skb_store[i];
+
+			if (skb && (txdesc->word1 & EDMA_TXDESC_PREHEADER))
+				edma_tx_release(priv, i, skb, 0);
+		}
 		kfree(ring->skb_store);
 		ring->skb_store = NULL;
 	}
@@ -331,6 +339,44 @@ static u16 edma_txdesc_free(struct edma_priv *priv)
 	       (priv->txdesc_ring.count - 1);
 }
 
+/* Unmaps every descriptor the frame was written from and releases the slots
+ * that named them, returning the bytes the frame carried. A slot goes back
+ * only once its descriptor has been read, so that a transmit taking the slot
+ * cannot place a frame over what this walk has yet to reach.
+ */
+static u32 edma_tx_release(struct edma_priv *priv, u32 idx, struct sk_buff *skb,
+			   int napi_budget)
+{
+	struct edma_ring *ring = &priv->txdesc_ring;
+	struct device *dev = &priv->pdev->dev;
+	struct edma_txdesc *txdesc;
+	u32 bytes, len;
+
+	txdesc = EDMA_TXDESC_DESC(ring, idx);
+	len = skb_headlen(skb);
+
+	dma_unmap_single(dev, le32_to_cpu(txdesc->buffer_addr), len,
+			 DMA_TO_DEVICE);
+	bytes = len - EDMA_TX_PREHDR_SIZE;
+	ring->skb_store[idx] = NULL;
+
+	idx = (idx + 1) & (ring->count - 1);
+	while (ring->skb_store[idx] == skb) {
+		txdesc = EDMA_TXDESC_DESC(ring, idx);
+		len = txdesc->word1 & EDMA_TXDESC_DATA_LENGTH_MASK;
+
+		dma_unmap_page(dev, le32_to_cpu(txdesc->buffer_addr), len,
+			       DMA_TO_DEVICE);
+		bytes += len;
+		ring->skb_store[idx] = NULL;
+		idx = (idx + 1) & (ring->count - 1);
+	}
+
+	napi_consume_skb(skb, napi_budget);
+
+	return bytes;
+}
+
 /* @napi_budget is the NAPI budget the poll was given, or zero when the caller
  * is not a poll: the skb cache napi_consume_skb() recycles into is per-CPU and
  * is only safe to touch from softirq context.
@@ -340,13 +386,11 @@ static u32 edma_clean_tx(struct edma_priv *priv, struct edma_ring *txcmpl_ring,
 {
 	const struct edma_soc_data *soc = priv->soc;
 	struct platform_device *pdev = priv->pdev;
+	u32 cleaned = 0, pkts = 0, bytes = 0;
 	struct edma_txcmpl *txcmpl;
-	struct edma_txdesc *txdesc;
-	u32 cleaned = 0, bytes = 0;
-	u16 prod, cons;
 	struct sk_buff *skb;
-	u32 val, len;
-	int idx;
+	u16 prod, cons;
+	u32 val;
 
 	regmap_read(priv->regmap,
 		    EDMA_REG_TXCMPL_PROD_IDX(soc->txcmpl_base,
@@ -363,27 +407,41 @@ static u32 edma_clean_tx(struct edma_priv *priv, struct edma_ring *txcmpl_ring,
 	while (cons != prod && cleaned < budget) {
 		txcmpl = EDMA_TXCMPL_DESC(txcmpl_ring, cons);
 
-		idx = txcmpl->buffer_addr;
-		skb = priv->txdesc_ring.skb_store[idx];
-		priv->txdesc_ring.skb_store[idx] = NULL;
-
-		if (unlikely(!skb)) {
-			dev_warn(&pdev->dev,
-				 "invalid skb: cons:%u prod:%u status %x\n",
-				 cons, prod, txcmpl->status);
-			goto next;
+		/* A frame is named by the first completion of its run and
+		 * released on the one that clears the more bit; the opaque of
+		 * the completions in between is not written.
+		 */
+		/* The opaque is only written for the descriptor that carried
+		 * the preheader, so it is read once per run and not again if
+		 * the run turns out to name no frame: a later completion of
+		 * the same run would otherwise hand back whatever its field
+		 * held and name a frame the engine still owns.
+		 */
+		if (!priv->txcmpl_run) {
+			priv->txcmpl_run = true;
+			priv->txcmpl_idx = txcmpl->buffer_addr;
+			if (priv->txcmpl_idx < priv->txdesc_ring.count)
+				priv->txcmpl_skb =
+					priv->txdesc_ring.skb_store[priv->txcmpl_idx];
 		}
 
-		txdesc = EDMA_TXDESC_DESC(&priv->txdesc_ring, idx);
-		len = skb_headlen(skb);
+		if (!(txcmpl->status & EDMA_TXCMPL_MORE)) {
+			skb = priv->txcmpl_skb;
+			priv->txcmpl_skb = NULL;
+			priv->txcmpl_run = false;
 
-		dma_unmap_single(&pdev->dev,
-				 le32_to_cpu(txdesc->buffer_addr),
-				 len, DMA_TO_DEVICE);
-		bytes += len - EDMA_TX_PREHDR_SIZE;
-		napi_consume_skb(skb, napi_budget);
+			if (unlikely(!skb)) {
+				dev_warn(&pdev->dev,
+					 "invalid skb: cons:%u prod:%u status %x\n",
+					 cons, prod, txcmpl->status);
+			} else {
+				bytes += edma_tx_release(priv,
+							 priv->txcmpl_idx, skb,
+							 napi_budget);
+				pkts++;
+			}
+		}
 
-next:
 		if (++cons == txcmpl_ring->count)
 			cons = 0;
 
@@ -397,7 +455,7 @@ next:
 	 * to be freed, so only a poll may wake it.
 	 */
 	__netif_txq_completed_wake(netdev_get_tx_queue(priv->netdev, 0),
-				   cleaned, bytes, edma_txdesc_free(priv),
+				   pkts, bytes, edma_txdesc_free(priv),
 				   EDMA_TX_RING_THRESH, !napi_budget);
 
 	/* Ensure all TX completions are processed before updating cons idx */
@@ -619,14 +677,18 @@ static netdev_tx_t edma_ring_xmit(struct edma_priv *priv, struct net_device *net
 				  struct sk_buff *skb,
 				  struct edma_ring *txdesc_ring)
 {
+	const struct skb_shared_info *shinfo = skb_shinfo(skb);
 	const struct edma_soc_data *soc = priv->soc;
+	struct device *dev = &priv->pdev->dev;
+	u16 mask = txdesc_ring->count - 1;
 	struct edma_tx_preheader *txph;
 	struct dsa_oob_tag_info *tag_info;
+	u16 ndesc = shinfo->nr_frags + 1;
 	struct edma_txdesc *txdesc;
-	u16 prod, cons, next;
-	u16 buf_len, dst_info;
-	dma_addr_t dma;
-	u32 val, idx;
+	u16 prod, cons, dst_info;
+	u32 val, idx, i, len, bytes;
+	dma_addr_t head_dma;
+	bool taken = false;
 	__be16 proto;
 
 	spin_lock_bh(&priv->tx_lock);
@@ -641,20 +703,24 @@ static netdev_tx_t edma_ring_xmit(struct edma_priv *priv, struct net_device *net
 		    &val);
 	cons = val & EDMA_TXDESC_CONS_IDX_MASK;
 
-	next = (prod + 1) & (txdesc_ring->count - 1);
-	idx = prod & (txdesc_ring->count - 1);
+	idx = prod & mask;
 
-	if (next == cons)
-		goto busy;
+	/* A frame holds every store slot it spans, not only the one its
+	 * preheader names, so that a later frame placed over its descriptors
+	 * cannot change the addresses its completion still has to unmap.
+	 */
+	for (i = 0; i < ndesc; i++)
+		taken |= !!txdesc_ring->skb_store[(idx + i) & mask];
 
 	/* Both refusals come before the preheader is pushed: the qdisc requeues
 	 * the frame as it was handed over, and a second push would prefix it
 	 * twice and hand the hardware a length that no longer describes it.
 	 */
-	if (unlikely(txdesc_ring->skb_store[idx]))
+	if (taken || ((cons - prod - 1) & mask) < ndesc)
 		goto busy;
 
-	buf_len = skb_headlen(skb);
+	len = skb_headlen(skb);
+	bytes = skb->len;
 
 	/* vlan_get_protocol() walks the tags from skb->data, so the protocol is
 	 * taken while that still points at the MAC header.
@@ -677,27 +743,43 @@ static netdev_tx_t edma_ring_xmit(struct edma_priv *priv, struct net_device *net
 	txdesc_ring->skb_store[idx] = skb;
 	txph->opaque = idx;
 
-	txdesc = EDMA_TXDESC_DESC(txdesc_ring, prod);
-
-	dma = dma_map_single(&priv->pdev->dev, skb->data,
-			     buf_len + EDMA_TX_PREHDR_SIZE, DMA_TO_DEVICE);
-	if (dma_mapping_error(&priv->pdev->dev, dma)) {
-		dev_kfree_skb_any(skb);
+	head_dma = dma_map_single(dev, skb->data, len + EDMA_TX_PREHDR_SIZE,
+				  DMA_TO_DEVICE);
+	if (dma_mapping_error(dev, head_dma)) {
 		txdesc_ring->skb_store[idx] = NULL;
-		spin_unlock_bh(&priv->tx_lock);
-		return NETDEV_TX_OK;
+		goto drop;
 	}
-	txdesc->buffer_addr = cpu_to_le32(dma);
 
+	txdesc = EDMA_TXDESC_DESC(txdesc_ring, idx);
+	txdesc->buffer_addr = cpu_to_le32(head_dma);
 	txdesc->word1 = (1 << EDMA_TXDESC_PREHEADER_SHIFT) |
+			(ndesc > 1 ? EDMA_TXDESC_MORE : 0) |
 			((EDMA_TX_PREHDR_SIZE & EDMA_TXDESC_DATA_OFFSET_MASK)
 			 << EDMA_TXDESC_DATA_OFFSET_SHIFT) |
-			(buf_len & EDMA_TXDESC_DATA_LENGTH_MASK);
+			(len & EDMA_TXDESC_DATA_LENGTH_MASK);
 
-	prod = (prod + 1) & (txdesc_ring->count - 1);
+	for (i = 0; i < shinfo->nr_frags; i++) {
+		const skb_frag_t *frag = &shinfo->frags[i];
+		u32 fidx = (idx + 1 + i) & mask;
+		dma_addr_t dma;
 
-	dev_sw_netstats_tx_add(netdev, 1, buf_len);
-	netdev_tx_sent_queue(netdev_get_tx_queue(netdev, 0), buf_len);
+		len = skb_frag_size(frag);
+		dma = skb_frag_dma_map(dev, frag, 0, len, DMA_TO_DEVICE);
+		if (dma_mapping_error(dev, dma))
+			goto unmap;
+
+		txdesc_ring->skb_store[fidx] = skb;
+		txdesc = EDMA_TXDESC_DESC(txdesc_ring, fidx);
+		txdesc->buffer_addr = cpu_to_le32(dma);
+		txdesc->word1 = (i + 1 < shinfo->nr_frags ?
+				 EDMA_TXDESC_MORE : 0) |
+				(len & EDMA_TXDESC_DATA_LENGTH_MASK);
+	}
+
+	prod = (prod + ndesc) & mask;
+
+	dev_sw_netstats_tx_add(netdev, 1, bytes);
+	netdev_tx_sent_queue(netdev_get_tx_queue(netdev, 0), bytes);
 
 	/* Ensure descriptor writes are visible before updating prod idx */
 	wmb();
@@ -712,12 +794,29 @@ static netdev_tx_t edma_ring_xmit(struct edma_priv *priv, struct net_device *net
 	 * placed from decide whether to stop at all, since a consumer index
 	 * only ages into reporting less room than the ring has.
 	 */
-	if (((cons - prod - 1) & (txdesc_ring->count - 1)) <
-	    EDMA_TX_RING_THRESH)
+	if (((cons - prod - 1) & mask) < EDMA_TX_RING_THRESH)
 		netif_txq_try_stop(netdev_get_tx_queue(netdev, 0),
 				   edma_txdesc_free(priv),
 				   EDMA_TX_RING_THRESH);
 
+	spin_unlock_bh(&priv->tx_lock);
+	return NETDEV_TX_OK;
+
+unmap:
+	while (i--) {
+		u32 fidx = (idx + 1 + i) & mask;
+
+		txdesc = EDMA_TXDESC_DESC(txdesc_ring, fidx);
+		dma_unmap_page(dev, le32_to_cpu(txdesc->buffer_addr),
+			       txdesc->word1 & EDMA_TXDESC_DATA_LENGTH_MASK,
+			       DMA_TO_DEVICE);
+		txdesc_ring->skb_store[fidx] = NULL;
+	}
+
+	dma_unmap_single(dev, head_dma, skb_headlen(skb), DMA_TO_DEVICE);
+	txdesc_ring->skb_store[idx] = NULL;
+drop:
+	dev_kfree_skb_any(skb);
 	spin_unlock_bh(&priv->tx_lock);
 	return NETDEV_TX_OK;
 
@@ -732,8 +831,8 @@ busy:
 	 * would restart the queue on a resource the refused frame still lacks.
 	 */
 	netif_txq_try_stop(netdev_get_tx_queue(netdev, 0),
-			   txdesc_ring->skb_store[idx] ? 0 :
-			   edma_txdesc_free(priv), EDMA_TX_RING_THRESH);
+			   taken ? 0 : edma_txdesc_free(priv),
+			   EDMA_TX_RING_THRESH);
 
 	spin_unlock_bh(&priv->tx_lock);
 	return NETDEV_TX_BUSY;
@@ -760,48 +859,6 @@ static void edma_rx_ring_free(struct edma_priv *priv, struct edma_ring *ring,
 	}
 
 	edma_ring_free(priv, ring, desc_size);
-}
-
-static void edma_txdesc_drain(struct edma_priv *priv, struct edma_ring *txdesc_ring)
-{
-	const struct edma_soc_data *soc = priv->soc;
-	struct platform_device *pdev = priv->pdev;
-	struct edma_txdesc *txdesc;
-	struct sk_buff *skb;
-	u16 prod, cons;
-	size_t buf_len;
-	u32 val;
-
-	regmap_read(priv->regmap,
-		    EDMA_REG_TXDESC_PROD_IDX(soc->txdesc_ring),
-		    &val);
-	prod = val & EDMA_TXDESC_PROD_IDX_MASK;
-
-	regmap_read(priv->regmap,
-		    EDMA_REG_TXDESC_CONS_IDX(soc->txdesc_ring),
-		    &val);
-	cons = val & EDMA_TXDESC_CONS_IDX_MASK;
-
-	while (cons != prod) {
-		txdesc = EDMA_TXDESC_DESC(txdesc_ring, cons);
-
-		skb = txdesc_ring->skb_store[cons];
-		txdesc_ring->skb_store[cons] = NULL;
-
-		if (!skb)
-			goto next;
-
-		buf_len = txdesc->word1 & EDMA_TXDESC_DATA_LENGTH_MASK;
-
-		dma_unmap_single(&pdev->dev,
-				 le32_to_cpu(txdesc->buffer_addr),
-				 buf_len + EDMA_TX_PREHDR_SIZE, DMA_TO_DEVICE);
-
-		dev_kfree_skb_any(skb);
-next:
-		if (++cons == txdesc_ring->count)
-			cons = 0;
-	}
 }
 
 static int edma_rings_alloc(struct edma_priv *priv)
@@ -842,8 +899,9 @@ err_txcmpl:
 
 static void edma_rings_drain(struct edma_priv *priv)
 {
-	edma_txdesc_drain(priv, &priv->txdesc_ring);
 	edma_clean_tx(priv, &priv->txcmpl_ring, INT_MAX, 0);
+	priv->txcmpl_skb = NULL;
+	priv->txcmpl_run = false;
 
 	edma_tx_ring_free(priv, &priv->txdesc_ring, sizeof(struct edma_txdesc));
 	edma_ring_free(priv, &priv->txcmpl_ring, sizeof(struct edma_txcmpl));
@@ -1116,6 +1174,25 @@ static int edma_ndo_stop(struct net_device *netdev)
 
 static int edma_ndo_change_mtu(struct net_device *netdev, int new_mtu);
 
+/* A frame outside the bounds it may be described within is made linear
+ * instead. The last buffer has no length floor, and the head grows by the
+ * preheader before it is mapped, so neither is counted here.
+ */
+static bool edma_tx_needs_linearize(const struct sk_buff *skb)
+{
+	const struct skb_shared_info *shinfo = skb_shinfo(skb);
+	int i;
+
+	if (shinfo->nr_frags + 1 > EDMA_TX_MAX_SEGS)
+		return true;
+
+	for (i = 0; i + 1 < shinfo->nr_frags; i++)
+		if (skb_frag_size(&shinfo->frags[i]) < EDMA_TX_MIN_SEG)
+			return true;
+
+	return false;
+}
+
 static netdev_tx_t edma_ndo_xmit(struct sk_buff *skb, struct net_device *netdev)
 {
 	struct edma_priv *priv = netdev_priv(netdev);
@@ -1125,7 +1202,7 @@ static netdev_tx_t edma_ndo_xmit(struct sk_buff *skb, struct net_device *netdev)
 	if (skb->len < ETH_HLEN)
 		goto drop;
 
-	if (skb_is_nonlinear(skb) && skb_linearize(skb))
+	if (edma_tx_needs_linearize(skb) && skb_linearize(skb))
 		goto drop;
 
 	/* skb_padto() zero-fills the tailroom but leaves the tail where it
@@ -1416,7 +1493,7 @@ static int edma_probe(struct platform_device *pdev)
 	netdev->dev.of_node = dev->of_node;
 	netdev->netdev_ops = &edma_netdev_ops;
 	netdev->hw_features = NETIF_F_RXCSUM | NETIF_F_IP_CSUM |
-			      NETIF_F_IPV6_CSUM;
+			      NETIF_F_IPV6_CSUM | NETIF_F_SG;
 	netdev->features = NETIF_F_GRO | netdev->hw_features;
 	/* A DSA user port takes its features from the conduit's vlan_features. */
 	netdev->vlan_features = netdev->hw_features;

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
@@ -140,6 +140,7 @@ static irqreturn_t edma_misc_irq_handle(int irq, void *ctx)
 	if (!val)
 		return IRQ_NONE;
 
+	priv->stats.misc_error++;
 	dev_warn_ratelimited(&priv->pdev->dev, "misc error %#x\n", val);
 
 	return IRQ_HANDLED;
@@ -413,6 +414,7 @@ static u32 edma_clean_tx(struct edma_priv *priv, struct edma_ring *txcmpl_ring,
 		if (unlikely(txcmpl->status & EDMA_TXCMPL_ERROR)) {
 			dev_warn_ratelimited(&pdev->dev, "tx error %#x\n",
 					     txcmpl->status);
+			priv->stats.tx_desc_error++;
 			priv->netdev->stats.tx_errors++;
 		}
 
@@ -443,6 +445,7 @@ static u32 edma_clean_tx(struct edma_priv *priv, struct edma_ring *txcmpl_ring,
 				dev_warn(&pdev->dev,
 					 "invalid skb: cons:%u prod:%u status %x\n",
 					 cons, prod, txcmpl->status);
+				priv->stats.tx_unnamed_frame++;
 			} else {
 				bytes += edma_tx_release(priv,
 							 priv->txcmpl_idx, skb,
@@ -567,10 +570,14 @@ static u32 edma_clean_rx(struct edma_priv *priv, int budget,
 
 		pkt_len = desc_status & EDMA_RXDESC_PACKET_LEN_MASK;
 
+		if (unlikely(desc_status & EDMA_RXDESC_MORE))
+			priv->stats.rx_split_frame++;
+
 		page_pool_dma_sync_for_cpu(priv->page_pool, page, 0,
 					   EDMA_RX_PREHDR_SIZE + pkt_len);
 		store_idx = le32_to_cpu(rxph->opaque);
 		if (unlikely(!edma_rx_page_take(priv, page, store_idx))) {
+			priv->stats.rx_untracked_page++;
 			netdev->stats.rx_errors++;
 			goto next;
 		}
@@ -583,6 +590,7 @@ static u32 edma_clean_rx(struct edma_priv *priv, int budget,
 					     le16_to_cpu(rxph->src_info),
 					     le16_to_cpu(rxph->dst_info));
 			page_pool_put_full_page(priv->page_pool, page, true);
+			priv->stats.rx_bad_src_info++;
 			netdev->stats.rx_errors++;
 			goto next;
 		}
@@ -592,6 +600,7 @@ static u32 edma_clean_rx(struct edma_priv *priv, int budget,
 		skb = napi_build_skb(page_address(page), page_size(page));
 		if (unlikely(!skb)) {
 			page_pool_put_full_page(priv->page_pool, page, true);
+			priv->stats.rx_no_skb++;
 			netdev->stats.rx_dropped++;
 			goto next;
 		}
@@ -607,6 +616,7 @@ static u32 edma_clean_rx(struct edma_priv *priv, int budget,
 		tag_info = skb_ext_add(skb, SKB_EXT_DSA_OOB);
 		if (unlikely(!tag_info)) {
 			dev_kfree_skb_any(skb);
+			priv->stats.rx_no_tag++;
 			netdev->stats.rx_dropped++;
 			goto next;
 		}
@@ -687,6 +697,7 @@ static int edma_rx_napi(struct napi_struct *napi, int budget)
 		if (prod == cons) {
 			dev_warn_ratelimited(&priv->pdev->dev,
 					     "RXFILL ring starved\n");
+			priv->stats.rx_fill_starved++;
 			priv->netdev->stats.rx_missed_errors++;
 			edma_rx_fill(priv, &priv->rxfill_ring);
 			return budget;
@@ -1269,7 +1280,47 @@ static void edma_get_regs(struct net_device *netdev,
 	}
 }
 
+static const char edma_stat_names[][ETH_GSTRING_LEN] = {
+	"rx_untracked_page",
+	"rx_bad_src_info",
+	"rx_no_skb",
+	"rx_no_tag",
+	"rx_split_frame",
+	"rx_fill_starved",
+	"tx_desc_error",
+	"tx_unnamed_frame",
+	"misc_error",
+};
+
+static int edma_get_sset_count(struct net_device *netdev, int sset)
+{
+	if (sset != ETH_SS_STATS)
+		return -EOPNOTSUPP;
+
+	return ARRAY_SIZE(edma_stat_names);
+}
+
+static void edma_get_strings(struct net_device *netdev, u32 sset, u8 *data)
+{
+	if (sset == ETH_SS_STATS)
+		memcpy(data, edma_stat_names, sizeof(edma_stat_names));
+}
+
+static void edma_get_ethtool_stats(struct net_device *netdev,
+				   struct ethtool_stats *stats, u64 *data)
+{
+	struct edma_priv *priv = netdev_priv(netdev);
+
+	BUILD_BUG_ON(sizeof(priv->stats) !=
+		     ARRAY_SIZE(edma_stat_names) * sizeof(u64));
+
+	memcpy(data, &priv->stats, sizeof(priv->stats));
+}
+
 static const struct ethtool_ops edma_ethtool_ops = {
+	.get_sset_count = edma_get_sset_count,
+	.get_strings = edma_get_strings,
+	.get_ethtool_stats = edma_get_ethtool_stats,
 	.get_drvinfo = edma_get_drvinfo,
 	.get_link = ethtool_op_get_link,
 	.get_ringparam = edma_get_ringparam,

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
@@ -1169,10 +1169,83 @@ static void edma_get_ringparam(struct net_device *netdev,
 	ring->rx_pending = EDMA_RX_RING_SIZE;
 }
 
+/* The registers the driver drives, in the order it configures them: the
+ * global block, then each ring it owns and the interrupt that serves it. The
+ * dump pairs every value with the offset it came from, so it reads without a
+ * table on the other side. The misc status is left out, so that a dump cannot
+ * take an error away from the handler.
+ */
+static int edma_get_regs_len(struct net_device *netdev)
+{
+	return EDMA_REGS_COUNT * 2 * sizeof(u32);
+}
+
+static void edma_get_regs(struct net_device *netdev,
+			  struct ethtool_regs *regs, void *p)
+{
+	struct edma_priv *priv = netdev_priv(netdev);
+	const struct edma_soc_data *soc = priv->soc;
+	const u32 off[EDMA_REGS_COUNT] = {
+		EDMA_REG_PORT_CTRL,
+		EDMA_REG_DMAR_CTRL,
+		EDMA_REG_AXIW_CTRL,
+		EDMA_REG_MISC_INT_MASK,
+
+		EDMA_REG_TXDESC_BA(soc->txdesc_ring),
+		EDMA_REG_TXDESC_PROD_IDX(soc->txdesc_ring),
+		EDMA_REG_TXDESC_CONS_IDX(soc->txdesc_ring),
+		EDMA_REG_TXDESC_RING_SIZE(soc->txdesc_ring),
+		EDMA_REG_TXDESC_CTRL(soc->txdesc_ring),
+
+		EDMA_REG_TXCMPL_BA(soc->txcmpl_base, soc->txcmpl_ring),
+		EDMA_REG_TXCMPL_PROD_IDX(soc->txcmpl_base, soc->txcmpl_ring),
+		EDMA_REG_TXCMPL_CONS_IDX(soc->txcmpl_base, soc->txcmpl_ring),
+		EDMA_REG_TXCMPL_RING_SIZE(soc->txcmpl_base, soc->txcmpl_ring),
+		EDMA_REG_TXCMPL_CTRL(soc->txcmpl_base, soc->txcmpl_ring),
+
+		EDMA_REG_TX_INT_STAT(soc->tx_int_base, soc->txcmpl_ring),
+		EDMA_REG_TX_INT_MASK(soc->tx_int_base, soc->txcmpl_ring),
+		EDMA_REG_TX_MOD_TIMER(soc->tx_int_base, soc->txcmpl_ring),
+		EDMA_REG_TX_INT_CTRL(soc->tx_int_base, soc->txcmpl_ring),
+
+		EDMA_REG_RXFILL_BA(soc->rxfill_ring),
+		EDMA_REG_RXFILL_PROD_IDX(soc->rxfill_ring),
+		EDMA_REG_RXFILL_CONS_IDX(soc->rxfill_ring),
+		EDMA_REG_RXFILL_RING_SIZE(soc->rxfill_ring),
+		EDMA_REG_RXFILL_RING_EN(soc->rxfill_ring),
+		EDMA_REG_RXFILL_INT_STAT(soc->rxfill_ring),
+		EDMA_REG_RXFILL_INT_MASK(soc->rxfill_ring),
+
+		EDMA_REG_RXDESC_BA(soc->rxdesc_ring),
+		EDMA_REG_RXDESC_PROD_IDX(soc->rxdesc_ring),
+		EDMA_REG_RXDESC_CONS_IDX(soc->rxdesc_ring),
+		EDMA_REG_RXDESC_RING_SIZE(soc->rxdesc_ring),
+		EDMA_REG_RXDESC_CTRL(soc->rxdesc_ring),
+		EDMA_REG_RXDESC_INT_STAT(soc->rxdesc_ring),
+		EDMA_REG_RXDESC_INT_MASK(soc->rxdesc_ring),
+		EDMA_REG_RX_MOD_TIMER(soc->rxdesc_ring),
+		EDMA_REG_RX_INT_CTRL(soc->rxdesc_ring),
+	};
+	u32 *out = p;
+	int i;
+
+	regs->version = 1;
+
+	for (i = 0; i < EDMA_REGS_COUNT; i++) {
+		u32 val;
+
+		regmap_read(priv->regmap, off[i], &val);
+		*out++ = off[i];
+		*out++ = val;
+	}
+}
+
 static const struct ethtool_ops edma_ethtool_ops = {
 	.get_drvinfo = edma_get_drvinfo,
 	.get_link = ethtool_op_get_link,
 	.get_ringparam = edma_get_ringparam,
+	.get_regs_len = edma_get_regs_len,
+	.get_regs = edma_get_regs,
 };
 
 static int edma_ndo_open(struct net_device *netdev)

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.c
@@ -597,6 +597,24 @@ static int edma_rx_napi(struct napi_struct *napi, int budget)
 	return done;
 }
 
+/* The engine generates the transport checksum of an outgoing TCP or UDP frame,
+ * and the IPv4 header checksum with it. It parses the frame for the offsets
+ * rather than being handed a start and an offset, so the offload is announced
+ * per protocol.
+ */
+static void edma_tx_csum(struct sk_buff *skb, struct edma_tx_preheader *txph,
+			 __be16 proto)
+{
+	if (skb->ip_summed != CHECKSUM_PARTIAL)
+		return;
+
+	txph->tx_pre4 |= EDMA_TX_PRE4_ADV_OFFLOAD_EN;
+	txph->tx_pre6 |= EDMA_TX_PRE6_CSUM_MODE_L4;
+
+	if (proto == htons(ETH_P_IP))
+		txph->tx_pre6 |= EDMA_TX_PRE6_IP_CSUM_EN;
+}
+
 static netdev_tx_t edma_ring_xmit(struct edma_priv *priv, struct net_device *netdev,
 				  struct sk_buff *skb,
 				  struct edma_ring *txdesc_ring)
@@ -609,6 +627,7 @@ static netdev_tx_t edma_ring_xmit(struct edma_priv *priv, struct net_device *net
 	u16 buf_len, dst_info;
 	dma_addr_t dma;
 	u32 val, idx;
+	__be16 proto;
 
 	spin_lock_bh(&priv->tx_lock);
 
@@ -637,6 +656,11 @@ static netdev_tx_t edma_ring_xmit(struct edma_priv *priv, struct net_device *net
 
 	buf_len = skb_headlen(skb);
 
+	/* vlan_get_protocol() walks the tags from skb->data, so the protocol is
+	 * taken while that still points at the MAC header.
+	 */
+	proto = vlan_get_protocol(skb);
+
 	tag_info = skb_ext_find(skb, SKB_EXT_DSA_OOB);
 	if (tag_info)
 		dst_info = (EDMA_DST_PORT_TYPE << 8) |
@@ -648,6 +672,7 @@ static netdev_tx_t edma_ring_xmit(struct edma_priv *priv, struct net_device *net
 	memset((void *)txph, 0, EDMA_TX_PREHDR_SIZE);
 
 	txph->dst_info = dst_info;
+	edma_tx_csum(skb, txph, proto);
 
 	txdesc_ring->skb_store[idx] = skb;
 	txph->opaque = idx;
@@ -1390,7 +1415,8 @@ static int edma_probe(struct platform_device *pdev)
 	SET_NETDEV_DEV(netdev, dev);
 	netdev->dev.of_node = dev->of_node;
 	netdev->netdev_ops = &edma_netdev_ops;
-	netdev->hw_features = NETIF_F_RXCSUM;
+	netdev->hw_features = NETIF_F_RXCSUM | NETIF_F_IP_CSUM |
+			      NETIF_F_IPV6_CSUM;
 	netdev->features = NETIF_F_GRO | netdev->hw_features;
 	/* A DSA user port takes its features from the conduit's vlan_features. */
 	netdev->vlan_features = netdev->hw_features;

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
@@ -146,6 +146,7 @@
  * TCP and UDP over either family.
  */
 #define EDMA_RXDESC_PID_IPV6 0x4
+#define EDMA_RXDESC_PID_NON_IP 0x8
 #define EDMA_RXDESC_PID_TCP_UDP (BIT(1) | BIT(2) | BIT(5) | BIT(6))
 
 /* RX preheader fields */
@@ -154,6 +155,10 @@
 #define EDMA_RXPH_HASH_FLAG_MASK 0x7
 #define EDMA_RXPH_HASH_5TUPLE 1
 #define EDMA_RXPH_HASH_3TUPLE 2
+#define EDMA_RXPH_L4_OFFSET_SHIFT 8
+#define EDMA_RXPH_L4_OFFSET_MASK 0xff
+#define EDMA_RXPH_CSUM_SHIFT 16
+#define EDMA_RXPH_CSUM_MASK 0xffff
 
 /* PPE queue to receive ring mapping: a four-bit ring id per switch queue. */
 #define EDMA_QID2RID_TABLE_MEM(n) (0x5a000 + (0x4 * (n)))

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
@@ -126,6 +126,18 @@
 #define EDMA_RXDESC_INT_MASK_PKT_INT 0x1
 #define EDMA_RX_MOD_TIMER_INIT 1000
 
+/* RX descriptor status fields */
+#define EDMA_RXDESC_L4_CSUM_OK BIT(14)
+#define EDMA_RXDESC_L3_CSUM_OK BIT(15)
+#define EDMA_RXDESC_PID_SHIFT 24
+#define EDMA_RXDESC_PID_MASK 0xf
+/* The packet type the parser reports: the low two bits name the transport and
+ * the next one the address family, so the four values the engine checksums are
+ * TCP and UDP over either family.
+ */
+#define EDMA_RXDESC_PID_IPV6 0x4
+#define EDMA_RXDESC_PID_TCP_UDP (BIT(1) | BIT(2) | BIT(5) | BIT(6))
+
 /* PPE queue to receive ring mapping: a four-bit ring id per switch queue. */
 #define EDMA_QID2RID_TABLE_MEM(n) (0x5a000 + (0x4 * (n)))
 #define EDMA_QID2RID_DEPTH 0x40

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
@@ -179,6 +179,11 @@
 #define EDMA_TXDESC_DATA_OFFSET_MASK 0xff
 #define EDMA_TXDESC_DATA_LENGTH_MASK 0xffff
 
+/* TX preheader fields */
+#define EDMA_TX_PRE4_ADV_OFFLOAD_EN BIT(28)
+#define EDMA_TX_PRE6_CSUM_MODE_L4 (0x1 << 29)
+#define EDMA_TX_PRE6_IP_CSUM_EN BIT(31)
+
 /* Preheader fields */
 #define EDMA_DST_PORT_TYPE 0x20
 #define EDMA_DST_PORT_ID_MASK 0x1f

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
@@ -143,6 +143,13 @@
 #define EDMA_RXDESC_PID_IPV6 0x4
 #define EDMA_RXDESC_PID_TCP_UDP (BIT(1) | BIT(2) | BIT(5) | BIT(6))
 
+/* RX preheader fields */
+#define EDMA_RXPH_HASH_MASK GENMASK(20, 0)
+#define EDMA_RXPH_HASH_FLAG_SHIFT 21
+#define EDMA_RXPH_HASH_FLAG_MASK 0x7
+#define EDMA_RXPH_HASH_5TUPLE 1
+#define EDMA_RXPH_HASH_3TUPLE 2
+
 /* PPE queue to receive ring mapping: a four-bit ring id per switch queue. */
 #define EDMA_QID2RID_TABLE_MEM(n) (0x5a000 + (0x4 * (n)))
 #define EDMA_QID2RID_DEPTH 0x40

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
@@ -74,6 +74,10 @@
 #define EDMA_TXCMPL_PROD_IDX_MASK 0xffff
 #define EDMA_TXCMPL_CONS_IDX_MASK 0xffff
 #define EDMA_TXCMPL_RETMODE_OPAQUE 0x0
+/* The engine returns one completion per descriptor: the more bit marks every
+ * completion of a frame but its last.
+ */
+#define EDMA_TXCMPL_MORE BIT(30)
 
 /* TX interrupt registers */
 #define EDMA_REG_TX_INT_STAT(b, n)  ((b) + (0x1000 * (n)))
@@ -164,7 +168,14 @@
 #define EDMA_TX_PREHDR_SIZE (sizeof(struct edma_tx_preheader))
 #define EDMA_TX_RING_SIZE 128
 #define EDMA_RX_RING_SIZE 2048
-#define EDMA_TX_RING_THRESH 16
+/* The bounds a frame is described to the engine within: at most this many
+ * buffers, and no buffer below this size before the last. The queue stops
+ * with room for a frame that takes every descriptor, or it would restart on
+ * space that the next frame still could not use.
+ */
+#define EDMA_TX_MAX_SEGS 32
+#define EDMA_TX_MIN_SEG 16
+#define EDMA_TX_RING_THRESH (EDMA_TX_MAX_SEGS + 1)
 
 /* Descriptor accessors */
 #define EDMA_GET_DESC(R, i, type) (&(((type *)((R)->desc))[i]))
@@ -174,7 +185,9 @@
 #define EDMA_TXCMPL_DESC(R, i) EDMA_GET_DESC(R, i, struct edma_txcmpl)
 
 /* TX descriptor fields */
+#define EDMA_TXDESC_MORE BIT(30)
 #define EDMA_TXDESC_PREHEADER_SHIFT 29
+#define EDMA_TXDESC_PREHEADER BIT(EDMA_TXDESC_PREHEADER_SHIFT)
 #define EDMA_TXDESC_DATA_OFFSET_SHIFT 16
 #define EDMA_TXDESC_DATA_OFFSET_MASK 0xff
 #define EDMA_TXDESC_DATA_LENGTH_MASK 0xffff
@@ -267,6 +280,13 @@ struct edma_priv {
 	struct page_pool *page_pool;
 	u32 rx_buffer_size;
 	u8 rx_page_order;
+
+	/* The frame a run of completions belongs to, named by the first of
+	 * them and released on the last.
+	 */
+	struct sk_buff *txcmpl_skb;
+	u32 txcmpl_idx;
+	bool txcmpl_run;
 
 	struct edma_ring txdesc_ring;
 	struct edma_ring txcmpl_ring;

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
@@ -16,7 +16,6 @@
 #define EDMA_HW_RESET_ID "edma_rst"
 
 /* Global / control registers */
-#define EDMA_REG_MAS_CTRL 0x0
 #define EDMA_REG_PORT_CTRL 0x4
 #define EDMA_REG_RXDESC2FILL_MAP_0 0x18
 #define EDMA_REG_RXDESC2FILL_MAP_1 0x1c
@@ -151,16 +150,6 @@
 
 /* TXDESC to TXCMPL ring mapping */
 #define EDMA_REG_TXDESC2CMPL_MAP(n) (0x0c + 0x4 * (n))
-
-/* Misc error interrupt masks */
-#define EDMA_MISC_AXI_RD_ERR_MASK_EN 0x1
-#define EDMA_MISC_AXI_WR_ERR_MASK_EN 0x2
-#define EDMA_MISC_RX_DESC_FIFO_FULL_MASK_EN 0x4
-#define EDMA_MISC_RX_ERR_BUF_SIZE_MASK_EN 0x8
-#define EDMA_MISC_TX_SRAM_FULL_MASK_EN 0x10
-#define EDMA_MISC_TX_CMPL_BUF_FULL_MASK_EN 0x20
-#define EDMA_MISC_DATA_LEN_ERR_MASK_EN 0x40
-#define EDMA_MISC_TX_TIMEOUT_MASK_EN 0x80
 
 /* Sizes and ring configuration */
 #define EDMA_MAX_FRAME_SIZE 12288

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
@@ -151,6 +151,9 @@
 /* TXDESC to TXCMPL ring mapping */
 #define EDMA_REG_TXDESC2CMPL_MAP(n) (0x0c + 0x4 * (n))
 
+/* Registers the ethtool dump reports, as offset and value pairs. */
+#define EDMA_REGS_COUNT 34
+
 /* Sizes and ring configuration */
 #define EDMA_MAX_FRAME_SIZE 12288
 #define EDMA_RX_PREHDR_SIZE (sizeof(struct edma_rx_preheader))

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
@@ -121,6 +121,11 @@
 #define EDMA_RXDESC_PL_OFFSET_SHIFT 16
 #define EDMA_RXDESC_RX_EN 0x1
 #define EDMA_RXDESC_PACKET_LEN_MASK 0x3fff
+/* A frame the engine had to spread over several receive descriptors. The fill
+ * buffers are sized for the largest frame the conduit accepts, so it does not
+ * arise; a frame that carried it would be handed up in pieces.
+ */
+#define EDMA_RXDESC_MORE BIT(30)
 
 /* RX descriptor ring interrupt registers */
 #define EDMA_REG_RXDESC_INT_STAT(n) (0x49000 + (0x1000 * (n)))
@@ -251,6 +256,18 @@ struct edma_rx_preheader {
 	u32 rx_pre7;
 };
 
+struct edma_stats {
+	u64 rx_untracked_page;
+	u64 rx_bad_src_info;
+	u64 rx_no_skb;
+	u64 rx_no_tag;
+	u64 rx_split_frame;
+	u64 rx_fill_starved;
+	u64 tx_desc_error;
+	u64 tx_unnamed_frame;
+	u64 misc_error;
+};
+
 struct edma_soc_data {
 	u32 txcmpl_base;
 	u32 tx_int_base;
@@ -290,6 +307,11 @@ struct edma_priv {
 	struct sk_buff *txcmpl_skb;
 	u32 txcmpl_idx;
 	bool txcmpl_run;
+
+	/* Counted here rather than in netdev->stats, which cannot say which of
+	 * the reasons a frame went missing for.
+	 */
+	struct edma_stats stats;
 
 	struct edma_ring txdesc_ring;
 	struct edma_ring txcmpl_ring;

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
@@ -75,8 +75,10 @@
 #define EDMA_TXCMPL_CONS_IDX_MASK 0xffff
 #define EDMA_TXCMPL_RETMODE_OPAQUE 0x0
 /* The engine returns one completion per descriptor: the more bit marks every
- * completion of a frame but its last.
+ * completion of a frame but its last, and the error field reports what the
+ * engine made of the descriptor, above the ring id it read it from.
  */
+#define EDMA_TXCMPL_ERROR GENMASK(29, 7)
 #define EDMA_TXCMPL_MORE BIT(30)
 
 /* TX interrupt registers */

--- a/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
+++ b/target/linux/qualcommax/files/drivers/net/ethernet/qualcomm/qca_edma.h
@@ -186,6 +186,7 @@
 
 /* TX descriptor fields */
 #define EDMA_TXDESC_MORE BIT(30)
+#define EDMA_TXDESC_TSO_EN BIT(28)
 #define EDMA_TXDESC_PREHEADER_SHIFT 29
 #define EDMA_TXDESC_PREHEADER BIT(EDMA_TXDESC_PREHEADER_SHIFT)
 #define EDMA_TXDESC_DATA_OFFSET_SHIFT 16
@@ -195,6 +196,7 @@
 /* TX preheader fields */
 #define EDMA_TX_PRE4_ADV_OFFLOAD_EN BIT(28)
 #define EDMA_TX_PRE6_CSUM_MODE_L4 (0x1 << 29)
+#define EDMA_TX_PRE6_MSS_MASK 0x3fff
 #define EDMA_TX_PRE6_IP_CSUM_EN BIT(31)
 
 /* Preheader fields */


### PR DESCRIPTION
The EDMA conduit advertised `NETIF_F_GRO` and nothing else, so the CPU
checksummed every frame in both directions, linearised every fragmented skb
before it reached the rings, and segmented every oversized frame in software.
The hardware does all three, and it already reported per-frame errors and an
RSS hash that the driver read and threw away.

What the series adds:

- `NETIF_F_RXCSUM` — `CHECKSUM_UNNECESSARY` from the per-descriptor verdict
  for TCP and UDP, `CHECKSUM_COMPLETE` from the checksum the hardware reports
  for every other IP protocol
- `NETIF_F_IP_CSUM` / `NETIF_F_IPV6_CSUM` — TX checksum offload
- `NETIF_F_SG` — scatter-gather, one descriptor per skb fragment
- `NETIF_F_TSO` / `NETIF_F_TSO6` — TSO, MSS handed to the hardware
- `NETIF_F_RXHASH` — RSS hash, spread over the whole 32-bit word the stack
  scales across
- TX completion errors, the misc interrupt status, five RX drop reasons that
  reached no counter, `ethtool -S` for all of them and an `ethtool -d`
  register dump

`vlan_features` carries the offloads to the DSA user ports, which is where the
traffic arrives.

## Measurements

Xiaomi AX3600 (IPQ8074), router-terminated iperf3 against a wired host on a
second port. Arms interleaved, medians quoted, CPU as a share of all four
cores.

TX, three interleaved pairs at line rate:

| | Mbit/s | CPU |
|---|---|---|
| offloads on | 941 / 941 / 941 | 27.3% / 26.8% / 23.0% |
| offloads off | 941 / 911 / 941 | 37.5% / 35.5% / 34.6% |

RX checksum, six interleaved pairs run in both orders, 1400-byte UDP
datagrams offered at 800 Mbit/s:

| | loss | delivered |
|---|---|---|
| on | 0.26 / 0.58 / 0.7 / 0.95 / 1.1 / 2.0 % | 783-798 Mbit/s |
| off | 2.7 / 2.9 / 6.8 / 9.2 / 11 / 14 % | 687-779 Mbit/s |

The CPU load is the same in both RX arms; the offload shows as headroom, not
as a lower number. TCP receive at line rate shows no difference at all,
because GRO already amortises the check.

RSS hash: four concurrent flows under RPS reach all four CPUs; three
ten-second runs steer 255000, 291000 and 381000 frames off the receiving one.
Left where the parser puts it, in the low 21 bits, `reciprocal_scale` maps
every value to CPU 0, so the hash is spread over the whole word first.

## Correctness

- 200 UDP datagrams with corrupt checksums, IPv4 and IPv6:
  `Udp:InCsumErrors` and `Udp6InCsumErrors` rise by exactly 200 with the
  offload on and with it off, and 200 correct ones are accepted in both arms.
- 200 ICMP echo requests with corrupt checksums, IPv4 and IPv6, which take the
  complete-checksum path rather than the verdict: `Icmp:InCsumErrors` and
  `Icmp6InCsumErrors` rise by 200 in both arms, and correct ones are answered
  in both.
- 190000 further frames over the complete-checksum path, IPv4 and IPv6 ICMP
  at 1400 and 8 bytes: no `hw csum failure`, no checksum error counted.
- 2000 transmitted TCP packets captured on the receiving host with GRO
  disabled, IPv4 and IPv6: every checksum correct, largest segment 1448 and
  1420 bytes with TSO on. Over an 802.1Q upper, where the tag is in the
  payload and the frame reaches the driver as `ETH_P_8021Q`: 796 IPv4 and 428
  IPv6 segments, every IP header and TCP checksum correct, 936 and 923
  Mbit/s.
- Three `ip link set eth0 down/up` cycles under four parallel TCP streams: no
  double free, `dmesg` clean, every port back at its link speed.
- Each feature toggled off and on again individually with traffic running.
- 22 million frames over a mixed soak: every `ethtool -S` counter and every
  `netdev->stats` error zero, `dmesg` clean.

## Left out, and why

- Interrupt coalescing. At a held 600 Mbit/s a hundredfold change in the
  moderation timer moves the interrupt count by 9%, against 5% between two
  runs of the same setting, so the timer does not measurably coalesce and an
  `ethtool -c` for it would be a knob that does not reach the hardware.
- The fill ring's low watermark. It reads zero and that interrupt has never
  fired; programming 64, 256, 512 and 1024 leaves it at zero interrupts and no
  starvation, because the receive poll refills the ring before it reaches any
  of them.
- `NETIF_F_HW_CSUM`. Of the four TX checksum modes, two produce correct
  checksums and two do not, and the two that work do so with the preheader's
  payload and checksum offsets left at zero, so none of them places a checksum
  where the caller asks.
- VLAN insert and strip offload. The switch already owns per-port VLAN
  translation, and a conduit that strips tags changes what a VLAN-aware bridge
  above the user ports sees.
- Timestamping. No timestamp reaches the driver on either ring, so there is
  nothing for a PHC to read.

