### PR TITLE
mediatek: filogic: increase spi flash memory speed on TP-Link  TL-XTR8488

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-tplink-tl-xtr8488.dts
+++ b/target/linux/mediatek/dts/mt7986a-tplink-tl-xtr8488.dts
@@ -212,7 +212,7 @@
 		compatible = "spi-nand";
 		reg = <0>;
 
-		spi-max-frequency = <20000000>;
+		spi-max-frequency = <52000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 


### PR DESCRIPTION
The built-in NAND memory supports frequencies up to 104 MHz, so 52 MHz should work just fine.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>