### PR TITLE
ramips: mt7621: gzip-wrap MikroTik NOR sysupgrade images

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2275,13 +2275,13 @@ define Device/MikroTik
   DEVICE_PACKAGES := kmod-usb3 -uboot-envtools
   KERNEL_NAME := vmlinuz
   KERNEL := kernel-bin | append-dtb-elf
-  IMAGE/sysupgrade.bin := append-kernel | yaffs-filesystem -L | \
+  IMAGES := sysupgrade.bin.gz sysupgrade-v7.bin.gz
+  IMAGE/sysupgrade.bin.gz := append-kernel | yaffs-filesystem -L | \
 	pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | \
-	append-metadata
-  IMAGES += sysupgrade-v7.bin
-  IMAGE/sysupgrade-v7.bin := append-kernel | kernel-pack-npk | \
+	libdeflate-gzip | append-metadata
+  IMAGE/sysupgrade-v7.bin.gz := append-kernel | kernel-pack-npk | \
 	  yaffs-filesystem -L | pad-to $$$$(BLOCKSIZE) | \
-	  append-rootfs | pad-rootfs | check-size | append-metadata
+	  append-rootfs | pad-rootfs | check-size | libdeflate-gzip | append-metadata
 endef
 
 define Device/mikrotik_ltap-2hnd


### PR DESCRIPTION
# ramips: mt7621: gzip-wrap MikroTik NOR sysupgrade images

## Summary

Wrap MikroTik NOR sysupgrade images in deterministic gzip to prevent a
RouterBOOT boot-object confusion vulnerability that can brick devices on
interrupted downloads or power loss.

**Fixes: #12290**

## Root cause

The current MikroTik NOR sysupgrade images begin with a valid YAFFS filesystem
containing the RouterBOOT boot object (`kernel` for RouterBOOT ≤ 6, `bootimage`
for ≥ 7) at byte offset 10. If a partial copy of the downloaded sysupgrade is
stored in writable SPI NOR, RouterBOOT can discover that second YAFFS boot
object and load a truncated kernel, even though the installed kernel partition
is intact. The MIPS self-decompressor then fails with corrupt compressed data.

This explains the historical hardware observations from #12290:
- RouterBOOT reaches "jumping to kernel code"
- The installed kernel's SHA-256 is unchanged before and after the failure
- Only the beginning of a real sysupgrade image reproduces the failure
- Erasing the offending later-NOR copy restores normal boot

## Fix

The downloadable artifact now starts with gzip magic (`1f 8b`) instead of a
valid YAFFS file header. The flash payload is gzip-compressed before fwtool
metadata is appended:

```diff
-  IMAGES += sysupgrade-v7.bin
-  IMAGE/sysupgrade.bin := append-kernel | yaffs-filesystem -L | \
+  IMAGES := sysupgrade.bin.gz sysupgrade-v7.bin.gz
+  IMAGE/sysupgrade.bin.gz := append-kernel | yaffs-filesystem -L | \
  	pad-to $$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | \
-	append-metadata
-  IMAGE/sysupgrade-v7.bin := append-kernel | kernel-pack-npk | \
+	libdeflate-gzip | append-metadata
+  IMAGE/sysupgrade-v7.bin.gz := append-kernel | kernel-pack-npk | \
  	  yaffs-filesystem -L | pad-to $$(BLOCKSIZE) | \
-	  append-rootfs | pad-rootfs | check-size | append-metadata
+	  append-rootfs | pad-rootfs | check-size | libdeflate-gzip | append-metadata
```

**Why this works:** OpenWrt's `get_image()` detects gzip by magic and runs `zcat`
before `default_do_upgrade()` pipes the payload to `mtd`. The on-flash layout
(kernel, YAFFS, rootfs, padding, JFFS2 EOF) is unchanged. Only the
downloadable/storage representation changes.

