### PR TITLE
linux-firmware: update to 20260910

### DIFF
--- a/package/firmware/linux-firmware/Makefile
+++ b/package/firmware/linux-firmware/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linux-firmware
-PKG_VERSION:=20260810
+PKG_VERSION:=20260910
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/firmware
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=ac17c34fe73756926a961fbafadf8d8f07a3bd2dd2f4ea31a0fb5d50c714a49a
+PKG_HASH:=f3937ca282ba256242e2b6dbe523df8a80007d29ffd61f56d270190865492ea8
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 


### PR DESCRIPTION
```
173d4852f468 cirrus: cs35l56: Update firmware for Cirrus Amps for some HP laptops
7f2c497b972b qcom: Update ADSP firmware for sa8775p platform
8a2964613ac5 cs35l56: Add non-spkid firmware names for Thinkbook 16P Gen6 (17AA3921)
f9ed3a03a0a2 QCA: Add Bluetooth firmware for WCN7750 on Maili platform
ff6861c6be6f qcom: point qcs8300 firmawre to sa8775p instance
5aeb5a22d894 qcom: update ADSP firmware for qcs615 platform
ef840dc38d33 qcom: Add ADSP firmware for sc8280xp-radxa-dragon-q8b
c3db0d7dcb35 qcom: vpu: Update video firmware binary for Glymur
8a69086b06dc qcom: sdm845: Add GPU firmware for SHIFT6mq
2936604f3f13 qcom: Update ADSP firmware for QCM6490 platform
ed94b35596b7 amdgpu: DMCUB updates for various ASICs
ff7a9e0ac803 cirrus: Version and cleanup of SDCA FW files
ef789e66fdac cirrus: cs35l41: Add Firmware for ASUS Zenbook Laptop using CS35L41 HDA
3f9bc12c099b QCA: Add Bluetooth firmware hmtnv20.b201/b202 for WCN7850 on Nord platform
59005d789813 ath12k: QCC2072 hw1.0: update to WLAN.COL.1.0.c2-00277-QCACOLSWPL_V1_TO_SILICONZ-1
a137a09be163 [cypress]: Update firmware for cyfmac43455 SDIO
94997d7b4720 QCA: Update Bluetooth QCA6698 firmware to 2.1.2-00079
9d5dfff36d37 amdgpu: DMCUB updates for various ASICs
ec0013690c39 amdgpu: add VCN 5.3.0 firmware
db9b63a5baed qcom: update CDSP firmware for x1e80100 platform
e6e0f66a32de qcom: add QUPv3 firmware for nord
d6371b0556ff qcom: add HPASS firmware for nord platform
df9a23cc65d4 linux-firmware: Update firmware file for Intel BlazarIW core
d4070db56a9c linux-firmware: Update firmware file for Intel BlazarU core
f6a848e7ddb7 linux-firmware: Update firmware file for Intel Scorpius core
9e3ce788d412 qcom/sa8775p: update signature on cdsp1 firmware
51bc8b9da4a3 cirrus: cs35l54: Add Cirrus CS35L54 firmware mappings for an HP laptop
d6387d51c9d4 linux-firmware: Upload firmware for tas2573 stereo
3c50ac89a72f intel: avs: Add AudioDSP base firmware for LKF platforms
377763d013a2 intel: avs: Update AudioDSP firmware for APL-based platforms
9103aed09374 intel: avs: Update AudioDSP firmware for SKL-based platforms
19c30f8f2b3d intel: catpt: Update AudioDSP firmware for BDW platforms
50e034a2c214 mediatek MT7925: update bluetooth firmware to 20260813113236
3c11e660d3a8 linux-firmware: update firmware for MT7925 WiFi device
ccbeeb0dcc56 copy-firmware: Do not fail without GNU parallel
8ee524354209 QCA: Update Bluetooth WCN3988 firmware 2.1.5.c5-00042 to 2.1.5.c5-00060
9a53463c13f6 amdgpu: add VPE 2.0.0 firmware
84b00ed1fd27 amdgpu: add SDMA 6.1.4 firmware
3e5fe4714e02 amdgpu: add DCN 4.2 firmware
c627626828a5 amdgpu: add PSP 15.0.9 firmware
6ac64aa9d26c amdgpu: add PSP 15.0.0 firmware
efc2d5a57db5 amdgpu: add GC 11.7.1 firmware
3e260acd406f amdgpu: add GC 11.7.0 firmware
cc116cc451f8 amdgpu: DMCUB update for DCN314
da4d65142f20 qca: Update Bluetooth QCC2072 UART interface firmware from 1.1.0-00295 to 1.1.0-00340
c5018ff6b11d iwlwifi: add Bz/Sc FW for core24.70-49 release
24ae7e959ed3 iwlwifi: Add Hr/Gf firmware for core24.70-49 release
6f28c042749d iwlwifi: update ty/So/Ma firmwares for core24.70-49 release
84b80e7bdedc iwlwifi: update cc/Qu/QuZ firmwares for core24.70-49 release
0199c5c2b321 cirrus: cs42l45: Add CS42L45 SDCA codec firmware for Samsung laptops
ad924a0129fc cirrus: cs42l45: Add new SSIDs for Dell laptops
391e1aa5d6c4 qcom: add NSP firmware for nord platform
f03e076ce0b4 cirrus: cs35l56: Add firmware for Cirrus Amps for an ASUS laptop
0c5877971c91 cirrus: cs35l56: Add Cirrus CS35L56 firmware mappings for some Dell laptops
2103fa87cc2e WHENCE: Move qcom qcdxkmsuc8[23]80.mbn firmwares to Adreno section
1dedbf3fea53 WHENCE: Separate qcom SoC remoteproc firmwares
5c57d4817ebd amdgpu: DMCUB updates for various ASICs
9305ccd3e07e Revert "amdgpu: update GC 10.3.6 firmware"
92ad97f5d074 qcom: add CDSP firmware for eliza platform
8d615152d436 qcom: vpu: add Gen2 firmware binary for Eliza
25c06030aa43 ath12k: QCC2072 hw1.0: update to WLAN.COL.1.0.c2-00228-QCACOLSWPL_V1_TO_SILICON-1
4cfb1cd751cb cirrus: cs35l63: Add Cirrus CS35L63 firmware mappings for some Dell laptops
```