### PR TITLE
ipq40xx: fix Zigbee SPI chip select on Linksys WHW03 v1

### DIFF
--- a/target/linux/ipq40xx/dts/qcom-ipq4019-whw03.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-whw03.dts
@@ -33,6 +33,16 @@
 	};
 };
 
+&spi_1_pins {
+	mux-2 {
+		pins = "gpio56", "gpio49";
+	};
+};
+
+&blsp1_spi2 {
+	cs-gpios = <&tlmm 56 GPIO_ACTIVE_LOW>;
+};
+
 &mdio {
 	status = "okay";
 	pinctrl-0 = <&mdio_pins>;


### PR DESCRIPTION
## Summary

The Linksys WHW03 v1 routes the internal EM3581 Zigbee NCP's SPI chip select
to GPIO56. The shared WHW03 device tree currently selects GPIO45, which is
correct for v2 but not v1.

Override the SPI pinctrl GPIO group and `cs-gpios` in the v1 DTS only.
The shared DTS and v2 remain unchanged.

## Validation

- Patch against current main; checkpatch: zero errors and warnings.
- Hardware validation used the identical overrides backported to a full-source
  OpenWrt 24.10.4 build on a WHW03 v1 (not a main-branch firmware build).
- Verified the compiled pinctrl group and live GPIO56 active-low CS property.
- After sysupgrade, EZSP-SPI commands work using `/dev/spidev1.0` with
  kernel-controlled chip select, without exporting or manually driving GPIO56.
- With the internal NCP running EmberZNet 6.7.8 / EZSP v8, an ESP32-C5 lab
  router passed five acknowledged On/Off commands after saved-network recovery
  with joining closed, and five after fresh commissioning with successful
  trust-center key verification. Each run lasted 45 seconds; peer state was
  independently checked over Wi-Fi.
- Reset GPIO49 and wake GPIO55 are still handled by a temporary userspace
  helper. This patch does not add NCP firmware, reset/wake management, or a
  persistent Zigbee host service.
- Configuration, both independent SSH recovery keys, client Wi-Fi radios,
  LAN/internet connectivity, and LuCI login serving were checked after upgrade.
- Separately, a WHW03 v2 with its existing GPIO45 mapping had already passed
  equivalent kernel-CS communication and ESP32-C6 commissioning/recovery tests.

Only the v1 DTS correction is included here; experimental host tools and NCP
firmware are outside this PR.