**Why the flash layout stays the same:** Exact A/B comparison of all ten
baseline/patched builds shows the same flash-payload length, the same SquashFS
offset, and byte-identical rootfs-through-JFFS2-EOF data. The independently
generated YAFFS portions differ by 18 bytes per pair before the rootfs; the fix
does not depend on interpreting those build-varying bytes.

## Why `.bin.gz` not `.bin`

OpenWrt convention uses `.gz` suffixes for sysupgrade artifacts whose payload is
gzip-compressed. The `include/image.mk` infrastructure and image metadata
generator both handle `.bin.gz` correctly.

## Scope

All five ramips MT7621 MikroTik NOR profiles share the `Device/MikroTik`
definition:

| Profile | Model |
|---|---|
| mikrotik_ltap-2hnd | LtAP-2HnD |
| mikrotik_routerboard-750gr3 | RouterBOARD 750Gr3 |
| mikrotik_routerboard-760igs | RouterBOARD 760iGS |
| mikrotik_routerboard-m11g | RouterBOARD M11G |
| mikrotik_routerboard-m33g | RouterBOARD M33G |

The M11G was independently reported to exhibit the same class of failure, so a
shared ramips fix is justified. The patch is not broadened to ath79/ipq40xx
MikroTik targets, which have different upgrade behavior and have not been
validated.

## Tests performed

- **ImageBuilder build**: All 5 profiles, both legacy and v7 variants (10
  artifacts). All produce valid gzip artifacts.
- **Gzip magic**: All 10 patched artifacts start with `1f 8b 08 00`.
- **Decompression**: All 10 decompress to the expected YAFFS boot objects
  (`kernel` at offset 10 for legacy, `bootimage` for v7).
- **Gzip integrity**: The first gzip member in all 10 artifacts passes CRC/ISIZE
  validation; the fwtool trailer is explicitly detected after that member.
- **JFFS2 EOF marker**: `de ad c0 de` present in all decompressed payloads.
- **A/B payload comparison**: all 10 pairs have identical payload length,
  rootfs offset, and rootfs-through-EOF bytes; each pair has 18 pre-rootfs
  build-varying bytes.
- **YAFFS name absence**: Zero ASCII `kernel` or `bootimage` strings in any
  compressed artifact or interrupted prefix (3K, 64K, 600K, 800K).
- **Structural YAFFS scan**: Zero plausible YAFFS file-object headers in all 10
  compressed artifacts.
- **Bundled Yafut validation**: The exact raw M33G baseline enumerates `/kernel`
  (legacy) and `/bootimage` (v7). Exact patched prefixes at 3K, 64K, 600K,
  800K, and 3.25 MiB expose neither boot object.
- **fwtool metadata**: extracted successfully from all 10 patched artifacts.
- **Regression test**: 70/70 assertions passed across all 10 artifacts.

## Interaction with #23089

PR #23089 adds `platform_check_image_mikrotik_nor()` which reads byte offset 10
of the sysupgrade image via `dd bs=10 skip=1 count=1 if="$1"`. This will not
work on gzip-wrapped artifacts. If both PRs are merged, #23089 must inspect the
decompressed stream using `get_image "$1"` semantics. If #23089 lands first,
this patch should be rebased to integrate the adaptation.

## Hardware validation status

**Not yet performed.** No physical RBM33G was available for testing. The
regression test script (`test_mikrotik_nor_corruption.sh`) is included for
community validation. The minimum required hardware tests are documented in the
linked issue and the FINAL_REPORT.md.

The exact final A/B artifacts, SHA-256 manifest, structural scan and validation
log are preserved under `.research-artifacts/final-evidence/` in the local
evidence bundle; they are supporting evidence, not a substitute for device tests.

## What this does NOT change

- DTS / partition layout
- RouterBOOT / bootloader
- Kernel decompressor
- MTD geometry
- YAFFS implementation
- JFFS2 behavior
- Recovery / failsafe mechanisms
