### PR TITLE
Revert "qualcommax: pcs-qca-uniphy: report a USXGMII speed only once the link is up"

### DIFF
--- a/target/linux/qualcommax/files/drivers/net/pcs/pcs-qca-uniphy.c
+++ b/target/linux/qualcommax/files/drivers/net/pcs/pcs-qca-uniphy.c
@@ -373,15 +373,7 @@ static void qca_uniphy_pcs_get_state_usxgmii(struct qca_uniphy *uniphy,
 		return;
 	}
 
-	/* The speed field of this word only means anything once USXGMII
-	 * autonegotiation has resolved it, so reporting the link before then
-	 * would hand phylink whatever the field happens to hold.
-	 */
 	state->an_complete = !!(val & XPCS_USXG_AN_LINK_STS);
-	if (!state->an_complete) {
-		state->link = false;
-		return;
-	}
 
 	switch (FIELD_GET(XPCS_USXG_AN_SPEED_MASK, val)) {
 	case XPCS_USXG_AN_SPEED_10000:


### PR DESCRIPTION
This reverts 8939d5654a77, which leaves the 10G ports of USXGMII boards
without carrier.

`qca_uniphy_pcs_get_state_usxgmii()` gates the reported state on the link
bit of the USXGMII code word. An AQR113C behind this XPCS leaves that bit
clear while autonegotiation completes and the speed field tracks the copper
rate, which is the behaviour dd78f34eba83 ("qualcommax: pcs-qca-uniphy: take
the USXGMII link from the receiver") was written for. With the gate in place
the ports never reach carrier even though the receiver reports link up.

Reported on two boards:

- QNAP QHora-301w: `10g-1` stays `NO-CARRIER`, `ethtool` reports
  `Speed: 1000Mb/s` with `Link detected: no`, and plugging or unplugging the
  cable produces no link message. The previous build works and the issue
  returns on this one.
- Zyxel NBG7815: the 10G port works again with the hunk dropped.

No board with a USXGMII port is available here, so the revert is not runtime
tested; the two reports above are the confirmation.