### PR TITLE
ramips: mt76x8: fix cudy tr1200-v1 switch port leak on boot

### DIFF
--- a/package/base-files/files/etc/init.d/95-switch-port-fixup
+++ b/package/base-files/files/etc/init.d/95-switch-port-fixup
@@ -1,0 +1,43 @@
+#!/bin/sh /etc/rc.common
+# Re-enable switch ports that may have been left disabled by the
+# hardware-level portdisable devicetree property, once VLAN
+# isolation is confirmed active. Runs early (right after network
+# setup) rather than at the very end of boot, to restore wired
+# client connectivity as soon as it is safe to do so.
+
+START=21
+
+reenable_switch_ports() {
+	local cfg="$1"
+	local device vlan ports
+
+	config_get device "$cfg" device
+	config_get vlan "$cfg" vlan
+	config_get ports "$cfg" ports
+
+	[ -n "$device" ] || return
+
+	# Wait up to ~10s for swconfig to confirm this VLAN/port
+	# assignment is actually active before re-enabling, so we
+	# never open a port ahead of its isolation being in effect.
+	local tries=0
+	while [ "$tries" -lt 10 ]; do
+		if swconfig dev "$device" vlan "$vlan" show 2>/dev/null | grep -q "ports: ${ports} "; then
+			break
+		fi
+		sleep 1
+		tries=$((tries + 1))
+	done
+
+	for p in $ports; do
+		swconfig dev "$device" port "${p%%[a-z]*}" set disable 0
+	done
+	swconfig dev "$device" set apply
+}
+
+boot() {
+	[ -x /sbin/swconfig ] || return
+	. /lib/functions.sh
+	config_load network
+	config_foreach reenable_switch_ports switch_vlan
+}

--- a/target/linux/ramips/dts/mt7628an_cudy_tr1200-v1.dts
+++ b/target/linux/ramips/dts/mt7628an_cudy_tr1200-v1.dts
@@ -194,5 +194,5 @@
 
 &esw {
 	mediatek,portmap = <0x3d>;
-	mediatek,portdisable = <0x3c>;
+	mediatek,portdisable = <0x3f>;
 };


### PR DESCRIPTION
## Problem

On the Cudy TR1200 v1, port 0 is used as LAN and port 1 as WAN,
isolated via VLANs configured through swconfig. During boot there
is a window of a few seconds where both ports are electrically up
and unfiltered, before VLAN isolation is applied.

Traced via kernel boot log timestamps:
- rt3050-esw driver brings ports 0 and 1 link-up at ~6s uptime
  (hardware probe), with no VLAN filtering active yet.
- preinit only resets the switch and applies VLAN isolation via
  swconfig at ~17-21s uptime.

For roughly 12-15 seconds, ports 0 and 1 share the same unfiltered
L2 domain. If a client is powered on in that window, it can reach
a DHCP server on the wrong port and get an IP from the wrong
network segment. Reproduced with two separate physical networks
connected to LAN and WAN: Windows clients ended up with an IP from
the wrong network and would not recover automatically until an
explicit `ipconfig /renew`, since Windows does not retry DHCP on
its own once a lease is (wrongly) obtained.

Confirmed the leak directly in the router's own DHCP log: a client
briefly received an IP from the unintended network, followed by a
DHCPNAK ("wrong network") and a corrected DHCPACK on the intended
subnet moments later.

## Root cause

`target/linux/ramips/dts/mt7628an_cudy_tr1200-v1.dts` sets:

    mediatek,portdisable = <0x3c>;   // ports 2-5 disabled by default

This does not cover ports 0 and 1, the two ports actually used
(LAN/WAN) on this device, so they come up enabled at the hardware
level before any VLAN configuration is applied.

## Fix

Two parts:

1. Extend `portdisable` to also cover ports 0 and 1
   (`mediatek,portdisable = <0x3f>;`), so all user-facing ports
   stay disabled at power-on. Port 6 (CPU port) is unaffected.
   Mirrors the approach already used on other rt3050/rt3052-family
   devices (e.g. mt7628an_duzun_dm06.dts).

2. Add `package/base-files/files/etc/init.d/95-switch-port-fixup`,
   a generic init script that re-enables every port referenced in
   the active `switch_vlan` UCI config, verifying via
   `swconfig ... show` that the VLAN assignment is actually in
   effect before doing so. This is necessary because neither
   preinit (which only handles the role matching the LAN
   interface) nor netifd re-enable ports disabled via the
   devicetree.

   Runs at START=21 (right after network setup) rather than at
   the very end of boot: on this hardware, wifi firmware and
   wpa_supplicant initialization alone account for ~15-20s of the
   boot sequence, and wired client connectivity has no reason to
   wait for it.

## Testing

Tested by compiling a full firmware image and flashing it on the
actual Cudy TR1200 v1 device described above. Boot log confirms
ports are re-enabled only after VLAN isolation is verified active,
with no early hardware-probe link-up leak window. A real
power-cycle test with a client PC on the LAN port showed correct
subnet assignment with no wrong-network DHCP lease and no need for
`ipconfig /renew`.

Two earlier approaches were tried and found insufficient during
this testing (re-enabling ports directly inside preinit — misses
the WAN role and gets raced by a later netifd switch touch), before
arriving at the init-script approach above.

Note on the PKG_RELEASE warning: package/base-files/Makefile sets
PKG_RELEASE:=$(COMMITCOUNT), so it's derived automatically from the
commit count and doesn't need a manual bump.