### PR TITLE
mediatek: add support for COMFAST CF-WR631AX (stock and all-in-UBI)

### DIFF
--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -330,6 +330,18 @@ define U-Boot/mt7981_cmcc_rax3000m-ubi-ddr4
   DEPENDS:=+trusted-firmware-a-mt7981-spim-nand-ubi-ddr4
 endef
 
+define U-Boot/mt7981_comfast_cf-wr631ax-ubi
+  NAME:=COMFAST CF-WR631AX (UBI)
+  BUILD_SUBTARGET:=filogic
+  BUILD_DEVICES:=comfast_cf-wr631ax-ubi
+  UBOOT_CONFIG:=mt7981_comfast_cf-wr631ax-ubi
+  UBOOT_IMAGE:=u-boot.fip
+  BL2_BOOTDEV:=spim-nand-ubi
+  BL2_SOC:=mt7981
+  BL2_DDRTYPE:=ddr3-1866
+  DEPENDS:=+trusted-firmware-a-mt7981-spim-nand-ubi-ddr3-1866
+endef
+
 define U-Boot/mt7981_comfast_cf-wr632ax
   NAME:=COMFAST CF-WR632AX
   BUILD_SUBTARGET:=filogic
@@ -1405,6 +1417,7 @@ UBOOT_TARGETS := \
 	mt7981_cmcc_rax3000m-nand-ddr4 \
 	mt7981_cmcc_rax3000m-ubi-ddr3 \
 	mt7981_cmcc_rax3000m-ubi-ddr4 \
+	mt7981_comfast_cf-wr631ax-ubi \
 	mt7981_comfast_cf-wr632ax \
 	mt7981_comfast_cf-wr632ax-ubi \
 	mt7981_creatlentem_clt-r30b1-ubi \

