### PR TITLE
mediatek: filogic: fix SPI-NAND write failures on JioRouter AX6000

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-jiorouter-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-jiorouter-common.dtsi
@@ -123,12 +123,12 @@
 		conf-pu {
 			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
 			drive-strength = <MTK_DRIVE_8mA>;
-			bias-disable;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
 		};
 		conf-pd {
 			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
 			drive-strength = <MTK_DRIVE_8mA>;
-			bias-disable;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
 		};
 	};
 


### PR DESCRIPTION
Currently, sysupgrade silently fails to erase or write to the SPI-NAND flash on the JioRouter AX6000. This is caused by the SPI pinctrl group mistakenly using `bias-disable`, which leaves the flash chip's hardware HOLD and Write Protect (#WP) pins floating.

When combined with an upstream kernel regression that accidentally arms the #HOLD function on Winbond W25N0xKV chips, these floating pins drop low (often exacerbated by UART noise). This pauses the chip and causes all flash operations to silently fail while returning success.

Fix this by properly configuring `bias-pull-up = <MTK_PUPD_SET_R1R0_11>` for `SPI2_CS`, `SPI2_HOLD`, and `SPI2_WP`, ensuring the flash chip remains electrically unpaused and unlocked. Additionally, apply `bias-pull-down` to the clock and data lines to match MediaTek reference designs.