--- a/package/boot/uboot-mediatek/patches/477-add-comfast_cf-wr631ax-ubi.patch
+++ b/package/boot/uboot-mediatek/patches/477-add-comfast_cf-wr631ax-ubi.patch
@@ -1,0 +1,315 @@
+--- /dev/null
++++ b/configs/mt7981_comfast_cf-wr631ax-ubi_defconfig
+@@ -0,0 +1,113 @@
++CONFIG_ARM=y
++CONFIG_ARM_SMCCC=y
++CONFIG_SYS_HAS_NONCACHED_MEMORY=y
++CONFIG_POSITION_INDEPENDENT=y
++CONFIG_ARCH_MEDIATEK=y
++CONFIG_TEXT_BASE=0x41e00000
++CONFIG_SYS_MALLOC_F_LEN=0x4000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEFAULT_DEVICE_TREE="mt7981-comfast-cf-wr631ax-ubi"
++CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_TARGET_MT7981=y
++CONFIG_SYS_LOAD_ADDR=0x46000000
++CONFIG_PRE_CON_BUF_ADDR=0x4007EF00
++CONFIG_DEBUG_UART_BASE=0x11002000
++CONFIG_DEBUG_UART_CLOCK=40000000
++CONFIG_DEBUG_UART=y
++CONFIG_FIT=y
++CONFIG_BOOTDELAY=30
++CONFIG_AUTOBOOT_KEYED=y
++CONFIG_AUTOBOOT_MENU_SHOW=y
++CONFIG_USE_PREBOOT=y
++CONFIG_DEFAULT_FDT_FILE="mt7981-comfast-cf-wr631ax-ubi"
++CONFIG_LOGLEVEL=7
++CONFIG_PRE_CONSOLE_BUFFER=y
++CONFIG_LOG=y
++# CONFIG_BOARD_INIT is not set
++CONFIG_BOARD_LATE_INIT=y
++CONFIG_HUSH_PARSER=y
++CONFIG_SYS_PROMPT="MT7981> "
++CONFIG_CMD_CPU=y
++CONFIG_CMD_LICENSE=y
++CONFIG_CMD_BOOTMENU=y
++CONFIG_CMD_ASKENV=y
++CONFIG_CMD_ERASEENV=y
++CONFIG_CMD_ENV_FLAGS=y
++CONFIG_CMD_RNG=y
++CONFIG_CMD_STRINGS=y
++CONFIG_CMD_DM=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_MTD=y
++CONFIG_CMD_PART=y
++CONFIG_CMD_TFTPSRV=y
++CONFIG_CMD_RARP=y
++CONFIG_CMD_CDP=y
++CONFIG_CMD_SNTP=y
++CONFIG_CMD_LINK_LOCAL=y
++CONFIG_CMD_DHCP=y
++CONFIG_CMD_DNS=y
++CONFIG_CMD_PING=y
++CONFIG_CMD_PXE=y
++CONFIG_CMD_CACHE=y
++CONFIG_CMD_PSTORE=y
++CONFIG_CMD_PSTORE_MEM_ADDR=0x42ff0000
++CONFIG_CMD_UUID=y
++CONFIG_CMD_HASH=y
++CONFIG_CMD_SMC=y
++CONFIG_CMD_UBI=y
++CONFIG_CMD_UBI_RENAME=y
++CONFIG_OF_EMBED=y
++CONFIG_ENV_OVERWRITE=y
++CONFIG_ENV_IS_IN_UBI=y
++CONFIG_ENV_REDUNDANT=y
++CONFIG_ENV_UBI_PART="ubi"
++CONFIG_ENV_UBI_VOLUME="ubootenv"
++CONFIG_ENV_UBI_VOLUME_REDUND="ubootenv2"
++CONFIG_ENV_RELOC_GD_ENV_ADDR=y
++CONFIG_ENV_USE_DEFAULT_ENV_TEXT_FILE=y
++CONFIG_ENV_DEFAULT_ENV_TEXT_FILE="defenvs/comfast_cf-wr631ax-ubi_env"
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_VERSION_VARIABLE=y
++CONFIG_NETCONSOLE=y
++CONFIG_USE_IPADDR=y
++CONFIG_IPADDR="192.168.1.1"
++CONFIG_USE_SERVERIP=y
++CONFIG_SERVERIP="192.168.1.254"
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_BUTTON=y
++CONFIG_BUTTON_GPIO=y
++CONFIG_CLK=y
++CONFIG_GPIO_HOG=y
++CONFIG_LED=y
++CONFIG_LED_BLINK=y
++CONFIG_LED_GPIO=y
++# CONFIG_MMC is not set
++CONFIG_MTD=y
++CONFIG_DM_MTD=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_MTD_UBI_FASTMAP=y
++CONFIG_PHY_FIXED=y
++CONFIG_MEDIATEK_ETH=y
++CONFIG_PHY=y
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++CONFIG_PINCTRL_MT7981=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MTK_POWER_DOMAIN=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_RAM=y
++CONFIG_DM_RNG=y
++CONFIG_RNG_MTK_V2=y
++CONFIG_DM_SERIAL=y
++CONFIG_SERIAL_RX_BUFFER=y
++CONFIG_MTK_SERIAL=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_MTK_SPIM=y
++CONFIG_ZSTD=y
++CONFIG_HEXDUMP=y
+--- /dev/null
++++ b/arch/arm/dts/mt7981-comfast-cf-wr631ax-ubi.dts
+@@ -0,0 +1,138 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++
++/dts-v1/;
++#include "mt7981.dtsi"
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/linux-event-codes.h>
++
++/ {
++	model = "COMFAST CF-WR631AX (UBI)";
++	compatible = "comfast,cf-wr631ax-ubi", "mediatek,mt7981";
++
++	chosen {
++		stdout-path = &uart0;
++		tick-timer = &timer0;
++	};
++
++	memory@40000000 {
++		device_type = "memory";
++		reg = <0x40000000 0x10000000>;
++	};
++
++	gpio-keys {
++		compatible = "gpio-keys";
++
++		button-mesh {
++			label = "mesh";
++			linux,code = <BTN_9>;
++			linux,input-type = <EV_SW>;
++			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
++		};
++
++		button-reset {
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	gpio-leds {
++		compatible = "gpio-leds";
++
++		led-0 {
++			label = "blue:status";
++			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
++		};
++
++		led-1 {
++			label = "green:status";
++			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
++		};
++
++		led-2 {
++			label = "red:status";
++			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&eth {
++	status = "okay";
++	mediatek,gmac-id = <0>;
++	phy-mode = "2500base-x";
++	mediatek,switch = "mt7531";
++	reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
++
++	fixed-link {
++		speed = <2500>;
++		full-duplex;
++	};
++};
++
++&pio {
++	spi_flash_pins: spi0-pins-func-1 {
++		mux {
++			function = "flash";
++			groups = "spi0", "spi0_wp_hold";
++		};
++
++		conf-pu {
++			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
++			drive-strength = <MTK_DRIVE_4mA>;
++			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
++		};
++
++		conf-pd {
++			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
++			drive-strength = <MTK_DRIVE_4mA>;
++			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
++		};
++	};
++};
++
++&spi0 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi_flash_pins>;
++	status = "okay";
++	must_tx;
++	enhance_timing;
++	dma_ext;
++	ipm_design;
++	support_quad;
++	tick_dly = <2>;
++	sample_sel = <0>;
++
++	spi_nand@0 {
++		compatible = "spi-nand";
++		reg = <0>;
++		spi-max-frequency = <52000000>;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "bl2";
++				reg = <0x0 0x100000>;
++			};
++
++			partition@100000 {
++				label = "ubi";
++				reg = <0x100000 0x7f00000>;
++				compatible = "linux,ubi";
++			};
++		};
++	};
++};
++
++&uart0 {
++	mediatek,force-highspeed;
++	status = "okay";
++};
++
++&watchdog {
++	status = "disabled";
++};
+--- /dev/null
++++ b/defenvs/comfast_cf-wr631ax-ubi_env
+@@ -0,0 +1,55 @@
++ipaddr=192.168.1.1
++serverip=192.168.1.254
++loadaddr=0x46000000
++console=earlycon=uart8250,mmio32,0x11002000 console=ttyS0
++bootcmd=if pstore check ; then run boot_recovery ; else run boot_ubi ; fi
++bootconf=config-1
++bootdelay=0
++bootfile=openwrt-mediatek-filogic-comfast_cf-wr631ax-ubi-initramfs-recovery.itb
++bootfile_bl2=openwrt-mediatek-filogic-comfast_cf-wr631ax-ubi-preloader.bin
++bootfile_fip=openwrt-mediatek-filogic-comfast_cf-wr631ax-ubi-bl31-uboot.fip
++bootfile_upg=openwrt-mediatek-filogic-comfast_cf-wr631ax-ubi-squashfs-sysupgrade.itb
++bootled_pwr=red:status
++bootled_rec=blue:status
++bootmenu_confirm_return=askenv - Press ENTER to return to menu ; bootmenu 60
++bootmenu_default=0
++bootmenu_delay=0
++bootmenu_title=      [0;34m( ( ( [1;39mOpenWrt[0;34m ) ) )
++bootmenu_0=Initialize environment.=run _firstboot
++bootmenu_0d=Run default boot command.=run boot_default
++bootmenu_1=Boot system via TFTP.=run boot_tftp ; run bootmenu_confirm_return
++bootmenu_2=Boot production system from NAND.=run boot_production ; run bootmenu_confirm_return
++bootmenu_3=Boot recovery system from NAND.=run boot_recovery ; run bootmenu_confirm_return
++bootmenu_4=Load production system via TFTP then write to NAND.=setenv noboot 1 ; setenv replacevol 1 ; run boot_tftp_production ; setenv noboot ; setenv replacevol ; run bootmenu_confirm_return
++bootmenu_5=Load recovery system via TFTP then write to NAND.=setenv noboot 1 ; setenv replacevol 1 ; run boot_tftp_recovery ; setenv noboot ; setenv replacevol ; run bootmenu_confirm_return
++bootmenu_6=[31mLoad BL31+U-Boot FIP via TFTP then write to NAND.[0m=run boot_tftp_write_fip ; run bootmenu_confirm_return
++bootmenu_7=[31mLoad BL2 preloader via TFTP then write to NAND.[0m=run boot_tftp_write_bl2 ; run bootmenu_confirm_return
++bootmenu_8=Reboot.=reset
++bootmenu_9=Reset all settings to factory defaults.=run reset_factory ; reset
++boot_first=if button reset ; then led green:status off ; led $bootled_rec on ; run boot_tftp_recovery ; setenv flag_recover 1 ; run boot_default ; fi ; bootmenu
++boot_default=if env exists flag_recover ; then else run bootcmd ; fi ; run boot_recovery ; setenv replacevol 1 ; run boot_tftp_forever
++boot_production=run reset_leds ; led $bootled_pwr on ; run ubi_read_production && bootm $loadaddr#$bootconf ; led $bootled_pwr off
++boot_recovery=run reset_leds ; led $bootled_rec on ; run ubi_read_recovery && bootm $loadaddr#$bootconf ; led $bootled_rec off
++boot_ubi=run boot_production ; run boot_recovery ; run boot_tftp_forever
++boot_tftp_forever=led green:status off ; led $bootled_rec on ; while true ; do run boot_tftp_recovery ; sleep 1 ; done
++boot_tftp_production=tftpboot $loadaddr $bootfile_upg && env exists replacevol && iminfo $loadaddr && run ubi_write_production ; if env exists noboot ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp_recovery=tftpboot $loadaddr $bootfile && env exists replacevol && iminfo $loadaddr && run ubi_write_recovery ; if env exists noboot ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp=tftpboot $loadaddr $bootfile && bootm $loadaddr#$bootconf
++boot_tftp_write_fip=tftpboot $loadaddr $bootfile_fip && run ubi_write_fip && run reset_factory
++boot_tftp_write_bl2=tftpboot $loadaddr $bootfile_bl2 && run mtd_write_bl2
++preboot=led $bootled_pwr on ; led $bootled_rec on ; led green:status on
++reset_factory=mw $loadaddr 0xff 0x1f000 ; ubi write $loadaddr ubootenv 0x1f000 ; ubi write $loadaddr ubootenv2 0x1f000 ; ubi remove rootfs_data
++reset_leds=led $bootled_pwr off ; led $bootled_rec off ; led green:status off
++mtd_write_bl2=mtd erase bl2 && mtd write bl2 $loadaddr
++ubi_create_env=ubi check ubootenv || ubi create ubootenv 0x1f000 dynamic ; ubi check ubootenv2 || ubi create ubootenv2 0x1f000 dynamic
++ubi_prepare_rootfs=if ubi check rootfs_data ; then else if env exists rootfs_data_max ; then ubi create rootfs_data $rootfs_data_max dynamic || ubi create rootfs_data - dynamic ; else ubi create rootfs_data - dynamic ; fi ; fi
++ubi_read_production=ubi read $loadaddr fit && iminfo $loadaddr && run ubi_prepare_rootfs
++ubi_read_recovery=ubi check recovery && ubi read $loadaddr recovery
++ubi_remove_rootfs=ubi check rootfs_data && ubi remove rootfs_data
++ubi_write_fip=run ubi_remove_rootfs ; ubi check fip && ubi remove fip ; ubi create fip $filesize static && ubi write $loadaddr fip $filesize
++ubi_write_production=ubi check fit && ubi remove fit ; run ubi_remove_rootfs ; ubi create fit $filesize dynamic && ubi write $loadaddr fit $filesize
++ubi_write_recovery=ubi check recovery && ubi remove recovery ; run ubi_remove_rootfs ; ubi create recovery $filesize dynamic && ubi write $loadaddr recovery $filesize
++_init_env=setenv _init_env ; run ubi_create_env ; saveenv ; saveenv
++_firstboot=setenv _firstboot ; run _switch_to_menu ; run _init_env ; run boot_first
++_switch_to_menu=setenv _switch_to_menu ; setenv bootdelay 3 ; setenv bootmenu_delay 3 ; setenv bootmenu_0 $bootmenu_0d ; setenv bootmenu_0d ; run _bootmenu_update_title
++_bootmenu_update_title=setenv _bootmenu_update_title ; setenv bootmenu_title "$bootmenu_title       [33m$ver[0m"

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -26,6 +26,7 @@ abt,asr3000|\
 acer,predator-w6x-ubootmod|\
 asus,zenwifi-bt8-ubootmod|\
 cmcc,a10-ubootmod|\
+comfast,cf-wr631ax-ubi|\
 comfast,cf-wr632ax-ubi|\
 comfast,cf-wr632ax-ubootmod|\
 creatlentem,clt-r30b1-ubi|\

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -84,6 +84,7 @@ nradio,c8-668gl)
 	;;
 asiarf,ap7986-003|\
 cetron,ct3003|\
+comfast,cf-wr631ax|\
 comfast,cf-wr632ax|\
 edgecore,eap111|\
 netgear,wax220|\

--- a/target/linux/mediatek/dts/mt7981b-comfast-cf-wr631ax-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-comfast-cf-wr631ax-common.dtsi
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "mt7981b.dtsi"
+
+/ {
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_green;
+		serial0 = &uart0;
+	};
+
+	chosen: chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-mesh {
+			label = "mesh";
+			linux,code = <BTN_9>;
+			linux,input-type = <EV_SW>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: led-0 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: led-1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: led-2 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_e000 0>;
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+};
+
+&mdio_bus {
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand: flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x00000 0x100000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			label = "lan1";
+			reg = <0>;
+		};
+
+		port@2 {
+			label = "lan2";
+			reg = <2>;
+		};
+
+		port@3 {
+			label = "lan3";
+			reg = <3>;
+		};
+
+		port@4 {
+			label = "wan";
+			reg = <4>;
+
+			nvmem-cells = <&macaddr_factory_e000 1>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_4 0>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_8000 0>;
+		nvmem-cell-names = "mac-address";
+	};
+};

--- a/target/linux/mediatek/dts/mt7981b-comfast-cf-wr631ax-ubi.dts
+++ b/target/linux/mediatek/dts/mt7981b-comfast-cf-wr631ax-ubi.dts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7981b-comfast-cf-wr631ax-common.dtsi"
+
+/ {
+	model = "COMFAST CF-WR631AX (UBI)";
+	compatible = "comfast,cf-wr631ax-ubi", "mediatek,mt7981";
+};
+
+&chosen {
+	bootargs = "root=/dev/fit0 rootwait";
+	rootdisk = <&ubi_rootdisk>;
+};
+
+&partitions {
+	partition@0 {
+		label = "bl2";
+	};
+
+	partition@100000 {
+		label = "ubi";
+		reg = <0x100000 0x7f00000>;
+		compatible = "linux,ubi";
+
+		volumes {
+			ubi_factory: ubi-volume-factory {
+				volname = "factory";
+			};
+
+			ubi_rootdisk: ubi-volume-fit {
+				volname = "fit";
+			};
+
+			ubi-volume-ubootenv {
+				volname = "ubootenv";
+				nvmem-layout {
+					compatible = "u-boot,env-redundant-bool";
+				};
+			};
+
+			ubi-volume-ubootenv2 {
+				volname = "ubootenv2";
+				nvmem-layout {
+					compatible = "u-boot,env-redundant-bool";
+				};
+			};
+		};
+	};
+};
+
+&ubi_factory {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		eeprom_factory_0: eeprom@0 {
+			reg = <0x0 0x1000>;
+		};
+
+		macaddr_factory_4: macaddr@4 {
+			reg = <0x4 0x6>;
+			compatible = "mac-base";
+			#nvmem-cell-cells = <1>;
+		};
+
+		macaddr_factory_8000: macaddr@8000 {
+			compatible = "mac-base";
+			reg = <0x8000 0x6>;
+			#nvmem-cell-cells = <1>;
+		};
+
+		macaddr_factory_e000: macaddr@e000 {
+			compatible = "mac-base";
+			reg = <0xe000 0x6>;
+			#nvmem-cell-cells = <1>;
+		};
+	};
+};

--- a/target/linux/mediatek/dts/mt7981b-comfast-cf-wr631ax.dts
+++ b/target/linux/mediatek/dts/mt7981b-comfast-cf-wr631ax.dts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7981b-comfast-cf-wr631ax-common.dtsi"
+
+/ {
+	model = "COMFAST CF-WR631AX";
+	compatible = "comfast,cf-wr631ax", "mediatek,mt7981";
+};
+
+&spi_nand {
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+	mediatek,bmt-mtd-overridden-oobsize = <64>;
+};
+
+&partitions {
+	partition@0 {
+		label = "BL2";
+	};
+
+	partition@100000 {
+		label = "u-boot-env";
+		reg = <0x100000 0x80000>;
+	};
+
+	partition@180000 {
+		label = "Factory";
+		reg = <0x180000 0x200000>;
+		read-only;
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x1000>;
+			};
+
+			macaddr_factory_e000: macaddr@e000 {
+				compatible = "mac-base";
+				reg = <0xe000 0x6>;
+				#nvmem-cell-cells = <1>;
+			};
+
+			macaddr_factory_4: macaddr@4 {
+				compatible = "mac-base";
+				reg = <0x4 0x6>;
+				#nvmem-cell-cells = <1>;
+			};
+
+			macaddr_factory_8000: macaddr@8000 {
+				compatible = "mac-base";
+				reg = <0x8000 0x6>;
+				#nvmem-cell-cells = <1>;
+			};
+		};
+	};
+
+	partition@380000 {
+		label = "FIP";
+		reg = <0x380000 0x200000>;
+		read-only;
+	};
+
+	ubi: partition@580000 {
+		label = "ubi";
+		reg = <0x580000 0x4000000>;
+		compatible = "linux,ubi";
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -57,6 +57,7 @@ mediatek_setup_interfaces()
 	cmcc,a10-ubootmod|\
 	cmcc,rax3000m|\
 	comfast,cf-wr631ax|\
+	comfast,cf-wr631ax-ubi|\
 	confiabits,mt7981|\
 	creatlentem,clt-r30b1|\
 	creatlentem,clt-r30b1-112m|\

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -56,6 +56,7 @@ mediatek_setup_interfaces()
 	cmcc,a10-stock|\
 	cmcc,a10-ubootmod|\
 	cmcc,rax3000m|\
+	comfast,cf-wr631ax|\
 	confiabits,mt7981|\
 	creatlentem,clt-r30b1|\
 	creatlentem,clt-r30b1-112m|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -172,6 +172,7 @@ platform_do_upgrade() {
 	bazis,ax3000wm|\
 	cmcc,a10-ubootmod|\
 	cmcc,rax3000m|\
+	comfast,cf-wr631ax-ubi|\
 	comfast,cf-wr632ax-ubi|\
 	comfast,cf-wr632ax-ubootmod|\
 	creatlentem,clt-r30b1-ubi|\
@@ -424,6 +425,7 @@ platform_check_image() {
 	bazis,ax3000wm|\
 	cmcc,a10-ubootmod|\
 	cmcc,rax3000m|\
+	comfast,cf-wr631ax-ubi|\
 	comfast,cf-wr632ax-ubi|\
 	comfast,cf-wr632ax-ubootmod|\
 	creatlentem,clt-r30b1-ubi|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1124,6 +1124,26 @@ define Device/comfast_cf-wa933-128m
 endef
 TARGET_DEVICES += comfast_cf-wa933-128m
 
+define Device/comfast_cf-wr631ax-common
+  DEVICE_VENDOR := COMFAST
+  DEVICE_MODEL := CF-WR631AX
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_IN_UBI := 1
+endef
+
+define Device/comfast_cf-wr631ax
+  $(call Device/comfast_cf-wr631ax-common)
+  DEVICE_DTS := mt7981b-comfast-cf-wr631ax
+  IMAGE_SIZE := 65536k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  SUPPORTED_DEVICES += cf-wr631ax
+endef
+TARGET_DEVICES += comfast_cf-wr631ax
+
 define Device/comfast_cf-wr632ax-common
   DEVICE_VENDOR := COMFAST
   DEVICE_MODEL := CF-WR632AX

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1144,6 +1144,24 @@ define Device/comfast_cf-wr631ax
 endef
 TARGET_DEVICES += comfast_cf-wr631ax
 
+define Device/comfast_cf-wr631ax-ubi
+  $(call Device/comfast_cf-wr631ax-common)
+  DEVICE_VARIANT := (UBI)
+  DEVICE_DTS := mt7981b-comfast-cf-wr631ax-ubi
+  UBOOTENV_IN_UBI := 1
+  IMAGES := sysupgrade.itb
+  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
+  KERNEL := kernel-bin | gzip
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/sysupgrade.itb := append-kernel | \
+	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
+  ARTIFACTS := preloader.bin bl31-uboot.fip
+  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ubi-ddr3-1866
+  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot comfast_cf-wr631ax-ubi
+endef
+TARGET_DEVICES += comfast_cf-wr631ax-ubi
+
 define Device/comfast_cf-wr632ax-common
   DEVICE_VENDOR := COMFAST
   DEVICE_MODEL := CF-WR632AX


### PR DESCRIPTION
```
The COMFAST CF-WR631AX is a Wi-Fi 6 wireless router
built on the ZR-3027_V1.2 board.

It currently has three hardware variants, of which
only V1 and V3 use the Filogic platform.

Specification
-------------
- SoC          : MediaTek MT7981BA dual-core ARM Cortex-A53 1.3 GHz
- RAM          : DDR3 256 MiB (Nanya NT5CB128M16IP-EK)
- Flash        : SPI-NAND 128 MiB (Winbond)
- WLAN         : MediaTek MT7976CN dual-band WiFi 6
  - 2.4 GHz    : b/g/n/ax, MU-MIMO (2x 5 dBi antennas)
  - 5 GHz      : a/n/ac/ax, MU-MIMO (3x 5 dBi antennas)
- Ethernet     :
  - LAN x3     : 10/100/1000 Mbps (MediaTek MT7531AE)
  - WAN x1     : 10/100/1000 Mbps (MediaTek MT7531AE)
- UART         : through-hole on PCB
  - assignment : [3.3V], (RX), (TX), (GND)
  - settings   : 115200n8
- Buttons x2   : Mesh, Reset
- LEDs x3      : Status (Red, Green, Blue)
- Power        : 12 VDC, 1 A, 5.5*2.1 mm

Installation
------------
1. Assign ip 192.168.1.254 netmask 255.255.255.0 to your computer's
   Ethernet port, then connect it to any LAN port on the router.

2. Power on the router while holding the Reset button until
   the LED flashes 5 times.

3. Flash openwrt*-comfast_cf-wr631ax-squashfs-sysupgrade.bin
   via U-Boot Flash WebUI available at http://192.168.1.1.

Return to OEM firmware
----------------------
Download the OEM firmware from the vendor's site and
flash it using the OpenWrt sysupgrade method.

Recovery
--------
The recovery process is the same as installation.

MAC Addresses:
----------------------------------------------------------------------
| Interface    | MAC               | Source              |           |
---------------|-------------------|----------------------------------
| LAN          | 40:A5:EF:xx:xx:xx | Factory, 0xe000     | label     |
| WAN          | 40:A5:EF:xx:xx:xx | Factory, 0xe000 + 1 | label + 1 |
| WLAN 2.4 GHz | 40:A5:EF:xx:xx:xx | Factory, 0x4        | label + 2 |
| WLAN 5 GHz   | 40:A5:EF:xx:xx:xx | Factory, 0x8000     | label + 3 |
----------------------------------------------------------------------
```

```
This commit introduces OpenWrt U-Boot all-in-UBI layout support
for the COMFAST CF-WR631AX, enabling:
- Prolonged device lifetime by allocating most of the flash
  to UBI (which takes care of wear-leveling)
- Maximum available storage space for OpenWrt

OpenWrt U-Boot UBI flash instructions
-------------------------------------
A device running stock firmware should be upgraded to the
latest OpenWrt firmware
(https://firmware-selector.openwrt.org/?target=mediatek%2Ffilogic&id=comfast_cf-wr631ax).

Back up critical data
---------------------
LuCI Web-UI:
"System" -> "Backup / Flash Firmware" -> "Save mtdblock contents"

Save mtdblock:
 - BL2
 - Factory
 - FIP
 - u-boot-env

Make sure the files were successfully downloaded to your downloads directory.

Using the installer image
-------------------------
To simplify the installation process, this method uses a fork
of Daniel Golle's (@dangowrt) UBI Installer
https://github.com/dangowrt/owrt-ubi-installer

1. Assign ip 192.168.1.254 netmask 255.255.255.0 to your computer's
   Ethernet port.

2. Ensure your router is running the latest generic OpenWrt firmware.
   Upgrade it if necessary.

3. Obtain the installer image:
   Build the installer from source
   https://github.com/andros-ua/owrt-ubi-installer/tree/cf-wr631ax
   or download a prebuilt image from the
   https://github.com/andros-ua/owrt-ubi-installer/releases

4. Flash the openwrt*-ubi-initramfs-recovery-installer.itb
   image using sysupgrade.

5. Wait for installation: the green status LED will blink rapidly,
   indicating that the all-in-UBI installer is running.
   Once the installation finishes,
   the status LED will turn solid purple for 5 seconds.

6. After the device reboots, perform a final sysupgrade using the
   openwrt*-ubi-squashfs-sysupgrade.itb image.

Return to stock layout
----------------------
You can use the files from the stock bootchain backup
that the installer image created.

To retrieve the files from the backup:
1. Extract the backup:
   cat /dev/ubi0_6 | tar xzv -C /tmp

2. Copy the files from /tmp/boot_backup to your PC via SCP.

Restore stock layout
--------------------
1. Flash openwrt*-comfast_cf-wr631ax-initramfs-kernel.bin
   via sysupgrade and wait for the device to boot.

2. Copy the following files to /tmp on the device via SCP:
   - BL2.bin
   - Factory.bin
   - FIP.bin
   - u-boot-env.bin
   - openwrt*-comfast_cf-wr631ax-squashfs-sysupgrade.bin

3. Restore the stock MTD partitions:
   apk add kmod-mtd-rw
   insmod mtd-rw i_want_a_brick=1
   mtd write /tmp/BL2.bin BL2
   mtd write /tmp/Factory.bin Factory
   mtd write /tmp/FIP.bin FIP
   mtd write /tmp/u-boot-env.bin u-boot-env

4. Install the system:
   sysupgrade /tmp/*sysupgrade.bin

Stock layout
----------------------------------------
| dev:    size   erasesize  name       |
| mtd0: 00100000 00020000 "BL2"        |
| mtd1: 00080000 00020000 "u-boot-env" |
| mtd2: 00200000 00020000 "Factory"    |
| mtd3: 00200000 00020000 "FIP"        |
| mtd4: 04000000 00020000 "ubi"        |
----------------------------------------

OpenWrt U-Boot UBI layout
----------------------------------
| dev:    size   erasesize  name |
| mtd0: 00100000 00020000 "bl2"  |
| mtd1: 07f00000 00020000 "ubi"  |
----------------------------------
```